### PR TITLE
Remove preview labels

### DIFF
--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -152,14 +152,14 @@ namespace DurableTask.AzureStorage
         public void FetchedInstanceHistory(string Account, string TaskHub, string InstanceId, string ExecutionId, int EventCount, int RequestCount, long LatencyMs, string ETag)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(110, Account, TaskHub, InstanceId, ExecutionId ?? string.Empty, EventCount, RequestCount, LatencyMs, ETag);
+            this.WriteEvent(110, Account, TaskHub, InstanceId, ExecutionId ?? string.Empty, EventCount, RequestCount, LatencyMs, ETag ?? string.Empty);
         }
 
         [Event(111, Level = EventLevel.Informational)]
         public void AppendedInstanceHistory(string Account, string TaskHub, string InstanceId, string ExecutionId, int NewEventCount, int TotalEventCount, string NewEvents, long LatencyMs, string ETag)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(111, Account, TaskHub, InstanceId, ExecutionId ?? string.Empty, NewEventCount, TotalEventCount, NewEvents, LatencyMs, ETag);
+            this.WriteEvent(111, Account, TaskHub, InstanceId, ExecutionId ?? string.Empty, NewEventCount, TotalEventCount, NewEvents, LatencyMs, ETag ?? string.Empty);
         }
 
         [Event(112, Level = EventLevel.Informational)]
@@ -329,7 +329,7 @@ namespace DurableTask.AzureStorage
         public void SplitBrainDetected(string Account, string TaskHub, string InstanceId, string ExecutionId, int NewEventCount, int TotalEventCount, string NewEvents, long LatencyMs, string ETag)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(138, Account, TaskHub, InstanceId, ExecutionId, NewEventCount, TotalEventCount, NewEvents, LatencyMs, ETag);
+            this.WriteEvent(138, Account, TaskHub, InstanceId, ExecutionId ?? string.Empty, NewEventCount, TotalEventCount, NewEvents, LatencyMs, ETag ?? string.Empty);
         }
     }
 }

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.1.8-beta</Version>
+    <Version>1.2.0</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <Description>Azure Storage provider extension for the Durable Task Framework.</Description>
     <Authors>cgillum</Authors>

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -12,8 +12,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Dynamitey" Version="2.0.6-beta111" />
-    <PackageReference Include="ImpromptuInterface" Version="7.0.1-beta40" />
+    <PackageReference Include="ImpromptuInterface" Version="7.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
   

--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -32,9 +32,9 @@
   <!-- Nuget Package Settings -->
   <PropertyGroup>
     <PackageOutputPath>..\..\build_output\packages</PackageOutputPath>
-    <AssemblyVersion>2.0.0.4</AssemblyVersion>
-    <FileVersion>2.0.0.4</FileVersion>
-    <Version>2.0.0.4-preview5</Version>
+    <AssemblyVersion>2.0.0.5</AssemblyVersion>
+    <FileVersion>2.0.0.5</FileVersion>
+    <Version>2.0.0.5</Version>
     <Company>Microsoft</Company>
     <Product>Durable Task Framework</Product>
     <Description>This package provides a C# based durable task framework for writing long running applications.</Description>
@@ -43,6 +43,7 @@
     <PackageProjectUrl>https://github.com/Azure/durabletask/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Azure/durabletask/</RepositoryUrl>
     <PackageTags>ServiceBus;Service Bus;Azure;Task;Durable;Orchestration;Workflow;Activity;Reliable</PackageTags>
+    <IncludeSymbols>true</IncludeSymbols>
   </PropertyGroup>
 
   <Target Name="Build">


### PR DESCRIPTION
- Incremented DurableTask.Core and DurableTask.ServiceBus to **2.0.0.5** and removed "-preview"
- Incremented DurableTask.AzureStorage to **1.2.0** and removed "-beta"
- Update DurableTask.Core netstandard2.0 nuget dependencies to non-preview versions
- Include symbols in DurableTask.Core nuget package (debugging is a huge pain without this)