### PR TITLE
return an empty list for 'all orchestration states'

### DIFF
--- a/Framework/ServiceBusOrchestrationService.cs
+++ b/Framework/ServiceBusOrchestrationService.cs
@@ -836,7 +836,7 @@ namespace DurableTask
         {
             ThrowIfInstanceStoreNotConfigured();
             IEnumerable<OrchestrationStateHistoryEvent> states = await InstanceStore.GetOrchestrationStateAsync(instanceId, allExecutions);
-            return states?.Select(s => s.State).ToList();
+            return states?.Select(s => s.State).ToList() ?? new List<OrchestrationState>();
         }
 
         /// <summary>


### PR DESCRIPTION
 instead of null when none found