### PR TITLE
Leaving the packageupgradeserialization binder com invisible to unblock the release build.

### DIFF
--- a/src/DurableTask.Core/Serializing/PackageUpgradeSerializationBinder.cs
+++ b/src/DurableTask.Core/Serializing/PackageUpgradeSerializationBinder.cs
@@ -16,11 +16,14 @@ namespace DurableTask.Core.Serializing
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Runtime.InteropServices;
     using Newtonsoft.Json.Serialization;
 
     /// <summary>
-    /// SerializationBinder to be used for deserializing DurableTask types that are pre v-2.0, this allows upgrade compaibility. This is not sufficient to deserialize objects from 1.0 which had the Tags Property set.
+    /// SerializationBinder to be used for deserializing DurableTask types that are pre v-2.0, this allows upgrade compaibility.
+    /// This is not sufficient to deserialize objects from 1.0 which had the Tags Property set.
     /// </summary>
+    [ComVisible(false)]
     public class PackageUpgradeSerializationBinder : DefaultSerializationBinder
     {
         static Lazy<IDictionary<string, Type>> KnownTypes = new Lazy<IDictionary<string, Type>>(() =>


### PR DESCRIPTION
Making it com visible would be messy until Json.Net is upgraded in the net 451 target, due to the breaking changes in the type of the serialization binder.
If com visibility is required this can be revisited.