### PR TITLE
Fix issue with ETag check when fanning out to 100+ parallel activities

### DIFF
--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <Description>Azure Storage provider extension for the Durable Task Framework.</Description>
     <Authors>cgillum</Authors>

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -442,7 +442,16 @@ namespace DurableTask.AzureStorage.Tracking
                 eTagValue = await this.UploadHistoryBatch(instanceId, executionId, historyEventBatch, newEventListBuffer, newEvents.Count, eTagValue);
             }
 
-            this.eTagValues[instanceId] = eTagValue;
+            if (orchestratorEventType == EventType.ExecutionCompleted ||
+                orchestratorEventType == EventType.ExecutionFailed ||
+                orchestratorEventType == EventType.ExecutionTerminated)
+            {
+                this.eTagValues.TryRemove(instanceId, out _);
+            }
+            else
+            {
+                this.eTagValues[instanceId] = eTagValue;
+            }
 
             Stopwatch orchestrationInstanceUpdateStopwatch = Stopwatch.StartNew();
             await this.instancesTable.ExecuteAsync(TableOperation.InsertOrMerge(orchestrationInstanceUpdate));

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -396,7 +396,7 @@ namespace DurableTask.AzureStorage.Tracking
                 // Table storage only supports inserts of up to 100 entities at a time.
                 if (historyEventBatch.Count == 99)
                 {
-                    await this.UploadHistoryBatch(instanceId, executionId, historyEventBatch, newEventListBuffer, newEvents.Count, eTagValue);
+                    eTagValue = await this.UploadHistoryBatch(instanceId, executionId, historyEventBatch, newEventListBuffer, newEvents.Count, eTagValue);
 
                     // Reset local state for the next batch
                     newEventListBuffer.Clear();
@@ -439,9 +439,11 @@ namespace DurableTask.AzureStorage.Tracking
             // First persistence step is to commit history to the history table. Messages must come after.
             if (historyEventBatch.Count > 0)
             {
-                await this.UploadHistoryBatch(instanceId, executionId, historyEventBatch, newEventListBuffer, newEvents.Count, eTagValue);
+                eTagValue = await this.UploadHistoryBatch(instanceId, executionId, historyEventBatch, newEventListBuffer, newEvents.Count, eTagValue);
             }
-            
+
+            this.eTagValues[instanceId] = eTagValue;
+
             Stopwatch orchestrationInstanceUpdateStopwatch = Stopwatch.StartNew();
             await this.instancesTable.ExecuteAsync(TableOperation.InsertOrMerge(orchestrationInstanceUpdate));
 
@@ -585,7 +587,7 @@ namespace DurableTask.AzureStorage.Tracking
             }
         }
 
-        async Task UploadHistoryBatch(
+        async Task<string> UploadHistoryBatch(
             string instanceId,
             string executionId,
             TableBatchOperation historyEventBatch,
@@ -593,7 +595,6 @@ namespace DurableTask.AzureStorage.Tracking
             int numberOfTotalEvents,
             string eTagValue)
         {
-
             // Adding / updating sentinel entity
             DynamicTableEntity sentinelEntity = new DynamicTableEntity(instanceId, SentinelRowKey)
             {
@@ -602,6 +603,7 @@ namespace DurableTask.AzureStorage.Tracking
                     ["ExecutionId"] = new EntityProperty(executionId),
                 }
             };
+
             if (!string.IsNullOrEmpty(eTagValue))
             {
                 sentinelEntity.ETag = eTagValue;
@@ -649,7 +651,7 @@ namespace DurableTask.AzureStorage.Tracking
                 {
                     if (((DynamicTableEntity)tableResultList[i].Result).RowKey == SentinelRowKey)
                     {
-                        this.eTagValues[instanceId] = tableResultList[i].Etag;
+                        eTagValue = tableResultList[i].Etag;
                         break;
                     }
                 }
@@ -665,6 +667,8 @@ namespace DurableTask.AzureStorage.Tracking
                 historyEventNamesBuffer.ToString(0, historyEventNamesBuffer.Length - 1), // remove trailing comma
                 stopwatch.ElapsedMilliseconds,
                 this.GetETagValue(instanceId));
+
+            return eTagValue;
         }
 
         async Task<string> GetOrchestrationOutputAsync(OrchestrationInstanceStatus orchestrationInstanceStatus)


### PR DESCRIPTION
FYI @gled4er. Let me know if you think this fix will work. I haven't had a chance to test it yet, but it looks like we need a new test case which fans out to 100+ activity functions.