### PR TITLE
Handle the case where orchestration termination and timer creation at the same time

### DIFF
--- a/Framework/ServiceBusOrchestrationService.cs
+++ b/Framework/ServiceBusOrchestrationService.cs
@@ -639,7 +639,7 @@ namespace DurableTask
                         this.ServiceStats.ActivityDispatcherStats.MessagesSent.Increment(outboundMessages.Count);
                     }
 
-                    if (timerMessages?.Count > 0)
+                    if (timerMessages?.Count > 0 && newOrchestrationRuntimeState != null)
                     {
                         await orchestratorQueueClient.SendBatchAsync(
                             await Task.WhenAll(timerMessages.Select(async m =>
@@ -649,7 +649,7 @@ namespace DurableTask
                                 m,
                                 Settings.MessageCompressionSettings,
                                 Settings.MessageSettings,
-                                newOrchestrationRuntimeState?.OrchestrationInstance,
+                                newOrchestrationRuntimeState.OrchestrationInstance,
                                 "Timer Message",
                                 this.BlobStore,
                                 messageFireTime);


### PR DESCRIPTION
Handle the case where orchestration termination and timer creation at the same time. 

newOrchestrationRuntimeState will be null when the orchestration is in terminated state. It will cause a null session id, which will fail the sending of the service bus messages