### PR TITLE
Adding RaiseEvent to client for scalability, Allow creating queue with specific size

### DIFF
--- a/samples/DurableTask.Samples/Program.cs
+++ b/samples/DurableTask.Samples/Program.cs
@@ -104,6 +104,14 @@ namespace DurableTask.Samples
                         case "Signal":
                             instance = taskHubClient.CreateOrchestrationInstanceAsync(typeof(SignalOrchestration), instanceId, null).Result;
                             break;
+                        case "SignalAndRaise":
+                            if (options.Parameters == null || options.Parameters.Length != 1)
+                            {
+                                throw new ArgumentException("parameters");
+                            }
+
+                            instance = taskHubClient.CreateOrchestrationInstanceWithRaisedEventAsync(typeof(SignalOrchestration), instanceId, null, options.Signal, options.Parameters[0]).Result;
+                            break;
                         case "Replat":
                             instance = taskHubClient.CreateOrchestrationInstanceAsync(typeof(MigrateOrchestration), instanceId,
                                 new MigrateOrchestrationData() { SubscriptionId = "03a1cd39-47ac-4a57-9ff5-a2c2a2a76088", IsDisabled = false }).Result;

--- a/samples/DurableTask.Samples/Signal/SignalOrchestration.cs
+++ b/samples/DurableTask.Samples/Signal/SignalOrchestration.cs
@@ -23,7 +23,7 @@ namespace DurableTask.Samples.Signal
         public override async Task<string> RunTask(OrchestrationContext context, string input)
         {
             string user = await WaitForSignal();
-            string greeting = await context.ScheduleTask<string>("DurableTaskSamples.Greetings.SendGreetingTask", string.Empty, user);
+            string greeting = await context.ScheduleTask<string>("DurableTask.Samples.Greetings.SendGreetingTask", string.Empty, user);
             return greeting;
         }
 

--- a/src/DurableTask.Framework/IOrchestrationServiceClient.cs
+++ b/src/DurableTask.Framework/IOrchestrationServiceClient.cs
@@ -33,9 +33,16 @@ namespace DurableTask
         /// <summary>
         /// Send a new message for an orchestration
         /// </summary>
-        /// <param name="messages">List of messages to send</param>
+        /// <param name="message">Message to send</param>
         /// <returns></returns>
-        Task SendTaskOrchestrationMessageAsync(params TaskMessage[] messages);
+        Task SendTaskOrchestrationMessageAsync(TaskMessage message);
+
+        /// <summary>
+        /// Send a new set of messages for an orchestration
+        /// </summary>
+        /// <param name="messages">Messages to send</param>
+        /// <returns></returns>
+        Task SendTaskOrchestrationMessageBatchAsync(params TaskMessage[] messages);
 
         /// <summary>
         /// Wait for an orchestration to reach any terminal state within the given timeout

--- a/src/DurableTask.Framework/IOrchestrationServiceClient.cs
+++ b/src/DurableTask.Framework/IOrchestrationServiceClient.cs
@@ -33,9 +33,9 @@ namespace DurableTask
         /// <summary>
         /// Send a new message for an orchestration
         /// </summary>
-        /// <param name="message">Message to send</param>
+        /// <param name="messages">List of messages to send</param>
         /// <returns></returns>
-        Task SendTaskOrchestrationMessageAsync(TaskMessage message);
+        Task SendTaskOrchestrationMessageAsync(params TaskMessage[] messages);
 
         /// <summary>
         /// Wait for an orchestration to reach any terminal state within the given timeout

--- a/src/DurableTask.Framework/ServiceBusOrchestrationService.cs
+++ b/src/DurableTask.Framework/ServiceBusOrchestrationService.cs
@@ -902,7 +902,10 @@ namespace DurableTask
         {
             var message = GetAndDeleteBrokeredMessageForWorkItem(workItem);
             TraceHelper.Trace(TraceEventType.Information, $"Abandoning message {workItem?.Id}");
-            return message?.AbandonAsync();
+
+            return message == null 
+                ? Task.FromResult<object>(null) 
+                : message.AbandonAsync();
         }
 
         /// <summary>

--- a/src/DurableTask.Framework/ServiceBusOrchestrationService.cs
+++ b/src/DurableTask.Framework/ServiceBusOrchestrationService.cs
@@ -974,6 +974,11 @@ namespace DurableTask
         /// <param name="messages">The task message to be sent for the orchestration</param>
         public async Task SendTaskOrchestrationMessageAsync(params TaskMessage[] messages)
         {
+            if (messages.Length == 0)
+            {
+                return;
+            }
+
             var brokeredMessages = new BrokeredMessage[messages.Length];
             for (int i = 0; i < messages.Length; i++)
             {

--- a/src/DurableTask.Framework/ServiceBusOrchestrationService.cs
+++ b/src/DurableTask.Framework/ServiceBusOrchestrationService.cs
@@ -972,10 +972,19 @@ namespace DurableTask
         }
 
         /// <summary>
+        ///    Sends an orchestration message
+        /// </summary>
+        /// <param name="message">The task message to be sent for the orchestration</param>
+        public Task SendTaskOrchestrationMessageAsync(TaskMessage message)
+        {
+            return SendTaskOrchestrationMessageBatchAsync(message);
+        }
+
+        /// <summary>
         ///    Sends a set of orchestration messages
         /// </summary>
-        /// <param name="messages">The task message to be sent for the orchestration</param>
-        public async Task SendTaskOrchestrationMessageAsync(params TaskMessage[] messages)
+        /// <param name="messages">The task messages to be sent for the orchestration</param>
+        public async Task SendTaskOrchestrationMessageBatchAsync(params TaskMessage[] messages)
         {
             if (messages.Length == 0)
             {

--- a/src/DurableTask.Framework/Settings/ServiceBusOrchestrationServiceSettings.cs
+++ b/src/DurableTask.Framework/Settings/ServiceBusOrchestrationServiceSettings.cs
@@ -63,7 +63,7 @@ namespace DurableTask.Settings
         /// <summary>
         ///     Maximum queue size, in megabytes, for the service bus queues
         /// </summary>
-        public long MaxQueueSizeInMegabytes { get; set; } = 1024;
+        public long MaxQueueSizeInMegabytes { get; set; } = 1024L;
 
         /// <summary>
         /// Gets the message prefetch count

--- a/src/DurableTask.Framework/Settings/ServiceBusOrchestrationServiceSettings.cs
+++ b/src/DurableTask.Framework/Settings/ServiceBusOrchestrationServiceSettings.cs
@@ -61,6 +61,11 @@ namespace DurableTask.Settings
         public int MaxTrackingDeliveryCount { get; set; }
 
         /// <summary>
+        ///     Maximum queue size, in megabytes, for the service bus queues
+        /// </summary>
+        public long MaxQueueSizeInMegabytes { get; set; } = 1024;
+
+        /// <summary>
         /// Gets the message prefetch count
         /// </summary>
         public int PrefetchCount { get; } = 50;

--- a/src/DurableTask.Framework/TaskHubClient.cs
+++ b/src/DurableTask.Framework/TaskHubClient.cs
@@ -172,6 +172,11 @@ namespace DurableTask
             string eventName, 
             object eventData)
         {
+            if (string.IsNullOrWhiteSpace(instanceId))
+            {
+                instanceId = Guid.NewGuid().ToString("N");
+            }
+
             var orchestrationInstance = new OrchestrationInstance
             {
                 InstanceId = instanceId,

--- a/src/DurableTask.Framework/TaskHubClient.cs
+++ b/src/DurableTask.Framework/TaskHubClient.cs
@@ -373,7 +373,7 @@ namespace DurableTask
                 });
             }
 
-            await this.serviceClient.SendTaskOrchestrationMessageAsync(taskMessages.ToArray());
+            await this.serviceClient.SendTaskOrchestrationMessageBatchAsync(taskMessages.ToArray());
             return orchestrationInstance;
         }
 

--- a/src/DurableTask.Framework/TaskHubClient.cs
+++ b/src/DurableTask.Framework/TaskHubClient.cs
@@ -354,7 +354,7 @@ namespace DurableTask
                 }
             };
 
-            if (!string.IsNullOrEmpty(eventName))
+            if (eventData != null)
             {
                 string serializedEventData = defaultConverter.Serialize(eventData);
                 taskMessages.Add(new TaskMessage

--- a/test/DurableTask.Framework.Tests/Mocks/LocalOrchestrationService.cs
+++ b/test/DurableTask.Framework.Tests/Mocks/LocalOrchestrationService.cs
@@ -189,7 +189,12 @@ namespace DurableTask.Framework.Tests.Mocks
             return Task.FromResult<object>(null);
         }
 
-        public Task SendTaskOrchestrationMessageAsync(params TaskMessage[] messages)
+        public Task SendTaskOrchestrationMessageAsync(TaskMessage message)
+        {
+            return SendTaskOrchestrationMessageBatchAsync(message);
+        }
+
+        public Task SendTaskOrchestrationMessageBatchAsync(params TaskMessage[] messages)
         {
             foreach (var message in messages)
             {

--- a/test/DurableTask.Framework.Tests/Mocks/LocalOrchestrationService.cs
+++ b/test/DurableTask.Framework.Tests/Mocks/LocalOrchestrationService.cs
@@ -189,9 +189,13 @@ namespace DurableTask.Framework.Tests.Mocks
             return Task.FromResult<object>(null);
         }
 
-        public Task SendTaskOrchestrationMessageAsync(TaskMessage message)
+        public Task SendTaskOrchestrationMessageAsync(params TaskMessage[] messages)
         {
-            this.orchestratorQueue.SendMessage(message);
+            foreach (var message in messages)
+            {
+                this.orchestratorQueue.SendMessage(message);
+            }
+
             return Task.FromResult<object>(null);
         }
 

--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -6,6 +6,7 @@
       <RunCodeAnalysis Condition=" '$(Configuration)' == 'Debug' ">False</RunCodeAnalysis>
       <RunCodeAnalysis Condition=" $(MSBuildProjectName.EndsWith('.Tests')) ">False</RunCodeAnalysis>
       <CodeAnalysisTreatWarningsAsErrors>True</CodeAnalysisTreatWarningsAsErrors>
+	  <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     </PropertyGroup>
   <Target Name="Build">
   </Target>


### PR DESCRIPTION
A common pattern for long-running orchestrations is to create an orchestration then raise an event on it. This causes twice as many messages to service bus. This change will do this process in a batch send.