### PR TITLE
DurableTask.AzureStorage API to enumerate instances

### DIFF
--- a/Test/DurableTask.AzureStorage.Tests/TestOrchestrationHost.cs
+++ b/Test/DurableTask.AzureStorage.Tests/TestOrchestrationHost.cs
@@ -50,6 +50,18 @@ namespace DurableTask.AzureStorage.Tests
             return this.worker.StopAsync(isForced: true);
         }
 
+        /// <summary>
+        /// This method is only for testing purpose. 
+        /// When we need to add fix to the DurableTask.Core (e.g. TaskHubClient), we need approval process. 
+        /// during wating for the approval, we can use this method to test the method. 
+        /// This method is not allowed for the production. Before going to the production, please refacotr to use TaskHubClient instead.
+        /// </summary>
+        /// <returns></returns>
+        internal AzureStorageOrchestrationService GetServiceClient()
+        {
+            return (AzureStorageOrchestrationService)this.client.serviceClient;
+        }
+
         public async Task<TestOrchestrationClient> StartOrchestrationAsync(
             Type orchestrationType,
             object input,

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1544,6 +1544,16 @@ namespace DurableTask.AzureStorage
         }
 
         /// <summary>
+        /// Get states of the all orchestration instances
+        /// </summary>
+        /// <returns>List of <see cref="OrchestrationState"/></returns>
+        public async Task<IList<OrchestrationState>> GetStateAsync()
+        {
+            await this.EnsureTaskHubAsync();
+            return await this.trackingStore.GetStateAsync();
+        }
+
+        /// <summary>
         /// Force terminates an orchestration by sending a execution terminated event
         /// </summary>
         /// <param name="instanceId">Instance ID of the orchestration to terminate.</param>

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1547,10 +1547,10 @@ namespace DurableTask.AzureStorage
         /// Get states of the all orchestration instances
         /// </summary>
         /// <returns>List of <see cref="OrchestrationState"/></returns>
-        public async Task<IList<OrchestrationState>> GetOrchestrationStateAsync()
+        public async Task<IList<OrchestrationState>> GetOrchestrationStateAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             await this.EnsureTaskHubAsync();
-            return await this.trackingStore.GetStateAsync();
+            return await this.trackingStore.GetStateAsync(cancellationToken);
         }
 
         /// <summary>

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1547,7 +1547,7 @@ namespace DurableTask.AzureStorage
         /// Get states of the all orchestration instances
         /// </summary>
         /// <returns>List of <see cref="OrchestrationState"/></returns>
-        public async Task<IList<OrchestrationState>> GetStateAsync()
+        public async Task<IList<OrchestrationState>> GetOrchestrationStateAsync()
         {
             await this.EnsureTaskHubAsync();
             return await this.trackingStore.GetStateAsync();

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.2.2</Version>
+    <Version>1.2.3</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <Description>Azure Storage provider extension for the Durable Task Framework.</Description>
     <Authors>cgillum</Authors>

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -330,7 +330,6 @@ namespace DurableTask.AzureStorage.Tracking
                 int previousCount = instancestatuses.Count;
                 instancestatuses.AddRange(segment.AsEnumerable<OrchestrationInstanceStatus>());
 
-                // TODO do we need these?
                 this.stats.StorageRequests.Increment();
                 this.stats.TableEntitiesRead.Increment(instancestatuses.Count - previousCount);
 

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -315,7 +315,7 @@ namespace DurableTask.AzureStorage.Tracking
             var query = new TableQuery<OrchestrationInstanceStatus>();
             TableContinuationToken token = null;
 
-            var instancestatuses = new List<OrchestrationInstanceStatus>(100);
+            var instanceStatuses = new List<OrchestrationInstanceStatus>(100);
             var stopwatch = new Stopwatch();
             var requestCount = 0;
             bool finishedEarly = false;
@@ -327,11 +327,11 @@ namespace DurableTask.AzureStorage.Tracking
                 var segment = await this.instancesTable.ExecuteQuerySegmentedAsync(query, token); // TODO make sure if it has enough parameters
                 stopwatch.Stop();
 
-                int previousCount = instancestatuses.Count;
-                instancestatuses.AddRange(segment.AsEnumerable<OrchestrationInstanceStatus>());
+                int previousCount = instanceStatuses.Count;
+                instanceStatuses.AddRange(segment.AsEnumerable<OrchestrationInstanceStatus>());
 
                 this.stats.StorageRequests.Increment();
-                this.stats.TableEntitiesRead.Increment(instancestatuses.Count - previousCount);
+                this.stats.TableEntitiesRead.Increment(instanceStatuses.Count - previousCount);
 
                 token = segment.ContinuationToken;
                 if (finishedEarly || token == null || cancellationToken.IsCancellationRequested)
@@ -342,11 +342,11 @@ namespace DurableTask.AzureStorage.Tracking
 
             IList<OrchestrationState> orchestrationStates;
 
-            orchestrationStates = new List<OrchestrationState>(instancestatuses.Count);
+            orchestrationStates = new List<OrchestrationState>(instanceStatuses.Count);
 
-            if (instancestatuses.Count > 0)
+            if (instanceStatuses.Count > 0)
             {
-                foreach(OrchestrationInstanceStatus entity in instancestatuses)
+                foreach(OrchestrationInstanceStatus entity in instanceStatuses)
                 {
                     var state = await ConvertFromAsync(entity, entity.PartitionKey);
                     orchestrationStates.Add(state);

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -316,16 +316,10 @@ namespace DurableTask.AzureStorage.Tracking
             TableContinuationToken token = null;
 
             var orchestrationStates = new List<OrchestrationState>(100);
-            var stopwatch = new Stopwatch();
-            var requestCount = 0;
-            bool finishedEarly = false;
 
             while (true)
             {
-                requestCount++;
-                stopwatch.Start();
                 var segment = await this.instancesTable.ExecuteQuerySegmentedAsync(query, token); // TODO make sure if it has enough parameters
-                stopwatch.Stop();
 
                 int previousCount = orchestrationStates.Count;
                 var tasks = segment.AsEnumerable<OrchestrationInstanceStatus>().Select(async x => await ConvertFromAsync(x, x.PartitionKey));
@@ -336,7 +330,7 @@ namespace DurableTask.AzureStorage.Tracking
                 this.stats.TableEntitiesRead.Increment(orchestrationStates.Count - previousCount);
 
                 token = segment.ContinuationToken;
-                if (finishedEarly || token == null || cancellationToken.IsCancellationRequested)
+                if (token == null || cancellationToken.IsCancellationRequested)
                 {
                     break;
                 }      

--- a/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
@@ -76,6 +76,12 @@ namespace DurableTask.AzureStorage.Tracking
         Task<OrchestrationState> GetStateAsync(string instanceId, string executionId);
 
         /// <summary>
+        /// Get The Orchestration State for querying all orchestration instances
+        /// </summary>
+        /// <returns></returns>
+        Task<IList<OrchestrationState>> GetStateAsync(CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
         /// Used to set a state in the tracking store whenever a new execution is initiated from the client
         /// </summary>
         /// <param name="executionStartedEvent">The Execution Started Event being queued</param>

--- a/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
@@ -96,6 +96,12 @@ namespace DurableTask.AzureStorage.Tracking
         }
 
         /// <inheritdoc />
+        public override Task<IList<OrchestrationState>> GetStateAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
         public override Task PurgeHistoryAsync(DateTime thresholdDateTimeUtc, OrchestrationStateTimeRangeFilterType timeRangeFilterType)
         {
             return instanceStore.PurgeOrchestrationHistoryEventsAsync(thresholdDateTimeUtc, timeRangeFilterType);

--- a/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
+++ b/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
@@ -43,6 +43,9 @@ namespace DurableTask.AzureStorage.Tracking
         public abstract Task<OrchestrationState> GetStateAsync(string instanceId, string executionId);
 
         /// <inheritdoc />
+        public abstract Task<IList<OrchestrationState>> GetStateAsync(CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <inheritdoc />
         public abstract Task PurgeHistoryAsync(DateTime thresholdDateTimeUtc, OrchestrationStateTimeRangeFilterType timeRangeFilterType);
 
         /// <inheritdoc />


### PR DESCRIPTION
Hi @cgillum and @gled4er,
 
I open this pull request to start discussion the details. 

I have two topic to discuss. 

1. How many attribute do we need? 

In the OrchestrationState has a lot of members. Which attribute do we need for this purpose?

2. Style of Query

We'll full scan search for the instance table. Is it OK? or do we have any other clever way to fetch the on the fly instances? Currenty, I just return all record of the isntance table. 

This pull request is correspond to this issue. 
https://github.com/Azure/azure-functions-durable-extension/issues/316

