### PR TITLE
Clone task session messages in the LocalOrchestrationService

### DIFF
--- a/src/DurableTask.Emulator/LocalOrchestrationService.cs
+++ b/src/DurableTask.Emulator/LocalOrchestrationService.cs
@@ -372,7 +372,7 @@ namespace DurableTask.Emulator
 
             TaskOrchestrationWorkItem wi = new TaskOrchestrationWorkItem()
             {
-                NewMessages = taskSession.Messages,
+                NewMessages = taskSession.Messages.ToList(),
                 InstanceId = taskSession.Id,
                 LockedUntilUtc = DateTime.UtcNow.AddMinutes(5),
                 OrchestrationRuntimeState =


### PR DESCRIPTION
Cloning task session messages in the LocationOrchestrationService to avoid Collection was modified exception