### PR TITLE
Cancellation tokens in work-item dispatcher logic

### DIFF
--- a/src/DurableTask.Core/TaskActivityDispatcher.cs
+++ b/src/DurableTask.Core/TaskActivityDispatcher.cs
@@ -78,9 +78,9 @@ namespace DurableTask.Core
         /// </summary>
         public bool IncludeDetails { get; set;} 
 
-        Task<TaskActivityWorkItem> OnFetchWorkItemAsync(TimeSpan receiveTimeout)
+        Task<TaskActivityWorkItem> OnFetchWorkItemAsync(TimeSpan receiveTimeout, CancellationToken cancellationToken)
         {
-            return this.orchestrationService.LockNextTaskActivityWorkItem(receiveTimeout, CancellationToken.None);
+            return this.orchestrationService.LockNextTaskActivityWorkItem(receiveTimeout, cancellationToken);
         }
 
         async Task OnProcessWorkItemAsync(TaskActivityWorkItem workItem)

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -101,11 +101,11 @@ namespace DurableTask.Core
         /// Method to get the next work item to process within supplied timeout
         /// </summary>
         /// <param name="receiveTimeout">The max timeout to wait</param>
+        /// <param name="cancellationToken">A cancellation token used to cancel a fetch operation.</param>
         /// <returns>A new TaskOrchestrationWorkItem</returns>
-        protected Task<TaskOrchestrationWorkItem> OnFetchWorkItemAsync(TimeSpan receiveTimeout)
+        protected Task<TaskOrchestrationWorkItem> OnFetchWorkItemAsync(TimeSpan receiveTimeout, CancellationToken cancellationToken)
         {
-            // AFFANDAR : TODO : wire-up cancellation tokens
-            return this.orchestrationService.LockNextTaskOrchestrationWorkItemAsync(receiveTimeout, CancellationToken.None);
+            return this.orchestrationService.LockNextTaskOrchestrationWorkItemAsync(receiveTimeout, cancellationToken);
         }
 
         async Task OnProcessWorkItemSessionAsync(TaskOrchestrationWorkItem workItem)

--- a/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
+++ b/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
@@ -1228,7 +1228,8 @@ namespace DurableTask.ServiceBus
         ///     Wait for the next orchestration work item and return the orchestration work item
         /// </summary>
         /// <param name="receiveTimeout">The timespan to wait for new messages before timing out</param>
-        async Task<TrackingWorkItem> FetchTrackingWorkItemAsync(TimeSpan receiveTimeout)
+        /// <param name="cancellationToken">A cancellation token which signals a host shutdown</param>
+        async Task<TrackingWorkItem> FetchTrackingWorkItemAsync(TimeSpan receiveTimeout, CancellationToken cancellationToken)
         {
             MessageSession session = await trackingQueueClient.AcceptMessageSessionAsync(receiveTimeout);
             if (session == null)


### PR DESCRIPTION
This PR resolves https://github.com/Azure/durabletask/issues/106 as well as an existing TODO in the code.  It is also a prerequisite for fixing https://github.com/Azure/azure-functions-durable-extension/issues/348 and https://github.com/Azure/azure-functions-durable-extension/issues/344.

### Issue
The current task hub worker shutdown logic is extremely slow because it depends on waiting for receive operations to time out. A simple "hello world" scenario where you create a task hub, start it, and shut it down, can take as long as 90 seconds. This might be acceptable if hosting on cloud services or VMs, but this is not acceptable when hosting in IIS-based platforms, like Azure App Service or Azure Functions.

### Fix
In this PR, we introduce cancellation tokens into the shutdown logic. The work-item dispatcher interfaces already support cancellation tokens, so this PR simply wires them up. The effect is that a graceful shutdown can happen in a few short seconds.