### PR TITLE
Add multi-targeting support for .NET standard 2.0.

### DIFF
--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -2,13 +2,20 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFramework>net451</TargetFramework>
+    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
     <PackageReference Include="ImpromptuInterface" Version="6.2.2" />
-    <PackageReference Include="Newtonsoft.Json" version="7.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Dynamitey" Version="2.0.6-beta111" />
+    <PackageReference Include="ImpromptuInterface" Version="7.0.1-beta40" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+  </ItemGroup>
+  
 </Project>

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -2,9 +2,8 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net451'">

--- a/src/DurableTask.Core/RetryProxy.cs
+++ b/src/DurableTask.Core/RetryProxy.cs
@@ -19,7 +19,6 @@ namespace DurableTask.Core
     using System.Linq;
     using System.Reflection;
     using System.Threading.Tasks;
-    using ImpromptuInterface;
 
     internal class RetryProxy<T> : DynamicObject
     {
@@ -84,7 +83,15 @@ namespace DurableTask.Core
 
         public async Task<ReturnType> InvokeWithRetry<ReturnType>(string methodName, object[] args)
         {
-            Func<Task<ReturnType>> retryCall = () => { return Impromptu.InvokeMember(wrappedObject, methodName, args); };
+            Func<Task<ReturnType>> retryCall = () => 
+            {
+#if NETSTANDARD2_0
+                return Dynamitey.Dynamic.InvokeMember(wrappedObject, methodName, args);
+#else
+                return ImpromptuInterface.Impromptu.InvokeMember(wrappedObject, methodName, args);
+#endif
+            };
+
             var retryInterceptor = new RetryInterceptor<ReturnType>(context, retryOptions, retryCall);
 
             return await retryInterceptor.Invoke();

--- a/src/DurableTask.Emulator/DurableTask.Emulator.csproj
+++ b/src/DurableTask.Emulator/DurableTask.Emulator.csproj
@@ -2,11 +2,15 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFramework>net451</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
     <PackageReference Include="Newtonsoft.Json" version="7.0.1" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Newtonsoft.Json" version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -24,9 +24,9 @@
   <!-- Nuget Package Settings -->
   <PropertyGroup>
     <PackageOutputPath>..\..\build_output\packages</PackageOutputPath>
-    <AssemblyVersion>2.1.0.0</AssemblyVersion>
-    <FileVersion>2.1.0.0</FileVersion>
-    <Version>2.1.0.0-preview</Version>
+    <AssemblyVersion>2.0.0.3</AssemblyVersion>
+    <FileVersion>2.0.0.3</FileVersion>
+    <Version>2.0.0.3-preview</Version>
     <Company>Microsoft</Company>
     <Product>Durable Task Framework</Product>
     <Description>This package provides a C# based durable task framework for writing long running applications.</Description>

--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -4,12 +4,13 @@
     <!-- Build Settings -->
     <DebugType Condition="'$(Configuration)'=='Release'">pdbonly</DebugType>
     <DebugSymbols>True</DebugSymbols>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <!-- Code Analysis Settings -->
     <RunCodeAnalysis>True</RunCodeAnalysis>
     <RunCodeAnalysis Condition=" '$(Configuration)' == 'Debug' ">False</RunCodeAnalysis>
+    <!-- Disable code analysis for netstandard2.0: https://github.com/dotnet/core/issues/758 -->
+    <RunCodeAnalysis Condition=" '$(TargetFramework)' == 'netstandard2.0'">False</RunCodeAnalysis>
     <CodeAnalysisTreatWarningsAsErrors>True</CodeAnalysisTreatWarningsAsErrors>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
@@ -23,9 +24,9 @@
   <!-- Nuget Package Settings -->
   <PropertyGroup>
     <PackageOutputPath>..\..\build_output\packages</PackageOutputPath>
-    <AssemblyVersion>2.0.0.2</AssemblyVersion>
-    <FileVersion>2.0.0.2</FileVersion>
-    <Version>2.0.0.2-preview</Version>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <FileVersion>2.1.0.0</FileVersion>
+    <Version>2.1.0.0-preview</Version>
     <Company>Microsoft</Company>
     <Product>Durable Task Framework</Product>
     <Description>This package provides a C# based durable task framework for writing long running applications.</Description>


### PR DESCRIPTION
This change enables multi-targeting of `DurableTask.Core` to both .NET 4.5.1 (the existing target) as well as .NET Standard 2.0 for .NET Core support. This is needed for the Azure Functions Durable Task extension, which needs to support .NET Core. The code changes are influenced by the [existing PR for .NET Core support](https://github.com/Azure/durabletask/pull/110), but this PR is only concerned with `DurableTask.Core` and it involves multi-targeting rather than a wholesale move to .NET Standard 2.0.

I arbitrarily bumped the version to 2.1.0.0-preview, but we can discuss this. I suspect it will need to remain as a preview release until the non-production NuGet dependencies can be removed or replaced with non-prerelease dependencies.

This change does not currently contain any support for signing the assemblies since that is not required for Azure Functions. This is another thing we can discuss if necessary.

There are no warnings or errors when built using Release configuration.