### PR TITLE
DurableTask.AzureStorage: Alternate fix for the 4 MB max entity size which covers more scenarios.

### DIFF
--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -255,7 +255,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(111, Level = EventLevel.Informational)]
+        [Event(111, Level = EventLevel.Informational, Version = 2)]
         public void AppendedInstanceHistory(
             string Account,
             string TaskHub,
@@ -265,6 +265,7 @@ namespace DurableTask.AzureStorage
             int TotalEventCount,
             string NewEvents,
             long LatencyMs,
+            int SizeInBytes,
             string ETag,
             string ExtensionVersion)
         {
@@ -279,6 +280,7 @@ namespace DurableTask.AzureStorage
                 TotalEventCount,
                 NewEvents,
                 LatencyMs,
+                SizeInBytes,
                 ETag ?? string.Empty,
                 ExtensionVersion);
         }

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -35,6 +35,7 @@ namespace DurableTask.AzureStorage.Tracking
     /// </summary>
     class AzureTableTrackingStore : TrackingStoreBase
     {
+        const string NameProperty = "Name";
         const string InputProperty = "Input";
         const string ResultProperty = "Result";
         const string OutputProperty = "Output";
@@ -42,6 +43,14 @@ namespace DurableTask.AzureStorage.Tracking
         const string SentinelRowKey = "sentinel";
         const int MaxStorageQueuePayloadSizeInBytes = 60 * 1024; // 60KB
         const int GuidByteSize = 72;
+
+        static readonly string[] VariableSizeEntityProperties = new[]
+        {
+            NameProperty,
+            InputProperty,
+            ResultProperty,
+            OutputProperty,
+        };
 
         readonly string storageAccountName;
         readonly string taskHubName;
@@ -432,6 +441,9 @@ namespace DurableTask.AzureStorage.Tracking
                 // Replacement can happen if the orchestration episode gets replayed due to a commit failure in one of the steps below.
                 historyEventBatch.InsertOrReplace(entity);
 
+                // Keep track of the byte count to ensure we don't hit the 4 MB per-batch maximum
+                estimatedBytes += GetEstimatedByteCount(entity);
+
                 // Monitor for orchestration instance events 
                 switch (historyEvent.EventType)
                 {
@@ -443,28 +455,24 @@ namespace DurableTask.AzureStorage.Tracking
                         orchestrationInstanceUpdate.Properties["CreatedTime"] = new EntityProperty(executionStartedEvent.Timestamp);
                         orchestrationInstanceUpdate.Properties["RuntimeStatus"] = new EntityProperty(OrchestrationStatus.Running.ToString());
                         this.SetTablePropertyForMessage(entity, orchestrationInstanceUpdate, InputProperty, InputProperty, executionStartedEvent.Input);
-                        this.UpdateEstimatedBytes(ref estimatedBytes, executionStartedEvent.Input);
                         break;
                     case EventType.ExecutionCompleted:
                         orchestratorEventType = historyEvent.EventType;
                         ExecutionCompletedEvent executionCompleted = (ExecutionCompletedEvent)historyEvent;
                         this.SetTablePropertyForMessage(entity, orchestrationInstanceUpdate, ResultProperty, OutputProperty, executionCompleted.Result);
                         orchestrationInstanceUpdate.Properties["RuntimeStatus"] = new EntityProperty(executionCompleted.OrchestrationStatus.ToString());
-                        this.UpdateEstimatedBytes(ref estimatedBytes, executionCompleted.Result);
                         break;
                     case EventType.ExecutionTerminated:
                         orchestratorEventType = historyEvent.EventType;
                         ExecutionTerminatedEvent executionTerminatedEvent = (ExecutionTerminatedEvent)historyEvent;
                         this.SetTablePropertyForMessage(entity, orchestrationInstanceUpdate, InputProperty, OutputProperty, executionTerminatedEvent.Input);
                         orchestrationInstanceUpdate.Properties["RuntimeStatus"] = new EntityProperty(OrchestrationStatus.Terminated.ToString());
-                        this.UpdateEstimatedBytes(ref estimatedBytes, executionTerminatedEvent.Input);
                         break;
                     case EventType.ContinueAsNew:
                         orchestratorEventType = historyEvent.EventType;
                         ExecutionCompletedEvent executionCompletedEvent = (ExecutionCompletedEvent)historyEvent;
                         this.SetTablePropertyForMessage(entity, orchestrationInstanceUpdate, ResultProperty, OutputProperty, executionCompletedEvent.Result);
                         orchestrationInstanceUpdate.Properties["RuntimeStatus"] = new EntityProperty(OrchestrationStatus.ContinuedAsNew.ToString());
-                        this.UpdateEstimatedBytes(ref estimatedBytes, executionCompletedEvent.Result);
                         break;
                 }
 
@@ -513,10 +521,22 @@ namespace DurableTask.AzureStorage.Tracking
                 Utils.ExtensionVersion);
         }
 
-        void UpdateEstimatedBytes(ref int estimatedBytes, string payload)
+        static int GetEstimatedByteCount(DynamicTableEntity entity)
         {
-            int payloadBytes = Encoding.Unicode.GetByteCount(payload);
-            estimatedBytes += payloadBytes > MaxStorageQueuePayloadSizeInBytes ? GuidByteSize : payloadBytes;
+            // Assume at least 1 KB of data per entity to account for static-length properties
+            int estimatedByteCount = 1024;
+
+            // Count the bytes for variable-length properties, which are assumed to always be strings
+            foreach (string propertyName in VariableSizeEntityProperties)
+            {
+                EntityProperty property;
+                if (entity.Properties.TryGetValue(propertyName, out property) && !string.IsNullOrEmpty(property.StringValue))
+                {
+                    estimatedByteCount += Encoding.Unicode.GetByteCount(property.StringValue);
+                }
+            }
+
+            return estimatedByteCount;
         }
 
 

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -479,7 +479,14 @@ namespace DurableTask.AzureStorage.Tracking
                 // Table storage only supports inserts of up to 100 entities at a time or 4 MB at a time.
                 if (historyEventBatch.Count == 99 || estimatedBytes > 3 * 1024 * 1024 /* 3 MB */)
                 {
-                    eTagValue = await this.UploadHistoryBatch(instanceId, executionId, historyEventBatch, newEventListBuffer, newEvents.Count, eTagValue);
+                    eTagValue = await this.UploadHistoryBatch(
+                        instanceId,
+                        executionId,
+                        historyEventBatch,
+                        newEventListBuffer,
+                        newEvents.Count,
+                        estimatedBytes,
+                        eTagValue);
 
                     // Reset local state for the next batch
                     newEventListBuffer.Clear();
@@ -491,7 +498,14 @@ namespace DurableTask.AzureStorage.Tracking
             // First persistence step is to commit history to the history table. Messages must come after.
             if (historyEventBatch.Count > 0)
             {
-                eTagValue = await this.UploadHistoryBatch(instanceId, executionId, historyEventBatch, newEventListBuffer, newEvents.Count, eTagValue);
+                eTagValue = await this.UploadHistoryBatch(
+                    instanceId,
+                    executionId,
+                    historyEventBatch,
+                    newEventListBuffer,
+                    newEvents.Count,
+                    estimatedBytes,
+                    eTagValue);
             }
 
             if (orchestratorEventType == EventType.ExecutionCompleted ||
@@ -674,6 +688,7 @@ namespace DurableTask.AzureStorage.Tracking
             TableBatchOperation historyEventBatch,
             StringBuilder historyEventNamesBuffer,
             int numberOfTotalEvents,
+            int estimatedBatchSizeInBytes,
             string eTagValue)
         {
             // Adding / updating sentinel entity
@@ -748,6 +763,7 @@ namespace DurableTask.AzureStorage.Tracking
                 numberOfTotalEvents,
                 historyEventNamesBuffer.ToString(0, historyEventNamesBuffer.Length - 1), // remove trailing comma
                 stopwatch.ElapsedMilliseconds,
+                estimatedBatchSizeInBytes,
                 this.GetETagValue(instanceId),
                 Utils.ExtensionVersion);
 


### PR DESCRIPTION
This is a revised version of a previous pull request: https://github.com/Azure/durabletask/pull/191.  After merging, I did some testing and found a few issues. This new version addresses those issues.

FYI @tohling, @gled4er

This addresses https://github.com/Azure/azure-functions-durable-extension/issues/339.