### PR TITLE
Allow extensibility for the NameVersionObjectManager

### DIFF
--- a/Framework/Framework.csproj
+++ b/Framework/Framework.csproj
@@ -101,6 +101,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BrokeredMessageExtensions.cs" />
+    <Compile Include="INameVersionObjectManager.cs" />
     <Compile Include="SynchronousTaskScheduler.cs" />
     <Compile Include="History\GenericEvent.cs" />
     <Compile Include="CompressionSettings.cs" />

--- a/Framework/INameVersionObjectManager.cs
+++ b/Framework/INameVersionObjectManager.cs
@@ -1,0 +1,21 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask
+{
+    public interface INameVersionObjectManager<T>
+    {
+        void Add(ObjectCreator<T> creator);
+        T GetObject(string name, string version);
+    }
+}

--- a/Framework/NameVersionObjectManager.cs
+++ b/Framework/NameVersionObjectManager.cs
@@ -16,7 +16,7 @@ namespace DurableTask
     using System;
     using System.Collections.Generic;
 
-    internal class NameVersionObjectManager<T>
+    internal class NameVersionObjectManager<T> : INameVersionObjectManager<T>
     {
         readonly IDictionary<string, ObjectCreator<T>> creators;
         readonly object thisLock = new object();

--- a/Framework/TaskActivityDispatcher.cs
+++ b/Framework/TaskActivityDispatcher.cs
@@ -26,7 +26,7 @@ namespace DurableTask
     {
         readonly MessagingFactory messagingFactory;
 
-        readonly NameVersionObjectManager<TaskActivity> objectManager;
+        readonly INameVersionObjectManager<TaskActivity> objectManager;
         readonly string orchestratorQueueName;
         readonly TaskHubWorkerSettings settings;
         readonly TaskHubDescription taskHubDescription;
@@ -39,7 +39,7 @@ namespace DurableTask
             TaskHubWorkerSettings workerSettings,
             string orchestratorQueueName,
             string workerQueueName,
-            NameVersionObjectManager<TaskActivity> objectManager)
+            INameVersionObjectManager<TaskActivity> objectManager)
             : base("TaskActivityDispatcher", item => item.MessageId)
         {
             this.taskHubDescription = taskHubDescription;

--- a/Framework/TaskOrchestrationDispatcher.cs
+++ b/Framework/TaskOrchestrationDispatcher.cs
@@ -44,7 +44,7 @@ namespace DurableTask
 
         protected readonly MessagingFactory messagingFactory;
 
-        readonly NameVersionObjectManager<TaskOrchestration> objectManager;
+        readonly INameVersionObjectManager<TaskOrchestration> objectManager;
         protected readonly string orchestratorEntityName;
         readonly TaskHubWorkerSettings settings;
         readonly TaskHubDescription taskHubDescription;
@@ -62,7 +62,7 @@ namespace DurableTask
             string orchestratorEntityName,
             string workerEntityName,
             string trackingEntityName,
-            NameVersionObjectManager<TaskOrchestration> objectManager)
+            INameVersionObjectManager<TaskOrchestration> objectManager)
             : base("TaskOrchestration Dispatcher", item => item.Session == null ? string.Empty : item.Session.SessionId)
         {
             this.taskHubDescription = taskHubDescription;

--- a/Framework/Test/FakeOrchestrationExecutor.cs
+++ b/Framework/Test/FakeOrchestrationExecutor.cs
@@ -26,10 +26,10 @@ namespace DurableTask.Test
         readonly IDictionary<string, TaskOrchestration> currentExecutions = new Dictionary<string, TaskOrchestration>();
         readonly JsonDataConverter dataConverter;
 
-        readonly NameVersionObjectManager<TaskOrchestration> orchestrationObjectManager;
+        readonly INameVersionObjectManager<TaskOrchestration> orchestrationObjectManager;
         readonly TaskScheduler scheduler;
 
-        public FakeOrchestrationExecutor(NameVersionObjectManager<TaskOrchestration> orchestrationObjectManager)
+        public FakeOrchestrationExecutor(INameVersionObjectManager<TaskOrchestration> orchestrationObjectManager)
         {
             scheduler = new SynchronousTaskScheduler();
             dataConverter = new JsonDataConverter();


### PR DESCRIPTION
I am working on a large project that heavily depends on DurableTask. We now have >150 activity classes, and similarly >70 orchestration classes. Since this number is growing almost daily, we would like to use dependency injection, Autofac in our case, to produce ObjectCreator<T> instances. 

What seemed to be the most straight forward and least intrusive way to implement this is by allowing extensibility at the NameVersionObjectManager level, allowing us to produce a singleton NameVersionObjectManager implementation that relies on Autofac.