### PR TITLE
Option: Add support for unhandled exception propagation

### DIFF
--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -90,6 +90,12 @@ namespace DurableTask.Core
         public bool IncludeParameters { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to serialize unhandled exception information in fault details.
+        /// This is an advanced setting mainly intended for direct inheritors of <see cref="TaskOrchestration"/>.
+        /// </summary>
+        public bool SerializeUnhandledExceptions { get; set; }
+
+        /// <summary>
         /// Method to get the next work item to process within supplied timeout
         /// </summary>
         /// <param name="receiveTimeout">The max timeout to wait</param>
@@ -304,7 +310,7 @@ namespace DurableTask.Core
             IEnumerable<OrchestratorAction> decisions = null;
             await this.dispatchPipeline.RunAsync(dispatchContext, _ =>
             {
-                var taskOrchestrationExecutor = new TaskOrchestrationExecutor(runtimeState, taskOrchestration);
+                var taskOrchestrationExecutor = new TaskOrchestrationExecutor(runtimeState, taskOrchestration, SerializeUnhandledExceptions);
                 decisions = taskOrchestrationExecutor.Execute();
 
                 return Task.FromResult(0);

--- a/src/DurableTask.Core/TaskOrchestrationExecutor.cs
+++ b/src/DurableTask.Core/TaskOrchestrationExecutor.cs
@@ -31,12 +31,23 @@ namespace DurableTask.Core
 
         public TaskOrchestrationExecutor(OrchestrationRuntimeState orchestrationRuntimeState,
             TaskOrchestration taskOrchestration)
+            : this(orchestrationRuntimeState, taskOrchestration, false)
+        {
+        }
+
+        public TaskOrchestrationExecutor(OrchestrationRuntimeState orchestrationRuntimeState,
+            TaskOrchestration taskOrchestration, bool serializeUnhandledExceptions)
         {
             decisionScheduler = new SynchronousTaskScheduler();
-            context = new TaskOrchestrationContext(orchestrationRuntimeState.OrchestrationInstance, decisionScheduler);
+            context = new TaskOrchestrationContext(
+                orchestrationRuntimeState.OrchestrationInstance,
+                decisionScheduler,
+                serializeUnhandledExceptions);
             this.orchestrationRuntimeState = orchestrationRuntimeState;
             this.taskOrchestration = taskOrchestration;
         }
+
+        public bool SerializeUnhandledExceptions { get; set; }
 
         public IEnumerable<OrchestratorAction> Execute()
         {


### PR DESCRIPTION
Allows `TaskActivity` and `TaskOrchestration` derivatives to flow exception details to parent orchestrations.

The alternative to this is making `TaskFailureException` and `OrchestrationFailureException` public, which I have in another PR (and may be more preferable).