### PR TITLE
Add return value(s) to purge history

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1289,7 +1289,7 @@ namespace DurableTask.AzureStorage
         /// </summary>
         /// <param name="instanceId">Instance ID of the orchestration.</param>
         /// <returns>Class containing number of storage requests sent, along with instances and rows deleted/purged</returns>
-        public Task<PurgeHistoryStats> PurgeInstanceHistoryAsync(string instanceId)
+        public Task<PurgeHistoryResult> PurgeInstanceHistoryAsync(string instanceId)
         {
             return this.trackingStore.PurgeInstanceHistoryAsync(instanceId);
         }
@@ -1301,7 +1301,7 @@ namespace DurableTask.AzureStorage
         /// <param name="createdTimeTo">CreatedTime of orchestrations. Purges history less than this value.</param>
         /// <param name="runtimeStatus">RuntimeStatus of orchestrations. You can specify several status.</param>
         /// <returns>Class containing number of storage requests sent, along with instances and rows deleted/purged</returns>
-        public Task<PurgeHistoryStats> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus)
+        public Task<PurgeHistoryResult> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus)
         {
             return this.trackingStore.PurgeInstanceHistoryAsync(createdTimeFrom, createdTimeTo, runtimeStatus);
         }

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1299,7 +1299,8 @@ namespace DurableTask.AzureStorage
         /// <param name="createdTimeFrom">CreatedTime of orchestrations. Purges history grater than this value.</param>
         /// <param name="createdTimeTo">CreatedTime of orchestrations. Purges history less than this value.</param>
         /// <param name="runtimeStatus">RuntimeStatus of orchestrations. You can specify several status.</param>
-        public Task PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus)
+        /// <returns>Number of instances and rows deleted/purged</returns>
+        public Task<(int instancesDeleted, int rowsDeleted)> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus)
         {
             return this.trackingStore.PurgeInstanceHistoryAsync(createdTimeFrom, createdTimeTo, runtimeStatus);
         }

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1288,7 +1288,8 @@ namespace DurableTask.AzureStorage
         /// Purge history for an orchestration with a specified instance id.
         /// </summary>
         /// <param name="instanceId">Instance ID of the orchestration.</param>
-        public Task PurgeInstanceHistoryAsync(string instanceId)
+        /// <returns>Class containing number of storage requests sent, along with instances and rows deleted/purged</returns>
+        public Task<PurgeHistoryStats> PurgeInstanceHistoryAsync(string instanceId)
         {
             return this.trackingStore.PurgeInstanceHistoryAsync(instanceId);
         }
@@ -1299,8 +1300,8 @@ namespace DurableTask.AzureStorage
         /// <param name="createdTimeFrom">CreatedTime of orchestrations. Purges history grater than this value.</param>
         /// <param name="createdTimeTo">CreatedTime of orchestrations. Purges history less than this value.</param>
         /// <param name="runtimeStatus">RuntimeStatus of orchestrations. You can specify several status.</param>
-        /// <returns>Number of instances and rows deleted/purged</returns>
-        public Task<(int instancesDeleted, int rowsDeleted)> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus)
+        /// <returns>Class containing number of storage requests sent, along with instances and rows deleted/purged</returns>
+        public Task<PurgeHistoryStats> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus)
         {
             return this.trackingStore.PurgeInstanceHistoryAsync(createdTimeFrom, createdTimeTo, runtimeStatus);
         }

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -24,10 +24,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\DurableTask.Core\DurableTask.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -24,6 +24,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\DurableTask.Core\DurableTask.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -603,23 +603,31 @@ namespace DurableTask.AzureStorage.Tracking
             return orchestrationStates;
         }
 
-        private async Task<int> DeleteHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus)
+        private async Task<(int storageRequests, int instancesDeleted, int rowsDeleted)> DeleteHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus)
         {
             TableQuery<OrchestrationInstanceStatus> query = OrchestrationInstanceStatusQueryCondition.Parse(createdTimeFrom, createdTimeTo, runtimeStatus)
                 .ToTableQuery<OrchestrationInstanceStatus>();
 
             TableContinuationToken token = null;
             var orchestrationStates = new List<OrchestrationInstanceStatus>(100);
+
             int storageRequests = 0;
+            int rowsDeleted = 0;
+            int instancesDeleted = 0;
+
             while (true)
             {
                 TableQuerySegment<OrchestrationInstanceStatus> segment = await this.InstancesTable.ExecuteQuerySegmentedAsync(query, token);
                 storageRequests++;
                 this.stats.StorageRequests.Increment();
                 this.stats.TableEntitiesRead.Increment(segment.Results.Count);
+                instancesDeleted = segment.Results.Count;
+
                 foreach (OrchestrationInstanceStatus orchestrationInstanceStatus in segment.Results)
                 {
-                    storageRequests += await this.DeleteAllDataForOrchestrationInstance(orchestrationInstanceStatus);
+                    (int intermedRequests, int intermedRows) = await this.DeleteAllDataForOrchestrationInstance(orchestrationInstanceStatus);
+                    storageRequests += intermedRequests;
+                    rowsDeleted += intermedRows;
                 }
                 orchestrationStates.AddRange(segment.Results);
                 token = segment.ContinuationToken;
@@ -629,12 +637,13 @@ namespace DurableTask.AzureStorage.Tracking
                 }
             }
 
-            return storageRequests;
+            return (storageRequests, instancesDeleted, rowsDeleted);
         }
 
-        private async Task<int> DeleteAllDataForOrchestrationInstance(OrchestrationInstanceStatus orchestrationInstanceStatus)
+        private async Task<(int storageRequests, int rowsDeleted)> DeleteAllDataForOrchestrationInstance(OrchestrationInstanceStatus orchestrationInstanceStatus)
         {
             int storageRequests = 0;
+            int rowsDeleted = 0;
             HistoryEntitiesResponseInfo historyEntitiesResponseInfo = await this.GetHistoryEntitiesResponseInfoAsync(
                 orchestrationInstanceStatus.PartitionKey,
                 null,
@@ -649,6 +658,7 @@ namespace DurableTask.AzureStorage.Tracking
             {
                 var batch = new TableBatchOperation();
                 List<DynamicTableEntity> batchForDeletion = historyEntitiesResponseInfo.HistoryEventEntities.Skip(pageOffset).Take(100).ToList();
+                rowsDeleted += batchForDeletion.Count;
 
                 foreach (DynamicTableEntity itemForDeletion in batchForDeletion)
                 {
@@ -672,7 +682,7 @@ namespace DurableTask.AzureStorage.Tracking
             this.stats.StorageRequests.Increment();
             storageRequests++;
 
-            return storageRequests;
+            return (storageRequests, rowsDeleted);
         }
 
         /// <inheritdoc />
@@ -701,7 +711,7 @@ namespace DurableTask.AzureStorage.Tracking
 
             if (orchestrationInstanceStatus != null)
             {
-                int storageRequests = await this.DeleteAllDataForOrchestrationInstance(orchestrationInstanceStatus);
+                (int storageRequests, int rowsDeleted) = await this.DeleteAllDataForOrchestrationInstance(orchestrationInstanceStatus);
                 AnalyticsEventSource.Log.PurgeInstanceHistory(
                     this.storageAccountName,
                     this.taskHubName,
@@ -716,7 +726,7 @@ namespace DurableTask.AzureStorage.Tracking
         }
 
         /// <inheritdoc />
-        public override  async Task PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus)
+        public override async Task<(int instancesDeleted, int rowsDeleted)> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus)
         {
             Stopwatch stopwatch = Stopwatch.StartNew();
             List<OrchestrationStatus> runtimeStatusList =  runtimeStatus?.Where(
@@ -725,7 +735,7 @@ namespace DurableTask.AzureStorage.Tracking
                     x == OrchestrationStatus.Canceled ||
                     x == OrchestrationStatus.Failed).ToList();
 
-            int storageRequests = await this.DeleteHistoryAsync(createdTimeFrom, createdTimeTo, runtimeStatusList);
+            (int storageRequests, int instancesDeleted, int rowsDeleted) = await this.DeleteHistoryAsync(createdTimeFrom, createdTimeTo, runtimeStatusList);
 
             AnalyticsEventSource.Log.PurgeInstanceHistory(
                 this.storageAccountName,
@@ -739,6 +749,8 @@ namespace DurableTask.AzureStorage.Tracking
                 storageRequests,
                 stopwatch.ElapsedMilliseconds,
                 Utils.ExtensionVersion);
+
+            return (instancesDeleted, rowsDeleted);
         }
 
         /// <inheritdoc />

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -626,8 +626,8 @@ namespace DurableTask.AzureStorage.Tracking
                 foreach (OrchestrationInstanceStatus orchestrationInstanceStatus in segment.Results)
                 {
                     var statisticsFromDeletion = await this.DeleteAllDataForOrchestrationInstance(orchestrationInstanceStatus);
-                    storageRequests += statisticsFromDeletion.storageRequests;
-                    rowsDeleted += statisticsFromDeletion.rowsDeleted;
+                    storageRequests += statisticsFromDeletion.StorageRequests;
+                    rowsDeleted += statisticsFromDeletion.RowsDeleted;
                 }
                 orchestrationStates.AddRange(segment.Results);
                 token = segment.ContinuationToken;
@@ -720,7 +720,7 @@ namespace DurableTask.AzureStorage.Tracking
                     DateTime.MinValue.ToString(),
                     DateTime.MinValue.ToString(),
                     null,
-                    deletionStats.storageRequests,
+                    deletionStats.StorageRequests,
                     stopwatch.ElapsedMilliseconds,
                     Utils.ExtensionVersion);
 
@@ -751,7 +751,7 @@ namespace DurableTask.AzureStorage.Tracking
                 runtimeStatus != null ?
                     string.Join(",", runtimeStatus.Select(x => x.ToString()).ToArray()) :
                     string.Empty,
-                stats.storageRequests,
+                stats.StorageRequests,
                 stopwatch.ElapsedMilliseconds,
                 Utils.ExtensionVersion);
 

--- a/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
@@ -145,6 +145,7 @@ namespace DurableTask.AzureStorage.Tracking
         /// <param name="createdTimeFrom">Start creation time for querying instances for purging</param>
         /// <param name="createdTimeTo">End creation time for querying instances for purging</param>
         /// <param name="runtimeStatus">List of runtime status for querying instances for purging. Only Completed, Terminated, or Failed will be processed</param>
-        Task PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus);
+        /// <returns>Number of instances and rows deleted/purged</returns>
+        Task<(int instancesDeleted, int rowsDeleted)> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus);
     }
 }

--- a/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
@@ -138,7 +138,7 @@ namespace DurableTask.AzureStorage.Tracking
         /// </summary>
         /// <param name="instanceId">Instance ID</param>
         /// <returns>Class containing number of storage requests sent, along with instances and rows deleted/purged</returns>
-        Task<PurgeHistoryStats> PurgeInstanceHistoryAsync(string instanceId);
+        Task<PurgeHistoryResult> PurgeInstanceHistoryAsync(string instanceId);
 
         /// <summary>
         /// Purge the orchestration history for instances that match the conditions
@@ -147,6 +147,6 @@ namespace DurableTask.AzureStorage.Tracking
         /// <param name="createdTimeTo">End creation time for querying instances for purging</param>
         /// <param name="runtimeStatus">List of runtime status for querying instances for purging. Only Completed, Terminated, or Failed will be processed</param>
         /// <returns>Class containing number of storage requests sent, along with instances and rows deleted/purged</returns>
-        Task<PurgeHistoryStats> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus);
+        Task<PurgeHistoryResult> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus);
     }
 }

--- a/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
@@ -137,7 +137,8 @@ namespace DurableTask.AzureStorage.Tracking
         /// Purge the history for a concrete instance 
         /// </summary>
         /// <param name="instanceId">Instance ID</param>
-        Task PurgeInstanceHistoryAsync(string instanceId);
+        /// <returns>Class containing number of storage requests sent, along with instances and rows deleted/purged</returns>
+        Task<PurgeHistoryStats> PurgeInstanceHistoryAsync(string instanceId);
 
         /// <summary>
         /// Purge the orchestration history for instances that match the conditions
@@ -145,7 +146,7 @@ namespace DurableTask.AzureStorage.Tracking
         /// <param name="createdTimeFrom">Start creation time for querying instances for purging</param>
         /// <param name="createdTimeTo">End creation time for querying instances for purging</param>
         /// <param name="runtimeStatus">List of runtime status for querying instances for purging. Only Completed, Terminated, or Failed will be processed</param>
-        /// <returns>Number of instances and rows deleted/purged</returns>
-        Task<(int instancesDeleted, int rowsDeleted)> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus);
+        /// <returns>Class containing number of storage requests sent, along with instances and rows deleted/purged</returns>
+        Task<PurgeHistoryStats> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus);
     }
 }

--- a/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
@@ -131,7 +131,7 @@ namespace DurableTask.AzureStorage.Tracking
         }
 
         /// <inheritdoc />
-        public override Task PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus)
+        public override Task<(int instancesDeleted, int rowsDeleted)> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus)
         {
             throw new NotImplementedException();
         }

--- a/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
@@ -125,13 +125,13 @@ namespace DurableTask.AzureStorage.Tracking
         }
 
         /// <inheritdoc />
-        public override Task PurgeInstanceHistoryAsync(string instanceId)
+        public override Task<PurgeHistoryStats> PurgeInstanceHistoryAsync(string instanceId)
         {
             throw new NotImplementedException();
         }
 
         /// <inheritdoc />
-        public override Task<(int instancesDeleted, int rowsDeleted)> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus)
+        public override Task<PurgeHistoryStats> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus)
         {
             throw new NotImplementedException();
         }

--- a/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
@@ -125,13 +125,13 @@ namespace DurableTask.AzureStorage.Tracking
         }
 
         /// <inheritdoc />
-        public override Task<PurgeHistoryStats> PurgeInstanceHistoryAsync(string instanceId)
+        public override Task<PurgeHistoryResult> PurgeInstanceHistoryAsync(string instanceId)
         {
             throw new NotImplementedException();
         }
 
         /// <inheritdoc />
-        public override Task<PurgeHistoryStats> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus)
+        public override Task<PurgeHistoryResult> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus)
         {
             throw new NotImplementedException();
         }

--- a/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
+++ b/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
@@ -61,7 +61,7 @@ namespace DurableTask.AzureStorage.Tracking
         public abstract Task PurgeInstanceHistoryAsync(string instanceId);
 
         /// <inheritdoc />
-        public abstract Task PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus);
+        public abstract Task<(int instancesDeleted, int rowsDeleted)> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus);
 
         /// <inheritdoc />
         public abstract Task SetNewExecutionAsync(ExecutionStartedEvent executionStartedEvent);

--- a/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
+++ b/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
@@ -58,10 +58,10 @@ namespace DurableTask.AzureStorage.Tracking
         public abstract Task PurgeHistoryAsync(DateTime thresholdDateTimeUtc, OrchestrationStateTimeRangeFilterType timeRangeFilterType);
 
         /// <inheritdoc />
-        public abstract Task<PurgeHistoryStats> PurgeInstanceHistoryAsync(string instanceId);
+        public abstract Task<PurgeHistoryResult> PurgeInstanceHistoryAsync(string instanceId);
 
         /// <inheritdoc />
-        public abstract Task<PurgeHistoryStats> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus);
+        public abstract Task<PurgeHistoryResult> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus);
 
         /// <inheritdoc />
         public abstract Task SetNewExecutionAsync(ExecutionStartedEvent executionStartedEvent);

--- a/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
+++ b/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
@@ -58,10 +58,10 @@ namespace DurableTask.AzureStorage.Tracking
         public abstract Task PurgeHistoryAsync(DateTime thresholdDateTimeUtc, OrchestrationStateTimeRangeFilterType timeRangeFilterType);
 
         /// <inheritdoc />
-        public abstract Task PurgeInstanceHistoryAsync(string instanceId);
+        public abstract Task<PurgeHistoryStats> PurgeInstanceHistoryAsync(string instanceId);
 
         /// <inheritdoc />
-        public abstract Task<(int instancesDeleted, int rowsDeleted)> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus);
+        public abstract Task<PurgeHistoryStats> PurgeInstanceHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus);
 
         /// <inheritdoc />
         public abstract Task SetNewExecutionAsync(ExecutionStartedEvent executionStartedEvent);

--- a/src/DurableTask.AzureStorage/Utils.cs
+++ b/src/DurableTask.AzureStorage/Utils.cs
@@ -64,4 +64,39 @@ namespace DurableTask.AzureStorage
             }
         }
     }
+
+    /// <summary>
+    /// Class to hold statistics about this execution of purge history
+    /// Implemented to avoid dependency on System.ValueTuple
+    /// </summary>
+    public class PurgeHistoryStats
+    {
+        /// <summary>
+        /// Number of requests sent to Storage during this execution of purge history
+        /// </summary>
+        public readonly int storageRequests;
+
+        /// <summary>
+        /// Number of instances deleted during this execution of purge history
+        /// </summary>
+        public readonly int instancesDeleted;
+
+        /// <summary>
+        /// Number of rows deleted during this execution of purge history
+        /// </summary>
+        public readonly int rowsDeleted;
+
+        /// <summary>
+        /// Constructor for readonly purge history statistics
+        /// </summary>
+        /// <param name="storageRequests">Requests sent to storage</param>
+        /// <param name="instancesDeleted">Number of instances deleted</param>
+        /// <param name="rowsDeleted">Number of rows deleted</param>
+        public PurgeHistoryStats(int storageRequests, int instancesDeleted, int rowsDeleted)
+        {
+            this.storageRequests = storageRequests;
+            this.instancesDeleted = instancesDeleted;
+            this.rowsDeleted = rowsDeleted;
+        }
+    }
 }

--- a/src/DurableTask.AzureStorage/Utils.cs
+++ b/src/DurableTask.AzureStorage/Utils.cs
@@ -67,7 +67,6 @@ namespace DurableTask.AzureStorage
 
     /// <summary>
     /// Class to hold statistics about this execution of purge history
-    /// Implemented to avoid dependency on System.ValueTuple
     /// </summary>
     public class PurgeHistoryResult
     {
@@ -79,24 +78,24 @@ namespace DurableTask.AzureStorage
         /// <param name="rowsDeleted">Number of rows deleted</param>
         public PurgeHistoryResult(int storageRequests, int instancesDeleted, int rowsDeleted)
         {
-            this.storageRequests = storageRequests;
-            this.instancesDeleted = instancesDeleted;
-            this.rowsDeleted = rowsDeleted;
+            this.StorageRequests = storageRequests;
+            this.InstancesDeleted = instancesDeleted;
+            this.RowsDeleted = rowsDeleted;
         }
 
         /// <summary>
         /// Number of requests sent to Storage during this execution of purge history
         /// </summary>
-        public int storageRequests { get; }
+        public int StorageRequests { get; }
 
         /// <summary>
         /// Number of instances deleted during this execution of purge history
         /// </summary>
-        public int instancesDeleted { get; }
+        public int InstancesDeleted { get; }
 
         /// <summary>
         /// Number of rows deleted during this execution of purge history
         /// </summary>
-        public int rowsDeleted { get; }
+        public int RowsDeleted { get; }
     }
 }

--- a/src/DurableTask.AzureStorage/Utils.cs
+++ b/src/DurableTask.AzureStorage/Utils.cs
@@ -69,34 +69,34 @@ namespace DurableTask.AzureStorage
     /// Class to hold statistics about this execution of purge history
     /// Implemented to avoid dependency on System.ValueTuple
     /// </summary>
-    public class PurgeHistoryStats
+    public class PurgeHistoryResult
     {
         /// <summary>
-        /// Number of requests sent to Storage during this execution of purge history
-        /// </summary>
-        public readonly int storageRequests;
-
-        /// <summary>
-        /// Number of instances deleted during this execution of purge history
-        /// </summary>
-        public readonly int instancesDeleted;
-
-        /// <summary>
-        /// Number of rows deleted during this execution of purge history
-        /// </summary>
-        public readonly int rowsDeleted;
-
-        /// <summary>
-        /// Constructor for readonly purge history statistics
+        /// Constructor for purge history statistics
         /// </summary>
         /// <param name="storageRequests">Requests sent to storage</param>
         /// <param name="instancesDeleted">Number of instances deleted</param>
         /// <param name="rowsDeleted">Number of rows deleted</param>
-        public PurgeHistoryStats(int storageRequests, int instancesDeleted, int rowsDeleted)
+        public PurgeHistoryResult(int storageRequests, int instancesDeleted, int rowsDeleted)
         {
             this.storageRequests = storageRequests;
             this.instancesDeleted = instancesDeleted;
             this.rowsDeleted = rowsDeleted;
         }
+
+        /// <summary>
+        /// Number of requests sent to Storage during this execution of purge history
+        /// </summary>
+        public int storageRequests { get; }
+
+        /// <summary>
+        /// Number of instances deleted during this execution of purge history
+        /// </summary>
+        public int instancesDeleted { get; }
+
+        /// <summary>
+        /// Number of rows deleted during this execution of purge history
+        /// </summary>
+        public int rowsDeleted { get; }
     }
 }


### PR DESCRIPTION
**Objective:** PurgeInstanceHistoryAsync now supports returning the number of instances purged, as well as the number of rows purged. Without this information, users have no way of telling whether or not their query was successful, let alone metrics about it, without querying again or manually checking the DurableFunctionsHubHistory table themselves.

- Adds new dependency on System.ValueTuple in order to return more than one value from an async task.
- Only implemented in the case where users pass a time range and list of statuses to filter by. I could add a rowsDeleted output for the PurgeInstanceHistory that only takes an instance ID.