### PR TITLE
Azure Functions Consumption Plan integration

### DIFF
--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -56,94 +56,234 @@ namespace DurableTask.AzureStorage
         }
 
         [Event(101, Level = EventLevel.Informational, Opcode = EventOpcode.Send)]
-        public void SendingMessage(Guid relatedActivityId, string EventType, string InstanceId, string ExecutionId, long SizeInBytes)
+        public void SendingMessage(
+            Guid relatedActivityId,
+            string Account,
+            string TaskHub,
+            string EventType,
+            string InstanceId,
+            string ExecutionId,
+            long SizeInBytes,
+            string PartitionId)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEventWithRelatedActivityId(101, relatedActivityId, EventType, InstanceId, ExecutionId, SizeInBytes);
+            this.WriteEventWithRelatedActivityId(101, relatedActivityId, Account, TaskHub, EventType, InstanceId, ExecutionId, SizeInBytes, PartitionId);
         }
 
         [Event(102, Level = EventLevel.Informational, Opcode = EventOpcode.Receive)]
         public void ReceivedMessage(
             Guid relatedActivityId,
+            string Account,
+            string TaskHub,
             string EventType,
             string InstanceId,
             string ExecutionId,
             string MessageId,
             int Age,
             int DequeueCount,
-            long SizeInBytes)
+            long SizeInBytes,
+            string PartitionId)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEventWithRelatedActivityId(102, relatedActivityId, EventType, InstanceId, ExecutionId, MessageId, Age, DequeueCount, SizeInBytes);
+            this.WriteEventWithRelatedActivityId(102, relatedActivityId, Account, TaskHub, EventType, InstanceId, ExecutionId, MessageId, Age, DequeueCount, SizeInBytes, PartitionId);
         }
 
         [Event(103, Level = EventLevel.Informational)]
-        public void DeletingMessage(string EventType, string MessageId, string InstanceId)
+        public void DeletingMessage(string Account, string TaskHub, string EventType, string MessageId, string InstanceId)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(103, EventType, MessageId, InstanceId);
+            this.WriteEvent(103, Account, TaskHub, EventType, MessageId, InstanceId);
         }
 
         [Event(104, Level = EventLevel.Warning, Message = "Abandoning message of type {0} with ID = {1}. Orchestration ID = {2}.")]
-        public void AbandoningMessage(string EventType, string MessageId, string InstanceId, string ExecutionId)
+        public void AbandoningMessage(string Account, string TaskHub, string EventType, string MessageId, string InstanceId, string ExecutionId)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(104, EventType, MessageId, InstanceId, ExecutionId);
+            this.WriteEvent(104, Account, TaskHub, EventType, MessageId, InstanceId, ExecutionId);
         }
 
         [Event(105, Level = EventLevel.Warning, Message = "An unexpected condition was detected: {0}")]
-        public void AssertFailure(string Details)
+        public void AssertFailure(string Account, string TaskHub, string Details)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(105, Details);
+            this.WriteEvent(105, Account, TaskHub, Details);
         }
 
         [Event(106, Level = EventLevel.Warning)]
-        public void MessageGone(string MessageId, string InstanceId, string Details)
+        public void MessageGone(string Account, string TaskHub, string MessageId, string InstanceId, string Details)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(106, MessageId, InstanceId, Details);
+            this.WriteEvent(106, Account, TaskHub, MessageId, InstanceId, Details);
+        }
+
+        [Event(107, Level = EventLevel.Error)]
+        public void GeneralError(string Account, string TaskHub, string Details)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(107, Account, TaskHub, Details);
+        }
+
+        [Event(108, Level = EventLevel.Warning, Message = "A duplicate message was detected. This can indicate a potential performance problem. Message ID = '{2}'. DequeueCount = {3}.")]
+        public void DuplicateMessageDetected(string Account, string TaskHub, string MessageId, int DequeueCount)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(108, Account, TaskHub, MessageId, DequeueCount);
         }
 
         [Event(110, Level = EventLevel.Informational)]
-        public void FetchedInstanceState(string InstanceId, string ExecutionId, int EventCount, int RequestCount, long LatencyMs)
+        public void FetchedInstanceState(string Account, string TaskHub, string InstanceId, string ExecutionId, int EventCount, int RequestCount, long LatencyMs)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(110, InstanceId, ExecutionId, EventCount, RequestCount, LatencyMs);
+            this.WriteEvent(110, Account, TaskHub, InstanceId, ExecutionId, EventCount, RequestCount, LatencyMs);
         }
 
         [Event(111, Level = EventLevel.Informational)]
-        public void AppendedInstanceState(string InstanceId, string ExecutionId, int NewEventCount, int TotalEventCount, string NewEvents, long LatencyMs)
+        public void AppendedInstanceState(string Account, string TaskHub, string InstanceId, string ExecutionId, int NewEventCount, int TotalEventCount, string NewEvents, long LatencyMs)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(111, InstanceId, ExecutionId, NewEventCount, TotalEventCount, NewEvents, LatencyMs);
+            this.WriteEvent(111, Account, TaskHub, InstanceId, ExecutionId, NewEventCount, TotalEventCount, NewEvents, LatencyMs);
+        }
+
+        [Event(112, Level = EventLevel.Informational)]
+        public void OrchestrationServiceStats(
+            string Account,
+            string TaskHub,
+            long StorageRequests,
+            long MessagesSent,
+            long MessagesRead,
+            long MessagesUpdated,
+            long TableEntitiesWritten,
+            long TableEntitiesRead,
+            long PendingOrchestrators,
+            long PendingOrchestratorMessages,
+            long ActiveOrchestrators,
+            long ActiveActivities)
+        {
+            this.WriteEvent(
+                112,
+                Account,
+                TaskHub,
+                StorageRequests,
+                MessagesSent,
+                MessagesRead,
+                MessagesUpdated,
+                TableEntitiesWritten,
+                TableEntitiesRead,
+                PendingOrchestrators,
+                PendingOrchestratorMessages,
+                ActiveOrchestrators,
+                ActiveActivities);
         }
 
         [Event(120, Level = EventLevel.Informational)]
-        public void LogPartitionInfo(string Details)
+        public void PartitionManagerInfo(string Account, string TaskHub, string WorkerName, string Details)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(120, Details);
+            this.WriteEvent(120, Account, TaskHub, WorkerName, Details);
         }
 
-        [Event(121, Level = EventLevel.Error)]
-        public void LogPartitionWarning(string Details)
+        [Event(121, Level = EventLevel.Warning)]
+        public void PartitionManagerWarning(string Account, string TaskHub, string WorkerName, string Details)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(121, Details);
+            this.WriteEvent(121, Account, TaskHub, WorkerName, Details);
         }
 
         [NonEvent]
-        public void LogPartitionException(Exception e)
+        public void PartitionManagerError(string account, string taskHub, string workerName, Exception exception)
         {
-            this.LogPartitionError(e.ToString());
+            this.PartitionManagerError(account, taskHub, workerName, exception.ToString());
         }
 
         [Event(122, Level = EventLevel.Error)]
-        public void LogPartitionError(string Details)
+        public void PartitionManagerError(string Account, string TaskHub, string WorkerName, string Details)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(122, Details);
+            this.WriteEvent(122, Account, TaskHub, WorkerName, Details);
+        }
+
+        [Event(123, Level = EventLevel.Verbose, Message = "Host '{2}' renewing lease for PartitionId '{3}' with lease token '{4}'.")]
+        public void StartingLeaseRenewal(string Account, string TaskHub, string WorkerName, string PartitionId, string Token)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(123, Account, TaskHub, WorkerName, PartitionId, Token);
+        }
+
+        [Event(124, Level = EventLevel.Verbose)]
+        public void LeaseRenewalResult(string Account, string TaskHub, string WorkerName, string PartitionId, bool Success, string Token, string Details)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(124, Account, TaskHub, WorkerName, PartitionId, Success, Token, Details);
+        }
+
+        [Event(125, Level = EventLevel.Informational)]
+        public void LeaseRenewalFailed(string Account, string TaskHub, string WorkerName, string PartitionId, string Token, string Details)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(125, Account, TaskHub, WorkerName, PartitionId, Token, Details);
+        }
+
+        [Event(126, Level = EventLevel.Informational, Message = "Host '{2}' attempting to take lease for PartitionId '{3}'.")]
+        public void LeaseAcquisitionStarted(string Account, string TaskHub, string WorkerName, string PartitionId)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(126, Account, TaskHub, WorkerName, PartitionId);
+        }
+
+        [Event(127, Level = EventLevel.Informational, Message = "Host '{2}' successfully acquired lease for PartitionId '{3}'.")]
+        public void LeaseAcquisitionSucceeded(string Account, string TaskHub, string WorkerName, string PartitionId)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(127, Account, TaskHub, WorkerName, PartitionId);
+        }
+
+        [Event(128, Level = EventLevel.Informational, Message = "Host '{2}' failed to acquire lease for PartitionId '{3}' due to conflict.")]
+        public void LeaseAcquisitionFailed(string Account, string TaskHub, string WorkerName, string PartitionId)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(128, Account, TaskHub, WorkerName, PartitionId);
+        }
+
+        [Event(129, Level = EventLevel.Informational, Message = "Host '{2} is attempting to steal a lease from '{3}' for PartitionId '{4}'.")]
+        public void AttemptingToStealLease(string Account, string TaskHub, string WorkerName, string FromWorkerName, string PartitionId)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(129, Account, TaskHub, WorkerName, FromWorkerName, PartitionId);
+        }
+
+        [Event(130, Level = EventLevel.Informational, Message = "Host '{2}' stole lease from '{3}' for PartitionId '{4}'.")]
+        public void LeaseStealingSucceeded(string Account, string TaskHub, string WorkerName, string FromWorkerName, string PartitionId)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(130, Account, TaskHub, WorkerName, FromWorkerName, PartitionId);
+        }
+
+        [Event(131, Level = EventLevel.Informational, Message = "Host '{2}' failed to steal lease for PartitionId '{3}' due to conflict.")]
+        public void LeaseStealingFailed(string Account, string TaskHub, string WorkerName, string PartitionId)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(131, Account, TaskHub, WorkerName, PartitionId);
+        }
+
+        [Event(132, Level = EventLevel.Informational, Message = "Host '{2}' successfully removed PartitionId '{3}' with lease token '{4}' from currently owned partitions.")]
+        public void PartitionRemoved(string Account, string TaskHub, string WorkerName, string PartitionId, string Token)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(132, Account, TaskHub, WorkerName, PartitionId, Token);
+        }
+
+        [Event(133, Level = EventLevel.Informational, Message = "Host '{2}' successfully released lease on PartitionId '{3}' with lease token '{4}'")]
+        public void LeaseRemoved(string Account, string TaskHub, string WorkerName, string PartitionId, string Token)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(133, Account, TaskHub, WorkerName, PartitionId, Token);
+        }
+
+        [Event(134, Level = EventLevel.Warning, Message = "Host '{2}' failed to release lease for PartitionId '{3}' with lease token '{4}' due to conflict.")]
+        public void LeaseRemovalFailed(string Account, string TaskHub, string WorkerName, string PartitionId, string Token)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(134, Account, TaskHub, WorkerName, PartitionId, Token);
         }
     }
 }

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -22,11 +22,19 @@ namespace DurableTask.AzureStorage
     /// </summary>
     public class AzureStorageOrchestrationServiceSettings
     {
+        internal const int DefaultPartitionCount = 4;
+
         /// <summary>
         /// Gets or sets the number of messages to pull from the control queue at a time. The default is 32.
         /// The maximum batch size supported by Azure Storage Queues is 32.
         /// </summary>
         public int ControlQueueBatchSize { get; set; } = 32;
+
+        /// <summary>
+        /// Gets or sets the number of control queue messages that can be buffered in memory at a time, at which
+        /// point the dispatcher will wait before dequeuing any additional messages. The default is 64.
+        /// </summary>
+        public int ControlQueueBufferThreshold { get; set; } = 64;
 
         /// <summary>
         /// Gets or sets the visibility timeout of dequeued control queue messages. The default is 90 seconds.
@@ -48,7 +56,6 @@ namespace DurableTask.AzureStorage
         /// Gets or sets the <see cref="QueueRequestOptions"/> that are provided to all internal 
         /// usage of <see cref="CloudQueue"/> APIs for the work item queue.
         /// </summary>
-
         public QueueRequestOptions WorkItemQueueRequestOptions { get; set; }
 
         /// <summary>
@@ -87,7 +94,7 @@ namespace DurableTask.AzureStorage
         /// <summary>
         /// Gets or sets the maximum number of orchestration partitions.
         /// </summary>
-        public int PartitionCount { get; set; } = 4;
+        public int PartitionCount { get; set; } = DefaultPartitionCount;
 
         /// <summary>
         /// Renew interval for all leases for partitions currently held.

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -3,6 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
     <TargetFramework>net451</TargetFramework>
+    <Version>0.2.0</Version>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,5 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\DurableTask.Core\DurableTask.Core.csproj" />
   </ItemGroup>
+  
+
 
 </Project>

--- a/src/DurableTask.AzureStorage/MessageData.cs
+++ b/src/DurableTask.AzureStorage/MessageData.cs
@@ -24,10 +24,11 @@ namespace DurableTask.AzureStorage
     [DataContract]
     class MessageData
     {
-        public MessageData(TaskMessage message, Guid activityId)
+        public MessageData(TaskMessage message, Guid activityId, string queueName)
         {
             this.TaskMessage = message;
             this.ActivityId = activityId;
+            this.QueueName = queueName;
         }
 
         public MessageData()
@@ -38,6 +39,8 @@ namespace DurableTask.AzureStorage
 
         [DataMember]
         public TaskMessage TaskMessage { get; private set; }
+
+        internal string QueueName { get; set; }
 
         internal CloudQueueMessage OriginalQueueMessage { get; set; }
 

--- a/src/DurableTask.AzureStorage/Monitoring/AzureStorageOrchestrationServiceStats.cs
+++ b/src/DurableTask.AzureStorage/Monitoring/AzureStorageOrchestrationServiceStats.cs
@@ -1,0 +1,36 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureStorage.Monitoring
+{
+    using DurableTask.Core.Stats;
+
+    class AzureStorageOrchestrationServiceStats
+    {
+        public Counter StorageRequests { get; } = new Counter();
+
+        public Counter MessagesSent { get; } = new Counter();
+
+        public Counter MessagesRead { get; } = new Counter();
+
+        public Counter MessagesUpdated { get; } = new Counter();
+
+        public Counter TableEntitiesWritten { get; } = new Counter();
+
+        public Counter TableEntitiesRead { get; } = new Counter();
+
+        public Counter ActiveActivityExecutions { get; } = new Counter();
+
+        public Counter PendingOrchestratorMessages { get; } = new Counter();
+    }
+}

--- a/src/DurableTask.AzureStorage/Monitoring/DisconnectedPerformanceMonitor.cs
+++ b/src/DurableTask.AzureStorage/Monitoring/DisconnectedPerformanceMonitor.cs
@@ -1,0 +1,357 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureStorage.Monitoring
+{
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.WindowsAzure.Storage;
+    using Microsoft.WindowsAzure.Storage.Queue;
+
+    /// <summary>
+    /// Utility class for collecting performance information for a Durable Task hub without actually running inside a Durable Task worker.
+    /// </summary>
+    public class DisconnectedPerformanceMonitor
+    {
+        internal const int QueueLengthSampleSize = 5;
+        internal const int MaxMessagesPerWorkerRatio = 100;
+
+        readonly QueueLengthHistory controlQueueLengths = new QueueLengthHistory(QueueLengthSampleSize);
+        readonly QueueLengthHistory workItemQueueLengths = new QueueLengthHistory(QueueLengthSampleSize);
+
+        readonly CloudStorageAccount storageAccount;
+        readonly string taskHub;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DisconnectedPerformanceMonitor"/> class.
+        /// </summary>
+        /// <param name="storageConnectionString">The connection string for the Azure Storage account to monitor.</param>
+        /// <param name="taskHub">The name of the task hub within the specified storage account.</param>
+        public DisconnectedPerformanceMonitor(string storageConnectionString, string taskHub)
+            : this(CloudStorageAccount.Parse(storageConnectionString), taskHub)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DisconnectedPerformanceMonitor"/> class.
+        /// </summary>
+        /// <param name="storageAccount">The Azure Storage account to monitor.</param>
+        /// <param name="taskHub">The name of the task hub within the specified storage account.</param>
+        public DisconnectedPerformanceMonitor(CloudStorageAccount storageAccount, string taskHub)
+        {
+            this.storageAccount = storageAccount;
+            this.taskHub = taskHub;
+        }
+
+        /// <summary>
+        /// Collects and returns a sampling of all performance metrics being observed by this instance.
+        /// </summary>
+        /// <param name="currentWorkerCount">The number of workers known to be processing messages for this task hub.</param>
+        /// <returns>Returns a performance data summary or <c>null</c> if data cannot be obtained.</returns>
+        public virtual async Task<PerformanceHeartbeat> PulseAsync(int currentWorkerCount)
+        {
+            int workItemQueueLength;
+            int aggregateControlQueueLength;
+            int partitionCount;
+
+            try
+            {
+                ControlQueueData controlQueueData = await this.GetAggregateControlQueueLengthAsync();
+                aggregateControlQueueLength = controlQueueData.AggregateQueueLength;
+                partitionCount = controlQueueData.PartitionCount;
+                workItemQueueLength = await this.GetWorkItemQueueLengthAsync();
+            }
+            catch (StorageException e) when (e.RequestInformation?.HttpStatusCode == 404)
+            {
+                // The queues are not yet provisioned.
+                return null;
+            }
+
+            this.AddWorkItemQueueLength(workItemQueueLength);
+            this.AddControlQueueLength(aggregateControlQueueLength);
+
+            var heartbeatPayload = new PerformanceHeartbeat
+            {
+                PartitionCount = partitionCount,
+                WorkItemQueueLength = workItemQueueLength,
+                WorkItemQueueLengthTrend = this.workItemQueueLengths.CurrentTrend,
+                AggregateControlQueueLength = aggregateControlQueueLength,
+                AggregateControlQueueLengthTrend = this.controlQueueLengths.CurrentTrend,
+                ScaleRecommendation = this.MakeScaleRecommendation(partitionCount, currentWorkerCount),
+            };
+
+            return heartbeatPayload;
+        }
+
+        /// <summary>
+        /// Gets the approximate length of the work-item queue.
+        /// </summary>
+        /// <returns>The approximate number of messages in the work-item queue.</returns>
+        protected virtual async Task<int> GetWorkItemQueueLengthAsync()
+        {
+            CloudQueue workItemQueue = AzureStorageOrchestrationService.GetWorkItemQueue(this.storageAccount, this.taskHub);
+            await workItemQueue.FetchAttributesAsync();
+            return workItemQueue.ApproximateMessageCount.GetValueOrDefault(0);
+        }
+
+        /// <summary>
+        /// Gets the approximate aggreate length (sum) of the all known control queues.
+        /// </summary>
+        /// <returns>The approximate number of messages across all control queues.</returns>
+        protected virtual async Task<ControlQueueData> GetAggregateControlQueueLengthAsync()
+        {
+            CloudQueue[] controlQueues = await AzureStorageOrchestrationService.GetControlQueuesAsync(
+                this.storageAccount,
+                this.taskHub,
+                AzureStorageOrchestrationServiceSettings.DefaultPartitionCount);
+
+            // There is one queue per partition.
+            var result = new ControlQueueData();
+            result.PartitionCount = controlQueues.Length;
+
+            // We treat all control queues like one big queue and sum the lengths together.
+            foreach (CloudQueue queue in controlQueues)
+            {
+                await queue.FetchAttributesAsync();
+                int queueLength = queue.ApproximateMessageCount.GetValueOrDefault(0);
+                result.AggregateQueueLength += queueLength;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Adds a work-item queue length sampling to the current monitor.
+        /// </summary>
+        /// <param name="queueLength">The approximate length of the work-item queue.</param>
+        protected virtual void AddWorkItemQueueLength(int queueLength)
+        {
+            this.workItemQueueLengths.Add(queueLength);
+        }
+
+        /// <summary>
+        /// Adds an aggregate control queue length sampling to the current monitor.
+        /// </summary>
+        /// <param name="aggregateQueueLength">The sum of all the control queue lengths.</param>
+        protected virtual void AddControlQueueLength(int aggregateQueueLength)
+        {
+            this.controlQueueLengths.Add(aggregateQueueLength);
+        }
+
+        ScaleRecommendation MakeScaleRecommendation(int partitionCount, int workerCount)
+        {
+            ScaleAction pendingVote = ScaleAction.None;
+            bool noWorkItems = false;
+
+            if (workerCount == 0 && !(this.workItemQueueLengths.IsAllZeros() && this.controlQueueLengths.IsAllZeros()))
+            {
+                return new ScaleRecommendation(ScaleAction.AddWorker, keepWorkersAlive: true, reason: "First worker");
+            }
+
+            // Wait until we have enough samples before making specific recommendations
+            if (!this.workItemQueueLengths.IsFull || !this.controlQueueLengths.IsFull)
+            {
+                bool keepWorkersAlive = !this.workItemQueueLengths.IsAllZeros() || !this.controlQueueLengths.IsAllZeros();
+                ScaleAction scaleAction = workerCount == 0 && keepWorkersAlive ? ScaleAction.AddWorker : ScaleAction.None;
+                return new ScaleRecommendation(scaleAction, keepWorkersAlive, reason: "Not enough samples");
+            }
+
+            // Look at the work item queue growth rate
+            if (workerCount > 0 && this.workItemQueueLengths.Last > MaxMessagesPerWorkerRatio / workerCount)
+            {
+                return new ScaleRecommendation(ScaleAction.AddWorker, keepWorkersAlive: true, reason: $"Work items per worker > {MaxMessagesPerWorkerRatio}");
+            }
+            else if (this.workItemQueueLengths.IsTrendingUpwards())
+            {
+                return new ScaleRecommendation(ScaleAction.AddWorker, keepWorkersAlive: true, reason: "Work items increasing");
+            }
+            else if (this.workItemQueueLengths.IsTrendingDownwards())
+            {
+                noWorkItems = false;
+                pendingVote = ScaleAction.RemoveWorker;
+            }
+            else if (this.workItemQueueLengths.IsAllZeros())
+            {
+                noWorkItems = true;
+                pendingVote = ScaleAction.RemoveWorker;
+            }
+
+            // Look at the control queue growth rate
+            // NOTE: The logic here assumes even distribution across all control queues.
+            if (workerCount > 0 && workerCount < partitionCount && this.controlQueueLengths.Last > MaxMessagesPerWorkerRatio / workerCount)
+            {
+                return new ScaleRecommendation(ScaleAction.AddWorker, keepWorkersAlive: true, reason: $"Control items per worker > {MaxMessagesPerWorkerRatio}");
+            }
+            else if (workerCount < partitionCount && this.controlQueueLengths.IsTrendingUpwards())
+            {
+                return new ScaleRecommendation(ScaleAction.AddWorker, keepWorkersAlive: true, reason: "Control items increasing");
+            }
+            else if (pendingVote == ScaleAction.RemoveWorker)
+            {
+                if (this.controlQueueLengths.IsTrendingDownwards())
+                {
+                    string reason = noWorkItems ? "No work items; control items decreasing" : "Both work items and control items decreasing";
+                    ScaleAction downscaleAction = workerCount > 0 ? ScaleAction.RemoveWorker : ScaleAction.None;
+                    return new ScaleRecommendation(downscaleAction, keepWorkersAlive: true, reason: reason);
+                }
+                else if (this.controlQueueLengths.IsAllZeros())
+                {
+                    string reason;
+                    bool keepWorkersAlive;
+                        
+                    if (noWorkItems)
+                    {
+                        reason = "Task hub idle";
+                        keepWorkersAlive = false;
+                    }
+                    else
+                    {
+                        reason = "No control events; work items decreasing";
+                        keepWorkersAlive = true;
+                    }
+
+                    ScaleAction downscaleAction = workerCount > 0 ? ScaleAction.RemoveWorker : ScaleAction.None;
+                    return new ScaleRecommendation(downscaleAction, keepWorkersAlive, reason); 
+                }
+            }
+
+            ScaleAction steadyStateAction = workerCount > 0 ? ScaleAction.None : ScaleAction.AddWorker;
+            return new ScaleRecommendation(steadyStateAction, keepWorkersAlive: true, reason: "Load is steady");
+        }
+
+        /// <summary>
+        /// Data structure containing the number of partitions and the aggregate
+        /// number of messages across those control queue partitions.
+        /// </summary>
+        public struct ControlQueueData
+        {
+            /// <summary>
+            /// Gets or sets the number of control queue partitions.
+            /// </summary>
+            public int PartitionCount { get; internal set; }
+
+            /// <summary>
+            /// Gets or sets the number of messages across all control queues.
+            /// </summary>
+            public int AggregateQueueLength { get; internal set; }
+        }
+
+        class QueueLengthHistory
+        {
+            const double TrendThreshold = 0.0;
+
+            readonly int[] history;
+            int next;
+            int count;
+            int lastValue;
+            double? currentTrend;
+
+            public QueueLengthHistory(int maxSize)
+            {
+                this.history = new int[maxSize];
+            }
+
+            public bool IsFull
+            {
+                get { return this.count == this.history.Length; }
+            }
+
+            public int Last => this.lastValue;
+
+            public double CurrentTrend
+            {
+                get
+                {
+                    if (!this.IsFull)
+                    {
+                        return 0.0;
+                    }
+
+                    if (!this.currentTrend.HasValue)
+                    {
+                        int firstIndex = this.IsFull ? this.next : 0;
+                        int first = this.history[firstIndex];
+                        if (first == 0)
+                        {
+                            // discard trend information when the first item is a zero.
+                            this.currentTrend = 0.0;
+                        }
+                        else
+                        {
+                            int sum = 0;
+                            for (int i = 0; i < this.history.Length; i++)
+                            {
+                                sum += this.history[i];
+                            }
+
+                            double average = (double)sum / this.history.Length;
+                            this.currentTrend = (average - first) / first;
+                        }
+                    }
+
+                    return this.currentTrend.Value;
+                }
+            }
+
+            public void Add(int value)
+            {
+                this.history[this.next++] = value;
+                if (this.count < this.history.Length)
+                {
+                    this.count++;
+                }
+
+                if (this.next >= this.history.Length)
+                {
+                    this.next = 0;
+                }
+
+                this.lastValue = value;
+
+                // invalidate any existing trend information
+                this.currentTrend = null;
+            }
+
+            public bool IsTrendingUpwards()
+            {
+                return this.CurrentTrend > TrendThreshold;
+            }
+
+            public bool IsTrendingDownwards()
+            {
+                return this.CurrentTrend < -TrendThreshold;
+            }
+
+            public bool IsAllZeros()
+            {
+                return Array.TrueForAll(this.history, i => i == 0);
+            }
+
+            static void ThrowIfNegative(string paramName, double value)
+            {
+                if (value < 0.0)
+                {
+                    throw new ArgumentOutOfRangeException(paramName, value, $"{paramName} cannot be negative.");
+                }
+            }
+
+            static void ThrowIfPositive(string paramName, double value)
+            {
+                if (value > 0.0)
+                {
+                    throw new ArgumentOutOfRangeException(paramName, value, $"{paramName} cannot be positive.");
+                }
+            }
+        }
+    }
+}

--- a/src/DurableTask.AzureStorage/Monitoring/PerformanceHeartbeat.cs
+++ b/src/DurableTask.AzureStorage/Monitoring/PerformanceHeartbeat.cs
@@ -1,0 +1,69 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+using System.Text;
+
+namespace DurableTask.AzureStorage.Monitoring
+{
+    /// <summary>
+    /// Data structure containing point-in-time performance metrics for a durable task hub.
+    /// </summary>
+    public class PerformanceHeartbeat
+    {
+        /// <summary>
+        /// Gets the number of partitions configured in the task hub.
+        /// </summary>
+        public int PartitionCount { get; internal set; }
+
+        /// <summary>
+        /// Gets the number of messages across all control queues.
+        /// </summary>
+        public int AggregateControlQueueLength { get; internal set; }
+
+        /// <summary>
+        /// Gets a trend value describing the number of messages in the control queues over a period of time.
+        /// </summary>
+        public double AggregateControlQueueLengthTrend { get; internal set; }
+
+        /// <summary>
+        /// Gets the number of messages in the work-item queue.
+        /// </summary>
+        public int WorkItemQueueLength { get; internal set; }
+
+        /// <summary>
+        /// Gets a trend value describing the number of messages in the work-item queue over a period of time.
+        /// </summary>
+        public double WorkItemQueueLengthTrend { get; internal set; }
+
+        /// <summary>
+        /// Gets a scale recommendation for the task hub given the current performance metrics.
+        /// </summary>
+        public ScaleRecommendation ScaleRecommendation { get; internal set; }
+
+        /// <summary>
+        /// Gets a string description of the current <see cref="PerformanceHeartbeat"/> object.
+        /// </summary>
+        /// <returns>A string description useful for diagnostics.</returns>
+        public override string ToString()
+        {
+            var sb = new StringBuilder(1024);
+            sb.Append(nameof(this.PartitionCount)).Append(": ").Append(this.PartitionCount).Append(", ");
+            sb.Append(nameof(this.AggregateControlQueueLength)).Append(": ").Append(this.AggregateControlQueueLength).Append(", ");
+            sb.Append(nameof(this.AggregateControlQueueLengthTrend)).Append(": ").Append(this.AggregateControlQueueLengthTrend).Append(", ");
+            sb.Append(nameof(this.WorkItemQueueLength)).Append(": ").Append(this.WorkItemQueueLength).Append(", ");
+            sb.Append(nameof(this.WorkItemQueueLengthTrend)).Append(": ").Append(this.WorkItemQueueLengthTrend).Append(", ");
+            sb.Append(nameof(this.ScaleRecommendation)).Append(": ").Append(this.ScaleRecommendation);
+            return sb.ToString();
+        }
+    }
+}

--- a/src/DurableTask.AzureStorage/Monitoring/ScaleAction.cs
+++ b/src/DurableTask.AzureStorage/Monitoring/ScaleAction.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DurableTask.AzureStorage.Monitoring
+{
+    /// <summary>
+    /// Possible scale actions for durable task hub.
+    /// </summary>
+    public enum ScaleAction
+    {
+        /// <summary>
+        /// Do not add or remove workers.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Add workers to the current task hub.
+        /// </summary>
+        AddWorker,
+
+        /// <summary>
+        /// Remove workers from the current task hub.
+        /// </summary>
+        RemoveWorker
+    }
+}

--- a/src/DurableTask.AzureStorage/Monitoring/ScaleRecommendation.cs
+++ b/src/DurableTask.AzureStorage/Monitoring/ScaleRecommendation.cs
@@ -1,0 +1,54 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureStorage.Monitoring
+{
+    using System;
+
+    /// <summary>
+    /// Represents a scale recommendation for the task hub given the current performance metrics.
+    /// </summary>
+    public class ScaleRecommendation : EventArgs
+    {
+        internal ScaleRecommendation(ScaleAction scaleAction, bool keepWorkersAlive, string reason)
+        {
+            this.Action = scaleAction;
+            this.KeepWorkersAlive = keepWorkersAlive;
+            this.Reason = reason;
+        }
+
+        /// <summary>
+        /// Gets the recommended scale action for the current task hub.
+        /// </summary>
+        public ScaleAction Action { get; }
+
+        /// <summary>
+        /// Gets a recommendation about whether to keep existing task hub workers alive.
+        /// </summary>
+        public bool KeepWorkersAlive { get; }
+
+        /// <summary>
+        /// Gets text describing why a particular scale action was recommended.
+        /// </summary>
+        public string Reason { get; }
+
+        /// <summary>
+        /// Gets a string description of the current <see cref="ScaleRecommendation"/> object.
+        /// </summary>
+        /// <returns>A string description useful for diagnostics.</returns>
+        public override string ToString()
+        {
+            return $"{nameof(this.Action)}: {this.Action}, {nameof(KeepWorkersAlive)}: {this.KeepWorkersAlive}, {nameof(Reason)}: {this.Reason}";
+        }
+    }
+}

--- a/src/DurableTask.AzureStorage/Utils.cs
+++ b/src/DurableTask.AzureStorage/Utils.cs
@@ -35,7 +35,7 @@ namespace DurableTask.AzureStorage
             return rawContent;
         }
 
-        public static MessageData DeserializeQueueMessage(CloudQueueMessage queueMessage)
+        public static MessageData DeserializeQueueMessage(CloudQueueMessage queueMessage, string queueName)
         {
             MessageData envelope = JsonConvert.DeserializeObject<MessageData>(
                 queueMessage.AsString,
@@ -43,6 +43,7 @@ namespace DurableTask.AzureStorage
 
             envelope.OriginalQueueMessage = queueMessage;
             envelope.TotalMessageSizeBytes = Encoding.UTF8.GetByteCount(queueMessage.AsString);
+            envelope.QueueName = queueName;
 
             return envelope;
         }

--- a/src/DurableTask.Core/Stats/Counter.cs
+++ b/src/DurableTask.Core/Stats/Counter.cs
@@ -45,6 +45,23 @@ namespace DurableTask.Core.Stats
         }
 
         /// <summary>
+        /// Decrements the counter by 1
+        /// </summary>
+        public void Decrement()
+        {
+            Interlocked.Decrement(ref counterValue);
+        }
+
+        /// <summary>
+        /// Resets the counter back to zero
+        /// </summary>
+        /// <returns>The value of the counter before it was reset</returns>
+        public long Reset()
+        {
+            return Interlocked.Exchange(ref counterValue, 0);
+        }
+
+        /// <summary>
         /// Returns a string that represents the Counter.
         /// </summary>
         public override string ToString()

--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -25,7 +25,7 @@
     <PackageOutputPath>..\..\build_output\packages</PackageOutputPath>
     <AssemblyVersion>2.0.0.1</AssemblyVersion>
     <FileVersion>2.0.0.1</FileVersion>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.1-private</Version>
     <Company>Microsoft</Company>
     <Product>Durable Task Framework</Product>
     <Description>This package provides a C# based durable task framework for writing long running applications.</Description>


### PR DESCRIPTION
This change is the initial work to enable dynamic scale-out for the Durable Task Framework in Azure Functions (i.e. *Durable Functions*).  It consists of two parts:

1. Created a `DisconnectedPerformanceMonitor` class which is responsible for examining queue metrics and making scale decisions. I call it "disconnected" because it's designed to be run outside of the task hub worker process. The intent is to run it in the Azure Scale Controller component.
2. Created a `AzureStorageOrchestrationServiceStats` and used it to track how often we do various operations against Azure Storage. This is intended to work just like `ServiceBusOrchestrationServiceStats`, but is specific to the Azure Storage provider.

The intent is to plug this new functionality into Azure Functions so that scale-out can happen and so that it will be easier to measure performance-sensitive statistics (which is important when you start scaling things out).