### PR TITLE
Adding ETW traces for uploading and downloading large messages to blob.

### DIFF
--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -316,5 +316,35 @@ namespace DurableTask.AzureStorage
             EnsureLogicalTraceActivityId();
             this.WriteEvent(136, Account, TaskHub, InstanceId, ExecutionId, LatencyMs);
         }
+
+        [Event(137, Level = EventLevel.Informational)]
+        public void UploadLargeMessage(
+            string Account,
+            string TaskHub,
+            string EventType,
+            string InstanceId,
+            string ExecutionId,
+            string BlobContainer, 
+            string BlobName,
+            long SizeInBytes)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(137, Account, TaskHub, EventType, InstanceId, ExecutionId, BlobContainer, BlobName, SizeInBytes);
+        }
+
+        [Event(138, Level = EventLevel.Informational)]
+        public void DownloadLargeMessage(
+            string Account,
+            string TaskHub,
+            string EventType,
+            string InstanceId,
+            string ExecutionId,
+            string BlobContainer,
+            string BlobName,
+            long SizeInBytes)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(138, Account, TaskHub, EventType, InstanceId, ExecutionId, BlobContainer, BlobName, SizeInBytes);
+        }
     }
 }

--- a/src/DurableTask.AzureStorage/ReceivedMessageContext.cs
+++ b/src/DurableTask.AzureStorage/ReceivedMessageContext.cs
@@ -133,7 +133,7 @@ namespace DurableTask.AzureStorage
             CloudQueueMessage queueMessage,
             string queueName)
         {
-            MessageData data = await messageManager.DeserializeQueueMessageAsync(queueMessage, queueName);
+            MessageData data = await messageManager.DeserializeQueueMessageAsync(queueMessage, queueName, null, null, null);
 
             Guid newTraceActivityId = StartNewLogicalTraceScope();
             TraceMessageReceived(storageAccountName, taskHub, data);
@@ -198,7 +198,11 @@ namespace DurableTask.AzureStorage
             Guid outboundTraceActivityId = Guid.NewGuid();
 
             var data = new MessageData(taskMessage, outboundTraceActivityId, queueName);
-            string rawContent = await messageManager.SerializeMessageDataAsync(data);
+            string rawContent = await messageManager.SerializeMessageDataAsync(
+                data,
+                taskMessage.Event.EventType.ToString(),
+                taskMessage.OrchestrationInstance.InstanceId,
+                taskMessage.OrchestrationInstance.ExecutionId);
 
             AnalyticsEventSource.Log.SendingMessage(
                 outboundTraceActivityId,


### PR DESCRIPTION
Added ETW traces when large messages are uploaded and downloaded from blob storage.

Sample snapshot from PerfView for large message **Upload**:

![etw-upload](https://user-images.githubusercontent.com/14911331/38645271-5b105584-3d98-11e8-800f-ee7ca98b1f62.PNG)

Sample snapshot from PerfView for large message **Download**:

![etw-download](https://user-images.githubusercontent.com/14911331/38645293-6c60cfd0-3d98-11e8-9ad6-ce54dca070b7.PNG)

