### PR TITLE
Fix orchestration completion/termination race condition

### DIFF
--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -386,7 +386,10 @@ namespace DurableTask.Core
 
         public void CompleteOrchestration(string result)
         {
-            CompleteOrchestration(result, null, OrchestrationStatus.Completed);
+            if (!executionTerminated)
+            {
+                CompleteOrchestration(result, null, OrchestrationStatus.Completed);
+            }
         }
 
         public void FailOrchestration(Exception failure)


### PR DESCRIPTION
This fix addresses an issue brought up by Durable Functions customers: https://github.com/Azure/azure-functions-durable-extension/issues/146.

The issue happens when DTFx receives a terminate message in the same message batch that would normally complete the orchestration. The terminate action gets executed, but then the completion action also gets executed, resulting in a state corruption error:

```
TaskOrchestrationDispatcher-f79977801ceb41aa82701d473427e52b-0: Exception while processing workItem 87e126f0d4f54d9ca092bf67c10cf4e0 Exception: System.InvalidOperationException : Multiple ExecutionCompletedEvent found, potential corruption in state storage at DurableTask.Core.OrchestrationRuntimeState.SetMarkerEvents(HistoryEvent historyEvent)
 at DurableTask.Core.OrchestrationRuntimeState.AddEvent(HistoryEvent historyEvent, Boolean isNewEvent)
 at DurableTask.Core.OrchestrationRuntimeState.AddEvent(HistoryEvent historyEvent)
 at DurableTask.Core.TaskOrchestrationDispatcher.ProcessWorkflowCompletedTaskDecision(OrchestrationCompleteOrchestratorAction completeOrchestratorAction, OrchestrationRuntimeState runtimeState, Boolean includeDetails, Boolean& continuedAsNew)
 at DurableTask.Core.TaskOrchestrationDispatcher.<OnProcessWorkItemAsync>d__17.MoveNext() --- End of stack trace from previous location where exception was thrown ---
 at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
 at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
 at DurableTask.Core.WorkItemDispatcher`1.<ProcessWorkItemAsync>d__34.MoveNext()
```

This is very similar to https://github.com/Azure/durabletask/issues/25 (which I think is actually fixed, based on my reading of the code) but is just a slightly different variation that involves orchestration completion.