### PR TITLE
DurableTask.AzureStorage ETW tracing improvements

### DIFF
--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -72,7 +72,7 @@ namespace DurableTask.AzureStorage
 #endif
         }
 
-        [Event(101, Level = EventLevel.Informational, Opcode = EventOpcode.Send)]
+        [Event(101, Level = EventLevel.Informational, Opcode = EventOpcode.Send, Task = Tasks.Enqueue, Version = 2)]
         public void SendingMessage(
             Guid relatedActivityId,
             string Account,
@@ -81,13 +81,28 @@ namespace DurableTask.AzureStorage
             string InstanceId,
             string ExecutionId,
             long SizeInBytes,
-            string PartitionId)
+            string PartitionId,
+            string TargetInstanceId,
+            string TargetExecutionId,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEventWithRelatedActivityId(101, relatedActivityId, Account, TaskHub, EventType, InstanceId, ExecutionId ?? string.Empty, SizeInBytes, PartitionId);
+            this.WriteEventWithRelatedActivityId(
+                101,
+                relatedActivityId,
+                Account,
+                TaskHub,
+                EventType,
+                InstanceId ?? string.Empty,
+                ExecutionId ?? string.Empty,
+                SizeInBytes,
+                PartitionId,
+                TargetInstanceId,
+                TargetExecutionId ?? string.Empty,
+                ExtensionVersion);
         }
 
-        [Event(102, Level = EventLevel.Informational, Opcode = EventOpcode.Receive)]
+        [Event(102, Level = EventLevel.Informational, Opcode = EventOpcode.Receive, Task = Tasks.Dequeue, Version = 2)]
         public void ReceivedMessage(
             Guid relatedActivityId,
             string Account,
@@ -98,68 +113,174 @@ namespace DurableTask.AzureStorage
             string MessageId,
             int Age,
             int DequeueCount,
+            DateTime NextVisibleTime,
             long SizeInBytes,
             string PartitionId,
-            bool IsExtendedSession)
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEventWithRelatedActivityId(102, relatedActivityId, Account, TaskHub, EventType, InstanceId, ExecutionId ?? string.Empty, MessageId, Age, DequeueCount, SizeInBytes, PartitionId, IsExtendedSession);
+            this.WriteEventWithRelatedActivityId(
+                102,
+                relatedActivityId,
+                Account,
+                TaskHub,
+                EventType,
+                InstanceId,
+                ExecutionId ?? string.Empty,
+                MessageId,
+                Age,
+                DequeueCount,
+                NextVisibleTime,
+                SizeInBytes,
+                PartitionId,
+                ExtensionVersion);
         }
 
-        [Event(103, Level = EventLevel.Informational)]
-        public void DeletingMessage(string Account, string TaskHub, string EventType, string MessageId, string InstanceId, string ExecutionId)
+        [Event(103, Level = EventLevel.Informational, Version = 2)]
+        public void DeletingMessage(
+            string Account,
+            string TaskHub,
+            string EventType,
+            string MessageId,
+            string InstanceId,
+            string ExecutionId,
+            string PartitionId,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(103, Account, TaskHub, EventType, MessageId, InstanceId, ExecutionId ?? string.Empty);
+            this.WriteEvent(
+                103,
+                Account,
+                TaskHub,
+                EventType,
+                MessageId,
+                InstanceId,
+                ExecutionId ?? string.Empty,
+                PartitionId,
+                ExtensionVersion);
         }
 
-        [Event(104, Level = EventLevel.Warning, Message = "Abandoning message of type {2} with ID = {3}. Orchestration ID = {4}.")]
-        public void AbandoningMessage(string Account, string TaskHub, string EventType, string MessageId, string InstanceId, string ExecutionId)
+        [Event(104, Level = EventLevel.Warning, Message = "Abandoning message of type {2} with ID = {3}. Orchestration ID = {4}.", Version = 2)]
+        public void AbandoningMessage(
+            string Account,
+            string TaskHub,
+            string EventType,
+            string MessageId,
+            string InstanceId,
+            string ExecutionId,
+            string PartitionId,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(104, Account, TaskHub, EventType, MessageId, InstanceId, ExecutionId ?? string.Empty);
+            this.WriteEvent(
+                104,
+                Account,
+                TaskHub,
+                EventType,
+                MessageId,
+                InstanceId,
+                ExecutionId ?? string.Empty,
+                PartitionId,
+                ExtensionVersion);
         }
 
         [Event(105, Level = EventLevel.Warning, Message = "An unexpected condition was detected: {0}")]
-        public void AssertFailure(string Account, string TaskHub, string Details)
+        public void AssertFailure(
+            string Account,
+            string TaskHub,
+            string Details,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(105, Account, TaskHub, Details);
+            this.WriteEvent(105, Account, TaskHub, Details, ExtensionVersion);
         }
 
-        [Event(106, Level = EventLevel.Warning)]
-        public void MessageGone(string Account, string TaskHub, string MessageId, string InstanceId, string Details)
+        [Event(106, Level = EventLevel.Warning, Version = 2)]
+        public void MessageGone(
+            string Account,
+            string TaskHub,
+            string MessageId,
+            string InstanceId,
+            string ExecutionId,
+            string PartitionId,
+            string Details,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(106, Account, TaskHub, MessageId, InstanceId, Details);
+            this.WriteEvent(106, Account, TaskHub, MessageId, InstanceId, ExecutionId ?? string.Empty, PartitionId, Details, ExtensionVersion);
         }
 
         [Event(107, Level = EventLevel.Error)]
-        public void GeneralError(string Account, string TaskHub, string Details)
+        public void GeneralError(string Account, string TaskHub, string Details, string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
             this.WriteEvent(107, Account, TaskHub, Details);
         }
 
         [Event(108, Level = EventLevel.Warning, Message = "A duplicate message was detected. This can indicate a potential performance problem. Message ID = '{2}'. DequeueCount = {3}.")]
-        public void DuplicateMessageDetected(string Account, string TaskHub, string MessageId, int DequeueCount)
+        public void DuplicateMessageDetected(
+            string Account,
+            string TaskHub,
+            string MessageId,
+            int DequeueCount,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(108, Account, TaskHub, MessageId, DequeueCount);
+            this.WriteEvent(108, Account, TaskHub, MessageId, DequeueCount, ExtensionVersion);
         }
 
         [Event(110, Level = EventLevel.Informational)]
-        public void FetchedInstanceHistory(string Account, string TaskHub, string InstanceId, string ExecutionId, int EventCount, int RequestCount, long LatencyMs, string ETag)
+        public void FetchedInstanceHistory(
+            string Account,
+            string TaskHub,
+            string InstanceId,
+            string ExecutionId,
+            int EventCount,
+            int RequestCount,
+            long LatencyMs,
+            string ETag,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(110, Account, TaskHub, InstanceId, ExecutionId ?? string.Empty, EventCount, RequestCount, LatencyMs, ETag ?? string.Empty);
+            this.WriteEvent(
+                110,
+                Account,
+                TaskHub,
+                InstanceId,
+                ExecutionId ?? string.Empty,
+                EventCount,
+                RequestCount,
+                LatencyMs,
+                ETag ?? string.Empty,
+                ExtensionVersion);
         }
 
         [Event(111, Level = EventLevel.Informational)]
-        public void AppendedInstanceHistory(string Account, string TaskHub, string InstanceId, string ExecutionId, int NewEventCount, int TotalEventCount, string NewEvents, long LatencyMs, string ETag)
+        public void AppendedInstanceHistory(
+            string Account,
+            string TaskHub,
+            string InstanceId,
+            string ExecutionId,
+            int NewEventCount,
+            int TotalEventCount,
+            string NewEvents,
+            long LatencyMs,
+            string ETag,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(111, Account, TaskHub, InstanceId, ExecutionId ?? string.Empty, NewEventCount, TotalEventCount, NewEvents, LatencyMs, ETag ?? string.Empty);
+            this.WriteEvent(
+                111,
+                Account,
+                TaskHub,
+                InstanceId,
+                ExecutionId ?? string.Empty,
+                NewEventCount,
+                TotalEventCount,
+                NewEvents,
+                LatencyMs,
+                ETag ?? string.Empty,
+                ExtensionVersion);
         }
 
         [Event(112, Level = EventLevel.Informational)]
@@ -175,7 +296,8 @@ namespace DurableTask.AzureStorage
             long PendingOrchestrators,
             long PendingOrchestratorMessages,
             long ActiveOrchestrators,
-            long ActiveActivities)
+            long ActiveActivities,
+            string ExtensionVersion)
         {
             this.WriteEvent(
                 112,
@@ -190,153 +312,463 @@ namespace DurableTask.AzureStorage
                 PendingOrchestrators,
                 PendingOrchestratorMessages,
                 ActiveOrchestrators,
-                ActiveActivities);
+                ActiveActivities,
+                ExtensionVersion);
+        }
+
+        [Event(113, Level = EventLevel.Informational)]
+        public void RenewingMessage(
+            string Account,
+            string TaskHub,
+            string InstanceId,
+            string ExecutionId,
+            string PartitionId,
+            string EventType,
+            string MessageId,
+            int VisibilityTimeoutSeconds,
+            string ExtensionVersion)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(
+                113,
+                Account,
+                TaskHub,
+                InstanceId,
+                ExecutionId ?? string.Empty,
+                PartitionId,
+                EventType,
+                MessageId,
+                VisibilityTimeoutSeconds,
+                ExtensionVersion);
+        }
+
+        [Event(114, Level = EventLevel.Error)]
+        public void MessageFailure(
+            string Account,
+            string TaskHub,
+            string InstanceId,
+            string ExecutionId,
+            string PartitionId,
+            string EventType,
+            string Details,
+            string ExtensionVersion)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(
+                114,
+                Account,
+                TaskHub,
+                InstanceId,
+                ExecutionId ?? string.Empty,
+                PartitionId,
+                EventType,
+                ExtensionVersion);
+        }
+
+        [Event(115, Level = EventLevel.Error)]
+        public void TrackingStoreUpdateFailure(
+            string Account,
+            string TaskHub,
+            string InstanceId,
+            string ExecutionId,
+            string Details,
+            string ExtensionVersion)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(
+                115,
+                Account,
+                TaskHub,
+                InstanceId,
+                ExecutionId ?? string.Empty,
+                ExtensionVersion);
         }
 
         [Event(120, Level = EventLevel.Informational)]
-        public void PartitionManagerInfo(string Account, string TaskHub, string WorkerName, string Details)
+        public void PartitionManagerInfo(
+            string Account,
+            string TaskHub,
+            string WorkerName,
+            string Details,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(120, Account, TaskHub, WorkerName ?? string.Empty, Details);
+            this.WriteEvent(120, Account, TaskHub, WorkerName ?? string.Empty, Details, ExtensionVersion);
         }
 
         [Event(121, Level = EventLevel.Warning)]
-        public void PartitionManagerWarning(string Account, string TaskHub, string WorkerName, string Details)
+        public void PartitionManagerWarning(
+            string Account,
+            string TaskHub,
+            string WorkerName,
+            string Details,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(121, Account, TaskHub, WorkerName ?? string.Empty, Details);
+            this.WriteEvent(121, Account, TaskHub, WorkerName ?? string.Empty, Details ?? string.Empty, ExtensionVersion);
         }
 
         [NonEvent]
-        public void PartitionManagerError(string account, string taskHub, string workerName, Exception exception)
+        public void PartitionManagerError(
+            string account,
+            string taskHub,
+            string workerName,
+            Exception exception,
+            string ExtensionVersion)
         {
-            this.PartitionManagerError(account, taskHub, workerName, exception.ToString());
+            this.PartitionManagerError(account, taskHub, workerName, exception.ToString(), ExtensionVersion);
         }
 
         [Event(122, Level = EventLevel.Error)]
-        public void PartitionManagerError(string Account, string TaskHub, string WorkerName, string Details)
+        public void PartitionManagerError(
+            string Account,
+            string TaskHub,
+            string WorkerName,
+            string Details,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(122, Account, TaskHub, WorkerName ?? string.Empty, Details);
+            this.WriteEvent(122, Account, TaskHub, WorkerName ?? string.Empty, Details ?? string.Empty, ExtensionVersion);
         }
 
         [Event(123, Level = EventLevel.Verbose, Message = "Host '{2}' renewing lease for PartitionId '{3}' with lease token '{4}'.")]
-        public void StartingLeaseRenewal(string Account, string TaskHub, string WorkerName, string PartitionId, string Token)
+        public void StartingLeaseRenewal(
+            string Account,
+            string TaskHub,
+            string WorkerName,
+            string PartitionId,
+            string Token,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(123, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, Token ?? string.Empty);
+            this.WriteEvent(
+                123,
+                Account,
+                TaskHub,
+                WorkerName ?? string.Empty,
+                PartitionId ?? string.Empty,
+                Token ?? string.Empty,
+                ExtensionVersion);
         }
 
         [Event(124, Level = EventLevel.Verbose)]
-        public void LeaseRenewalResult(string Account, string TaskHub, string WorkerName, string PartitionId, bool Success, string Token, string Details)
+        public void LeaseRenewalResult(
+            string Account,
+            string TaskHub,
+            string WorkerName,
+            string PartitionId,
+            bool Success,
+            string Token,
+            string Details,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(124, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, Success, Token ?? string.Empty, Details);
+            this.WriteEvent(
+                124,
+                Account,
+                TaskHub,
+                WorkerName ?? string.Empty,
+                PartitionId ?? string.Empty,
+                Success,
+                Token ?? string.Empty,
+                Details ?? string.Empty,
+                ExtensionVersion);
         }
 
         [Event(125, Level = EventLevel.Informational)]
-        public void LeaseRenewalFailed(string Account, string TaskHub, string WorkerName, string PartitionId, string Token, string Details)
+        public void LeaseRenewalFailed(
+            string Account,
+            string TaskHub,
+            string WorkerName,
+            string PartitionId,
+            string Token,
+            string Details,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(125, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, Token ?? string.Empty, Details);
+            this.WriteEvent(
+                125,
+                Account,
+                TaskHub,
+                WorkerName ?? string.Empty,
+                PartitionId ?? string.Empty,
+                Token ?? string.Empty,
+                Details ?? string.Empty,
+                ExtensionVersion);
         }
 
         [Event(126, Level = EventLevel.Informational, Message = "Host '{2}' attempting to take lease for PartitionId '{3}'.")]
-        public void LeaseAcquisitionStarted(string Account, string TaskHub, string WorkerName, string PartitionId)
+        public void LeaseAcquisitionStarted(
+            string Account,
+            string TaskHub,
+            string WorkerName,
+            string PartitionId,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(126, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty);
+            this.WriteEvent(126, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, ExtensionVersion);
         }
 
         [Event(127, Level = EventLevel.Informational, Message = "Host '{2}' successfully acquired lease for PartitionId '{3}'.")]
-        public void LeaseAcquisitionSucceeded(string Account, string TaskHub, string WorkerName, string PartitionId)
+        public void LeaseAcquisitionSucceeded(
+            string Account,
+            string TaskHub,
+            string WorkerName,
+            string PartitionId,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(127, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty);
+            this.WriteEvent(127, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, ExtensionVersion);
         }
 
         [Event(128, Level = EventLevel.Informational, Message = "Host '{2}' failed to acquire lease for PartitionId '{3}' due to conflict.")]
-        public void LeaseAcquisitionFailed(string Account, string TaskHub, string WorkerName, string PartitionId)
+        public void LeaseAcquisitionFailed(
+            string Account,
+            string TaskHub,
+            string WorkerName,
+            string PartitionId,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(128, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty);
+            this.WriteEvent(128, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, ExtensionVersion);
         }
 
         [Event(129, Level = EventLevel.Informational, Message = "Host '{2} is attempting to steal a lease from '{3}' for PartitionId '{4}'.")]
-        public void AttemptingToStealLease(string Account, string TaskHub, string WorkerName, string FromWorkerName, string PartitionId)
+        public void AttemptingToStealLease(
+            string Account,
+            string TaskHub,
+            string WorkerName,
+            string FromWorkerName,
+            string PartitionId,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(129, Account, TaskHub, WorkerName ?? string.Empty, FromWorkerName ?? string.Empty, PartitionId ?? string.Empty);
+            this.WriteEvent(
+                129,
+                Account,
+                TaskHub,
+                WorkerName ?? string.Empty,
+                FromWorkerName ?? string.Empty,
+                PartitionId ?? string.Empty,
+                ExtensionVersion);
         }
 
         [Event(130, Level = EventLevel.Informational, Message = "Host '{2}' stole lease from '{3}' for PartitionId '{4}'.")]
-        public void LeaseStealingSucceeded(string Account, string TaskHub, string WorkerName, string FromWorkerName, string PartitionId)
+        public void LeaseStealingSucceeded(
+            string Account,
+            string TaskHub,
+            string WorkerName,
+            string FromWorkerName,
+            string PartitionId,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(130, Account, TaskHub, WorkerName ?? string.Empty, FromWorkerName ?? string.Empty, PartitionId ?? string.Empty);
+            this.WriteEvent(
+                130,
+                Account,
+                TaskHub,
+                WorkerName ?? string.Empty,
+                FromWorkerName ?? string.Empty,
+                PartitionId ?? string.Empty,
+                ExtensionVersion);
         }
 
         [Event(131, Level = EventLevel.Informational, Message = "Host '{2}' failed to steal lease for PartitionId '{3}' due to conflict.")]
-        public void LeaseStealingFailed(string Account, string TaskHub, string WorkerName, string PartitionId)
+        public void LeaseStealingFailed(
+            string Account,
+            string TaskHub,
+            string WorkerName,
+            string PartitionId,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(131, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty);
+            this.WriteEvent(131, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, ExtensionVersion);
         }
 
         [Event(132, Level = EventLevel.Informational, Message = "Host '{2}' successfully removed PartitionId '{3}' with lease token '{4}' from currently owned partitions.")]
-        public void PartitionRemoved(string Account, string TaskHub, string WorkerName, string PartitionId, string Token)
+        public void PartitionRemoved(
+            string Account,
+            string TaskHub,
+            string WorkerName,
+            string PartitionId,
+            string Token,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(132, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, Token ?? string.Empty);
+            this.WriteEvent(
+                132,
+                Account,
+                TaskHub,
+                WorkerName ?? string.Empty,
+                PartitionId ?? string.Empty,
+                Token ?? string.Empty,
+                ExtensionVersion);
         }
 
         [Event(133, Level = EventLevel.Informational, Message = "Host '{2}' successfully released lease on PartitionId '{3}' with lease token '{4}'")]
-        public void LeaseRemoved(string Account, string TaskHub, string WorkerName, string PartitionId, string Token)
+        public void LeaseRemoved(
+            string Account,
+            string TaskHub,
+            string WorkerName,
+            string PartitionId,
+            string Token,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(133, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, Token ?? string.Empty);
+            this.WriteEvent(
+                133,
+                Account,
+                TaskHub,
+                WorkerName ?? string.Empty,
+                PartitionId ?? string.Empty,
+                Token ?? string.Empty,
+                ExtensionVersion);
         }
 
         [Event(134, Level = EventLevel.Warning, Message = "Host '{2}' failed to release lease for PartitionId '{3}' with lease token '{4}' due to conflict.")]
-        public void LeaseRemovalFailed(string Account, string TaskHub, string WorkerName, string PartitionId, string Token)
+        public void LeaseRemovalFailed(
+            string Account,
+            string TaskHub,
+            string WorkerName,
+            string PartitionId,
+            string Token,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(134, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, Token ?? string.Empty);
+            this.WriteEvent(
+                134,
+                Account,
+                TaskHub,
+                WorkerName ?? string.Empty,
+                PartitionId ?? string.Empty,
+                Token ?? string.Empty,
+                ExtensionVersion);
         }
 
         [Event(135, Level = EventLevel.Informational)]
-        public void InstanceStatusUpdate(string Account, string TaskHub, string InstanceId, string ExecutionId, string EventType, long LatencyMs)
+        public void InstanceStatusUpdate(
+            string Account,
+            string TaskHub,
+            string InstanceId,
+            string ExecutionId,
+            string EventType,
+            long LatencyMs,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(135, Account, TaskHub, InstanceId, ExecutionId ?? string.Empty, EventType, LatencyMs);
+            this.WriteEvent(135, Account, TaskHub, InstanceId, ExecutionId ?? string.Empty, EventType, LatencyMs, ExtensionVersion);
         }
 
         [Event(136, Level = EventLevel.Informational)]
-        public void FetchedInstanceStatus(string Account, string TaskHub, string InstanceId, string ExecutionId, long LatencyMs)
+        public void FetchedInstanceStatus(
+            string Account,
+            string TaskHub,
+            string InstanceId,
+            string ExecutionId,
+            long LatencyMs,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(136, Account, TaskHub, InstanceId, ExecutionId ?? string.Empty, LatencyMs);
+            this.WriteEvent(136, Account, TaskHub, InstanceId, ExecutionId ?? string.Empty, LatencyMs, ExtensionVersion);
         }
 
         [Event(137, Level = EventLevel.Warning)]
-        public void GeneralWarning(string Account, string TaskHub, string Details)
+        public void GeneralWarning(string Account, string TaskHub, string Details, string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(137, Account, TaskHub, Details);
+            this.WriteEvent(137, Account, TaskHub, Details, ExtensionVersion);
         }
 
         [Event(138, Level = EventLevel.Warning)]
-        public void SplitBrainDetected(string Account, string TaskHub, string InstanceId, string ExecutionId, int NewEventCount, int TotalEventCount, string NewEvents, long LatencyMs, string ETag)
+        public void SplitBrainDetected(
+            string Account,
+            string TaskHub,
+            string InstanceId,
+            string ExecutionId,
+            int NewEventCount,
+            int TotalEventCount,
+            string NewEvents,
+            long LatencyMs,
+            string ETag,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(138, Account, TaskHub, InstanceId, ExecutionId ?? string.Empty, NewEventCount, TotalEventCount, NewEvents, LatencyMs, ETag ?? string.Empty);
+            this.WriteEvent(
+                138,
+                Account,
+                TaskHub,
+                InstanceId,
+                ExecutionId ?? string.Empty,
+                NewEventCount,
+                TotalEventCount,
+                NewEvents,
+                LatencyMs,
+                ETag ?? string.Empty,
+                ExtensionVersion);
         }
 
         [Event(139, Level = EventLevel.Warning)]
-        public void DiscardingWorkItem(string Account, string TaskHub, string InstanceId, string ExecutionId, int NewEventCount, int TotalEventCount, string NewEvents, string Details)
+        public void DiscardingWorkItem(
+            string Account,
+            string TaskHub,
+            string InstanceId,
+            string ExecutionId,
+            int NewEventCount,
+            int TotalEventCount,
+            string NewEvents,
+            string Details,
+            string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(139, Account, TaskHub, InstanceId, ExecutionId ?? string.Empty, NewEventCount, TotalEventCount, NewEvents, Details);
+            this.WriteEvent(
+                139,
+                Account,
+                TaskHub,
+                InstanceId,
+                ExecutionId ?? string.Empty,
+                NewEventCount,
+                TotalEventCount,
+                NewEvents,
+                Details,
+                ExtensionVersion);
+        }
+
+        [Event(140, Level = EventLevel.Informational, Task = Tasks.Processing, Opcode = EventOpcode.Receive)]
+        public void ProcessingMessage(
+            Guid relatedActivityId,
+            string Account,
+            string TaskHub,
+            string EventType,
+            string InstanceId,
+            string ExecutionId,
+            string MessageId,
+            int Age,
+            bool IsExtendedSession,
+            string ExtensionVersion)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEventWithRelatedActivityId(
+                140,
+                relatedActivityId,
+                Account,
+                TaskHub,
+                EventType,
+                InstanceId,
+                ExecutionId ?? string.Empty,
+                MessageId,
+                Age,
+                IsExtendedSession,
+                ExtensionVersion);
+        }
+
+        // Specifying tasks is necessary when using WriteEventWithRelatedActivityId
+        // or else the "TaskName" property written to ETW is the name of the opcode instead
+        // of the name of the trace method.
+        static class Tasks
+        {
+            public const EventTask Enqueue = (EventTask)0x01;
+            public const EventTask Dequeue = (EventTask)0x02;
+            public const EventTask Processing = (EventTask)0x03;
         }
     }
 }

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -5,6 +5,8 @@
     <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>1.2.3</Version>
+    <AssemblyVersion>$(Version)</AssemblyVersion>
+    <FileVersion>$(Version)</FileVersion>
     <IncludeSymbols>true</IncludeSymbols>
     <Description>Azure Storage provider extension for the Durable Task Framework.</Description>
     <Authors>cgillum</Authors>

--- a/src/DurableTask.AzureStorage/Messaging/ActivitySession.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ActivitySession.cs
@@ -20,8 +20,9 @@ namespace DurableTask.AzureStorage.Messaging
         public ActivitySession(
             string storageAccountName,
             string taskHubName,
-            MessageData message)
-            : base(storageAccountName, taskHubName, message.TaskMessage.OrchestrationInstance)
+            MessageData message,
+            Guid traceActivityId)
+            : base(storageAccountName, taskHubName, message.TaskMessage.OrchestrationInstance, traceActivityId)
         {
             this.MessageData = message ?? throw new ArgumentNullException(nameof(message));
         }

--- a/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
+++ b/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
@@ -31,8 +31,9 @@ namespace DurableTask.AzureStorage.Messaging
             OrchestrationInstance orchestrationInstance,
             IReadOnlyList<MessageData> initialMessageBatch,
             Func<OrchestrationInstance, List<MessageData>> fetchMessagesCallback,
-            TimeSpan idleTimeout)
-            : base(storageAccountName, taskHubName, orchestrationInstance)
+            TimeSpan idleTimeout,
+            Guid traceActivityId)
+            : base(storageAccountName, taskHubName, orchestrationInstance, traceActivityId)
         {
             this.idleTimeout = idleTimeout;
             this.CurrentMessageBatch = initialMessageBatch;
@@ -65,7 +66,7 @@ namespace DurableTask.AzureStorage.Messaging
             var messages = new List<TaskMessage>(this.CurrentMessageBatch.Count);
             foreach (MessageData msg in this.CurrentMessageBatch)
             {
-                this.TraceMessageReceived(msg, isExtendedSession: true);
+                this.TraceProcessingMessage(msg, isExtendedSession: true);
                 messages.Add(msg.TaskMessage);
             }
 

--- a/src/DurableTask.AzureStorage/Monitoring/DisconnectedPerformanceMonitor.cs
+++ b/src/DurableTask.AzureStorage/Monitoring/DisconnectedPerformanceMonitor.cs
@@ -122,7 +122,8 @@ namespace DurableTask.AzureStorage.Monitoring
                 AnalyticsEventSource.Log.GeneralWarning(
                     this.storageAccount.Credentials.AccountName,
                     this.taskHub,
-                    $"Task hub has not been provisioned: {e.RequestInformation.ExtendedErrorInformation?.ErrorMessage}");
+                    $"Task hub has not been provisioned: {e.RequestInformation.ExtendedErrorInformation?.ErrorMessage}",
+                    Utils.ExtensionVersion);
                 return false;
             }
 

--- a/src/DurableTask.AzureStorage/Partitioning/BlobLeaseManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/BlobLeaseManager.cs
@@ -147,7 +147,8 @@ namespace DurableTask.AzureStorage.Partitioning
                         this.leaseContainerName,
                         this.consumerGroupName,
                         paritionId,
-                        this.blobPrefix ?? string.Empty));
+                        this.blobPrefix ?? string.Empty),
+                    Utils.ExtensionVersion);
 
                 await leaseBlob.UploadTextAsync(serializedLease, null, AccessCondition.GenerateIfNoneMatchCondition("*"), null, null);
             }
@@ -166,7 +167,8 @@ namespace DurableTask.AzureStorage.Partitioning
                         this.consumerGroupName,
                         paritionId,
                         this.blobPrefix ?? string.Empty,
-                        se.Message));
+                        se.Message),
+                    Utils.ExtensionVersion);
             }
             finally
             {

--- a/src/DurableTask.AzureStorage/Partitioning/PartitionManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/PartitionManager.cs
@@ -69,7 +69,12 @@ namespace DurableTask.AzureStorage.Partitioning
             var addLeaseTasks = new List<Task>();
             foreach (T lease in leases)
             {
-                AnalyticsEventSource.Log.PartitionManagerInfo(this.accountName, this.taskHub, this.workerName, $"Acquired lease for PartitionId '{lease.PartitionId}' on startup.");
+                AnalyticsEventSource.Log.PartitionManagerInfo(
+                    this.accountName,
+                    this.taskHub,
+                    this.workerName,
+                    $"Acquired lease for PartitionId '{lease.PartitionId}' on startup.",
+                    Utils.ExtensionVersion);
                 addLeaseTasks.Add(this.AddLeaseAsync(lease));
             }
 
@@ -135,7 +140,12 @@ namespace DurableTask.AzureStorage.Partitioning
 
         async Task LeaseRenewer()
         {
-            AnalyticsEventSource.Log.PartitionManagerInfo(this.accountName, this.taskHub, this.workerName, $"Starting background renewal of leases with interval: {this.options.RenewInterval}.");
+            AnalyticsEventSource.Log.PartitionManagerInfo(
+                this.accountName,
+                this.taskHub,
+                this.workerName,
+                $"Starting background renewal of leases with interval: {this.options.RenewInterval}.",
+                Utils.ExtensionVersion);
 
             while (this.isStarted == 1 || !shutdownComplete)
             {
@@ -188,22 +198,37 @@ namespace DurableTask.AzureStorage.Partitioning
                 }
                 catch (OperationCanceledException)
                 {
-                    AnalyticsEventSource.Log.PartitionManagerInfo(this.accountName, this.taskHub, this.workerName, $"Background renewal task was canceled.");
+                    AnalyticsEventSource.Log.PartitionManagerInfo(
+                        this.accountName,
+                        this.taskHub,
+                        this.workerName,
+                        "Background renewal task was canceled.",
+                        Utils.ExtensionVersion);
                 }
                 catch (Exception ex)
                 {
-                    AnalyticsEventSource.Log.PartitionManagerError(this.accountName, this.taskHub, this.workerName, ex);
+                    AnalyticsEventSource.Log.PartitionManagerError(this.accountName, this.taskHub, this.workerName, ex, Utils.ExtensionVersion);
                 }
             }
 
             this.currentlyOwnedShards.Clear();
             this.keepRenewingDuringClose.Clear();
-            AnalyticsEventSource.Log.PartitionManagerInfo(this.accountName, this.taskHub, this.workerName, "Background renewer task completed.");
+            AnalyticsEventSource.Log.PartitionManagerInfo(
+                this.accountName,
+                this.taskHub,
+                this.workerName,
+                "Background renewer task completed.",
+                Utils.ExtensionVersion);
         }
 
         async Task LeaseTakerAsync()
         {
-            AnalyticsEventSource.Log.PartitionManagerInfo(this.accountName, this.taskHub, this.workerName, $"Starting to check for available leases with interval: {this.options.AcquireInterval}.");
+            AnalyticsEventSource.Log.PartitionManagerInfo(
+                this.accountName,
+                this.taskHub,
+                this.workerName,
+                $"Starting to check for available leases with interval: {this.options.AcquireInterval}.",
+                Utils.ExtensionVersion);
 
             while (this.isStarted == 1)
             {
@@ -221,7 +246,7 @@ namespace DurableTask.AzureStorage.Partitioning
                 }
                 catch (Exception ex)
                 {
-                    AnalyticsEventSource.Log.PartitionManagerError(this.accountName, this.taskHub, this.workerName, ex);
+                    AnalyticsEventSource.Log.PartitionManagerError(this.accountName, this.taskHub, this.workerName, ex, Utils.ExtensionVersion);
                 }
 
                 try
@@ -230,11 +255,21 @@ namespace DurableTask.AzureStorage.Partitioning
                 }
                 catch (OperationCanceledException)
                 {
-                    AnalyticsEventSource.Log.PartitionManagerInfo(this.accountName, this.taskHub, this.workerName, $"Background AcquireLease task was canceled.");
+                    AnalyticsEventSource.Log.PartitionManagerInfo(
+                        this.accountName,
+                        this.taskHub,
+                        this.workerName,
+                        "Background AcquireLease task was canceled.",
+                        Utils.ExtensionVersion);
                 }
             }
 
-            AnalyticsEventSource.Log.PartitionManagerInfo(this.accountName, this.taskHub, this.workerName, "Background AcquireLease task completed.");
+            AnalyticsEventSource.Log.PartitionManagerInfo(
+                this.accountName,
+                this.taskHub,
+                this.workerName,
+                "Background AcquireLease task completed.",
+                Utils.ExtensionVersion);
         }
 
         async Task<IDictionary<string, T>> TakeLeasesAsync()
@@ -294,11 +329,23 @@ namespace DurableTask.AzureStorage.Partitioning
                         {
                             if (moreShardsNeeded == 0) break;
 
-                            AnalyticsEventSource.Log.LeaseAcquisitionStarted(this.accountName, this.taskHub, this.workerName, leaseToTake.PartitionId);
+                            AnalyticsEventSource.Log.LeaseAcquisitionStarted(
+                                this.accountName,
+                                this.taskHub,
+                                this.workerName,
+                                leaseToTake.PartitionId,
+                                Utils.ExtensionVersion);
+
                             bool leaseAcquired = await this.AcquireLeaseAsync(leaseToTake);
                             if (leaseAcquired)
                             {
-                                AnalyticsEventSource.Log.LeaseAcquisitionSucceeded(this.accountName, this.taskHub, this.workerName, leaseToTake.PartitionId);
+                                AnalyticsEventSource.Log.LeaseAcquisitionSucceeded(
+                                    this.accountName,
+                                    this.taskHub,
+                                    this.workerName,
+                                    leaseToTake.PartitionId,
+                                    Utils.ExtensionVersion);
+
                                 takenLeases.Add(leaseToTake.PartitionId, leaseToTake);
 
                                 moreShardsNeeded--;
@@ -323,11 +370,25 @@ namespace DurableTask.AzureStorage.Partitioning
                                 if (string.Equals(kvp.Value.Owner, workerToStealFrom.Key, StringComparison.OrdinalIgnoreCase))
                                 {
                                     T leaseToTake = kvp.Value;
-                                    AnalyticsEventSource.Log.AttemptingToStealLease(this.accountName, this.taskHub, this.workerName, workerToStealFrom.Key, leaseToTake.PartitionId);
+                                    AnalyticsEventSource.Log.AttemptingToStealLease(
+                                        this.accountName,
+                                        this.taskHub,
+                                        this.workerName,
+                                        workerToStealFrom.Key,
+                                        leaseToTake.PartitionId,
+                                        Utils.ExtensionVersion);
+
                                     bool leaseStolen = await this.StealLeaseAsync(leaseToTake);
                                     if (leaseStolen)
                                     {
-                                        AnalyticsEventSource.Log.LeaseStealingSucceeded(this.accountName, this.taskHub, this.workerName, workerToStealFrom.Key, leaseToTake.PartitionId);
+                                        AnalyticsEventSource.Log.LeaseStealingSucceeded(
+                                            this.accountName,
+                                            this.taskHub,
+                                            this.workerName,
+                                            workerToStealFrom.Key,
+                                            leaseToTake.PartitionId,
+                                            Utils.ExtensionVersion);
+
                                         takenLeases.Add(leaseToTake.PartitionId, leaseToTake);
 
                                         moreShardsNeeded--;
@@ -362,7 +423,14 @@ namespace DurableTask.AzureStorage.Partitioning
 
             try
             {
-                AnalyticsEventSource.Log.StartingLeaseRenewal(this.accountName, this.taskHub, this.workerName, lease.PartitionId, lease.Token);
+                AnalyticsEventSource.Log.StartingLeaseRenewal(
+                    this.accountName,
+                    this.taskHub,
+                    this.workerName,
+                    lease.PartitionId,
+                    lease.Token,
+                    Utils.ExtensionVersion);
+
                 renewed = await this.leaseManager.RenewAsync(lease);
             }
             catch (Exception ex)
@@ -382,10 +450,26 @@ namespace DurableTask.AzureStorage.Partitioning
                 }
             }
 
-            AnalyticsEventSource.Log.LeaseRenewalResult(this.accountName, this.taskHub, this.workerName, lease.PartitionId, renewed, lease.Token, errorMessage);
+            AnalyticsEventSource.Log.LeaseRenewalResult(
+                this.accountName,
+                this.taskHub,
+                this.workerName,
+                lease.PartitionId,
+                renewed,
+                lease.Token,
+                errorMessage,
+                Utils.ExtensionVersion);
+
             if (!renewed)
             {
-                AnalyticsEventSource.Log.LeaseRenewalFailed(this.accountName, this.taskHub, this.workerName, lease.PartitionId, lease.Token, errorMessage);
+                AnalyticsEventSource.Log.LeaseRenewalFailed(
+                    this.accountName,
+                    this.taskHub,
+                    this.workerName,
+                    lease.PartitionId,
+                    lease.Token,
+                    errorMessage,
+                    Utils.ExtensionVersion);
             }
 
             return renewed;
@@ -400,12 +484,22 @@ namespace DurableTask.AzureStorage.Partitioning
             }
             catch (LeaseLostException)
             {
-                AnalyticsEventSource.Log.LeaseAcquisitionFailed(this.accountName, this.taskHub, this.workerName, lease.PartitionId);
+                AnalyticsEventSource.Log.LeaseAcquisitionFailed(
+                    this.accountName,
+                    this.taskHub,
+                    this.workerName,
+                    lease.PartitionId,
+                    Utils.ExtensionVersion);
             }
             catch (Exception ex)
             {
                 // Eat any exceptions during acquiring lease.
-                AnalyticsEventSource.Log.PartitionManagerError(this.accountName, this.taskHub, this.workerName, ex);
+                AnalyticsEventSource.Log.PartitionManagerError(
+                    this.accountName,
+                    this.taskHub,
+                    this.workerName,
+                    ex,
+                    Utils.ExtensionVersion);
             }
 
             return acquired;
@@ -421,12 +515,12 @@ namespace DurableTask.AzureStorage.Partitioning
             catch (LeaseLostException)
             {
                 // Concurrency issue in stealing the lease, someone else got it before us
-                AnalyticsEventSource.Log.LeaseStealingFailed(this.accountName, this.taskHub, this.workerName, lease.PartitionId);
+                AnalyticsEventSource.Log.LeaseStealingFailed(this.accountName, this.taskHub, this.workerName, lease.PartitionId, Utils.ExtensionVersion);
             }
             catch (Exception ex)
             {
                 // Eat any exceptions during stealing
-                AnalyticsEventSource.Log.PartitionManagerError(this.accountName, this.taskHub, this.workerName, ex);
+                AnalyticsEventSource.Log.PartitionManagerError(this.accountName, this.taskHub, this.workerName, ex, Utils.ExtensionVersion);
             }
 
             return stolen;
@@ -446,7 +540,7 @@ namespace DurableTask.AzureStorage.Partitioning
                     failedToInitialize = true;
 
                     // Eat any exceptions during notification of observers
-                    AnalyticsEventSource.Log.PartitionManagerError(this.accountName, this.taskHub, this.workerName, ex);
+                    AnalyticsEventSource.Log.PartitionManagerError(this.accountName, this.taskHub, this.workerName, ex, Utils.ExtensionVersion);
                 }
 
                 // We need to release the lease if we fail to initialize the processor, so some other node can pick up the parition
@@ -462,19 +556,41 @@ namespace DurableTask.AzureStorage.Partitioning
                 // pick it up.
                 try
                 {
-                    AnalyticsEventSource.Log.PartitionManagerWarning(this.accountName, this.taskHub, this.workerName, $"Unable to add PartitionId '{lease.PartitionId}' with lease token '{lease.Token}' to currently owned partitions.");
+                    AnalyticsEventSource.Log.PartitionManagerWarning(
+                        this.accountName,
+                        this.taskHub,
+                        this.workerName,
+                        $"Unable to add PartitionId '{lease.PartitionId}' with lease token '{lease.Token}' to currently owned partitions.",
+                        Utils.ExtensionVersion);
 
                     await this.leaseManager.ReleaseAsync(lease);
-                    AnalyticsEventSource.Log.LeaseRemoved(this.accountName, this.taskHub, this.workerName, lease.PartitionId, lease.Token);
+                    AnalyticsEventSource.Log.LeaseRemoved(
+                        this.accountName,
+                        this.taskHub,
+                        this.workerName,
+                        lease.PartitionId,
+                        lease.Token,
+                        Utils.ExtensionVersion);
                 }
                 catch (LeaseLostException)
                 {
                     // We have already shutdown the processor so we can ignore any LeaseLost at this point
-                    AnalyticsEventSource.Log.LeaseRemovalFailed(this.accountName, this.taskHub, this.workerName, lease.PartitionId, lease.Token);
+                    AnalyticsEventSource.Log.LeaseRemovalFailed(
+                        this.accountName,
+                        this.taskHub,
+                        this.workerName,
+                        lease.PartitionId,
+                        lease.Token,
+                        Utils.ExtensionVersion);
                 }
                 catch (Exception ex)
                 {
-                    AnalyticsEventSource.Log.PartitionManagerError(this.accountName, this.taskHub, this.workerName, ex);
+                    AnalyticsEventSource.Log.PartitionManagerError(
+                        this.accountName,
+                        this.taskHub,
+                        this.workerName,
+                        ex,
+                        Utils.ExtensionVersion);
                 }
             }
         }
@@ -485,7 +601,13 @@ namespace DurableTask.AzureStorage.Partitioning
 
             if (lease != null && this.currentlyOwnedShards != null && this.currentlyOwnedShards.TryRemove(lease.PartitionId, out lease))
             {
-                AnalyticsEventSource.Log.PartitionRemoved(this.accountName, this.taskHub, this.workerName, lease.PartitionId, lease.Token);
+                AnalyticsEventSource.Log.PartitionRemoved(
+                    this.accountName,
+                    this.taskHub,
+                    this.workerName,
+                    lease.PartitionId,
+                    lease.Token,
+                    Utils.ExtensionVersion);
 
                 try
                 {
@@ -500,7 +622,7 @@ namespace DurableTask.AzureStorage.Partitioning
                 catch (Exception ex)
                 {
                     // Eat any exceptions during notification of observers
-                    AnalyticsEventSource.Log.PartitionManagerError(this.accountName, this.taskHub, this.workerName, ex);
+                    AnalyticsEventSource.Log.PartitionManagerError(this.accountName, this.taskHub, this.workerName, ex, Utils.ExtensionVersion);
                 }
                 finally
                 {
@@ -515,16 +637,28 @@ namespace DurableTask.AzureStorage.Partitioning
                     try
                     {
                         await this.leaseManager.ReleaseAsync(lease);
-                        AnalyticsEventSource.Log.LeaseRemoved(this.accountName, this.taskHub, this.workerName, lease.PartitionId, lease.Token);
+                        AnalyticsEventSource.Log.LeaseRemoved(
+                            this.accountName,
+                            this.taskHub,
+                            this.workerName,
+                            lease.PartitionId,
+                            lease.Token,
+                            Utils.ExtensionVersion);
                     }
                     catch (LeaseLostException)
                     {
                         // We have already shutdown the processor so we can ignore any LeaseLost at this point
-                        AnalyticsEventSource.Log.LeaseRemovalFailed(this.accountName, this.taskHub, this.workerName, lease.PartitionId, lease.Token);
+                        AnalyticsEventSource.Log.LeaseRemovalFailed(
+                            this.accountName,
+                            this.taskHub,
+                            this.workerName,
+                            lease.PartitionId,
+                            lease.Token,
+                            Utils.ExtensionVersion);
                     }
                     catch (Exception ex)
                     {
-                        AnalyticsEventSource.Log.PartitionManagerError(this.accountName, this.taskHub, this.workerName, ex);
+                        AnalyticsEventSource.Log.PartitionManagerError(this.accountName, this.taskHub, this.workerName, ex, Utils.ExtensionVersion);
                     }
                 }
             }
@@ -556,7 +690,12 @@ namespace DurableTask.AzureStorage.Partitioning
                         catch (Exception ex)
                         {
                             // Eat any exceptions during notification of observers
-                            AnalyticsEventSource.Log.PartitionManagerError(partitionManager.accountName, partitionManager.taskHub, partitionManager.workerName, ex);
+                            AnalyticsEventSource.Log.PartitionManagerError(
+                                partitionManager.accountName,
+                                partitionManager.taskHub,
+                                partitionManager.workerName,
+                                ex,
+                                Utils.ExtensionVersion);
                         }
                     }
                 }

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -240,7 +240,8 @@ namespace DurableTask.AzureStorage.Tracking
                 historyEvents.Count,
                 requestCount,
                 stopwatch.ElapsedMilliseconds,
-                this.GetETagValue(instanceId));
+                this.GetETagValue(instanceId),
+                Utils.ExtensionVersion);
 
             return historyEvents;
         }
@@ -270,7 +271,8 @@ namespace DurableTask.AzureStorage.Tracking
                 this.taskHubName,
                 instanceId,
                 executionId ?? string.Empty,
-                stopwatch.ElapsedMilliseconds);
+                stopwatch.ElapsedMilliseconds,
+                Utils.ExtensionVersion);
 
             OrchestrationInstanceStatus orchestrationInstanceStatus = (OrchestrationInstanceStatus)orchestration.Result;
             if (orchestrationInstanceStatus == null)
@@ -375,7 +377,8 @@ namespace DurableTask.AzureStorage.Tracking
                 executionStartedEvent.OrchestrationInstance.InstanceId,
                 executionStartedEvent.OrchestrationInstance.ExecutionId,
                 executionStartedEvent.EventType.ToString(),
-                stopwatch.ElapsedMilliseconds);
+                stopwatch.ElapsedMilliseconds,
+                Utils.ExtensionVersion);
         }
 
         /// <inheritdoc />
@@ -499,7 +502,8 @@ namespace DurableTask.AzureStorage.Tracking
                 instanceId,
                 executionId,
                 orchestratorEventType?.ToString() ?? string.Empty,
-                orchestrationInstanceUpdateStopwatch.ElapsedMilliseconds);
+                orchestrationInstanceUpdateStopwatch.ElapsedMilliseconds,
+                Utils.ExtensionVersion);
         }
 
         Type GetTypeForTableEntity(DynamicTableEntity tableEntity)
@@ -679,7 +683,8 @@ namespace DurableTask.AzureStorage.Tracking
                         numberOfTotalEvents,
                         historyEventNamesBuffer.ToString(0, historyEventNamesBuffer.Length - 1), // remove trailing comma
                         stopwatch.ElapsedMilliseconds,
-                        eTagValue);
+                        eTagValue,
+                        Utils.ExtensionVersion);
                 }
 
                 throw;
@@ -709,7 +714,8 @@ namespace DurableTask.AzureStorage.Tracking
                 numberOfTotalEvents,
                 historyEventNamesBuffer.ToString(0, historyEventNamesBuffer.Length - 1), // remove trailing comma
                 stopwatch.ElapsedMilliseconds,
-                this.GetETagValue(instanceId));
+                this.GetETagValue(instanceId),
+                Utils.ExtensionVersion);
 
             return eTagValue;
         }

--- a/src/DurableTask.AzureStorage/Utils.cs
+++ b/src/DurableTask.AzureStorage/Utils.cs
@@ -15,11 +15,14 @@ namespace DurableTask.AzureStorage
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Threading.Tasks;
 
     static class Utils
     {
         public static readonly Task CompletedTask = Task.FromResult(0);
+
+        public static readonly string ExtensionVersion = FileVersionInfo.GetVersionInfo(typeof(AzureStorageOrchestrationService).Assembly.Location).FileVersion;
 
         public static async Task ParallelForEachAsync<TSource>(
             this IEnumerable<TSource> enumerable,


### PR DESCRIPTION
This addresses much of https://github.com/Azure/azure-functions-durable-extension/issues/326.

Summary of changes:
* The version of the DurableTask.AzureStorage nuget package is traced everywhere.
* Added several new traces to capture errors. Previously we didn't trace unhandled exceptions when calling storage, and this made diagnosing issues very painful. The exceptions do get traced to the DurableTask.Core provider, but those traces are very difficult to correlate back to specific customer incidents.
* Refactored message processing trace into two events (was previously just one) so we can see both when a message was dequeued and when it was scheduled for processing. In production we've seen a case where messages appear to be sent but never received, and this update will help us identify what's happening
* Added a trace for when a message has its visibility updated
* Added "target instance" information to the `SendMessage` trace to make it easier to correlate sub-orchestrations back to their parents
* Other misc. improvements, including code formatting

FYI @tohling and @kashimiz to help review