### PR TITLE
Add possibility of scheduling an orchestration start

### DIFF
--- a/src/DurableTask.AzureServiceFabric/FabricOrchestrationServiceClient.cs
+++ b/src/DurableTask.AzureServiceFabric/FabricOrchestrationServiceClient.cs
@@ -92,6 +92,11 @@ namespace DurableTask.AzureServiceFabric
                 throw new NotSupportedException($"DedupeStatuses are not supported yet with service fabric provider");
             }
 
+            if (creationMessage.Event is ExecutionStartedEvent executionStarted && executionStarted.ScheduledStartTime.HasValue)
+            {
+                throw new NotSupportedException("Service Fabric storage provider for Durable Tasks currently does not support scheduled starts");
+            }
+
             creationMessage.OrchestrationInstance.InstanceId.EnsureValidInstanceId();
 
             return CreateTaskOrchestrationAsync(creationMessage);

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -171,6 +171,17 @@ namespace DurableTask.AzureStorage.Messaging
                     initialVisibilityDelay = TimeSpan.Zero;
                 }
             }
+            else if (taskMessage.Event is ExecutionStartedEvent executionStartedEvent)
+            {
+                if (executionStartedEvent.ScheduledStartTime.HasValue)
+                {
+                    initialVisibilityDelay = executionStartedEvent.ScheduledStartTime.Value.Subtract(DateTime.UtcNow);
+                    if (initialVisibilityDelay < TimeSpan.Zero)
+                    {
+                        initialVisibilityDelay = TimeSpan.Zero;
+                    }
+                }
+            }
 
             // Special functionality for entity messages with a delivery delay 
             if (taskMessage.Event is EventRaisedEvent eventRaisedEvent

--- a/src/DurableTask.AzureStorage/OrchestrationInstanceStatus.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationInstanceStatus.cs
@@ -30,5 +30,6 @@ namespace DurableTask.AzureStorage
         public DateTime CreatedTime { get; set; }
         public DateTime LastUpdatedTime { get; set; }
         public string RuntimeStatus { get; set; }
+        public DateTime? ScheduledStartTime { get; set; }
     }
 }

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -556,6 +556,7 @@ namespace DurableTask.AzureStorage.Tracking
             orchestrationState.LastUpdatedTime = orchestrationInstanceStatus.LastUpdatedTime;
             orchestrationState.Input = orchestrationInstanceStatus.Input;
             orchestrationState.Output = orchestrationInstanceStatus.Output;
+            orchestrationState.ScheduledStartTime = orchestrationInstanceStatus.ScheduledStartTime;
 
             if (this.settings.FetchLargeMessageDataEnabled)
             {
@@ -830,7 +831,8 @@ namespace DurableTask.AzureStorage.Tracking
                     ["Version"] = new EntityProperty(executionStartedEvent.Version),
                     ["RuntimeStatus"] = new EntityProperty(OrchestrationStatus.Pending.ToString()),
                     ["LastUpdatedTime"] = new EntityProperty(DateTime.UtcNow),
-                    ["TaskHubName"] = new EntityProperty(this.settings.TaskHubName)
+                    ["TaskHubName"] = new EntityProperty(this.settings.TaskHubName),
+                    ["ScheduledStartTime"] = new EntityProperty(executionStartedEvent.ScheduledStartTime)
                 }
             };
 
@@ -982,6 +984,8 @@ namespace DurableTask.AzureStorage.Tracking
                         instanceEntity.Properties["Version"] = new EntityProperty(executionStartedEvent.Version);
                         instanceEntity.Properties["CreatedTime"] = new EntityProperty(executionStartedEvent.Timestamp);
                         instanceEntity.Properties["RuntimeStatus"] = new EntityProperty(OrchestrationStatus.Running.ToString());
+                        if (executionStartedEvent.ScheduledStartTime.HasValue)
+                            instanceEntity.Properties["ScheduledStartTime"] = new EntityProperty(executionStartedEvent.ScheduledStartTime);
                         this.SetInstancesTablePropertyFromHistoryProperty(
                             historyEntity,
                             instanceEntity,

--- a/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
@@ -114,7 +114,8 @@ namespace DurableTask.AzureStorage.Tracking
                 Tags = executionStartedEvent.Tags,
                 CreatedTime = executionStartedEvent.Timestamp,
                 LastUpdatedTime = DateTime.UtcNow,
-                CompletedTime = Core.Common.DateTimeUtils.MinDateTime
+                CompletedTime = Core.Common.DateTimeUtils.MinDateTime,
+                ScheduledStartTime = executionStartedEvent.ScheduledStartTime
             };
 
             var orchestrationStateEntity = new OrchestrationStateInstanceEntity()

--- a/src/DurableTask.Core/History/ExecutionStartedEvent.cs
+++ b/src/DurableTask.Core/History/ExecutionStartedEvent.cs
@@ -13,6 +13,7 @@
 
 namespace DurableTask.Core.History
 {
+    using System;
     using System.Collections.Generic;
     using System.Runtime.Serialization;
 
@@ -79,5 +80,12 @@ namespace DurableTask.Core.History
         /// </summary>
         [DataMember]
         public IDictionary<string, string> Tags { get; set; }
+
+        /// <summary>
+        /// Gets or sets date to start the orchestration
+        /// </summary>
+        [DataMember]
+        public DateTime? ScheduledStartTime { get; set; }
+
     }
 }

--- a/src/DurableTask.Core/OrchestrationState.cs
+++ b/src/DurableTask.Core/OrchestrationState.cs
@@ -108,6 +108,12 @@ namespace DurableTask.Core
         public string Version;
 
         /// <summary>
+        /// Gets or sets date to start the orchestration
+        /// </summary>
+        [DataMember]
+        public DateTime? ScheduledStartTime { get; set; }
+
+        /// <summary>
         /// Implementation for <see cref="IExtensibleDataObject.ExtensionData"/>.
         /// </summary>
         public ExtensionDataObject ExtensionData { get; set; }

--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -124,6 +124,26 @@ namespace DurableTask.Core
         }
 
         /// <summary>
+        ///     Create a new orchestration of the specified type with an automatically generated instance id
+        /// </summary>
+        /// <param name="orchestrationType">Type that derives from TaskOrchestration</param>
+        /// <param name="input">Input parameter to the specified TaskOrchestration</param>
+        /// <param name="startAt">Orchestration start time</param>
+        /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
+        public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(Type orchestrationType, object input, DateTime startAt)
+        {
+            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
+                NameVersionHelper.GetDefaultName(orchestrationType),
+                NameVersionHelper.GetDefaultVersion(orchestrationType),
+                null,
+                input,
+                null,
+                null,
+                null,
+                startAt);
+        }
+
+        /// <summary>
         ///     Create a new orchestration of the specified type with the specified instance id
         /// </summary>
         /// <param name="orchestrationType">Type that derives from TaskOrchestration</param>

--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -55,6 +55,56 @@ namespace DurableTask.Core
         }
 
         /// <summary>
+        ///     Create a new orchestration of the specified type with the specified instance id, scheduled to start at an specific time
+        /// </summary>
+        /// <param name="orchestrationType">Type that derives from TaskOrchestration</param>
+        /// <param name="input">Input parameter to the specified TaskOrchestration</param>
+        /// <param name="startAt">Orchestration start time</param>
+        /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
+        public Task<OrchestrationInstance> CreateScheduledOrchestrationInstanceAsync(
+            Type orchestrationType,
+            object input,
+            DateTime startAt)
+        {
+            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
+                NameVersionHelper.GetDefaultName(orchestrationType),
+                NameVersionHelper.GetDefaultVersion(orchestrationType),
+                null,
+                input,
+                null,
+                null,
+                null,
+                null,
+                startAt: startAt);
+        }
+
+        /// <summary>
+        ///     Create a new orchestration of the specified type with the specified instance id, scheduled to start at an specific time
+        /// </summary>
+        /// <param name="orchestrationType">Type that derives from TaskOrchestration</param>
+        /// <param name="instanceId">Instance id for the orchestration to be created, must be unique across the Task Hub</param>
+        /// <param name="input">Input parameter to the specified TaskOrchestration</param>
+        /// <param name="startAt">Orchestration start time</param>
+        /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
+        public Task<OrchestrationInstance> CreateScheduledOrchestrationInstanceAsync(
+            Type orchestrationType,
+            string instanceId,
+            object input,
+            DateTime startAt)
+        {
+            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
+                NameVersionHelper.GetDefaultName(orchestrationType),
+                NameVersionHelper.GetDefaultVersion(orchestrationType),
+                instanceId,
+                input,
+                null,
+                null,
+                null,
+                null,
+                startAt: startAt);
+        }
+
+        /// <summary>
         ///     Create a new orchestration of the specified type with an automatically generated instance id
         /// </summary>
         /// <param name="orchestrationType">Type that derives from TaskOrchestration</param>
@@ -448,7 +498,8 @@ namespace DurableTask.Core
             IDictionary<string, string> orchestrationTags,
             OrchestrationStatus[] dedupeStatuses,
             string eventName,
-            object eventData)
+            object eventData,
+            DateTime? startAt = null)
         {
             if (string.IsNullOrWhiteSpace(orchestrationInstanceId))
             {
@@ -467,7 +518,8 @@ namespace DurableTask.Core
                 Tags = orchestrationTags,
                 Name = orchestrationName,
                 Version = orchestrationVersion,
-                OrchestrationInstance = orchestrationInstance
+                OrchestrationInstance = orchestrationInstance,
+                ScheduledStartTime = startAt
             };
 
             var taskMessages = new List<TaskMessage>

--- a/src/DurableTask.Redis/RedisOrchestrationService.cs
+++ b/src/DurableTask.Redis/RedisOrchestrationService.cs
@@ -371,6 +371,13 @@ namespace DurableTask.Redis
             {
                 await StartAsync();
             }
+
+            if (creationMessage.Event is ExecutionStartedEvent executionStarted &&
+                executionStarted.ScheduledStartTime.HasValue)
+            {
+                throw new NotSupportedException("Redis storage provider for Durable Tasks currently does not support scheduled starts");
+            }
+
             await this.partitionOrchestrationManager.CreateTaskOrchestration(creationMessage, dedupeStatuses);
         }
 

--- a/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
+++ b/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
@@ -623,7 +623,8 @@ namespace DurableTask.ServiceBus
                 CreatedTime = executionStartedEvent.Timestamp,
                 LastUpdatedTime = DateTime.UtcNow,
                 CompletedTime = DateTimeUtils.MinDateTime,
-                ParentInstance = executionStartedEvent.ParentInstance
+                ParentInstance = executionStartedEvent.ParentInstance,
+                ScheduledStartTime = executionStartedEvent.ScheduledStartTime
             };
 
             var orchestrationStateEntity = new OrchestrationStateInstanceEntity
@@ -1132,7 +1133,8 @@ namespace DurableTask.ServiceBus
                 Tags = executionStartedEvent?.Tags,
                 CreatedTime = createTime,
                 LastUpdatedTime = createTime,
-                CompletedTime = DateTimeUtils.MinDateTime
+                CompletedTime = DateTimeUtils.MinDateTime,
+                ScheduledStartTime = executionStartedEvent?.ScheduledStartTime
             };
 
             var jumpStartEntity = new OrchestrationJumpStartInstanceEntity
@@ -1189,6 +1191,11 @@ namespace DurableTask.ServiceBus
             if (message.Event is ExecutionStartedEvent executionStartedEvent)
             {
                 brokeredMessage.MessageId = $"{executionStartedEvent.OrchestrationInstance.InstanceId}_{executionStartedEvent.OrchestrationInstance.ExecutionId}";
+
+                // setting the enqueue time here as ServiceBusUtils.GetBrokeredMessageFromObjectAsync is not using the messageFireTime parameter
+                // in every scenario
+                if (executionStartedEvent.ScheduledStartTime.HasValue)
+                    brokeredMessage.ScheduledEnqueueTimeUtc = executionStartedEvent.ScheduledStartTime.Value.ToUniversalTime();
             }
 
             return brokeredMessage;

--- a/src/DurableTask.ServiceBus/Tracking/AzureTableOrchestrationStateEntity.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureTableOrchestrationStateEntity.cs
@@ -95,6 +95,7 @@ namespace DurableTask.ServiceBus.Tracking
             returnValues.Add("CompressedSize", new EntityProperty(State.CompressedSize));
             returnValues.Add("Input", new EntityProperty(State.Input.Truncate(ServiceBusConstants.MaxStringLengthForAzureTableColumn)));
             returnValues.Add("Output", new EntityProperty(State.Output.Truncate(ServiceBusConstants.MaxStringLengthForAzureTableColumn)));
+            returnValues.Add("ScheduledStartTime", new EntityProperty(State.ScheduledStartTime));
 
             return returnValues;
         }
@@ -145,7 +146,10 @@ namespace DurableTask.ServiceBus.Tracking
                 CompressedSize =
                     GetValue("CompressedSize", properties, property => property.Int64Value).GetValueOrDefault(),
                 Input = GetValue("Input", properties, property => property.StringValue),
-                Output = GetValue("Output", properties, property => property.StringValue)
+                Output = GetValue("Output", properties, property => property.StringValue),
+                ScheduledStartTime = GetValue("ScheduledStartTime", properties, property => property.DateTimeOffsetValue)
+                    .GetValueOrDefault()
+                    .DateTime,
             };
 
             TaskTimeStamp =

--- a/test/DurableTask.AzureServiceFabric.Integration.Tests/FunctionalTests.cs
+++ b/test/DurableTask.AzureServiceFabric.Integration.Tests/FunctionalTests.cs
@@ -404,5 +404,15 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests
 
             Assert.IsNull(state);
         }
+
+        /// <summary>
+        /// Validates scheduled starts, ensuring that invalid operation exception is raised since the feature is not supported
+        /// </summary>
+        [TestMethod]
+        public async Task ScheduledStartTest_NotSupported()
+        {
+            var expectedStartTime = DateTime.UtcNow.AddSeconds(30);
+            await Assert.ThrowsExceptionAsync<NotSupportedException>(() => this.taskHubClient.CreateScheduledOrchestrationInstanceAsync(typeof(SimpleOrchestrationWithTasks), null, expectedStartTime));
+        }
     }
 }

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -1795,6 +1795,122 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
+                /// <summary>
+        /// Validates scheduled starts, ensuring they are executed according to defined start date time
+        /// </summary>
+        /// <param name="enableExtendedSessions"></param>
+        /// <returns></returns>
+        [DataTestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async Task ScheduledStart_Inline(bool enableExtendedSessions)
+        {
+            using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(enableExtendedSessions))
+            {
+                await host.StartAsync();
+
+                var expectedStartTime = DateTime.UtcNow.AddSeconds(30);
+                var clientStartingIn30Seconds = await host.StartOrchestrationAsync(typeof(Orchestrations.CurrentTimeInline), "Current Time!", startAt: expectedStartTime);
+                var clientStartingNow = await host.StartOrchestrationAsync(typeof(Orchestrations.CurrentTimeInline), "Current Time!");
+
+                var statusStartingNow = clientStartingNow.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+                var statusStartingIn30Seconds = clientStartingIn30Seconds.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
+
+                await Task.WhenAll(statusStartingNow, statusStartingIn30Seconds);
+
+                Assert.AreEqual(OrchestrationStatus.Completed, statusStartingNow.Result?.OrchestrationStatus);
+                Assert.AreEqual("Current Time!", JToken.Parse(statusStartingNow.Result?.Input));
+                Assert.IsNull(statusStartingNow.Result.ScheduledStartTime);
+
+                Assert.AreEqual(OrchestrationStatus.Completed, statusStartingIn30Seconds.Result?.OrchestrationStatus);
+                Assert.AreEqual("Current Time!", JToken.Parse(statusStartingIn30Seconds.Result?.Input));
+                Assert.AreEqual(expectedStartTime, statusStartingIn30Seconds.Result.ScheduledStartTime);
+
+                var startNowResult = (DateTime)JToken.Parse(statusStartingNow.Result?.Output);
+                var startIn30SecondsResult = (DateTime)JToken.Parse(statusStartingIn30Seconds.Result?.Output);
+
+                Assert.IsTrue(startIn30SecondsResult > startNowResult);
+                Assert.IsTrue(startIn30SecondsResult >= expectedStartTime);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// Validates scheduled starts, ensuring they are executed according to defined start date time
+        /// </summary>
+        /// <param name="enableExtendedSessions"></param>
+        /// <returns></returns>
+        [DataTestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async Task ScheduledStart_Activity(bool enableExtendedSessions)
+        {
+            using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(enableExtendedSessions))
+            {
+                await host.StartAsync();
+
+                var expectedStartTime = DateTime.UtcNow.AddSeconds(30);
+                var clientStartingIn30Seconds = await host.StartOrchestrationAsync(typeof(Orchestrations.CurrentTimeActivity), "Current Time!", startAt: expectedStartTime);
+                var clientStartingNow = await host.StartOrchestrationAsync(typeof(Orchestrations.CurrentTimeActivity), "Current Time!");
+
+                var statusStartingNow = clientStartingNow.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+                var statusStartingIn30Seconds = clientStartingIn30Seconds.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
+
+                await Task.WhenAll(statusStartingNow, statusStartingIn30Seconds);
+
+                Assert.AreEqual(OrchestrationStatus.Completed, statusStartingNow.Result?.OrchestrationStatus);
+                Assert.AreEqual("Current Time!", JToken.Parse(statusStartingNow.Result?.Input));
+                Assert.IsNull(statusStartingNow.Result.ScheduledStartTime);
+
+                Assert.AreEqual(OrchestrationStatus.Completed, statusStartingIn30Seconds.Result?.OrchestrationStatus);
+                Assert.AreEqual("Current Time!", JToken.Parse(statusStartingIn30Seconds.Result?.Input));
+                Assert.AreEqual(expectedStartTime, statusStartingIn30Seconds.Result.ScheduledStartTime);
+
+                var startNowResult = (DateTime)JToken.Parse(statusStartingNow.Result?.Output);
+                var startIn30SecondsResult = (DateTime)JToken.Parse(statusStartingIn30Seconds.Result?.Output);
+
+                Assert.IsTrue(startIn30SecondsResult > startNowResult);
+                Assert.IsTrue(startIn30SecondsResult >= expectedStartTime);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// Validates scheduled starts, ensuring they are executed according to defined start date time
+        /// </summary>
+        /// <param name="enableExtendedSessions"></param>
+        /// <returns></returns>
+        [DataTestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async Task ScheduledStart_Activity_GetStatus_Returns_ScheduledStart(bool enableExtendedSessions)
+        {
+            using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(enableExtendedSessions))
+            {
+                await host.StartAsync();
+
+                var expectedStartTime = DateTime.UtcNow.AddSeconds(30);
+                var clientStartingIn30Seconds = await host.StartOrchestrationAsync(typeof(Orchestrations.DelayedCurrentTimeActivity), "Delayed Current Time!", startAt: expectedStartTime);
+                var clientStartingNow = await host.StartOrchestrationAsync(typeof(Orchestrations.DelayedCurrentTimeActivity), "Delayed Current Time!");
+
+                var statusStartingIn30Seconds = await clientStartingIn30Seconds.GetStatusAsync();
+                Assert.IsNotNull(statusStartingIn30Seconds.ScheduledStartTime);
+                Assert.AreEqual(expectedStartTime, statusStartingIn30Seconds.ScheduledStartTime);
+
+                var statusStartingNow = await clientStartingNow.GetStatusAsync();
+                Assert.IsNull(statusStartingNow.ScheduledStartTime);
+
+                await Task.WhenAll(
+                    clientStartingNow.WaitForCompletionAsync(TimeSpan.FromSeconds(35)),
+                    clientStartingIn30Seconds.WaitForCompletionAsync(TimeSpan.FromSeconds(65))
+                    );
+
+                await host.StopAsync();
+            }
+        }
+
         static class Orchestrations
         {
             internal class SayHelloInline : TaskOrchestration<string, string>
@@ -2506,6 +2622,41 @@ namespace DurableTask.AzureStorage.Tests
                     }
                 }
             }
+
+            internal class CurrentTimeInline : TaskOrchestration<DateTime, string>
+            {
+                public override Task<DateTime> RunTask(OrchestrationContext context, string input)
+                {
+                    return Task.FromResult(context.CurrentUtcDateTime);
+                }
+            }
+
+            [KnownType(typeof(Activities.CurrentTime))]
+            internal class CurrentTimeActivity : TaskOrchestration<DateTime, string>
+            {
+                public override Task<DateTime> RunTask(OrchestrationContext context, string input)
+                {
+                    return context.ScheduleTask<DateTime>(typeof(Activities.CurrentTime), input);
+                }
+            }
+
+            internal class DelayedCurrentTimeInline : TaskOrchestration<DateTime, string>
+            {
+                public override async Task<DateTime> RunTask(OrchestrationContext context, string input)
+                {
+                    await context.CreateTimer<bool>(context.CurrentUtcDateTime.Add(TimeSpan.FromSeconds(3)), true);
+                    return context.CurrentUtcDateTime;
+                }
+            }
+
+            [KnownType(typeof(Activities.DelayedCurrentTime))]
+            internal class DelayedCurrentTimeActivity : TaskOrchestration<DateTime, string>
+            {
+                public override Task<DateTime> RunTask(OrchestrationContext context, string input)
+                {
+                    return context.ScheduleTask<DateTime>(typeof(Activities.DelayedCurrentTime), input);
+                }
+            }
         }
 
         static class Activities
@@ -2740,6 +2891,33 @@ namespace DurableTask.AzureStorage.Tests
                 protected override byte[] Execute(TaskContext context, byte[] input)
                 {
                     return input;
+                }
+            }
+
+            internal class CurrentTime : TaskActivity<string, DateTime>
+            {
+                protected override DateTime Execute(TaskContext context, string input)
+                {
+                    if (string.IsNullOrEmpty(input))
+                    {
+                        throw new ArgumentNullException(nameof(input));
+                    }
+                    return DateTime.UtcNow;
+                }
+            }
+
+            internal class DelayedCurrentTime : TaskActivity<string, DateTime>
+            {
+                protected override DateTime Execute(TaskContext context, string input)
+                {
+                    if (string.IsNullOrEmpty(input))
+                    {
+                        throw new ArgumentNullException(nameof(input));
+                    }
+
+                    Thread.Sleep(TimeSpan.FromSeconds(3));
+
+                    return DateTime.UtcNow;
                 }
             }
         }

--- a/test/DurableTask.AzureStorage.Tests/TestOrchestrationHost.cs
+++ b/test/DurableTask.AzureStorage.Tests/TestOrchestrationHost.cs
@@ -69,7 +69,8 @@ namespace DurableTask.AzureStorage.Tests
         public async Task<TestOrchestrationClient> StartOrchestrationAsync(
             Type orchestrationType,
             object input,
-            string instanceId = null)
+            string instanceId = null,
+            DateTime? startAt = null)
         {
             if (!this.addedOrchestrationTypes.Contains(orchestrationType))
             {
@@ -100,10 +101,17 @@ namespace DurableTask.AzureStorage.Tests
             }
 
             DateTime creationTime = DateTime.UtcNow;
-            OrchestrationInstance instance = await this.client.CreateOrchestrationInstanceAsync(
-                orchestrationType,
-                instanceId,
-                input);
+            OrchestrationInstance instance = startAt.HasValue ?
+                await this.client.CreateScheduledOrchestrationInstanceAsync(
+                    orchestrationType,
+                    instanceId,
+                    input,
+                    startAt.Value)
+                    : 
+                await this.client.CreateOrchestrationInstanceAsync(
+                    orchestrationType,
+                    instanceId,
+                    input);
 
             Trace.TraceInformation($"Started {orchestrationType.Name}, Instance ID = {instance.InstanceId}");
             return new TestOrchestrationClient(this.client, orchestrationType, instance.InstanceId, creationTime);


### PR DESCRIPTION
I would like to start conversation about adding scheduled start to durable functions. One of the possible ways to achieve the same behavior today is by creating a timer activity at the orchestration function start, as illustrated below:
```c#
[FunctionName("OrchestrationStart")]
public static Task OrchestrationStart(
    [OrchestrationClient] DurableOrchestrationClient starter)
{
    // Orchestration input comes from the queue message content.
    return starter.StartNewAsync("Orchestration", "input-for-the-orchestration");
}

[FunctionName("Orchestration")]
public static async Task<bool> Orchestration(
    [OrchestrationTrigger] DurableOrchestrationContext context)
{
   await context.CreateTimer(context.CurrentUtcDateTime.Add(TimeSpan.FromDays(1)));
  // real activities will start here
}
```

The PR contains an implementation that creates the execution start with a delay, thus saving one execution:
```c#
[FunctionName("OrchestrationStart")]
public static Task OrchestrationStart(
    [OrchestrationClient] DurableOrchestrationClient starter)
{
    // Orchestration input comes from the queue message content.
    return starter.ScheduleNewAsync(DateTime.UtcNow.Add(TimeSpan.FromDays(1)), "Orchestration", "input-for-the-orchestration");
}

[FunctionName("Orchestration")]
public static async Task<bool> Orchestration(
    [OrchestrationTrigger] DurableOrchestrationContext context)
{
  // only real activities go here
}
```

Wonder what @cgillum and others think about the idea.

Thanks!