### PR TITLE
DurableTask.AzureStorage significant performance and reliability fixes

### DIFF
--- a/Test/DurableTask.AzureStorage.Tests/AsyncAutoResetEventTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/AsyncAutoResetEventTests.cs
@@ -1,0 +1,74 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureStorage.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class AsyncAutoResetEventTests
+    {
+        [DataTestMethod]
+        [DataRow(false, false)]
+        [DataRow(true, true)]
+        public async Task InitialState(bool initiallySignaled, bool expectedResult)
+        {
+            var resetEvent = new AsyncAutoResetEvent(initiallySignaled);
+            bool result = await resetEvent.WaitAsync(TimeSpan.Zero);
+            Assert.AreEqual<bool>(result, expectedResult);
+        }
+
+        [TestMethod]
+        public async Task SignalSingleWaiter()
+        {
+            var resetEvent = new AsyncAutoResetEvent(signaled: false);
+            Task<bool> waiter = resetEvent.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.IsFalse(waiter.IsCompleted);
+            resetEvent.Set();
+            Task winner = await Task.WhenAny(waiter, Task.Delay(TimeSpan.FromSeconds(2)));
+            Assert.IsTrue(waiter == winner, "waiter is supposed to be the winner");
+            Assert.IsTrue(waiter.IsCompleted, "waiter.IsCompleted should be true");
+            Assert.IsTrue(waiter.Result, "waiter.Result should be true");
+        }
+
+        [TestMethod]
+        public async Task SignalMultipleWaiters()
+        {
+            var resetEvent = new AsyncAutoResetEvent(signaled: false);
+
+            var waiters = new List<Task<bool>>();
+            for (int i = 0; i < 10; i++)
+            {
+                Task<bool> waiter = resetEvent.WaitAsync(TimeSpan.FromSeconds(60));
+                waiters.Add(waiter);
+            }
+
+            for (int i = 0; i < waiters.Count; i++)
+            {
+                resetEvent.Set();
+
+                // Sleep to let the signaling happen
+                await Task.Delay(200);
+
+                for (int j = i; j < waiters.Count; j++)
+                {
+                    Task<bool> waiter = waiters[j];
+                    Assert.AreEqual(i == j, waiter.IsCompleted && waiter.Result);
+                }
+            }
+        }
+    }
+}

--- a/Test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -625,19 +625,19 @@ namespace DurableTask.AzureStorage.Tests
                 {
                     var timeout = TimeSpan.FromSeconds(10);
                     var client = await host.StartOrchestrationAsync(typeof(Orchestrations.Approval), timeout);
-                    await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+                    await client.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
 
                     // Don't send any notification - let the internal timeout expire
                 };
 
-                int iterations = 50;
+                int iterations = 10;
                 var tasks = new Task[iterations];
                 for (int i = 0; i < iterations; i++)
                 {
                     tasks[i] = orchestrationStarter();
                 }
 
-                // The 50 orchestrations above (which each delay for 10 seconds) should all complete in less than 60 seconds.
+                // The 10 orchestrations above (which each delay for 10 seconds) should all complete in less than 60 seconds.
                 Task parallelOrchestrations = Task.WhenAll(tasks);
                 Task timeoutTask = Task.Delay(TimeSpan.FromSeconds(60));
 

--- a/Test/DurableTask.AzureStorage.Tests/TestHelpers.cs
+++ b/Test/DurableTask.AzureStorage.Tests/TestHelpers.cs
@@ -24,18 +24,15 @@ namespace DurableTask.AzureStorage.Tests
         {
             string storageConnectionString = GetTestStorageAccountConnectionString();
 
-            var service = new AzureStorageOrchestrationService(
-                new AzureStorageOrchestrationServiceSettings
-                {
-                    StorageConnectionString = storageConnectionString,
-                    TaskHubName = ConfigurationManager.AppSettings.Get("TaskHubName"),
-                    ExtendedSessionsEnabled = enableExtendedSessions,
-                    ExtendedSessionIdleTimeout = TimeSpan.FromSeconds(extendedSessionTimeoutInSeconds),
-                });
+            var settings = new AzureStorageOrchestrationServiceSettings
+            {
+                StorageConnectionString = storageConnectionString,
+                TaskHubName = ConfigurationManager.AppSettings.Get("TaskHubName"),
+                ExtendedSessionsEnabled = enableExtendedSessions,
+                ExtendedSessionIdleTimeout = TimeSpan.FromSeconds(extendedSessionTimeoutInSeconds),
+            };
 
-            service.CreateAsync().GetAwaiter().GetResult();
-
-            return new TestOrchestrationHost(service);
+            return new TestOrchestrationHost(settings);
         }
 
         public static string GetTestStorageAccountConnectionString()

--- a/Test/DurableTask.AzureStorage.Tests/TestOrchestrationClient.cs
+++ b/Test/DurableTask.AzureStorage.Tests/TestOrchestrationClient.cs
@@ -43,6 +43,8 @@ namespace DurableTask.AzureStorage.Tests
             this.instanceCreationTime = instanceCreationTime;
         }
 
+        public string InstanceId => this.instanceId;
+
         public async Task<OrchestrationState> WaitForCompletionAsync(TimeSpan timeout)
         {
             timeout = AdjustTimeout(timeout);

--- a/Test/DurableTask.AzureStorage.Tests/TestOrchestrationHost.cs
+++ b/Test/DurableTask.AzureStorage.Tests/TestOrchestrationHost.cs
@@ -22,18 +22,26 @@ namespace DurableTask.AzureStorage.Tests
 
     internal sealed class TestOrchestrationHost : IDisposable
     {
+        readonly AzureStorageOrchestrationServiceSettings settings;
         readonly TaskHubWorker worker;
         readonly TaskHubClient client;
         readonly HashSet<Type> addedOrchestrationTypes;
         readonly HashSet<Type> addedActivityTypes;
 
-        public TestOrchestrationHost(AzureStorageOrchestrationService service)
+        public TestOrchestrationHost(AzureStorageOrchestrationServiceSettings settings)
         {
+            var service = new AzureStorageOrchestrationService(settings);
+            service.CreateAsync().GetAwaiter().GetResult();
+
+            this.settings = settings;
+
             this.worker = new TaskHubWorker(service);
             this.client = new TaskHubClient(service);
             this.addedOrchestrationTypes = new HashSet<Type>();
             this.addedActivityTypes = new HashSet<Type>();
         }
+
+        public string TaskHub => this.settings.TaskHubName;
 
         public void Dispose()
         {

--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -199,7 +199,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(105, Level = EventLevel.Warning, Message = "An unexpected condition was detected: {0}")]
+        [Event(105, Level = EventLevel.Warning, Message = "An unexpected condition was detected: {2}")]
         public void AssertFailure(
             string Account,
             string TaskHub,

--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -173,7 +173,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(104, Level = EventLevel.Warning, Version = 3)]
+        [Event(104, Level = EventLevel.Warning, Version = 4)]
         public void AbandoningMessage(
             string Account,
             string TaskHub,
@@ -183,6 +183,7 @@ namespace DurableTask.AzureStorage
             string ExecutionId,
             string PartitionId,
             long SequenceNumber,
+            int VisibilityTimeoutSeconds,
             string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
@@ -196,6 +197,7 @@ namespace DurableTask.AzureStorage
                 ExecutionId ?? string.Empty,
                 PartitionId,
                 SequenceNumber,
+                VisibilityTimeoutSeconds,
                 ExtensionVersion);
         }
 
@@ -241,16 +243,52 @@ namespace DurableTask.AzureStorage
             this.WriteEvent(107, Account, TaskHub, Details, ExtensionVersion);
         }
 
-        [Event(108, Level = EventLevel.Warning, Message = "A duplicate message was detected. This can indicate a potential performance problem. Message ID = '{2}'. DequeueCount = {3}.")]
+        [Event(108, Level = EventLevel.Warning, Version = 2, Message = "A duplicate message was detected. This can indicate a potential performance problem. Message ID = '{2}'. DequeueCount = {3}.")]
         public void DuplicateMessageDetected(
             string Account,
             string TaskHub,
             string MessageId,
+            string InstanceId,
+            string ExecutionId,
+            string PartitionId,
             int DequeueCount,
             string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(108, Account, TaskHub, MessageId, DequeueCount, ExtensionVersion);
+            this.WriteEvent(
+                108,
+                Account,
+                TaskHub,
+                MessageId,
+                InstanceId,
+                ExecutionId ?? string.Empty,
+                PartitionId,
+                DequeueCount,
+                ExtensionVersion);
+        }
+
+        [Event(109, Level = EventLevel.Warning, Message = "A poison message was detected! Message ID = '{2}'. DequeueCount = {6}.")]
+        public void PoisonMessageDetected(
+            string Account,
+            string TaskHub,
+            string MessageId,
+            string InstanceId,
+            string ExecutionId,
+            string PartitionId,
+            int DequeueCount,
+            string ExtensionVersion)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(
+                109,
+                Account,
+                TaskHub,
+                MessageId,
+                InstanceId,
+                ExecutionId ?? string.Empty,
+                PartitionId,
+                DequeueCount,
+                ExtensionVersion);
         }
 
         [Event(110, Level = EventLevel.Informational, Version = 2)]

--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -72,7 +72,7 @@ namespace DurableTask.AzureStorage
 #endif
         }
 
-        [Event(101, Level = EventLevel.Informational, Opcode = EventOpcode.Send, Task = Tasks.Enqueue, Version = 3)]
+        [Event(101, Level = EventLevel.Informational, Opcode = EventOpcode.Send, Task = Tasks.Enqueue, Version = 4)]
         public void SendingMessage(
             Guid relatedActivityId,
             string Account,
@@ -85,6 +85,7 @@ namespace DurableTask.AzureStorage
             string TargetInstanceId,
             string TargetExecutionId,
             long SequenceNumber,
+            int Episode,
             string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
@@ -101,10 +102,11 @@ namespace DurableTask.AzureStorage
                 TargetInstanceId,
                 TargetExecutionId ?? string.Empty,
                 SequenceNumber,
+                Episode,
                 ExtensionVersion);
         }
 
-        [Event(102, Level = EventLevel.Informational, Opcode = EventOpcode.Receive, Task = Tasks.Dequeue, Version = 3)]
+        [Event(102, Level = EventLevel.Informational, Opcode = EventOpcode.Receive, Task = Tasks.Dequeue, Version = 4)]
         public void ReceivedMessage(
             Guid relatedActivityId,
             string Account,
@@ -119,6 +121,7 @@ namespace DurableTask.AzureStorage
             long SizeInBytes,
             string PartitionId,
             long SequenceNumber,
+            int Episode,
             string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
@@ -137,6 +140,7 @@ namespace DurableTask.AzureStorage
                 SizeInBytes,
                 PartitionId,
                 SequenceNumber,
+                Episode,
                 ExtensionVersion);
         }
 
@@ -246,13 +250,14 @@ namespace DurableTask.AzureStorage
             this.WriteEvent(108, Account, TaskHub, MessageId, DequeueCount, ExtensionVersion);
         }
 
-        [Event(110, Level = EventLevel.Informational)]
+        [Event(110, Level = EventLevel.Informational, Version = 2)]
         public void FetchedInstanceHistory(
             string Account,
             string TaskHub,
             string InstanceId,
             string ExecutionId,
             int EventCount,
+            int Episode,
             int RequestCount,
             long LatencyMs,
             string ETag,
@@ -266,13 +271,14 @@ namespace DurableTask.AzureStorage
                 InstanceId,
                 ExecutionId ?? string.Empty,
                 EventCount,
+                Episode,
                 RequestCount,
                 LatencyMs,
                 ETag ?? string.Empty,
                 ExtensionVersion);
         }
 
-        [Event(111, Level = EventLevel.Informational, Version = 2)]
+        [Event(111, Level = EventLevel.Informational, Version = 3)]
         public void AppendedInstanceHistory(
             string Account,
             string TaskHub,
@@ -281,6 +287,7 @@ namespace DurableTask.AzureStorage
             int NewEventCount,
             int TotalEventCount,
             string NewEvents,
+            int Episode,
             long LatencyMs,
             int SizeInBytes,
             string ETag,
@@ -296,6 +303,7 @@ namespace DurableTask.AzureStorage
                 NewEventCount,
                 TotalEventCount,
                 NewEvents,
+                Episode,
                 LatencyMs,
                 SizeInBytes,
                 ETag ?? string.Empty,
@@ -402,6 +410,64 @@ namespace DurableTask.AzureStorage
                 InstanceId,
                 ExecutionId ?? string.Empty,
                 Details,
+                ExtensionVersion);
+        }
+
+        [Event(116, Level = EventLevel.Informational)]
+        public void PendingOrchestratorMessageLimitReached(
+            string Account,
+            string TaskHub,
+            long PendingOrchestratorMessages,
+            string ExtensionVersion)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(
+                116,
+                Account,
+                TaskHub,
+                PendingOrchestratorMessages,
+                ExtensionVersion);
+        }
+
+        [Event(117, Level = EventLevel.Informational)]
+        public void WaitingForMoreMessages(
+            string Account,
+            string TaskHub,
+            string PartitionId,
+            string ExtensionVersion)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(
+                117,
+                Account,
+                TaskHub,
+                PartitionId,
+                ExtensionVersion);
+        }
+
+        [Event(118, Level = EventLevel.Warning)]
+        public void ReceivedOutOfOrderMessage(
+            string Account,
+            string TaskHub,
+            string InstanceId,
+            string ExecutionId,
+            string PartitionId,
+            string EventType,
+            string MessageId,
+            int Episode,
+            string ExtensionVersion)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(
+                118,
+                Account,
+                TaskHub,
+                InstanceId,
+                ExecutionId ?? string.Empty,
+                PartitionId,
+                EventType,
+                MessageId,
+                Episode,
                 ExtensionVersion);
         }
 
@@ -670,18 +736,19 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(135, Level = EventLevel.Informational)]
+        [Event(135, Level = EventLevel.Informational, Version = 2)]
         public void InstanceStatusUpdate(
             string Account,
             string TaskHub,
             string InstanceId,
             string ExecutionId,
             string EventType,
+            int Episode,
             long LatencyMs,
             string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(135, Account, TaskHub, InstanceId, ExecutionId ?? string.Empty, EventType, LatencyMs, ExtensionVersion);
+            this.WriteEvent(135, Account, TaskHub, InstanceId, ExecutionId ?? string.Empty, EventType, Episode, LatencyMs, ExtensionVersion);
         }
 
         [Event(136, Level = EventLevel.Informational)]
@@ -758,7 +825,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(140, Level = EventLevel.Informational, Task = Tasks.Processing, Opcode = EventOpcode.Receive, Version = 2)]
+        [Event(140, Level = EventLevel.Informational, Task = Tasks.Processing, Opcode = EventOpcode.Receive, Version = 3)]
         public void ProcessingMessage(
             Guid relatedActivityId,
             string Account,
@@ -769,6 +836,7 @@ namespace DurableTask.AzureStorage
             string MessageId,
             int Age,
             long SequenceNumber,
+            int Episode,
             bool IsExtendedSession,
             string ExtensionVersion)
         {
@@ -784,6 +852,7 @@ namespace DurableTask.AzureStorage
                 MessageId,
                 Age,
                 SequenceNumber,
+                Episode,
                 IsExtendedSession,
                 ExtensionVersion);
         }

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -598,7 +598,6 @@ namespace DurableTask.AzureStorage
                     List<MessageData> outOfOrderMessages = null;
                     foreach (MessageData message in session.CurrentMessageBatch)
                     {
-                        // TODO: How do we handle out-of-order messages for extended sessions?
                         if (session.IsOutOfOrderMessage(message))
                         {
                             if (outOfOrderMessages == null)

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1134,13 +1134,18 @@ namespace DurableTask.AzureStorage
         /// <inheritdoc />
         public bool IsMaxMessageCountExceeded(int currentMessageCount, OrchestrationRuntimeState runtimeState)
         {
-            // We will process at most 500 events at a time. Any remaining events will be
-            // scheduled in a subsequent episode. We do this to ensure we don't exceed the
+            if (this.settings.MaxCheckpointBatchSize <= 0)
+            {
+                return false;
+            }
+
+            // We will process at most N events at a time. Any remaining events will be
+            // scheduled in a subsequent episode. This is useful to ensure we don't exceed the
             // orchestrator queue timeout while trying to checkpoint massive numbers of actions.
             // It also reduces the amount of re-work that needs to be done if there is a failure
             // in the middle of a checkpoint. Note that having a number too small could
             // drastically increase the end-to-end processing time of an orchestration.
-            return runtimeState.NewEvents.Count >= 450;
+            return runtimeState.NewEvents.Count > this.settings.MaxCheckpointBatchSize;
         }
 
         /// <inheritdoc />

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -93,6 +93,11 @@ namespace DurableTask.AzureStorage
         public int MaxStorageOperationConcurrency { get; set; } = Environment.ProcessorCount * 25;
 
         /// <summary>
+        /// Gets the maximum number of orchestrator actions to checkpoint at a time.
+        /// </summary>
+        public int MaxCheckpointBatchSize { get; set; }
+
+        /// <summary>
         /// Gets or sets the identifier for the current worker.
         /// </summary>
         public string WorkerId { get; set; } = Environment.MachineName;

--- a/src/DurableTask.AzureStorage/BackoffPollingHelper.cs
+++ b/src/DurableTask.AzureStorage/BackoffPollingHelper.cs
@@ -14,7 +14,6 @@
 namespace DurableTask.AzureStorage
 {
     using System;
-    using System.Diagnostics;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -23,75 +22,109 @@ namespace DurableTask.AzureStorage
     /// </summary>
     class BackoffPollingHelper
     {
-        readonly long maxDelayMs;
-        readonly long minDelayThreasholdMs;
-        readonly double sleepToWaitRatio;
-        readonly Stopwatch stopwatch;
+        readonly RandomizedExponentialBackoffStrategy backoffStrategy;
+        readonly AsyncAutoResetEvent resetEvent;
 
-        TimeSpan delayTimeout;
-        AsyncAutoResetEvent resetEvent;
-
-        public BackoffPollingHelper(TimeSpan maxDelay, TimeSpan minDelayThreshold)
-            : this(maxDelay, minDelayThreshold, sleepToWaitRatio: 0.1)
+        public BackoffPollingHelper(TimeSpan minimumInterval, TimeSpan maximumInterval)
         {
-        }
-
-        public BackoffPollingHelper(TimeSpan maxDelay, TimeSpan minDelayThreshold, double sleepToWaitRatio)
-        {
-            Debug.Assert(maxDelay >= TimeSpan.Zero);
-            Debug.Assert(sleepToWaitRatio > 0 && sleepToWaitRatio <= 1);
-
-            this.maxDelayMs = (long)maxDelay.TotalMilliseconds;
-            this.minDelayThreasholdMs = (long)minDelayThreshold.TotalMilliseconds;
-            this.sleepToWaitRatio = sleepToWaitRatio;
-            this.stopwatch = new Stopwatch();
+            this.backoffStrategy = new RandomizedExponentialBackoffStrategy(minimumInterval, maximumInterval);
             this.resetEvent = new AsyncAutoResetEvent(signaled: false);
-            this.delayTimeout = TimeSpan.Zero;
         }
 
         public void Reset()
         {
-            this.stopwatch.Reset();
             this.resetEvent.Set();
         }
 
         public async Task<bool> WaitAsync(CancellationToken hostCancellationToken)
         {
-            bool signaled = await this.resetEvent.WaitAsync(this.delayTimeout, hostCancellationToken);
-            if (!signaled)
-            {
-                this.IncreaseDelay();
-            }
-
+            bool signaled = await this.resetEvent.WaitAsync(this.backoffStrategy.CurrentInterval, hostCancellationToken);
+            this.backoffStrategy.UpdateDelay(signaled);
             return signaled;
         }
 
-        private void IncreaseDelay()
+        // Borrowed from https://raw.githubusercontent.com/Azure/azure-webjobs-sdk/b798412ad74ba97cf2d85487ae8479f277bdd85c/src/Microsoft.Azure.WebJobs.Host/Timers/RandomizedExponentialBackoffStrategy.cs
+        class RandomizedExponentialBackoffStrategy
         {
-            if (!this.stopwatch.IsRunning)
+            public const double RandomizationFactor = 0.2;
+
+            private readonly TimeSpan minimumInterval;
+            private readonly TimeSpan maximumInterval;
+            private readonly TimeSpan deltaBackoff;
+
+            private uint backoffExponent;
+            private Random random;
+
+            public RandomizedExponentialBackoffStrategy(TimeSpan minimumInterval, TimeSpan maximumInterval)
+                : this(minimumInterval, maximumInterval, minimumInterval)
             {
-                this.stopwatch.Start();
             }
 
-            long elapsedMs = this.stopwatch.ElapsedMilliseconds;
-            double sleepDelayMs = elapsedMs * this.sleepToWaitRatio;
-
-            TimeSpan nextDelay;
-            if (sleepDelayMs < minDelayThreasholdMs)
+            public RandomizedExponentialBackoffStrategy(TimeSpan minimumInterval, TimeSpan maximumInterval,
+                TimeSpan deltaBackoff)
             {
-                nextDelay = TimeSpan.Zero;
-            }
-            else
-            {
-                if (sleepDelayMs > this.maxDelayMs)
+                if (minimumInterval.Ticks < 0)
                 {
-                    sleepDelayMs = this.maxDelayMs;
+                    throw new ArgumentOutOfRangeException(nameof(minimumInterval), "The TimeSpan must not be negative.");
                 }
 
-                nextDelay = TimeSpan.FromMilliseconds(sleepDelayMs);
+                if (maximumInterval.Ticks < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(maximumInterval), "The TimeSpan must not be negative.");
+                }
+
+                if (minimumInterval.Ticks > maximumInterval.Ticks)
+                {
+                    throw new ArgumentException(
+                        $"The {nameof(minimumInterval)} must not be greater than the {nameof(maximumInterval)}.",
+                        nameof(minimumInterval));
+                }
+
+                this.minimumInterval = minimumInterval;
+                this.maximumInterval = maximumInterval;
+                this.deltaBackoff = deltaBackoff;
             }
 
-            this.delayTimeout = nextDelay;
+            public TimeSpan CurrentInterval { get; private set; }
+
+            public TimeSpan UpdateDelay(bool executionSucceeded)
+            {
+                if (executionSucceeded)
+                {
+                    this.CurrentInterval = this.minimumInterval;
+                    this.backoffExponent = 1;
+                }
+                else if (this.CurrentInterval != this.maximumInterval)
+                {
+                    TimeSpan backoffInterval = this.minimumInterval;
+
+                    if (this.backoffExponent > 0)
+                    {
+                        if (this.random == null)
+                        {
+                            this.random = new Random();
+                        }
+
+                        double incrementMsec = 
+                            this.random.Next(1.0 - RandomizationFactor, 1.0 + RandomizationFactor) *
+                            Math.Pow(2.0, this.backoffExponent - 1) * this.deltaBackoff.TotalMilliseconds;
+                        backoffInterval += TimeSpan.FromMilliseconds(incrementMsec);
+                    }
+
+                    if (backoffInterval < this.maximumInterval)
+                    {
+                        this.CurrentInterval = backoffInterval;
+                        this.backoffExponent++;
+                    }
+                    else
+                    {
+                        this.CurrentInterval = this.maximumInterval;
+                    }
+                }
+                // else do nothing and keep current interval equal to max
+
+                return this.CurrentInterval;
+            }
         }
     }
 }

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -4,9 +4,9 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>1.3.2</Version>
-    <AssemblyVersion>$(Version)</AssemblyVersion>
-    <FileVersion>$(Version)</FileVersion>
+    <FileVersion>1.4.0</FileVersion>
+    <AssemblyVersion>$(FileVersion)</AssemblyVersion>
+    <Version>$(FileVersion)-rc</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <Description>Azure Storage provider extension for the Durable Task Framework.</Description>
     <PackageTags>Azure Task Durable Orchestration Workflow Activity Reliable AzureStorage</PackageTags>

--- a/src/DurableTask.AzureStorage/MessageData.cs
+++ b/src/DurableTask.AzureStorage/MessageData.cs
@@ -27,11 +27,12 @@ namespace DurableTask.AzureStorage
         /// <summary>
         /// The MessageData object.
         /// </summary>
-        public MessageData(TaskMessage message, Guid activityId, string queueName)
+        public MessageData(TaskMessage message, Guid activityId, string queueName, int orchestrationEpisode)
         {
             this.TaskMessage = message;
             this.ActivityId = activityId;
             this.QueueName = queueName;
+            this.Episode = orchestrationEpisode;
         }
 
         /// <summary>
@@ -63,6 +64,16 @@ namespace DurableTask.AzureStorage
         /// </summary>
         [DataMember]
         public long SequenceNumber { get; set; }
+
+        /// <summary>
+        /// The episode number of the orchestration which created this message.
+        /// </summary>
+        /// <remarks>
+        /// This value may be <c>0</c> if the orchestration instance that created
+        /// the message was started before episode numbers were tracked.
+        /// </remarks>
+        [DataMember]
+        public int Episode { get; private set; }
 
         internal string Id => this.OriginalQueueMessage?.Id;
 

--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -27,7 +27,7 @@ namespace DurableTask.AzureStorage
     /// <summary>
     /// The message manager for messages from MessageData, and DynamicTableEntities
     /// </summary>
-    public class MessageManager
+    class MessageManager
     {
         const int MaxStorageQueuePayloadSizeInBytes = 60 * 1024; // 60KB
         const int DefaultBufferSize = 64 * 2014; // 64KB
@@ -38,6 +38,8 @@ namespace DurableTask.AzureStorage
         readonly string blobContainerName;
         readonly CloudBlobContainer cloudBlobContainer;
         readonly JsonSerializerSettings taskMessageSerializerSettings;
+
+        bool containerInitialized;
 
         /// <summary>
         /// The message manager.
@@ -50,6 +52,26 @@ namespace DurableTask.AzureStorage
             {
                 TypeNameHandling = TypeNameHandling.Objects
             };
+        }
+
+        public async Task<bool> EnsureContainerAsync()
+        {
+            bool created = false;
+
+            if (!this.containerInitialized)
+            {
+                created = await this.cloudBlobContainer.CreateIfNotExistsAsync();
+                this.containerInitialized = true;
+            }
+
+            return created;
+        }
+
+        public async Task<bool> DeleteContainerAsync()
+        {
+            bool deleted = await this.cloudBlobContainer.DeleteIfExistsAsync();
+            this.containerInitialized = false;
+            return deleted;
         }
 
         /// <summary>
@@ -65,16 +87,14 @@ namespace DurableTask.AzureStorage
 
             if (messageFormat != MessageFormatFlags.InlineJson)
             {
+                // Get Compressed bytes and upload the full message to blob storage.
                 byte[] messageBytes = Encoding.UTF8.GetBytes(rawContent);
-
-                // Get Compressed bytes
-                string blobName = this.GetNewLargeMessageBlobName(messageData.TaskMessage.OrchestrationInstance.InstanceId);
+                string blobName = this.GetNewLargeMessageBlobName(messageData);
+                messageData.CompressedBlobName = blobName;
                 await this.CompressAndUploadAsBytesAsync(messageBytes, blobName);
-                MessageData wrapperMessageData = new MessageData
-                {
-                    CompressedBlobName = blobName
-                };
 
+                // Create a "wrapper" message which has the blob name but not a task message.
+                var wrapperMessageData = new MessageData { CompressedBlobName = blobName };
                 return JsonConvert.SerializeObject(wrapperMessageData, this.taskMessageSerializerSettings);
             }
 
@@ -144,6 +164,8 @@ namespace DurableTask.AzureStorage
 
         internal async Task<string> DownloadAndDecompressAsBytesAsync(string blobName)
         {
+            await this.EnsureContainerAsync();
+
             CloudBlockBlob cloudBlockBlob = this.cloudBlobContainer.GetBlockBlobReference(blobName);
             Stream downloadBlobAsStream = await cloudBlockBlob.OpenReadAsync();
             ArraySegment<byte> decompressedSegment = this.Decompress(downloadBlobAsStream);
@@ -197,25 +219,19 @@ namespace DurableTask.AzureStorage
         /// </summary>
         internal async Task UploadToBlobAsync(byte[] data, int dataByteCount, string blobName)
         {
-            await this.cloudBlobContainer.CreateIfNotExistsAsync();
+            await this.EnsureContainerAsync();
+
             CloudBlockBlob cloudBlockBlob = this.cloudBlobContainer.GetBlockBlobReference(blobName);
             await cloudBlockBlob.UploadFromByteArrayAsync(data, 0, dataByteCount);
         }
 
-        /// <summary>
-        /// Generates name for large message blob
-        /// </summary>
-        /// <param name="instanceId">Orchestration Instance ID</param>
-        /// <returns>Large message blob name in the format - '/{container}/{instance-id}/{blob-id}.json.gz' where container is '{taskhub}-largemessages'</returns>
-        internal string GetNewLargeMessageBlobName(string instanceId)
+        internal string GetNewLargeMessageBlobName(MessageData message)
         {
-            var blobNameBuilder = new StringBuilder();
-            blobNameBuilder.
-                Append(instanceId).
-                Append(LargeMessageBlobNameSeparator).
-                Append(Guid.NewGuid().ToString()).
-                Append(blobExtension);
-            return blobNameBuilder.ToString();
+            string instanceId = message.TaskMessage.OrchestrationInstance.InstanceId;
+            string eventType = message.TaskMessage.Event.EventType.ToString();
+            string sequenceNumber = message.SequenceNumber.ToString("X16");
+
+            return $"{instanceId}/message-{sequenceNumber}-{eventType}.json.gz".ToLowerInvariant();
         }
 
         internal async Task DeleteLargeMessageBlobs(string instanceId, AzureStorageOrchestrationServiceStats stats)
@@ -225,11 +241,12 @@ namespace DurableTask.AzureStorage
             {
                 return;
             }
-            CloudBlobDirectory instnaceDirectory = this.cloudBlobContainer.GetDirectoryReference(instanceId);
+
+            CloudBlobDirectory instanceDirectory = this.cloudBlobContainer.GetDirectoryReference(instanceId);
             BlobContinuationToken blobContinuationToken = null;
             while (true)
             {
-                BlobResultSegment segment = await instnaceDirectory.ListBlobsSegmentedAsync(blobContinuationToken);
+                BlobResultSegment segment = await instanceDirectory.ListBlobsSegmentedAsync(blobContinuationToken);
                 stats.StorageRequests.Increment();
                 foreach (IListBlobItem blobListItem in segment.Results)
                 {
@@ -239,6 +256,7 @@ namespace DurableTask.AzureStorage
                 }
 
                 await Task.WhenAll(blobForDeletionTaskList);
+
                 stats.StorageRequests.Increment(blobForDeletionTaskList.Count);
                 if (blobContinuationToken == null)
                 {

--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -150,6 +150,11 @@ namespace DurableTask.AzureStorage
             return Encoding.UTF8.GetString(decompressedSegment.Array, 0, decompressedSegment.Count);
         }
 
+        internal string GetBlobUrl(string blobName)
+        {
+            return this.cloudBlobContainer.GetBlockBlobReference(blobName).Uri.AbsoluteUri;
+        }
+
         internal ArraySegment<byte> Decompress(Stream blobStream)
         {
             using (GZipStream gZipStream = new GZipStream(blobStream, CompressionMode.Decompress))

--- a/src/DurableTask.AzureStorage/Messaging/ActivitySession.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ActivitySession.cs
@@ -17,6 +17,8 @@ namespace DurableTask.AzureStorage.Messaging
 
     class ActivitySession : SessionBase
     {
+        readonly int orchestrationEpisode;
+
         public ActivitySession(
             string storageAccountName,
             string taskHubName,
@@ -25,8 +27,14 @@ namespace DurableTask.AzureStorage.Messaging
             : base(storageAccountName, taskHubName, message.TaskMessage.OrchestrationInstance, traceActivityId)
         {
             this.MessageData = message ?? throw new ArgumentNullException(nameof(message));
+            this.orchestrationEpisode = message.Episode;
         }
 
         public MessageData MessageData { get; }
+
+        public override int GetCurrentEpisode()
+        {
+            return this.orchestrationEpisode;
+        }
     }
 }

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -50,14 +50,30 @@ namespace DurableTask.AzureStorage.Messaging
         {
             using (var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(this.releaseCancellationToken, cancellationToken))
             {
+                bool pendingOrchestratorMessageLimitReached = false;
+                bool isWaitingForMoreMessages = false;
+
                 while (!linkedCts.IsCancellationRequested)
                 {
                     // Pause dequeuing if the total number of locked messages gets too high.
-                    if (this.stats.PendingOrchestratorMessages.Value >= this.settings.ControlQueueBufferThreshold)
+                    long pendingOrchestratorMessages = this.stats.PendingOrchestratorMessages.Value;
+                    if (pendingOrchestratorMessages >= this.settings.ControlQueueBufferThreshold)
                     {
+                        if (!pendingOrchestratorMessageLimitReached)
+                        {
+                            pendingOrchestratorMessageLimitReached = true;
+                            AnalyticsEventSource.Log.PendingOrchestratorMessageLimitReached(
+                                this.storageAccountName,
+                                this.settings.TaskHubName,
+                                pendingOrchestratorMessages,
+                                Utils.ExtensionVersion);
+                        }
+
                         await Task.Delay(TimeSpan.FromSeconds(1));
                         continue;
                     }
+
+                    pendingOrchestratorMessageLimitReached = false;
 
                     try
                     {
@@ -72,9 +88,21 @@ namespace DurableTask.AzureStorage.Messaging
 
                         if (!batch.Any())
                         {
+                            if (!isWaitingForMoreMessages)
+                            {
+                                isWaitingForMoreMessages = true;
+                                AnalyticsEventSource.Log.WaitingForMoreMessages(
+                                    this.storageAccountName,
+                                    this.settings.TaskHubName,
+                                    this.storageQueue.Name,
+                                    Utils.ExtensionVersion);
+                            }
+
                             await this.backoffHelper.WaitAsync(linkedCts.Token);
                             continue;
                         }
+
+                        isWaitingForMoreMessages = false;
 
                         var batchMessages = new ConcurrentBag<MessageData>();
                         await batch.ParallelForEachAsync(async delegate (CloudQueueMessage queueMessage)

--- a/src/DurableTask.AzureStorage/Messaging/MessageCollection.cs
+++ b/src/DurableTask.AzureStorage/Messaging/MessageCollection.cs
@@ -13,18 +13,11 @@
 
 namespace DurableTask.AzureStorage.Messaging
 {
-    using System.Collections;
     using System.Collections.Generic;
     using Microsoft.WindowsAzure.Storage.Queue;
 
-    class MessageCollection : IReadOnlyList<MessageData>
+    class MessageCollection : List<MessageData>
     {
-        readonly List<MessageData> innerList = new List<MessageData>();
-
-        public MessageData this[int index] => this.innerList[index];
-
-        public int Count => this.innerList.Count;
-
         /// <summary>
         /// Adds or replaces a message in the list based on the message ID. Returns true for adds, false for replaces.
         /// </summary>
@@ -33,33 +26,18 @@ namespace DurableTask.AzureStorage.Messaging
             // If a message has been sitting in the buffer for too long, the invisibility timeout may expire and 
             // it may get dequeued a second time. In such cases, we should replace the existing copy of the message
             // with the newer copy to ensure it can be deleted successfully after being processed.
-            for (int i = 0; i < this.innerList.Count; i++)
+            for (int i = 0; i < this.Count; i++)
             {
-                CloudQueueMessage existingMessage = this.innerList[i].OriginalQueueMessage;
+                CloudQueueMessage existingMessage = this[i].OriginalQueueMessage;
                 if (existingMessage.Id == message.OriginalQueueMessage.Id)
                 {
-                    this.innerList[i] = message;
+                    this[i] = message;
                     return false;
                 }
             }
 
-            this.innerList.Add(message);
+            this.Add(message);
             return true;
-        }
-
-        public void Clear()
-        {
-            this.innerList.Clear();
-        }
-
-        public IEnumerator<MessageData> GetEnumerator()
-        {
-            return this.innerList.GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return this.GetEnumerator();
         }
     }
 }

--- a/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
+++ b/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
@@ -18,6 +18,7 @@ namespace DurableTask.AzureStorage.Messaging
     using System.Linq;
     using System.Threading.Tasks;
     using DurableTask.Core;
+    using DurableTask.Core.History;
 
     sealed class OrchestrationSession : SessionBase, IOrchestrationSession
     {
@@ -32,7 +33,7 @@ namespace DurableTask.AzureStorage.Messaging
             string taskHubName,
             OrchestrationInstance orchestrationInstance,
             ControlQueue controlQueue,
-            IReadOnlyList<MessageData> initialMessageBatch,
+            IList<MessageData> initialMessageBatch,
             OrchestrationRuntimeState runtimeState,
             string eTag,
             TimeSpan idleTimeout,
@@ -52,7 +53,7 @@ namespace DurableTask.AzureStorage.Messaging
 
         public ControlQueue ControlQueue { get; }
 
-        public IReadOnlyList<MessageData> CurrentMessageBatch { get; private set; }
+        public IList<MessageData> CurrentMessageBatch { get; private set; }
 
         public OrchestrationRuntimeState RuntimeState { get; }
 
@@ -114,6 +115,48 @@ namespace DurableTask.AzureStorage.Messaging
             }
 
             return messages;
+        }
+
+        internal bool IsOutOfOrderMessage(MessageData message)
+        {
+            int taskScheduledId = -1;
+            HistoryEvent messageEvent = message.TaskMessage.Event;
+            switch (messageEvent.EventType)
+            {
+                case EventType.TaskCompleted:
+                    taskScheduledId = ((TaskCompletedEvent)messageEvent).TaskScheduledId;
+                    break;
+                case EventType.TaskFailed:
+                    taskScheduledId = ((TaskFailedEvent)messageEvent).TaskScheduledId;
+                    break;
+                case EventType.SubOrchestrationInstanceCompleted:
+                    taskScheduledId = ((SubOrchestrationInstanceCompletedEvent)messageEvent).TaskScheduledId;
+                    break;
+                case EventType.SubOrchestrationInstanceFailed:
+                    taskScheduledId = ((SubOrchestrationInstanceFailedEvent)messageEvent).TaskScheduledId;
+                    break;
+                case EventType.TimerFired:
+                    taskScheduledId = ((TimerFiredEvent)messageEvent).TimerId;
+                    break;
+            }
+
+            if (taskScheduledId < 0)
+            {
+                // This message does not require ordering (RaiseEvent, ExecutionStarted, Terminate, etc.).
+                return false;
+            }
+
+            // This message is a response to a task. Make sure the event ID matches the range of the previously known
+            // scheduled events. We don't need to ensure the event types actually match because the core runtime
+            // will do that anyways and fail the orchestration if there is a non-matching event type.
+            HistoryEvent mostRecentTaskEvent = this.RuntimeState.Events.LastOrDefault(e => e.EventId != -1);
+            if (mostRecentTaskEvent != null && taskScheduledId <= mostRecentTaskEvent.EventId)
+            {
+                return false;
+            }
+
+            // The message is out of order and cannot be handled by the current session.
+            return true;
         }
     }
 }

--- a/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
+++ b/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
@@ -149,7 +149,7 @@ namespace DurableTask.AzureStorage.Messaging
             // This message is a response to a task. Make sure the event ID matches the range of the previously known
             // scheduled events. We don't need to ensure the event types actually match because the core runtime
             // will do that anyways and fail the orchestration if there is a non-matching event type.
-            HistoryEvent mostRecentTaskEvent = this.RuntimeState.Events.LastOrDefault(e => e.EventId != -1);
+            HistoryEvent mostRecentTaskEvent = this.RuntimeState.Events.LastOrDefault(e => e.EventId >= 0);
             if (mostRecentTaskEvent != null && taskScheduledId <= mostRecentTaskEvent.EventId)
             {
                 return false;

--- a/src/DurableTask.AzureStorage/Messaging/Session.cs
+++ b/src/DurableTask.AzureStorage/Messaging/Session.cs
@@ -70,8 +70,11 @@ namespace DurableTask.AzureStorage.Messaging
                 queueMessage.Id,
                 Math.Max(0, (int)DateTimeOffset.UtcNow.Subtract(queueMessage.InsertionTime.Value).TotalMilliseconds),
                 data.SequenceNumber,
+                data.Episode,
                 isExtendedSession,
                 Utils.ExtensionVersion);
         }
+
+        public abstract int GetCurrentEpisode();
     }
 }

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -48,9 +48,9 @@ namespace DurableTask.AzureStorage.Messaging
             this.stats = stats;
             this.messageManager = messageManager;
 
+            TimeSpan minPollingDelay = TimeSpan.FromMilliseconds(50);
             TimeSpan maxPollingDelay = AzureStorageOrchestrationService.MaxQueuePollingDelay;
-            TimeSpan minPollingDelayThreshold = TimeSpan.FromMilliseconds(500);
-            this.backoffHelper = new BackoffPollingHelper(maxPollingDelay, minPollingDelayThreshold);
+            this.backoffHelper = new BackoffPollingHelper(minPollingDelay, maxPollingDelay);
         }
 
         public string Name => this.storageQueue.Name;

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -111,7 +111,7 @@ namespace DurableTask.AzureStorage
                     IReadOnlyList<MessageData> messages = await controlQueue.GetMessagesAsync(cancellationToken);
                     if (messages.Count > 0)
                     {
-                        this.AddMessageToPendingOrchestration(messages, traceActivityId, cancellationToken);
+                        this.AddMessageToPendingOrchestration(controlQueue, messages, traceActivityId, cancellationToken);
                     }
                 }
             }
@@ -128,6 +128,7 @@ namespace DurableTask.AzureStorage
         }
 
         void AddMessageToPendingOrchestration(
+            ControlQueue controlQueue,
             IEnumerable<MessageData> queueMessages,
             Guid traceActivityId,
             CancellationToken cancellationToken)
@@ -185,7 +186,7 @@ namespace DurableTask.AzureStorage
 
                     if (targetBatch == null)
                     {
-                        targetBatch = new PendingMessageBatch(instanceId, executionId);
+                        targetBatch = new PendingMessageBatch(controlQueue, instanceId, executionId);
                         node = this.pendingOrchestrationMessageBatches.AddLast(targetBatch);
 
                         // Before the batch of messages can be processed, we need to download the latest execution state.
@@ -316,6 +317,7 @@ namespace DurableTask.AzureStorage
                             this.storageAccountName,
                             this.settings.TaskHubName,
                             instance,
+                            nextBatch.ControlQueue,
                             nextBatch.Messages,
                             nextBatch.OrchestrationState,
                             nextBatch.ETag,
@@ -376,7 +378,11 @@ namespace DurableTask.AzureStorage
                     this.activeOrchestrationSessions.Remove(instanceId))
                 {
                     // Put any unprocessed messages back into the pending buffer.
-                    this.AddMessageToPendingOrchestration(session.PendingMessages, session.TraceActivityId, cancellationToken);
+                    this.AddMessageToPendingOrchestration(
+                        session.ControlQueue,
+                        session.PendingMessages,
+                        session.TraceActivityId,
+                        cancellationToken);
                 }
                 else
                 {
@@ -410,12 +416,14 @@ namespace DurableTask.AzureStorage
 
         class PendingMessageBatch
         {
-            public PendingMessageBatch(string instanceId, string executionId)
+            public PendingMessageBatch(ControlQueue controlQueue, string instanceId, string executionId)
             {
+                this.ControlQueue = controlQueue ?? throw new ArgumentNullException(nameof(controlQueue));
                 this.OrchestrationInstanceId = instanceId ?? throw new ArgumentNullException(nameof(instanceId));
                 this.OrchestrationExecutionId = executionId; // null is expected in some cases
             }
 
+            public ControlQueue ControlQueue { get; }
             public string OrchestrationInstanceId { get; }
             public string OrchestrationExecutionId { get; }
             public MessageCollection Messages { get; } = new MessageCollection();

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -207,6 +207,9 @@ namespace DurableTask.AzureStorage
                             this.storageAccountName,
                             this.settings.TaskHubName,
                             data.OriginalQueueMessage.Id,
+                            instanceId,
+                            executionId,
+                            controlQueue.Name,
                             data.OriginalQueueMessage.DequeueCount,
                             Utils.ExtensionVersion);
                     }
@@ -225,6 +228,9 @@ namespace DurableTask.AzureStorage
                             this.storageAccountName,
                             this.settings.TaskHubName,
                             replacementMessage.OriginalQueueMessage.Id,
+                            session.Instance.InstanceId,
+                            session.Instance.ExecutionId,
+                            controlQueue.Name,
                             replacementMessage.OriginalQueueMessage.DequeueCount,
                             Utils.ExtensionVersion);
                     }

--- a/src/DurableTask.AzureStorage/Partitioning/BlobLeaseManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/BlobLeaseManager.cs
@@ -214,7 +214,7 @@ namespace DurableTask.AzureStorage.Partitioning
             try
             {
                 await leaseBlob.FetchAttributesAsync();
-                string newLeaseId = Guid.NewGuid().ToString("N");
+                string newLeaseId = Guid.NewGuid().ToString();
                 if (leaseBlob.Properties.LeaseState == LeaseState.Leased)
                 {
                     lease.Token = await leaseBlob.ChangeLeaseAsync(newLeaseId, accessCondition: AccessCondition.GenerateLeaseCondition(lease.Token));

--- a/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
@@ -118,7 +118,8 @@ namespace DurableTask.AzureStorage.Tracking
         /// Used to set a state in the tracking store whenever a new execution is initiated from the client
         /// </summary>
         /// <param name="executionStartedEvent">The Execution Started Event being queued</param>
-        Task SetNewExecutionAsync(ExecutionStartedEvent executionStartedEvent);
+        /// <param name="blobName">The name of the blob if the content of the event is stored in blob storage.</param>
+        Task SetNewExecutionAsync(ExecutionStartedEvent executionStartedEvent, string blobName);
 
         /// <summary>
         /// Used to update a state in the tracking store to pending whenever a rewind is initiated from the client

--- a/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
@@ -118,8 +118,10 @@ namespace DurableTask.AzureStorage.Tracking
         /// Used to set a state in the tracking store whenever a new execution is initiated from the client
         /// </summary>
         /// <param name="executionStartedEvent">The Execution Started Event being queued</param>
-        /// <param name="blobName">The name of the blob if the content of the event is stored in blob storage.</param>
-        Task SetNewExecutionAsync(ExecutionStartedEvent executionStartedEvent, string blobName);
+        /// <param name="ignoreExistingInstances">When <c>true</c>, this operation is a no-op if an execution with this ID already exists.</param>
+        /// <param name="inputStatusOverride">An override value to use for the Input column. If not specified, uses <see cref="ExecutionStartedEvent.Input"/>.</param>
+        /// <returns>Returns <c>true</c> if the record was created successfully; <c>false</c> otherwise.</returns>
+        Task<bool> SetNewExecutionAsync(ExecutionStartedEvent executionStartedEvent, bool ignoreExistingInstances, string inputStatusOverride);
 
         /// <summary>
         /// Used to update a state in the tracking store to pending whenever a rewind is initiated from the client

--- a/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
@@ -137,7 +137,9 @@ namespace DurableTask.AzureStorage.Tracking
         }
 
         /// <inheritdoc />
-        public override async Task SetNewExecutionAsync(ExecutionStartedEvent executionStartedEvent)
+        public override async Task SetNewExecutionAsync(
+            ExecutionStartedEvent executionStartedEvent,
+            string blobName)
         {
             var orchestrationState = new OrchestrationState()
             {
@@ -145,7 +147,7 @@ namespace DurableTask.AzureStorage.Tracking
                 Version = executionStartedEvent.Version,
                 OrchestrationInstance = executionStartedEvent.OrchestrationInstance,
                 OrchestrationStatus = OrchestrationStatus.Pending,
-                Input = executionStartedEvent.Input,
+                Input = blobName ?? executionStartedEvent.Input,
                 Tags = executionStartedEvent.Tags,
                 CreatedTime = executionStartedEvent.Timestamp,
                 LastUpdatedTime = DateTime.UtcNow,

--- a/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
@@ -24,7 +24,6 @@ namespace DurableTask.AzureStorage.Tracking
 
     class InstanceStoreBackedTrackingStore : TrackingStoreBase
     {
-
         readonly IOrchestrationServiceInstanceStore instanceStore;
 
         /// <inheritdoc />
@@ -43,15 +42,6 @@ namespace DurableTask.AzureStorage.Tracking
         public override Task DeleteAsync()
         {
             return this.instanceStore.DeleteStoreAsync();
-        }
-
-        /// <summary>
-        /// Instance Store Does not Support this currently
-        /// </summary>
-        /// <returns></returns>
-        public override Task<bool> ExistsAsync()
-        {
-            throw new NotSupportedException();
         }
 
         /// <inheritdoc />
@@ -75,11 +65,6 @@ namespace DurableTask.AzureStorage.Tracking
             }
         }
 
-        public override Task<IList<string>> RewindHistoryAsync(string instanceId, IList<string> failedLeaves, CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
-
         /// <inheritdoc />
         public override async Task<IList<OrchestrationState>> GetStateAsync(string instanceId, bool allExecutions, bool fetchInput = true)
         {
@@ -101,45 +86,16 @@ namespace DurableTask.AzureStorage.Tracking
         }
 
         /// <inheritdoc />
-        public override Task<IList<OrchestrationState>> GetStateAsync(CancellationToken cancellationToken = default(CancellationToken))
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <inheritdoc />
-        public override Task<IList<OrchestrationState>> GetStateAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus, CancellationToken cancellationToken = default(CancellationToken))
-       {
-            throw new NotImplementedException();
-        }
-    
-        /// <inheritdoc />
-        public override Task<DurableStatusQueryResult> GetStateAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus, int top, string continuationToken, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <inheritdoc />
         public override Task PurgeHistoryAsync(DateTime thresholdDateTimeUtc, OrchestrationStateTimeRangeFilterType timeRangeFilterType)
         {
             return instanceStore.PurgeOrchestrationHistoryEventsAsync(thresholdDateTimeUtc, timeRangeFilterType);
         }
 
         /// <inheritdoc />
-        public override Task<PurgeHistoryResult> PurgeInstanceHistoryAsync(string instanceId)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <inheritdoc />
-        public override Task<PurgeHistoryResult> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <inheritdoc />
-        public override async Task SetNewExecutionAsync(
+        public override async Task<bool> SetNewExecutionAsync(
             ExecutionStartedEvent executionStartedEvent,
-            string blobName)
+            bool ignoreExistingInstances /* not used */,
+            string inputStatusOverride)
         {
             var orchestrationState = new OrchestrationState()
             {
@@ -147,7 +103,7 @@ namespace DurableTask.AzureStorage.Tracking
                 Version = executionStartedEvent.Version,
                 OrchestrationInstance = executionStartedEvent.OrchestrationInstance,
                 OrchestrationStatus = OrchestrationStatus.Pending,
-                Input = blobName ?? executionStartedEvent.Input,
+                Input = inputStatusOverride ?? executionStartedEvent.Input,
                 Tags = executionStartedEvent.Tags,
                 CreatedTime = executionStartedEvent.Timestamp,
                 LastUpdatedTime = DateTime.UtcNow,
@@ -161,11 +117,7 @@ namespace DurableTask.AzureStorage.Tracking
             };
 
             await this.instanceStore.WriteEntitiesAsync(new[] { orchestrationStateEntity });
-        }
-
-        public override Task UpdateStatusForRewindAsync(string instanceId)
-        {
-            throw new NotImplementedException();
+            return true;
         }
 
         /// <inheritdoc />

--- a/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
+++ b/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
@@ -31,13 +31,19 @@ namespace DurableTask.AzureStorage.Tracking
         public abstract Task DeleteAsync();
 
         /// <inheritdoc />
-        public abstract Task<bool> ExistsAsync();
+        public virtual Task<bool> ExistsAsync()
+        {
+            throw new NotSupportedException();
+        }
 
         /// <inheritdoc />
         public abstract Task<OrchestrationHistory> GetHistoryEventsAsync(string instanceId, string expectedExecutionId, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <inheritdoc />
-        public abstract Task<IList<string>> RewindHistoryAsync(string instanceId, IList<string> failedLeaves, CancellationToken cancellationToken);
+        public virtual Task<IList<string>> RewindHistoryAsync(string instanceId, IList<string> failedLeaves, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
 
         /// <inheritdoc />
         public abstract Task<IList<OrchestrationState>> GetStateAsync(string instanceId, bool allExecutions, bool fetchInput);
@@ -46,28 +52,46 @@ namespace DurableTask.AzureStorage.Tracking
         public abstract Task<OrchestrationState> GetStateAsync(string instanceId, string executionId, bool fetchInput);
 
         /// <inheritdoc />
-        public abstract Task<IList<OrchestrationState>> GetStateAsync(CancellationToken cancellationToken = default(CancellationToken));
+        public virtual Task<IList<OrchestrationState>> GetStateAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            throw new NotSupportedException();
+        }
 
         /// <inheritdoc />
-        public abstract Task<IList<OrchestrationState>> GetStateAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus, CancellationToken cancellationToken = default(CancellationToken));
+        public virtual Task<IList<OrchestrationState>> GetStateAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            throw new NotSupportedException();
+        }
 
         /// <inheritdoc />
-        public abstract Task<DurableStatusQueryResult> GetStateAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus, int top, string continuationToken, CancellationToken cancellationToken = default(CancellationToken));
+        public virtual Task<DurableStatusQueryResult> GetStateAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus, int top, string continuationToken, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            throw new NotSupportedException();
+        }
 
         /// <inheritdoc />
         public abstract Task PurgeHistoryAsync(DateTime thresholdDateTimeUtc, OrchestrationStateTimeRangeFilterType timeRangeFilterType);
 
         /// <inheritdoc />
-        public abstract Task<PurgeHistoryResult> PurgeInstanceHistoryAsync(string instanceId);
+        public virtual Task<PurgeHistoryResult> PurgeInstanceHistoryAsync(string instanceId)
+        {
+            throw new NotSupportedException();
+        }
 
         /// <inheritdoc />
-        public abstract Task<PurgeHistoryResult> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus);
+        public virtual Task<PurgeHistoryResult> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus)
+        {
+            throw new NotSupportedException();
+        }
 
         /// <inheritdoc />
-        public abstract Task SetNewExecutionAsync(ExecutionStartedEvent executionStartedEvent, string blobName);
+        public abstract Task<bool> SetNewExecutionAsync(ExecutionStartedEvent executionStartedEvent, bool ignoreExistingInstances, string inputStatusOverride);
 
         /// <inheritdoc />
-        public abstract Task UpdateStatusForRewindAsync(string instanceId);
+        public virtual Task UpdateStatusForRewindAsync(string instanceId)
+        {
+            throw new NotSupportedException();
+        }
 
         /// <inheritdoc />
         public abstract Task StartAsync();

--- a/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
+++ b/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
@@ -64,7 +64,7 @@ namespace DurableTask.AzureStorage.Tracking
         public abstract Task PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus);
 
         /// <inheritdoc />
-        public abstract Task SetNewExecutionAsync(ExecutionStartedEvent executionStartedEvent);
+        public abstract Task SetNewExecutionAsync(ExecutionStartedEvent executionStartedEvent, string blobName);
 
         /// <inheritdoc />
         public abstract Task UpdateStatusForRewindAsync(string instanceId);

--- a/src/DurableTask.AzureStorage/Utils.cs
+++ b/src/DurableTask.AzureStorage/Utils.cs
@@ -16,11 +16,11 @@ namespace DurableTask.AzureStorage
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Text;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using DurableTask.Core;
-    using Microsoft.WindowsAzure.Storage.Queue;
+    using DurableTask.Core.History;
 
     static class Utils
     {
@@ -71,6 +71,17 @@ namespace DurableTask.AzureStorage
         public static double Next(this Random random, double minValue, double maxValue)
         {
             return random.NextDouble() * (maxValue - minValue) + minValue;
+        }
+
+        public static int GetEpisodeNumber(OrchestrationRuntimeState runtimeState)
+        {
+            return GetEpisodeNumber(runtimeState.Events);
+        }
+
+        public static int GetEpisodeNumber(IEnumerable<HistoryEvent> historyEvents)
+        {
+            // DTFx core writes an "OrchestratorStarted" event at the start of each episode.
+            return historyEvents.Count(e => e.EventType == EventType.OrchestratorStarted);
         }
     }
 }

--- a/src/DurableTask.AzureStorage/Utils.cs
+++ b/src/DurableTask.AzureStorage/Utils.cs
@@ -67,5 +67,10 @@ namespace DurableTask.AzureStorage
                 semaphore.Release();
             }
         }
+
+        public static double Next(this Random random, double minValue, double maxValue)
+        {
+            return random.NextDouble() * (maxValue - minValue) + minValue;
+        }
     }
 }

--- a/src/DurableTask.AzureStorage/Utils.cs
+++ b/src/DurableTask.AzureStorage/Utils.cs
@@ -41,7 +41,7 @@ namespace DurableTask.AzureStorage
             await Task.WhenAll(tasks.ToArray());
         }
 
-        public static async Task ParallelForEachAsync<T>(this IReadOnlyList<T> items, int maxConcurrency, Func<T, Task> action)
+        public static async Task ParallelForEachAsync<T>(this IList<T> items, int maxConcurrency, Func<T, Task> action)
         {
             using (var semaphore = new SemaphoreSlim(maxConcurrency))
             {


### PR DESCRIPTION
This PR contains the following bug fixes: 

* Fix for https://github.com/Azure/azure-functions-durable-extension/issues/462: Excessive polling of storage queues
* Fix for https://github.com/Azure/azure-functions-durable-extension/issues/460: Internal message loss due to partition movement
* Fix for https://github.com/Azure/azure-functions-durable-extension/issues/502: Large exception payloads will hang orchestration instances
* Fix for https://github.com/Azure/azure-functions-durable-extension/issues/520: Instances stuck in the "Pending" state but actually completed
* Partial fix for https://github.com/Azure/azure-functions-durable-extension/issues/312: Change format of blob lease IDs
* Partial fix for https://github.com/Azure/azure-functions-durable-extension/issues/338: Internal poison message handling (introducing 10 minute delays)