### PR TITLE
Add support for deserializing a statemessage from the service bus tracking queue

### DIFF
--- a/src/DurableTask.Core/Common/Utils.cs
+++ b/src/DurableTask.Core/Common/Utils.cs
@@ -97,6 +97,14 @@ namespace DurableTask.Core.Common
         /// </summary>
         public static T ReadObjectFromStream<T>(Stream objectStream)
         {
+            return ReadObjectFromByteArray<T>(ReadBytesFromStream(objectStream));
+        }
+
+        /// <summary>
+        /// Reads bytes from the supplied stream
+        /// </summary>
+        public static byte[] ReadBytesFromStream(Stream objectStream)
+        {
             if (objectStream == null || !objectStream.CanRead || !objectStream.CanSeek)
             {
                 throw new ArgumentException("stream is not seekable or readable", nameof(objectStream));
@@ -108,7 +116,16 @@ namespace DurableTask.Core.Common
             objectStream.Read(serializedBytes, 0, serializedBytes.Length);
             objectStream.Position = 0;
 
-            var settings = new JsonSerializerSettings {
+            return serializedBytes;
+        }
+
+        /// <summary>
+        /// Deserializes an Object from the supplied bytes
+        /// </summary>
+        public static T ReadObjectFromByteArray<T>(byte[] serializedBytes)
+        {
+            var settings = new JsonSerializerSettings
+            {
                 TypeNameHandling = TypeNameHandling.All,
 
 #if NETSTANDARD2_0
@@ -121,7 +138,6 @@ namespace DurableTask.Core.Common
             return JsonConvert.DeserializeObject<T>(
                                 Encoding.UTF8.GetString(serializedBytes),
                                 settings);
-
         }
 
         /// <summary>

--- a/src/DurableTask.Core/StateMessage.cs
+++ b/src/DurableTask.Core/StateMessage.cs
@@ -1,0 +1,31 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// Deprecated Wrapper for the OrchestrationState in the Tracking Queue
+    /// </summary>
+    [Obsolete("This has been Replaced by a combination of the HistoryStateEvent and TaskMessage")]
+    [DataContract]
+    public class StateMessage
+    {
+        /// <summary>
+        /// The Orchestration State
+        /// </summary>
+        [DataMember] public OrchestrationState State;
+    }
+}


### PR DESCRIPTION
This is required for an upgrade path from DurableTask 1.0