### PR TITLE
Missing Exception information related to which trace listener is throwing the exception

### DIFF
--- a/Framework/Tracing/TraceHelper.cs
+++ b/Framework/Tracing/TraceHelper.cs
@@ -11,6 +11,8 @@
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
 
+using System.Globalization;
+
 namespace DurableTask.Tracing
 {
     using System;
@@ -208,7 +210,9 @@ namespace DurableTask.Tracing
                 try
                 {
                     source.TraceEvent(TraceEventType.Critical, 0,
-                        "Failed to log actual trace because one or more trace listeners threw an exception.");
+                        string.Format(CultureInfo.InvariantCulture,
+                        "Failed to log actual trace because one or more trace listeners threw an exception. Message: {0}", 
+                        exception.ToString()));
                 }
                 catch (Exception anotherException)
                 {

--- a/Framework/Tracing/TraceHelper.cs
+++ b/Framework/Tracing/TraceHelper.cs
@@ -11,8 +11,6 @@
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
 
-using System.Globalization;
-
 namespace DurableTask.Tracing
 {
     using System;
@@ -210,8 +208,7 @@ namespace DurableTask.Tracing
                 try
                 {
                     source.TraceEvent(TraceEventType.Critical, 0,
-                        string.Format(CultureInfo.InvariantCulture,
-                        "Failed to log actual trace because one or more trace listeners threw an exception. Message: {0}", 
+                        string.Format("Failed to log actual trace because one or more trace listeners threw an exception. Message: {0}", 
                         exception.ToString()));
                 }
                 catch (Exception anotherException)


### PR DESCRIPTION
We get weekly 3 alerts with this exception "Failed to log actual trace because one or more trace listeners threw an exception", but are not able to figure out the root cause.

Logging the stack trace can help us locate and fix the issue.