### PR TITLE
Better concurrency throttling

### DIFF
--- a/src/DurableTask.Core/TaskActivityDispatcher.cs
+++ b/src/DurableTask.Core/TaskActivityDispatcher.cs
@@ -78,9 +78,9 @@ namespace DurableTask.Core
         /// </summary>
         public bool IncludeDetails { get; set;} 
 
-        Task<TaskActivityWorkItem> OnFetchWorkItemAsync(TimeSpan receiveTimeout)
+        Task<TaskActivityWorkItem> OnFetchWorkItemAsync(TimeSpan receiveTimeout, CancellationToken cancellationToken)
         {
-            return this.orchestrationService.LockNextTaskActivityWorkItem(receiveTimeout, CancellationToken.None);
+            return this.orchestrationService.LockNextTaskActivityWorkItem(receiveTimeout, cancellationToken);
         }
 
         async Task OnProcessWorkItemAsync(TaskActivityWorkItem workItem)

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -101,11 +101,11 @@ namespace DurableTask.Core
         /// Method to get the next work item to process within supplied timeout
         /// </summary>
         /// <param name="receiveTimeout">The max timeout to wait</param>
+        /// <param name="cancellationToken">A cancellation token used to cancel a fetch operation.</param>
         /// <returns>A new TaskOrchestrationWorkItem</returns>
-        protected Task<TaskOrchestrationWorkItem> OnFetchWorkItemAsync(TimeSpan receiveTimeout)
+        protected Task<TaskOrchestrationWorkItem> OnFetchWorkItemAsync(TimeSpan receiveTimeout, CancellationToken cancellationToken)
         {
-            // AFFANDAR : TODO : wire-up cancellation tokens
-            return this.orchestrationService.LockNextTaskOrchestrationWorkItemAsync(receiveTimeout, CancellationToken.None);
+            return this.orchestrationService.LockNextTaskOrchestrationWorkItemAsync(receiveTimeout, cancellationToken);
         }
 
         async Task OnProcessWorkItemSessionAsync(TaskOrchestrationWorkItem workItem)

--- a/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
+++ b/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
@@ -1228,7 +1228,8 @@ namespace DurableTask.ServiceBus
         ///     Wait for the next orchestration work item and return the orchestration work item
         /// </summary>
         /// <param name="receiveTimeout">The timespan to wait for new messages before timing out</param>
-        async Task<TrackingWorkItem> FetchTrackingWorkItemAsync(TimeSpan receiveTimeout)
+        /// <param name="cancellationToken">A cancellation token which signals a host shutdown</param>
+        async Task<TrackingWorkItem> FetchTrackingWorkItemAsync(TimeSpan receiveTimeout, CancellationToken cancellationToken)
         {
             MessageSession session = await trackingQueueClient.AcceptMessageSessionAsync(receiveTimeout);
             if (session == null)


### PR DESCRIPTION
This PR is intended to fix https://github.com/Azure/azure-functions-durable-extension/issues/370, which represents a significant performance bottleneck when running large number of orchestrations or activities.

### Problem
The WorkItemDispatcher sleeps for 5 seconds whenever it notices that we've reached the maximum configured concurrency. This looping 5 second sleep effectively blocks all orchestration processing and can have a significant impact on throughput, especially when orchestrations or activities normally execute quickly.

### Change
The change is to replace the looping 5 second sleep with a `SemaphoreSlim` named `concurrencyLock` to block additional fetches until we're under our throttle limitations. With this solution, there is no sleeping, and the dispatcher will **immediately** start a new fetch as soon as a previous work-item is completed, rather than waiting for an arbitrary number of seconds.