### PR TITLE
Fix for the issue with multiple Terminate events in a single batch

### DIFF
--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -33,6 +33,7 @@ namespace DurableTask.Core
         readonly IDictionary<int, OrchestratorAction> orchestratorActionsMap;
         readonly TaskScheduler taskScheduler;
         OrchestrationCompleteOrchestratorAction continueAsNew;
+        bool executionTerminated;
         int idCounter;
 
         public TaskOrchestrationContext(OrchestrationInstance orchestrationInstance, TaskScheduler taskScheduler)
@@ -376,7 +377,11 @@ namespace DurableTask.Core
 
         public void HandleExecutionTerminatedEvent(ExecutionTerminatedEvent terminatedEvent)
         {
-            CompleteOrchestration(terminatedEvent.Input, null, OrchestrationStatus.Terminated);
+            if (!executionTerminated)
+            {
+                executionTerminated = true;
+                CompleteOrchestration(terminatedEvent.Input, null, OrchestrationStatus.Terminated);
+            }
         }
 
         public void CompleteOrchestration(string result)


### PR DESCRIPTION
Fix for the issue where issuing TerminateInstanceAsync twice from client before the orchestration is picked up by dispatcher leads to a blocked orchestration (the processing keeps abandoning the orchestration).

Only the first terminate request is honored and subsequent terminates are ignored. (That makes the fix simple and hopefully not a problematic behavior from user's perspective)