### PR TITLE
Sticky sessions support in DurableTask.Core

### DIFF
--- a/src/DurableTask.Core/IOrchestrationSession.cs
+++ b/src/DurableTask.Core/IOrchestrationSession.cs
@@ -13,35 +13,13 @@
 
 namespace DurableTask.Core
 {
-    using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
 
-    /// <summary>
-    /// An active instance / work item of an orchestration
-    /// </summary>
-    public class TaskOrchestrationWorkItem
+    /// <summary>TODO</summary>
+    public interface IOrchestrationSession
     {
-        /// <summary>
-        /// The instance id of this orchestration
-        /// </summary>
-        public string InstanceId;
-
-        /// <summary>
-        /// The current runtimestate of this work item
-        /// </summary>
-        public OrchestrationRuntimeState OrchestrationRuntimeState;
-
-        /// <summary>
-        /// The datetime this orchestraion work item is locked until
-        /// </summary>
-        public DateTime LockedUntilUtc;
-
-        /// <summary>
-        /// The list of new task messages associated with this work item instance
-        /// </summary>
-        public IList<TaskMessage> NewMessages;
-
         /// <summary>TODO</summary>
-        public IOrchestrationSession Session;
+        Task<IList<TaskMessage>> FetchNewOrchestrationMessagesAsync(TaskOrchestrationWorkItem workItem);
     }
 }

--- a/src/DurableTask.Core/OrchestrationExecutionCursor.cs
+++ b/src/DurableTask.Core/OrchestrationExecutionCursor.cs
@@ -1,0 +1,38 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core
+{
+    using System.Collections.Generic;
+    using DurableTask.Core.Command;
+
+    class OrchestrationExecutionCursor
+    {
+        public OrchestrationExecutionCursor(
+            OrchestrationRuntimeState state,
+            TaskOrchestration orchestration,
+            TaskOrchestrationExecutor executor,
+            IEnumerable<OrchestratorAction> latestDecisions)
+        {
+            this.RuntimeState = state;
+            this.TaskOrchestration = orchestration;
+            this.OrchestrationExecutor = executor;
+            this.LatestDecisions = latestDecisions;
+        }
+
+        public OrchestrationRuntimeState RuntimeState { get; }
+        public TaskOrchestration TaskOrchestration { get; }
+        public TaskOrchestrationExecutor OrchestrationExecutor { get; }
+        public IEnumerable<OrchestratorAction> LatestDecisions { get; set; }
+    }
+}

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -57,6 +57,11 @@ namespace DurableTask.Core
             get { return openTasks.Count > 0; }
         }
 
+        internal void ClearPendingActions()
+        {
+            orchestratorActionsMap.Clear();
+        }
+
         public override async Task<TResult> ScheduleTask<TResult>(string name, string version,
             params object[] parameters)
         {

--- a/src/DurableTask.Core/TaskOrchestrationExecutor.cs
+++ b/src/DurableTask.Core/TaskOrchestrationExecutor.cs
@@ -38,7 +38,20 @@ namespace DurableTask.Core
             this.taskOrchestration = taskOrchestration;
         }
 
+        public bool IsCompleted => this.result != null && (this.result.IsCompleted || this.result.IsFaulted);
+
         public IEnumerable<OrchestratorAction> Execute()
+        {
+            return this.ExecuteCore(orchestrationRuntimeState.Events);
+        }
+
+        public IEnumerable<OrchestratorAction> ExecuteNewEvents()
+        {
+            context.ClearPendingActions();
+            return this.ExecuteCore(orchestrationRuntimeState.NewEvents);
+        }
+
+        IEnumerable<OrchestratorAction> ExecuteCore(IEnumerable<HistoryEvent> eventHistory)
         {
             SynchronizationContext prevCtx = SynchronizationContext.Current;
 
@@ -49,11 +62,11 @@ namespace DurableTask.Core
 
                 try
                 {
-                    foreach (HistoryEvent historyEvent in orchestrationRuntimeState.Events)
+                    foreach (HistoryEvent historyEvent in eventHistory)
                     {
                         if (historyEvent.EventType == EventType.OrchestratorStarted)
                         {
-                            var decisionStartedEvent = (OrchestratorStartedEvent) historyEvent;
+                            var decisionStartedEvent = (OrchestratorStartedEvent)historyEvent;
                             context.CurrentUtcDateTime = decisionStartedEvent.Timestamp;
                             continue;
                         }
@@ -101,39 +114,39 @@ namespace DurableTask.Core
             switch (historyEvent.EventType)
             {
                 case EventType.ExecutionStarted:
-                    var executionStartedEvent = (ExecutionStartedEvent) historyEvent;
+                    var executionStartedEvent = (ExecutionStartedEvent)historyEvent;
                     result = taskOrchestration.Execute(context, executionStartedEvent.Input);
                     break;
                 case EventType.ExecutionTerminated:
-                    context.HandleExecutionTerminatedEvent((ExecutionTerminatedEvent) historyEvent);
+                    context.HandleExecutionTerminatedEvent((ExecutionTerminatedEvent)historyEvent);
                     break;
                 case EventType.TaskScheduled:
-                    context.HandleTaskScheduledEvent((TaskScheduledEvent) historyEvent);
+                    context.HandleTaskScheduledEvent((TaskScheduledEvent)historyEvent);
                     break;
                 case EventType.TaskCompleted:
-                    context.HandleTaskCompletedEvent((TaskCompletedEvent) historyEvent);
+                    context.HandleTaskCompletedEvent((TaskCompletedEvent)historyEvent);
                     break;
                 case EventType.TaskFailed:
-                    context.HandleTaskFailedEvent((TaskFailedEvent) historyEvent);
+                    context.HandleTaskFailedEvent((TaskFailedEvent)historyEvent);
                     break;
                 case EventType.SubOrchestrationInstanceCreated:
-                    context.HandleSubOrchestrationCreatedEvent((SubOrchestrationInstanceCreatedEvent) historyEvent);
+                    context.HandleSubOrchestrationCreatedEvent((SubOrchestrationInstanceCreatedEvent)historyEvent);
                     break;
                 case EventType.SubOrchestrationInstanceCompleted:
                     context.HandleSubOrchestrationInstanceCompletedEvent(
-                        (SubOrchestrationInstanceCompletedEvent) historyEvent);
+                        (SubOrchestrationInstanceCompletedEvent)historyEvent);
                     break;
                 case EventType.SubOrchestrationInstanceFailed:
-                    context.HandleSubOrchestrationInstanceFailedEvent((SubOrchestrationInstanceFailedEvent) historyEvent);
+                    context.HandleSubOrchestrationInstanceFailedEvent((SubOrchestrationInstanceFailedEvent)historyEvent);
                     break;
                 case EventType.TimerCreated:
-                    context.HandleTimerCreatedEvent((TimerCreatedEvent) historyEvent);
+                    context.HandleTimerCreatedEvent((TimerCreatedEvent)historyEvent);
                     break;
                 case EventType.TimerFired:
-                    context.HandleTimerFiredEvent((TimerFiredEvent) historyEvent);
+                    context.HandleTimerFiredEvent((TimerFiredEvent)historyEvent);
                     break;
                 case EventType.EventRaised:
-                    var eventRaisedEvent = (EventRaisedEvent) historyEvent;
+                    var eventRaisedEvent = (EventRaisedEvent)historyEvent;
                     taskOrchestration.RaiseEvent(context, eventRaisedEvent.Name, eventRaisedEvent.Input);
                     break;
             }


### PR DESCRIPTION
This PR enables "sticky-sessions", which is a feature to minimize the number of orchestration replays when multiple messages arrive in quick succession.  The previous flow for orchestrations was as follows:

1. Provider's `LockNextTaskOrchestrationWorkItemAsync` locks a session and returns a work item + new events
2. DTFx reconciles the new work item events into state
3. DTFx executions the orchestration from scratch
4. Provider's `CompleteTaskOrchestrationWorkItemAsync` checkpoints the new state
5. Provider's `ReleaseTaskOrchestrationWorkItemAsync` releases the session

This PR changes the flow as follows:

1. Provider's `LockNextTaskOrchestrationWorkItemAsync` locks a session and returns a work item with an attached `IOrchestrationSession`.
2. DTFx pulls new events from `IOrchestrationSession.FetchNewOrchestrationMessagesAsync` and reconciles them into state
3. DTFx executions the orchestration from where it left off
4. Provider's `CompleteTaskOrchestrationWorkItemAsync` checkpoints the new state
5. DTFx repeats (2) above, stopping only when `IOrchestrationSession.FetchNewOrchestrationMessagesAsync` returns `null`.
6. Provider's `ReleaseTaskOrchestrationWorkItemAsync` releases the session

I tested this with a refactored version of **DurableTask.AzureStorage** and verified that I can step through a sequential Fibonacci orchestration using the debugger and it behaves just as if it were normal C# method calls (i.e. no replays). I also verified that an unmodified **DurableTask.AzureStorage** continues to work as it did before, even with sticky-sessions enabled (demonstrating backwards compatibility).

This change is backwards compatible with existing provider code. This way Azure Functions (which is on a tight shipping schedule) can leverage it first in **DurableTask.AzureStorage** and then we can later add support to **DurableTask.ServiceBus**.