### PR TITLE
Add the ability to specify which Orchestration statuses should be used during Client Side De-dupe

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1670,7 +1670,6 @@ namespace DurableTask.AzureStorage
         /// </summary>
         /// <param name="creationMessage">Orchestration creation message</param>
         /// <param name="dedupeStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
-        /// <returns></returns>
         public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, IEnumerable<OrchestrationStatus> dedupeStatuses)
         {
             return this.SendTaskOrchestrationMessageAsync(creationMessage);

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1662,6 +1662,17 @@ namespace DurableTask.AzureStorage
         /// <param name="creationMessage">The message which creates and starts the orchestration.</param>
         public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage)
         {
+            return this.CreateTaskOrchestrationAsync(creationMessage, null);
+        }
+
+        /// <summary>
+        /// Creates a new orchestration
+        /// </summary>
+        /// <param name="creationMessage">Orchestration creation message</param>
+        /// <param name="deDupStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
+        /// <returns></returns>
+        public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, IEnumerable<OrchestrationStatus> deDupStatuses)
+        {
             return this.SendTaskOrchestrationMessageAsync(creationMessage);
         }
 

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1669,9 +1669,9 @@ namespace DurableTask.AzureStorage
         /// Creates a new orchestration
         /// </summary>
         /// <param name="creationMessage">Orchestration creation message</param>
-        /// <param name="deDupStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
+        /// <param name="dedupeStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
         /// <returns></returns>
-        public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, IEnumerable<OrchestrationStatus> deDupStatuses)
+        public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, IEnumerable<OrchestrationStatus> dedupeStatuses)
         {
             return this.SendTaskOrchestrationMessageAsync(creationMessage);
         }

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1670,7 +1670,8 @@ namespace DurableTask.AzureStorage
         /// </summary>
         /// <param name="creationMessage">Orchestration creation message</param>
         /// <param name="dedupeStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
-        public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, IEnumerable<OrchestrationStatus> dedupeStatuses)
+        /// <returns></returns>
+        public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, OrchestrationStatus[] dedupeStatuses)
         {
             return this.SendTaskOrchestrationMessageAsync(creationMessage);
         }

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1670,7 +1670,6 @@ namespace DurableTask.AzureStorage
         /// </summary>
         /// <param name="creationMessage">Orchestration creation message</param>
         /// <param name="dedupeStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
-        /// <returns></returns>
         public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, OrchestrationStatus[] dedupeStatuses)
         {
             return this.SendTaskOrchestrationMessageAsync(creationMessage);

--- a/src/DurableTask.Core/FilterComparisonType.cs
+++ b/src/DurableTask.Core/FilterComparisonType.cs
@@ -1,6 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
 
 namespace DurableTask.Core
 {

--- a/src/DurableTask.Core/FilterComparisonType.cs
+++ b/src/DurableTask.Core/FilterComparisonType.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DurableTask.Core
+{
+    /// <summary>
+    /// The kind of comparison to be performed in the State Filter.
+    /// </summary>
+    public enum FilterComparisonType
+    {
+        /// <summary>
+        /// Equality Comparison
+        /// </summary>
+        Equals = 0,
+
+        /// <summary>
+        /// In-Equality Comparison
+        /// </summary>
+        NotEquals = 1
+    }
+}

--- a/src/DurableTask.Core/IOrchestrationServiceClient.cs
+++ b/src/DurableTask.Core/IOrchestrationServiceClient.cs
@@ -36,10 +36,10 @@ namespace DurableTask.Core
         /// Creates a new orchestration and specifies a subset of states which should be de duplicated on in the client side
         /// </summary>
         /// <param name="creationMessage">Orchestration creation message</param>
-        /// <param name="deDupStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
-        /// <exception cref="OrchestrationAlreadyExistsException">Will throw an OrchestrationAlreadyExistsException exception If any orchestration with the same instance Id exists in the instance store and it has a status specified in deDupStatuses.</exception>
+        /// <param name="dedupeStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
+        /// <exception cref="OrchestrationAlreadyExistsException">Will throw an OrchestrationAlreadyExistsException exception If any orchestration with the same instance Id exists in the instance store and it has a status specified in dedupeStatuses.</exception>
         /// <returns></returns>
-        Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, IEnumerable<OrchestrationStatus> deDupStatuses);
+        Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, IEnumerable<OrchestrationStatus> dedupeStatuses);
 
         /// <summary>
         /// Send a new message for an orchestration

--- a/src/DurableTask.Core/IOrchestrationServiceClient.cs
+++ b/src/DurableTask.Core/IOrchestrationServiceClient.cs
@@ -39,7 +39,7 @@ namespace DurableTask.Core
         /// <param name="dedupeStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
         /// <exception cref="OrchestrationAlreadyExistsException">Will throw an OrchestrationAlreadyExistsException exception If any orchestration with the same instance Id exists in the instance store and it has a status specified in dedupeStatuses.</exception>
         /// <returns></returns>
-        Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, IEnumerable<OrchestrationStatus> dedupeStatuses);
+        Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, OrchestrationStatus[] dedupeStatuses);
 
         /// <summary>
         /// Send a new message for an orchestration

--- a/src/DurableTask.Core/IOrchestrationServiceClient.cs
+++ b/src/DurableTask.Core/IOrchestrationServiceClient.cs
@@ -17,6 +17,7 @@ namespace DurableTask.Core
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using DurableTask.Core.Exceptions;
 
     /// <summary>
     /// Interface to allow creation of new task orchestrations and query their status.
@@ -27,8 +28,18 @@ namespace DurableTask.Core
         /// Creates a new orchestration
         /// </summary>
         /// <param name="creationMessage">Orchestration creation message</param>
+        /// <exception cref="OrchestrationAlreadyExistsException">Will throw an OrchestrationAlreadyExistsException exception If any orchestration with the same instance Id exists in the instance store.</exception>
         /// <returns></returns>
         Task CreateTaskOrchestrationAsync(TaskMessage creationMessage);
+
+        /// <summary>
+        /// Creates a new orchestration and specifies a subset of states which should be de duplicated on in the client side
+        /// </summary>
+        /// <param name="creationMessage">Orchestration creation message</param>
+        /// <param name="deDupStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
+        /// <exception cref="OrchestrationAlreadyExistsException">Will throw an OrchestrationAlreadyExistsException exception If any orchestration with the same instance Id exists in the instance store and it has a status specified in deDupStatuses.</exception>
+        /// <returns></returns>
+        Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, IEnumerable<OrchestrationStatus> deDupStatuses);
 
         /// <summary>
         /// Send a new message for an orchestration

--- a/src/DurableTask.Core/OrchestrationStateQuery.cs
+++ b/src/DurableTask.Core/OrchestrationStateQuery.cs
@@ -187,13 +187,24 @@ namespace DurableTask.Core
         /// <returns></returns>
         public OrchestrationStateQuery AddStatusFilter(OrchestrationStatus status)
         {
-            if (FilterMap.ContainsKey(typeof (OrchestrationStateStatusFilter)))
+            return AddStatusFilter(status, false);
+        }
+
+        /// <summary>
+        ///     Adds a status filter on the returned orchestrations
+        /// </summary>
+        /// <param name="status">The status to filter by</param>
+        /// <param name="inverted">true if the status is to be excluded</param>
+        /// <returns></returns>
+        public OrchestrationStateQuery AddStatusFilter(OrchestrationStatus status, bool inverted)
+        {
+            if (FilterMap.ContainsKey(typeof(OrchestrationStateStatusFilter)))
             {
                 throw new ArgumentException("Cannot add more than one status filters");
             }
 
-            FilterMap.Add(typeof (OrchestrationStateStatusFilter),
-                new OrchestrationStateStatusFilter {Status = status});
+            FilterMap.Add(typeof(OrchestrationStateStatusFilter),
+                new OrchestrationStateStatusFilter { Status = status, Inverted = inverted });
 
             return this;
         }

--- a/src/DurableTask.Core/OrchestrationStateQuery.cs
+++ b/src/DurableTask.Core/OrchestrationStateQuery.cs
@@ -181,22 +181,22 @@ namespace DurableTask.Core
         }
 
         /// <summary>
-        ///     Adds a status filter on the returned orchestrations
+        ///     Adds a status filter on the returned orchestrations. Defaults to the equality Comparison Type.
         /// </summary>
         /// <param name="status">The status to filter by</param>
         /// <returns></returns>
         public OrchestrationStateQuery AddStatusFilter(OrchestrationStatus status)
         {
-            return AddStatusFilter(status, false);
+            return AddStatusFilter(status, FilterComparisonType.Equals);
         }
 
         /// <summary>
         ///     Adds a status filter on the returned orchestrations
         /// </summary>
         /// <param name="status">The status to filter by</param>
-        /// <param name="inverted">true if the status is to be excluded</param>
+        /// <param name="comparisonType">type of comparison to be performed on the status</param>
         /// <returns></returns>
-        public OrchestrationStateQuery AddStatusFilter(OrchestrationStatus status, bool inverted)
+        public OrchestrationStateQuery AddStatusFilter(OrchestrationStatus status, FilterComparisonType comparisonType)
         {
             if (FilterMap.ContainsKey(typeof(OrchestrationStateStatusFilter)))
             {
@@ -204,7 +204,7 @@ namespace DurableTask.Core
             }
 
             FilterMap.Add(typeof(OrchestrationStateStatusFilter),
-                new OrchestrationStateStatusFilter { Status = status, Inverted = inverted });
+                new OrchestrationStateStatusFilter { Status = status, ComparisonType = comparisonType });
 
             return this;
         }

--- a/src/DurableTask.Core/OrchestrationStateStatusFilter.cs
+++ b/src/DurableTask.Core/OrchestrationStateStatusFilter.cs
@@ -22,5 +22,10 @@ namespace DurableTask.Core
         /// Gets or sets the Status for the filter
         /// </summary>
         public OrchestrationStatus Status { get; set; }
+
+        /// <summary>
+        /// True if we would like the inverse of this condition
+        /// </summary>
+        public bool Inverted { get; set; }
     }
 }

--- a/src/DurableTask.Core/OrchestrationStateStatusFilter.cs
+++ b/src/DurableTask.Core/OrchestrationStateStatusFilter.cs
@@ -24,8 +24,8 @@ namespace DurableTask.Core
         public OrchestrationStatus Status { get; set; }
 
         /// <summary>
-        /// True if we would like the inverse of this condition
+        /// Type of comparison to be formed with the state
         /// </summary>
-        public bool Inverted { get; set; }
+        public FilterComparisonType ComparisonType { get; set; }
     }
 }

--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -103,7 +103,7 @@ namespace DurableTask.Core
             Type orchestrationType,
             string instanceId,
             object input, 
-            IEnumerable<OrchestrationStatus> dedupeStatuses
+            OrchestrationStatus[] dedupeStatuses
             )
         {
             return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
@@ -177,7 +177,7 @@ namespace DurableTask.Core
             string instanceId,
             object input,
             IDictionary<string, string> tags,
-            IEnumerable<OrchestrationStatus> dedupeStatuses)
+            OrchestrationStatus[] dedupeStatuses)
         {
             return InternalCreateOrchestrationInstanceWithRaisedEventAsync(name, version, instanceId, input, tags, dedupeStatuses, null, null);
         }
@@ -251,7 +251,7 @@ namespace DurableTask.Core
             Type orchestrationType,
             string instanceId,
             object orchestrationInput,
-            IEnumerable<OrchestrationStatus> dedupeStatuses,
+            OrchestrationStatus[] dedupeStatuses,
             string eventName,
             object eventData)
         {
@@ -395,7 +395,7 @@ namespace DurableTask.Core
             string instanceId,
             object orchestrationInput,
             IDictionary<string, string> orchestrationTags,
-            IEnumerable<OrchestrationStatus> dedupeStatuses,
+            OrchestrationStatus[] dedupeStatuses,
             string eventName,
             object eventData)
         {
@@ -441,7 +441,7 @@ namespace DurableTask.Core
             string orchestrationInstanceId, 
             object orchestrationInput, 
             IDictionary<string, string> orchestrationTags,
-            IEnumerable<OrchestrationStatus> dedupeStatuses,
+            OrchestrationStatus[] dedupeStatuses,
             string eventName, 
             object eventData)
         {

--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -64,6 +64,7 @@ namespace DurableTask.Core
                 input,
                 null,
                 null,
+                null,
                 null);
         }
 
@@ -86,6 +87,33 @@ namespace DurableTask.Core
                 input,
                 null,
                 null,
+                null,
+                null);
+        }
+
+        /// <summary>
+        ///     Create a new orchestration of the specified type with the specified instance id
+        /// </summary>
+        /// <param name="orchestrationType">Type that derives from TaskOrchestration</param>
+        /// <param name="instanceId">Instance id for the orchestration to be created, must be unique across the Task Hub</param>
+        /// <param name="input">Input parameter to the specified TaskOrchestration</param>
+        /// <param name="deDupStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
+        /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
+        public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(
+            Type orchestrationType,
+            string instanceId,
+            object input, 
+            IEnumerable<OrchestrationStatus> deDupStatuses
+            )
+        {
+            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
+                NameVersionHelper.GetDefaultName(orchestrationType),
+                NameVersionHelper.GetDefaultVersion(orchestrationType),
+                instanceId,
+                input,
+                null,
+                deDupStatuses,
+                null,
                 null);
         }
 
@@ -98,7 +126,7 @@ namespace DurableTask.Core
         /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
         public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(string name, string version, object input)
         {
-            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(name, version, null, input, null, null, null);
+            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(name, version, null, input, null, null, null, null);
         }
 
         /// <summary>
@@ -111,7 +139,7 @@ namespace DurableTask.Core
         /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
         public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(string name, string version, string instanceId, object input)
         {
-            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(name, version, instanceId, input, null, null, null);
+            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(name, version, instanceId, input, null, null, null, null);
         }
 
         /// <summary>
@@ -130,7 +158,28 @@ namespace DurableTask.Core
             object input, 
             IDictionary<string, string> tags)
         {
-            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(name, version, instanceId, input, tags, null, null);
+            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(name, version, instanceId, input, tags, null, null, null);
+        }
+
+        /// <summary>
+        ///     Create a new orchestration of the specified name and version
+        /// </summary>
+        /// <param name="name">Name of the orchestration as specified by the ObjectCreator</param>
+        /// <param name="version">Name of the orchestration as specified by the ObjectCreator</param>
+        /// <param name="instanceId">Instance id for the orchestration to be created, must be unique across the Task Hub</param>
+        /// <param name="input">Input parameter to the specified TaskOrchestration</param>
+        /// <param name="tags">Dictionary of key/value tags associated with this instance</param>
+        /// <param name="deDupStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
+        /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
+        public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(
+            string name,
+            string version,
+            string instanceId,
+            object input,
+            IDictionary<string, string> tags,
+            IEnumerable<OrchestrationStatus> deDupStatuses)
+        {
+            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(name, version, instanceId, input, tags, deDupStatuses, null, null);
         }
 
         /// <summary>
@@ -153,6 +202,7 @@ namespace DurableTask.Core
                 NameVersionHelper.GetDefaultVersion(orchestrationType),
                 null,
                 orchestrationInput,
+                null,
                 null,
                 eventName,
                 eventData);
@@ -181,6 +231,37 @@ namespace DurableTask.Core
                 instanceId,
                 orchestrationInput,
                 null,
+                null,
+                eventName,
+                eventData);
+        }
+
+        /// <summary>
+        ///     Creates an orchestration instance, and raises an event for it, which eventually causes the OnEvent() method in the
+        ///     orchestration to fire.
+        /// </summary>
+        /// <param name="orchestrationType">Type that derives from TaskOrchestration</param>
+        /// <param name="instanceId">Instance id for the orchestration to be created, must be unique across the Task Hub</param>
+        /// <param name="orchestrationInput">Input parameter to the specified TaskOrchestration</param>
+        /// <param name="deDupStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
+        /// <param name="eventName">Name of the event</param>
+        /// <param name="eventData">Data for the event</param>
+        /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
+        public Task<OrchestrationInstance> CreateOrchestrationInstanceWithRaisedEventAsync(
+            Type orchestrationType,
+            string instanceId,
+            object orchestrationInput,
+            IEnumerable<OrchestrationStatus> deDupStatuses,
+            string eventName,
+            object eventData)
+        {
+            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
+                NameVersionHelper.GetDefaultName(orchestrationType),
+                NameVersionHelper.GetDefaultVersion(orchestrationType),
+                instanceId,
+                orchestrationInput,
+                null,
+                deDupStatuses,
                 eventName,
                 eventData);
         }
@@ -202,6 +283,7 @@ namespace DurableTask.Core
             return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 orchestrationName,
                 orchestrationVersion,
+                null,
                 null,
                 null,
                 null, eventName, eventData);
@@ -228,7 +310,8 @@ namespace DurableTask.Core
                 orchestrationName, 
                 orchestrationVersion, 
                 null, orchestrationInput, 
-                null, 
+                null,
+                null,
                 eventName, 
                 eventData);
         }
@@ -256,7 +339,7 @@ namespace DurableTask.Core
                 orchestrationName, 
                 orchestrationVersion, 
                 instanceId, 
-                orchestrationInput, null, 
+                orchestrationInput, null, null,
                 eventName, 
                 eventData);
         }
@@ -287,7 +370,42 @@ namespace DurableTask.Core
                 orchestrationVersion, 
                 instanceId, 
                 orchestrationInput, 
-                orchestrationTags, 
+                orchestrationTags,
+                null,
+                eventName,
+                eventData);
+        }
+
+        /// <summary>
+        ///     Creates an orchestration instance, and raises an event for it, which eventually causes the OnEvent() method in the
+        ///     orchestration to fire.
+        /// </summary>
+        /// <param name="orchestrationName">Name of the TaskOrchestration</param>
+        /// <param name="orchestrationVersion">Version of the TaskOrchestration</param>
+        /// <param name="instanceId">Instance id for the orchestration to be created, must be unique across the Task Hub</param>
+        /// <param name="orchestrationInput">Input parameter to the specified TaskOrchestration</param>
+        /// <param name="orchestrationTags">Dictionary of key/value tags associated with this instance</param>
+        /// <param name="deDupStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
+        /// <param name="eventName">Name of the event</param>
+        /// <param name="eventData">Data for the event</param>
+        /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
+        public Task<OrchestrationInstance> CreateOrchestrationInstanceWithRaisedEventAsync(
+            string orchestrationName,
+            string orchestrationVersion,
+            string instanceId,
+            object orchestrationInput,
+            IDictionary<string, string> orchestrationTags,
+            IEnumerable<OrchestrationStatus> deDupStatuses,
+            string eventName,
+            object eventData)
+        {
+            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
+                orchestrationName,
+                orchestrationVersion,
+                instanceId,
+                orchestrationInput,
+                orchestrationTags,
+                deDupStatuses,
                 eventName,
                 eventData);
         }
@@ -313,6 +431,7 @@ namespace DurableTask.Core
                 orchestrationVersion,
                 instanceId,
                 null,
+                null,
                 null, eventName, eventData);
         }
 
@@ -321,7 +440,8 @@ namespace DurableTask.Core
             string orchestrationVersion, 
             string orchestrationInstanceId, 
             object orchestrationInput, 
-            IDictionary<string, string> orchestrationTags, 
+            IDictionary<string, string> orchestrationTags,
+            IEnumerable<OrchestrationStatus> deDupStatuses,
             string eventName, 
             object eventData)
         {
@@ -374,7 +494,7 @@ namespace DurableTask.Core
             }
 
             // Raised events and create orchestration calls use different methods so get handled separately
-            await Task.WhenAll(taskMessages.Where(t => !(t.Event is EventRaisedEvent)).Select(this.serviceClient.CreateTaskOrchestrationAsync));
+            await Task.WhenAll(taskMessages.Where(t => !(t.Event is EventRaisedEvent)).Select(x=>this.serviceClient.CreateTaskOrchestrationAsync(x, deDupStatuses)));
             await this.serviceClient.SendTaskOrchestrationMessageBatchAsync(taskMessages.Where(t => (t.Event is EventRaisedEvent)).ToArray());
             return orchestrationInstance;
         }

--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -97,13 +97,13 @@ namespace DurableTask.Core
         /// <param name="orchestrationType">Type that derives from TaskOrchestration</param>
         /// <param name="instanceId">Instance id for the orchestration to be created, must be unique across the Task Hub</param>
         /// <param name="input">Input parameter to the specified TaskOrchestration</param>
-        /// <param name="deDupStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
+        /// <param name="dedupeStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
         /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
         public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(
             Type orchestrationType,
             string instanceId,
             object input, 
-            IEnumerable<OrchestrationStatus> deDupStatuses
+            IEnumerable<OrchestrationStatus> dedupeStatuses
             )
         {
             return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
@@ -112,7 +112,7 @@ namespace DurableTask.Core
                 instanceId,
                 input,
                 null,
-                deDupStatuses,
+                dedupeStatuses,
                 null,
                 null);
         }
@@ -169,7 +169,7 @@ namespace DurableTask.Core
         /// <param name="instanceId">Instance id for the orchestration to be created, must be unique across the Task Hub</param>
         /// <param name="input">Input parameter to the specified TaskOrchestration</param>
         /// <param name="tags">Dictionary of key/value tags associated with this instance</param>
-        /// <param name="deDupStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
+        /// <param name="dedupeStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
         /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
         public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(
             string name,
@@ -177,9 +177,9 @@ namespace DurableTask.Core
             string instanceId,
             object input,
             IDictionary<string, string> tags,
-            IEnumerable<OrchestrationStatus> deDupStatuses)
+            IEnumerable<OrchestrationStatus> dedupeStatuses)
         {
-            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(name, version, instanceId, input, tags, deDupStatuses, null, null);
+            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(name, version, instanceId, input, tags, dedupeStatuses, null, null);
         }
 
         /// <summary>
@@ -243,7 +243,7 @@ namespace DurableTask.Core
         /// <param name="orchestrationType">Type that derives from TaskOrchestration</param>
         /// <param name="instanceId">Instance id for the orchestration to be created, must be unique across the Task Hub</param>
         /// <param name="orchestrationInput">Input parameter to the specified TaskOrchestration</param>
-        /// <param name="deDupStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
+        /// <param name="dedupeStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
         /// <param name="eventName">Name of the event</param>
         /// <param name="eventData">Data for the event</param>
         /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
@@ -251,7 +251,7 @@ namespace DurableTask.Core
             Type orchestrationType,
             string instanceId,
             object orchestrationInput,
-            IEnumerable<OrchestrationStatus> deDupStatuses,
+            IEnumerable<OrchestrationStatus> dedupeStatuses,
             string eventName,
             object eventData)
         {
@@ -261,7 +261,7 @@ namespace DurableTask.Core
                 instanceId,
                 orchestrationInput,
                 null,
-                deDupStatuses,
+                dedupeStatuses,
                 eventName,
                 eventData);
         }
@@ -385,7 +385,7 @@ namespace DurableTask.Core
         /// <param name="instanceId">Instance id for the orchestration to be created, must be unique across the Task Hub</param>
         /// <param name="orchestrationInput">Input parameter to the specified TaskOrchestration</param>
         /// <param name="orchestrationTags">Dictionary of key/value tags associated with this instance</param>
-        /// <param name="deDupStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
+        /// <param name="dedupeStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
         /// <param name="eventName">Name of the event</param>
         /// <param name="eventData">Data for the event</param>
         /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
@@ -395,7 +395,7 @@ namespace DurableTask.Core
             string instanceId,
             object orchestrationInput,
             IDictionary<string, string> orchestrationTags,
-            IEnumerable<OrchestrationStatus> deDupStatuses,
+            IEnumerable<OrchestrationStatus> dedupeStatuses,
             string eventName,
             object eventData)
         {
@@ -405,7 +405,7 @@ namespace DurableTask.Core
                 instanceId,
                 orchestrationInput,
                 orchestrationTags,
-                deDupStatuses,
+                dedupeStatuses,
                 eventName,
                 eventData);
         }
@@ -441,7 +441,7 @@ namespace DurableTask.Core
             string orchestrationInstanceId, 
             object orchestrationInput, 
             IDictionary<string, string> orchestrationTags,
-            IEnumerable<OrchestrationStatus> deDupStatuses,
+            IEnumerable<OrchestrationStatus> dedupeStatuses,
             string eventName, 
             object eventData)
         {
@@ -494,7 +494,7 @@ namespace DurableTask.Core
             }
 
             // Raised events and create orchestration calls use different methods so get handled separately
-            await Task.WhenAll(taskMessages.Where(t => !(t.Event is EventRaisedEvent)).Select(x=>this.serviceClient.CreateTaskOrchestrationAsync(x, deDupStatuses)));
+            await Task.WhenAll(taskMessages.Where(t => !(t.Event is EventRaisedEvent)).Select(x=>this.serviceClient.CreateTaskOrchestrationAsync(x, dedupeStatuses)));
             await this.serviceClient.SendTaskOrchestrationMessageBatchAsync(taskMessages.Where(t => (t.Event is EventRaisedEvent)).ToArray());
             return orchestrationInstance;
         }

--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -494,7 +494,7 @@ namespace DurableTask.Core
             }
 
             // Raised events and create orchestration calls use different methods so get handled separately
-            await Task.WhenAll(taskMessages.Where(t => !(t.Event is EventRaisedEvent)).Select(x=>this.serviceClient.CreateTaskOrchestrationAsync(x, dedupeStatuses)));
+            await Task.WhenAll(taskMessages.Where(t => !(t.Event is EventRaisedEvent)).Select(sEvent=>this.serviceClient.CreateTaskOrchestrationAsync(sEvent, dedupeStatuses)));
             await this.serviceClient.SendTaskOrchestrationMessageBatchAsync(taskMessages.Where(t => (t.Event is EventRaisedEvent)).ToArray());
             return orchestrationInstance;
         }

--- a/src/DurableTask.Emulator/LocalOrchestrationService.cs
+++ b/src/DurableTask.Emulator/LocalOrchestrationService.cs
@@ -186,7 +186,7 @@ namespace DurableTask.Emulator
                     this.instanceStore[creationMessage.OrchestrationInstance.InstanceId] = ed;
                 }
 
-                var latestState = ed.Values.OrderBy(x => x.CreatedTime).FirstOrDefault(x => x.OrchestrationStatus != OrchestrationStatus.ContinuedAsNew);
+                var latestState = ed.Values.OrderBy(state => state.CreatedTime).FirstOrDefault(state => state.OrchestrationStatus != OrchestrationStatus.ContinuedAsNew);
 
                 if (latestState != null && (dedupeStatuses == null || dedupeStatuses.Contains(latestState.OrchestrationStatus)))
                 {

--- a/src/DurableTask.Emulator/LocalOrchestrationService.cs
+++ b/src/DurableTask.Emulator/LocalOrchestrationService.cs
@@ -167,7 +167,7 @@ namespace DurableTask.Emulator
         }
 
         /// <inheritdoc />
-        public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, IEnumerable<OrchestrationStatus> deDupStatuses)
+        public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, IEnumerable<OrchestrationStatus> dedupeStatuses)
         {
             ExecutionStartedEvent ee = creationMessage.Event as ExecutionStartedEvent;
 
@@ -188,7 +188,7 @@ namespace DurableTask.Emulator
 
                 var latestState = ed.Values.OrderBy(x => x.CreatedTime).FirstOrDefault(x => x.OrchestrationStatus != OrchestrationStatus.ContinuedAsNew);
 
-                if (latestState != null && (deDupStatuses == null || deDupStatuses.Contains(latestState.OrchestrationStatus)))
+                if (latestState != null && (dedupeStatuses == null || dedupeStatuses.Contains(latestState.OrchestrationStatus)))
                 {
                     // An orchestration with same instance id is already running
                     throw new OrchestrationAlreadyExistsException($"An orchestration with id '{creationMessage.OrchestrationInstance.InstanceId}' already exists. It is in state {latestState.OrchestrationStatus}");

--- a/src/DurableTask.Emulator/LocalOrchestrationService.cs
+++ b/src/DurableTask.Emulator/LocalOrchestrationService.cs
@@ -167,7 +167,7 @@ namespace DurableTask.Emulator
         }
 
         /// <inheritdoc />
-        public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, IEnumerable<OrchestrationStatus> dedupeStatuses)
+        public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, OrchestrationStatus[] dedupeStatuses)
         {
             ExecutionStartedEvent ee = creationMessage.Event as ExecutionStartedEvent;
 

--- a/src/DurableTask.Emulator/LocalOrchestrationService.cs
+++ b/src/DurableTask.Emulator/LocalOrchestrationService.cs
@@ -14,6 +14,7 @@
 namespace DurableTask.Emulator
 {
     using DurableTask.Core;
+    using DurableTask.Core.Exceptions;
     using DurableTask.Core.History;
     using Newtonsoft.Json;
     using System;
@@ -162,6 +163,12 @@ namespace DurableTask.Emulator
         /// <inheritdoc />
         public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage)
         {
+            return CreateTaskOrchestrationAsync(creationMessage, null);
+        }
+
+        /// <inheritdoc />
+        public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, IEnumerable<OrchestrationStatus> deDupStatuses)
+        {
             ExecutionStartedEvent ee = creationMessage.Event as ExecutionStartedEvent;
 
             if (ee == null)
@@ -171,14 +178,20 @@ namespace DurableTask.Emulator
 
             lock (this.thisLock)
             {
-                this.orchestratorQueue.SendMessage(creationMessage);
-
                 Dictionary<string, OrchestrationState> ed;
 
                 if (!this.instanceStore.TryGetValue(creationMessage.OrchestrationInstance.InstanceId, out ed))
                 {
                     ed = new Dictionary<string, OrchestrationState>();
                     this.instanceStore[creationMessage.OrchestrationInstance.InstanceId] = ed;
+                }
+
+                var latestState = ed.Values.OrderBy(x => x.CreatedTime).FirstOrDefault(x => x.OrchestrationStatus != OrchestrationStatus.ContinuedAsNew);
+
+                if (latestState != null && (deDupStatuses == null || deDupStatuses.Contains(latestState.OrchestrationStatus)))
+                {
+                    // An orchestration with same instance id is already running
+                    throw new OrchestrationAlreadyExistsException($"An orchestration with id '{creationMessage.OrchestrationInstance.InstanceId}' already exists. It is in state {latestState.OrchestrationStatus}");
                 }
 
                 OrchestrationState newState = new OrchestrationState()
@@ -196,6 +209,8 @@ namespace DurableTask.Emulator
                 };
 
                 ed.Add(creationMessage.OrchestrationInstance.ExecutionId, newState);
+
+                this.orchestratorQueue.SendMessage(creationMessage);
             }
 
             return Task.FromResult<object>(null);

--- a/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
+++ b/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
@@ -1002,6 +1002,7 @@ namespace DurableTask.ServiceBus
             {
                 // TODO: GetOrchestrationState is still flaky as we are fetching from 2 tables while messages are being deleted and added
                 // to JumpStart table by JumpStart manager
+                // not threadsafe in case multiple clients attempt to create an orchestration instance with the same id at the same time
 
                 var latestState = (await this.GetOrchestrationStateAsync(creationMessage.OrchestrationInstance.InstanceId, false)).FirstOrDefault();
                 if (latestState != null && (dedupeStatuses == null || dedupeStatuses.Contains(latestState.OrchestrationStatus)))

--- a/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
+++ b/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
@@ -977,10 +977,24 @@ namespace DurableTask.ServiceBus
         }
 
         /// <summary>
-        ///    Create/start a new Orchestration
+        /// Creates a new orchestration
         /// </summary>
-        /// <param name="creationMessage">The task message for the new Orchestration</param>
-        public async Task CreateTaskOrchestrationAsync(TaskMessage creationMessage)
+        /// <param name="creationMessage">Orchestration creation message</param>
+        /// <exception cref="OrchestrationAlreadyExistsException">Will throw exception If any orchestration with the same instance Id exists in the instance store.</exception>
+        /// <returns></returns>
+        public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage)
+        {
+            return CreateTaskOrchestrationAsync(creationMessage, null);
+        }
+
+        /// <summary>
+        /// Creates a new orchestration and specifies a subset of states which should be de duplicated on in the client side
+        /// </summary>
+        /// <param name="creationMessage">Orchestration creation message</param>
+        /// <param name="deDupStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
+        /// <exception cref="OrchestrationAlreadyExistsException">Will throw an OrchestrationAlreadyExistsException exception If any orchestration with the same instance Id exists in the instance store and it has a status specified in deDupStatuses.</exception>
+        /// <returns></returns>
+        public async Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, IEnumerable<OrchestrationStatus> deDupStatuses)
         {
             // First, lets push the orchestration state (Pending) into JumpStart table
             bool jumpStartEnabled = false;
@@ -988,10 +1002,12 @@ namespace DurableTask.ServiceBus
             {
                 // TODO: GetOrchestrationState is still flaky as we are fetching from 2 tables while messages are being deleted and added
                 // to JumpStart table by JumpStart manager
-                if ((await this.GetOrchestrationStateAsync(creationMessage.OrchestrationInstance.InstanceId, true)).Count != 0)
+
+                var latestState = (await this.GetOrchestrationStateAsync(creationMessage.OrchestrationInstance.InstanceId, false)).FirstOrDefault();
+                if (latestState != null && (deDupStatuses == null || deDupStatuses.Contains(latestState.OrchestrationStatus)))
                 {
-                    // An orchestratoion with same instance id is already running
-                    throw new OrchestrationAlreadyExistsException($"An orchestration with id '{creationMessage.OrchestrationInstance.InstanceId}' already exists");
+                    // An orchestration with same instance id is already running
+                    throw new OrchestrationAlreadyExistsException($"An orchestration with id '{creationMessage.OrchestrationInstance.InstanceId}' already exists. It is in state {latestState.OrchestrationStatus}");
                 }
 
                 await this.UpdateJumpStartStoreAsync(creationMessage);
@@ -1580,7 +1596,7 @@ namespace DurableTask.ServiceBus
             {
                 try
                 {
-                await CreateQueueAsync(namespaceManager, path, requiresSessions, requiresDuplicateDetection, maxDeliveryCount, maxSizeInMegabytes);
+                    await CreateQueueAsync(namespaceManager, path, requiresSessions, requiresDuplicateDetection, maxDeliveryCount, maxSizeInMegabytes);
                 }
                 catch (MessagingEntityAlreadyExistsException)
                 {

--- a/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
+++ b/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
@@ -994,7 +994,7 @@ namespace DurableTask.ServiceBus
         /// <param name="dedupeStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
         /// <exception cref="OrchestrationAlreadyExistsException">Will throw an OrchestrationAlreadyExistsException exception If any orchestration with the same instance Id exists in the instance store and it has a status specified in dedupeStatuses.</exception>
         /// <returns></returns>
-        public async Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, IEnumerable<OrchestrationStatus> dedupeStatuses)
+        public async Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, OrchestrationStatus[] dedupeStatuses)
         {
             // First, lets push the orchestration state (Pending) into JumpStart table
             bool jumpStartEnabled = false;
@@ -1002,7 +1002,6 @@ namespace DurableTask.ServiceBus
             {
                 // TODO: GetOrchestrationState is still flaky as we are fetching from 2 tables while messages are being deleted and added
                 // to JumpStart table by JumpStart manager
-                // not threadsafe in case multiple clients attempt to create an orchestration instance with the same id at the same time
 
                 var latestState = (await this.GetOrchestrationStateAsync(creationMessage.OrchestrationInstance.InstanceId, false)).FirstOrDefault();
                 if (latestState != null && (dedupeStatuses == null || dedupeStatuses.Contains(latestState.OrchestrationStatus)))

--- a/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
+++ b/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
@@ -1002,6 +1002,8 @@ namespace DurableTask.ServiceBus
             {
                 // TODO: GetOrchestrationState is still flaky as we are fetching from 2 tables while messages are being deleted and added
                 // to JumpStart table by JumpStart manager
+                // not threadsafe in case multiple clients attempt to create an orchestration instance with the same id at the same time
+
 
                 var latestState = (await this.GetOrchestrationStateAsync(creationMessage.OrchestrationInstance.InstanceId, false)).FirstOrDefault();
                 if (latestState != null && (dedupeStatuses == null || dedupeStatuses.Contains(latestState.OrchestrationStatus)))

--- a/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
+++ b/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
@@ -991,10 +991,10 @@ namespace DurableTask.ServiceBus
         /// Creates a new orchestration and specifies a subset of states which should be de duplicated on in the client side
         /// </summary>
         /// <param name="creationMessage">Orchestration creation message</param>
-        /// <param name="deDupStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
-        /// <exception cref="OrchestrationAlreadyExistsException">Will throw an OrchestrationAlreadyExistsException exception If any orchestration with the same instance Id exists in the instance store and it has a status specified in deDupStatuses.</exception>
+        /// <param name="dedupeStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
+        /// <exception cref="OrchestrationAlreadyExistsException">Will throw an OrchestrationAlreadyExistsException exception If any orchestration with the same instance Id exists in the instance store and it has a status specified in dedupeStatuses.</exception>
         /// <returns></returns>
-        public async Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, IEnumerable<OrchestrationStatus> deDupStatuses)
+        public async Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, IEnumerable<OrchestrationStatus> dedupeStatuses)
         {
             // First, lets push the orchestration state (Pending) into JumpStart table
             bool jumpStartEnabled = false;
@@ -1004,7 +1004,7 @@ namespace DurableTask.ServiceBus
                 // to JumpStart table by JumpStart manager
 
                 var latestState = (await this.GetOrchestrationStateAsync(creationMessage.OrchestrationInstance.InstanceId, false)).FirstOrDefault();
-                if (latestState != null && (deDupStatuses == null || deDupStatuses.Contains(latestState.OrchestrationStatus)))
+                if (latestState != null && (dedupeStatuses == null || dedupeStatuses.Contains(latestState.OrchestrationStatus)))
                 {
                     // An orchestration with same instance id is already running
                     throw new OrchestrationAlreadyExistsException($"An orchestration with id '{creationMessage.OrchestrationInstance.InstanceId}' already exists. It is in state {latestState.OrchestrationStatus}");

--- a/src/DurableTask.ServiceBus/Tracking/AzureTableClient.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureTableClient.cs
@@ -159,7 +159,6 @@ namespace DurableTask.ServiceBus.Tracking
         {
             OrchestrationStateQueryFilter primaryFilter = null;
             IEnumerable<OrchestrationStateQueryFilter> secondaryFilters = null;
-
             Tuple<OrchestrationStateQueryFilter, IEnumerable<OrchestrationStateQueryFilter>> filters =
                 stateQuery.GetFilters();
             if (filters != null)
@@ -300,8 +299,9 @@ namespace DurableTask.ServiceBus.Tracking
             else if (filter is OrchestrationStateStatusFilter)
             {
                 var typedFilter = filter as OrchestrationStateStatusFilter;
+                var template = typedFilter.Inverted ? AzureTableConstants.StatusQueryInvertedSecondaryFilterTemplate : AzureTableConstants.StatusQuerySecondaryFilterTemplate;
                 filterExpression = string.Format(CultureInfo.InvariantCulture,
-                    AzureTableConstants.StatusQuerySecondaryFilterTemplate, typedFilter.Status);
+                    template, typedFilter.Status);
             }
             else if (filter is OrchestrationStateTimeRangeFilter)
             {

--- a/src/DurableTask.ServiceBus/Tracking/AzureTableClient.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureTableClient.cs
@@ -41,6 +41,11 @@ namespace DurableTask.ServiceBus.Tracking
         readonly CloudTableClient tableClient;
         readonly object thisLock = new object();
 
+        static readonly IDictionary<FilterComparisonType, string> comparisonOperatorMap 
+            = new Dictionary<FilterComparisonType, string>()
+            {{ FilterComparisonType.Equals, AzureTableConstants.EqualityOperator},
+            { FilterComparisonType.NotEquals, AzureTableConstants.InEqualityOperator}};
+
         volatile CloudTable historyTable;
         volatile CloudTable jumpStartTable;
 
@@ -299,9 +304,9 @@ namespace DurableTask.ServiceBus.Tracking
             else if (filter is OrchestrationStateStatusFilter)
             {
                 var typedFilter = filter as OrchestrationStateStatusFilter;
-                var template = typedFilter.Inverted ? AzureTableConstants.StatusQueryInvertedSecondaryFilterTemplate : AzureTableConstants.StatusQuerySecondaryFilterTemplate;
+                var template = AzureTableConstants.StatusQuerySecondaryFilterTemplate;
                 filterExpression = string.Format(CultureInfo.InvariantCulture,
-                    template, typedFilter.Status);
+                    template, comparisonOperatorMap[typedFilter.ComparisonType], typedFilter.Status);
             }
             else if (filter is OrchestrationStateTimeRangeFilter)
             {

--- a/src/DurableTask.ServiceBus/Tracking/AzureTableConstants.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureTableConstants.cs
@@ -80,6 +80,7 @@ namespace DurableTask.ServiceBus.Tracking
         public const string NameVersionQuerySecondaryFilterExactTemplate = "((Name eq '{0}') and (Version eq '{1}'))";
 
         public const string StatusQuerySecondaryFilterTemplate = "(OrchestrationStatus eq '{0}')";
+        public const string StatusQueryInvertedSecondaryFilterTemplate = "(OrchestrationStatus ne '{0}')";
 
         public const string CreatedTimeRangeQuerySecondaryFilterTemplate =
             "((CreatedTime ge datetime'{0}') and (CreatedTime lt datetime'{1}')) ";

--- a/src/DurableTask.ServiceBus/Tracking/AzureTableConstants.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureTableConstants.cs
@@ -79,8 +79,10 @@ namespace DurableTask.ServiceBus.Tracking
         public const string NameVersionQuerySecondaryFilterTemplate = "(Name eq '{0}')";
         public const string NameVersionQuerySecondaryFilterExactTemplate = "((Name eq '{0}') and (Version eq '{1}'))";
 
-        public const string StatusQuerySecondaryFilterTemplate = "(OrchestrationStatus eq '{0}')";
-        public const string StatusQueryInvertedSecondaryFilterTemplate = "(OrchestrationStatus ne '{0}')";
+        public const string StatusQuerySecondaryFilterTemplate = "(OrchestrationStatus {0} '{1}')";
+
+        public const string EqualityOperator = "eq";
+        public const string InEqualityOperator = "ne";
 
         public const string CreatedTimeRangeQuerySecondaryFilterTemplate =
             "((CreatedTime ge datetime'{0}') and (CreatedTime lt datetime'{1}')) ";

--- a/src/DurableTask.ServiceBus/Tracking/AzureTableInstanceStore.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureTableInstanceStore.cs
@@ -133,7 +133,7 @@ namespace DurableTask.ServiceBus.Tracking
         public async Task<IEnumerable<OrchestrationStateInstanceEntity>> GetOrchestrationStateAsync(string instanceId, bool allInstances)
         {
             var query = new OrchestrationStateQuery().AddInstanceFilter(instanceId);
-            query = allInstances ? query : query.AddStatusFilter(OrchestrationStatus.ContinuedAsNew, true);
+            query = allInstances ? query : query.AddStatusFilter(OrchestrationStatus.ContinuedAsNew, FilterComparisonType.NotEquals);
 
             // Fetch unscheduled orchestrations from JumpStart table
             // We need to get this first to avoid a race condition.

--- a/test/DurableTask.Emulator.Tests/EmulatorFunctionalTests.cs
+++ b/test/DurableTask.Emulator.Tests/EmulatorFunctionalTests.cs
@@ -56,7 +56,7 @@ namespace DurableTask.Emulator.Tests
         }
 
         [TestMethod]
-        public async Task MockReCreateOrchestrationTest()
+        public async Task MockRecreateOrchestrationTest()
         {
             LocalOrchestrationService orchService = new LocalOrchestrationService();
 

--- a/test/DurableTask.ServiceBus.Tests/SampleScenarioTests.cs
+++ b/test/DurableTask.ServiceBus.Tests/SampleScenarioTests.cs
@@ -92,7 +92,7 @@ namespace DurableTask.ServiceBus.Tests
         }
 
         [TestMethod]
-        public async Task SimplestGreetingsReCreationTest()
+        public async Task SimplestGreetingsRecreationTest()
         {
             SimplestGreetingsOrchestration.Result = string.Empty;
 

--- a/test/DurableTask.ServiceBus.Tests/SampleScenarioTests.cs
+++ b/test/DurableTask.ServiceBus.Tests/SampleScenarioTests.cs
@@ -92,6 +92,49 @@ namespace DurableTask.ServiceBus.Tests
         }
 
         [TestMethod]
+        public async Task SimplestGreetingsReCreationTest()
+        {
+            SimplestGreetingsOrchestration.Result = string.Empty;
+
+            await taskHub.AddTaskOrchestrations(typeof(SimplestGreetingsOrchestration))
+                .AddTaskActivities(typeof(SimplestGetUserTask), typeof(SimplestSendGreetingTask))
+                .StartAsync();
+
+            OrchestrationInstance id = await client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), null);
+
+            bool isCompleted = await TestHelpers.WaitForInstanceAsync(client, id, 60, true, true);
+            Assert.IsTrue(isCompleted, TestHelpers.GetInstanceNotCompletedMessage(client, id, 60));
+            Assert.AreEqual("Greeting send to Gabbar", SimplestGreetingsOrchestration.Result,
+                "Orchestration Result is wrong!!!");
+
+            await Assert.ThrowsExceptionAsync<OrchestrationAlreadyExistsException>(() => client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null));
+
+            await Assert.ThrowsExceptionAsync<OrchestrationAlreadyExistsException>(() => client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null, null));
+
+            await Assert.ThrowsExceptionAsync<OrchestrationAlreadyExistsException>(() => client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null, new OrchestrationStatus[] { OrchestrationStatus.Completed, OrchestrationStatus.Terminated }));
+
+            isCompleted = false;
+            SimplestGreetingsOrchestration.Result = string.Empty;
+
+            OrchestrationInstance id2 = await client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null, new OrchestrationStatus[] { OrchestrationStatus.Terminated });
+
+            isCompleted = await TestHelpers.WaitForInstanceAsync(client, id2, 60, true, true);
+            Assert.IsTrue(isCompleted, TestHelpers.GetInstanceNotCompletedMessage(client, id2, 60));
+            Assert.AreEqual("Greeting send to Gabbar", SimplestGreetingsOrchestration.Result,
+                "Orchestration Result on re create is wrong!!!");
+
+            isCompleted = false;
+            SimplestGreetingsOrchestration.Result = string.Empty;
+
+            OrchestrationInstance id3 = await client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null, new OrchestrationStatus[] { });
+
+            isCompleted = await TestHelpers.WaitForInstanceAsync(client, id3, 60, true, true);
+            Assert.IsTrue(isCompleted, TestHelpers.GetInstanceNotCompletedMessage(client, id3, 60));
+            Assert.AreEqual("Greeting send to Gabbar", SimplestGreetingsOrchestration.Result,
+                "Orchestration Result on 2nd re create is wrong!!!");
+        }
+
+        [TestMethod]
         public async Task SimplestGreetingsNoCompressionTest()
         {
             await taskHubNoCompression.AddTaskOrchestrations(typeof (SimplestGreetingsOrchestration))

--- a/test/DurableTask.ServiceBus.Tests/TestHelpers.cs
+++ b/test/DurableTask.ServiceBus.Tests/TestHelpers.cs
@@ -178,7 +178,8 @@ namespace DurableTask.ServiceBus.Tests
 
         public static async Task<bool> WaitForInstanceAsync(TaskHubClient taskHubClient, OrchestrationInstance instance,
             int timeoutSeconds,
-            bool waitForCompletion = true)
+            bool waitForCompletion = true,
+            bool exactExecution = false)
         {
             if (string.IsNullOrWhiteSpace(instance?.InstanceId))
             {
@@ -189,7 +190,14 @@ namespace DurableTask.ServiceBus.Tests
 
             while (timeoutSeconds > 0)
             {
-                OrchestrationState state = await taskHubClient.GetOrchestrationStateAsync(instance.InstanceId);
+                OrchestrationState state;
+                if (exactExecution)
+                {
+                    state = await taskHubClient.GetOrchestrationStateAsync(instance);
+                }
+                else {
+                    state = await taskHubClient.GetOrchestrationStateAsync(instance.InstanceId);
+                }
                 if (state == null)
                 {
                     throw new ArgumentException("OrchestrationState is expected but NULL value returned");


### PR DESCRIPTION
Add the ability to specify which Orchestration statuses should be used during Client Side De-dupe Made Local Orchestration Service behavior consistent with Service Bus