### PR TITLE
WIP: Orchestration caching (aka "sticky sessions")

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -29,6 +29,7 @@ namespace DurableTask.AzureStorage
     using DurableTask.AzureStorage.Partitioning;
     using DurableTask.Core;
     using DurableTask.Core.History;
+    using DurableTask.Core.Settings;
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Queue;
     using Microsoft.WindowsAzure.Storage.Table;
@@ -40,6 +41,7 @@ namespace DurableTask.AzureStorage
     public class AzureStorageOrchestrationService :
         IOrchestrationService,
         IOrchestrationServiceClient,
+        IOrchestrationCaching,
         IPartitionObserver<BlobLease>
     {
         static readonly HistoryEvent[] EmptyHistoryEventList = new HistoryEvent[0];
@@ -256,6 +258,12 @@ namespace DurableTask.AzureStorage
         public int MaxConcurrentTaskActivityWorkItems
         {
             get { return this.settings.MaxConcurrentTaskActivityWorkItems; }
+        }
+
+        /// <inheritdoc />
+        public OrchestrationInstanceCacheSettings OrchestrationCacheSettings
+        {
+            get { return this.settings.OrchestrationCacheSettings; }
         }
 
         // We always leave the dispatcher counts at one unless we can find a customer workload that requires more.
@@ -698,6 +706,15 @@ namespace DurableTask.AzureStorage
 
                 return null;
             }
+        }
+
+        /// <summary>
+        /// Fetches the runtime state for a particular orchestration instance.
+        /// </summary>
+        public Task<OrchestrationRuntimeState> FetchOrchestrationRuntimeStateAsync(TaskOrchestrationWorkItem workItem)
+        {
+            // TODO, cgillum: Implement this in such a way that we can get the information we need from the work item.
+            throw new NotImplementedException("TODO");
         }
 
         Task<OrchestrationRuntimeState> GetOrchestrationRuntimeStateAsync(

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -14,6 +14,7 @@
 namespace DurableTask.AzureStorage
 {
     using System;
+    using DurableTask.Core.Settings;
     using Microsoft.WindowsAzure.Storage.Queue;
     using Microsoft.WindowsAzure.Storage.Table;
 
@@ -112,5 +113,10 @@ namespace DurableTask.AzureStorage
         /// interval, it will cause it to expire and ownership of the partition will move to another worker instance.
         /// </summary>
         public TimeSpan LeaseInterval { get; set; } = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// Settings to configure orchestration instance caching.
+        /// </summary>
+        public OrchestrationInstanceCacheSettings OrchestrationCacheSettings { get; set; } = new OrchestrationInstanceCacheSettings { MaxCachedInstances = 10 };
     }
 }

--- a/src/DurableTask.Core/Common/MruCache.cs
+++ b/src/DurableTask.Core/Common/MruCache.cs
@@ -1,0 +1,229 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core.Common
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Simple MRU cache implementation. TODO, cgillum: Implement locking for thread safety!
+    /// </summary>
+    class MruCache<TKey, TValue> where TValue : class
+    {
+        readonly LinkedList<TKey> mruList;
+        readonly Dictionary<TKey, CacheEntry> items;
+
+        CacheEntry mruEntry;
+
+        public MruCache(int watermark)
+            : this(watermark * 4 / 5, watermark)
+        {
+        }
+
+        // The cache will grow until the high watermark. At which point, the least recently used items
+        // will be purge until the cache's size is reduced to low watermark
+        public MruCache(int lowWatermark, int highWatermark)
+            : this(lowWatermark, highWatermark, null)
+        {
+        }
+
+        public MruCache(int lowWatermark, int highWatermark, IEqualityComparer<TKey> comparer)
+        {
+            System.Diagnostics.Debug.Assert(lowWatermark < highWatermark, "lowWatermark must be less than highWatermark");
+            System.Diagnostics.Debug.Assert(lowWatermark >= 0, "lowWatermark must be greater than or equal to zero");
+
+            this.LowWatermark = lowWatermark;
+            this.HighWatermark = highWatermark;
+            this.mruList = new LinkedList<TKey>();
+            if (comparer == null)
+            {
+                this.items = new Dictionary<TKey, CacheEntry>();
+            }
+            else
+            {
+                this.items = new Dictionary<TKey, CacheEntry>(comparer);
+            }
+        }
+
+        public int LowWatermark { get; }
+
+        public int HighWatermark { get; }
+
+        public void Add(TKey key, TValue value)
+        {
+            this.Add(key, value, DateTime.MaxValue);
+        }
+
+        public void Add(TKey key, TValue value, DateTime expiresAfter)
+        {
+            this.Add(key, value, expiresAfter, TimeSpan.Zero);
+        }
+
+        public void Add(TKey key, TValue value, TimeSpan timeToLive)
+        {
+            this.Add(key, value, DateTime.UtcNow.Add(timeToLive), timeToLive);
+        }
+
+        public void Add(TKey key, TValue value, DateTime expiresAfter, TimeSpan timeToLive)
+        {
+            // if anything goes wrong (duplicate entry, etc) we should 
+            // clear our caches so that we don't get out of sync
+            bool success = false;
+            try
+            {
+                if (this.items.Count >= this.HighWatermark)
+                {
+                    // If the cache is full, purge enough LRU items to shrink the 
+                    // cache down to the low watermark
+                    int countToPurge = this.HighWatermark - this.LowWatermark;
+
+                    var last = this.mruList.Last;
+                    while (last != null && countToPurge > 0)
+                    {
+                        TKey keyToRemove = last.Value;
+                        CacheEntry entryToRemove = this.items[keyToRemove];
+                        if (entryToRemove.TimeToLiveTicks > 0 && entryToRemove.ExpiresAfterUtcTicks > DateTime.UtcNow.Ticks)
+                        {
+                            // Skip this item since it's in use.
+                            last = last.Previous;
+                            continue;
+                        }
+
+                        this.mruList.Remove(last);
+                        TValue item = entryToRemove.Value;
+                        this.items.Remove(keyToRemove);
+                        this.OnSingleItemRemoved(item);
+
+                        countToPurge--;
+                        last = last.Previous;
+                    }
+                }
+
+                // Add  the new entry to the cache and make it the MRU element
+                CacheEntry entry;
+                entry.Node = this.mruList.AddFirst(key);
+                entry.Value = value;
+                entry.ExpiresAfterUtcTicks = expiresAfter.ToUniversalTime().Ticks;
+                entry.TimeToLiveTicks = timeToLive.Ticks;
+
+                this.items.Add(key, entry);
+                this.mruEntry = entry;
+                success = true;
+            }
+            finally
+            {
+                if (!success)
+                {
+                    this.Clear();
+                }
+            }
+        }
+
+        public void Clear()
+        {
+            this.mruList.Clear();
+            this.items.Clear();
+            this.mruEntry.Value = null;
+            this.mruEntry.Node = null;
+        }
+
+        public bool Remove(TKey key)
+        {
+            CacheEntry entry;
+            if (this.items.TryGetValue(key, out entry))
+            {
+                this.items.Remove(key);
+                this.OnSingleItemRemoved(entry.Value);
+                this.mruList.Remove(entry.Node);
+                if (object.ReferenceEquals(this.mruEntry.Node, entry.Node))
+                {
+                    this.mruEntry.Value = null;
+                    this.mruEntry.Node = null;
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        // If found, make the entry most recently used
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            // remove the MRU item if it is invalid
+            if (this.mruEntry.Node != null && !IsValid(this.mruEntry))
+            {
+                this.Remove(this.mruEntry.Node.Value);
+            }
+
+            // first check our MRU item
+            if (this.mruEntry.Node != null && key != null && key.Equals(this.mruEntry.Node.Value))
+            {
+                value = this.mruEntry.Value;
+                return true;
+            }
+
+            CacheEntry entry;
+
+            bool found = this.items.TryGetValue(key, out entry);
+            if (found)
+            {
+                if (entry.TimeToLiveTicks > 0)
+                {
+                    entry.ExpiresAfterUtcTicks = DateTime.UtcNow.AddTicks(entry.TimeToLiveTicks).Ticks;
+                }
+                else if (!IsValid(entry))
+                {
+                    this.Remove(key);
+                    found = false;
+                }
+            }
+
+            value = entry.Value;
+
+            // Move the node to the head of the MRU list if it's not already there
+            if (found && this.mruList.Count > 1
+                && !object.ReferenceEquals(this.mruList.First, entry.Node))
+            {
+                this.mruList.Remove(entry.Node);
+                this.mruList.AddFirst(entry.Node);
+                this.mruEntry = entry;
+            }
+
+            return found;
+        }
+
+        protected virtual void OnSingleItemRemoved(TValue item)
+        {
+            IDisposable disposable = item as IDisposable;
+            if (disposable != null)
+            {
+                disposable.Dispose();
+            }
+        }
+
+        static bool IsValid(CacheEntry item)
+        {
+            return DateTime.UtcNow.Ticks <= item.ExpiresAfterUtcTicks;
+        }
+
+        struct CacheEntry
+        {
+            internal TValue Value;
+            internal LinkedListNode<TKey> Node;
+            internal long ExpiresAfterUtcTicks;
+            internal long TimeToLiveTicks;
+        }
+    }
+}

--- a/src/DurableTask.Core/IOrchestrationCaching.cs
+++ b/src/DurableTask.Core/IOrchestrationCaching.cs
@@ -1,0 +1,35 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core
+{
+    using System.Threading.Tasks;
+    using DurableTask.Core.Settings;
+
+    /// <summary>
+    /// Optional interface for <see cref="IOrchestrationService"/> implementations which can be used to enable orchestration caching.
+    /// </summary>
+    public interface IOrchestrationCaching
+    {
+        /// <summary>
+        /// Fetch the runtime state for a particular orchestration work item.
+        /// </summary>
+        Task<OrchestrationRuntimeState> FetchOrchestrationRuntimeStateAsync(TaskOrchestrationWorkItem workItem);
+
+        /// <summary>
+        /// The cache settings for the orchestration dispatcher. Returning null will disable caching.
+        /// </summary>
+        OrchestrationInstanceCacheSettings OrchestrationCacheSettings { get; }
+    }
+
+}

--- a/src/DurableTask.Core/Settings/OrchestrationInstanceCacheSettings.cs
+++ b/src/DurableTask.Core/Settings/OrchestrationInstanceCacheSettings.cs
@@ -1,0 +1,27 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core.Settings
+{
+    /// <summary>
+    /// Settings to configure orchestration instance caching in the task orchestration dispatcher.
+    /// </summary>
+    public class OrchestrationInstanceCacheSettings
+    {
+        /// <summary>
+        /// The maximum number of orchestration instances to cache.
+        /// Setting to zero or less disables orchestration instance caching.
+        /// </summary>
+        public int MaxCachedInstances { get; set; }
+    }
+}

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -57,6 +57,11 @@ namespace DurableTask.Core
             get { return openTasks.Count > 0; }
         }
 
+        internal void ClearPendingActions()
+        {
+            orchestratorActionsMap.Clear();
+        }
+
         public override async Task<TResult> ScheduleTask<TResult>(string name, string version,
             params object[] parameters)
         {

--- a/src/DurableTask.Core/TaskOrchestrationExecutor.cs
+++ b/src/DurableTask.Core/TaskOrchestrationExecutor.cs
@@ -38,7 +38,20 @@ namespace DurableTask.Core
             this.taskOrchestration = taskOrchestration;
         }
 
+        public bool IsCompleted => this.result != null && (this.result.IsCompleted || this.result.IsFaulted);
+
         public IEnumerable<OrchestratorAction> Execute()
+        {
+            return this.ExecuteCore(orchestrationRuntimeState.Events);
+        }
+
+        public IEnumerable<OrchestratorAction> ExecuteNewEvents()
+        {
+            context.ClearPendingActions();
+            return this.ExecuteCore(orchestrationRuntimeState.NewEvents);
+        }
+
+        IEnumerable<OrchestratorAction> ExecuteCore(IEnumerable<HistoryEvent> eventHistory)
         {
             SynchronizationContext prevCtx = SynchronizationContext.Current;
 
@@ -49,7 +62,7 @@ namespace DurableTask.Core
 
                 try
                 {
-                    foreach (HistoryEvent historyEvent in orchestrationRuntimeState.Events)
+                    foreach (HistoryEvent historyEvent in eventHistory)
                     {
                         if (historyEvent.EventType == EventType.OrchestratorStarted)
                         {


### PR DESCRIPTION
# Overview
This PR is intended to dramatically improve the throughput of individual orchestrations. The primary motivation is to improve the performance of Durable Functions, especially large fan-out/fan-in scenarios like https://github.com/Azure/azure-functions-durable-extension/issues/81.

The meat of the change is in DurableTask.Core. There are two parts:

1. Caching and reusing of task executors to avoid history replay whenever possible.
2. Separating work-item fetching from runtime state fetching, since we can usually just get the runtime state from the cache.

# Performance Implications
The effectiveness of the caching depends on how the storage provider is implemented. For **DurableTask.AzureStorage**, instances are pinned to workers (in steady state) so it can benefit quite a lot from caching. **DurableTask.ServiceBus** on the other hand does not pin orchestration instances to workers, so additional changes would be required in order for `DurableTask.ServiceBus` to get the most out of caching.

Whenever there is a cache hit, we will skip loading the orchestration state from the task hub (session state for Service Bus and table storage for Azure Storage), and will skip replaying the orchestration history. This means that we can simply resume the most recent open task and keep the local memory in-tact. If large messages are involved, then we would not need to fetch those from blob storage either.

# Design
A new interface, **IOrchestrationCaching**, was created and can be optionally implemented by the provider. This interface has methods for getting the cache configuration as well as loading orchestration state separate from the orchestration work items. When not implemented, caching will be disabled. This design allows us to start with an implementation in `DurableTask.AzureStorage` and allows us to leave `DurableTask.ServiceBus` untouched until we're ready.

Users can decide how many instances they want to cache per worker (for example, 10 instances). I decided to make this configurable because caching introduces additional memory pressure, which the customer has to pay for when running in the Azure Functions consumption plan. Also, some orchestrations may be heavier than others and the VM hosting the worker may have memory constraints (thus some users may opt to configure smaller numbers).

The first execution of an orchestration instance will always go down the original path. If the orchestration hits an `await`, we will cache the instance state, context, and executor in an in-memory MRU cache. Subsequent executions will then try to use the cached instance data. If we find the instance data in the cache, we simply reuse the existing `TaskOrchestrationExecutor` and execute **only the new events which are part of the work item**.

# Performance Comparison
TODO
