### PR TITLE
delay by the non transient error backoff on jsonserialization exceptions 

### DIFF
--- a/Framework/TaskActivityDispatcher.cs
+++ b/Framework/TaskActivityDispatcher.cs
@@ -20,6 +20,7 @@ namespace DurableTask
     using System.Transactions;
     using History;
     using Microsoft.ServiceBus.Messaging;
+    using Newtonsoft.Json;
     using Tracing;
 
     public sealed class TaskActivityDispatcher : DispatcherBase<BrokeredMessage>
@@ -254,6 +255,11 @@ namespace DurableTask
             if (exception is MessagingException)
             {
                 return settings.TaskActivityDispatcherSettings.TransientErrorBackOffSecs;
+            }
+
+            if (exception is JsonSerializationException)
+            {
+                return settings.TaskActivityDispatcherSettings.NonTransientErrorBackOffSecs;
             }
 
             return 0;

--- a/Framework/TaskOrchestrationDispatcher.cs
+++ b/Framework/TaskOrchestrationDispatcher.cs
@@ -883,6 +883,11 @@ namespace DurableTask
                 return settings.TaskOrchestrationDispatcherSettings.TransientErrorBackOffSecs;
             }
 
+            if (exception is JsonSerializationException)
+            {
+                return settings.TaskOrchestrationDispatcherSettings.NonTransientErrorBackOffSecs;
+            }
+
             return 0;
         }
 

--- a/Framework/TrackingDispatcher.cs
+++ b/Framework/TrackingDispatcher.cs
@@ -298,7 +298,10 @@ namespace DurableTask
             {
                 return settings.TransientErrorBackOffSecs;
             }
-
+            if (exception is JsonSerializationException)
+            {
+                return settings.NonTransientErrorBackOffSecs;
+            }
             return 0;
         }
 


### PR DESCRIPTION
delay by the non transient error backoff on jsonserialization exceptions while processing work items to allow forward compatibility.