### PR TITLE
Make OrchestrationInstance and IsReplaying internal protected

### DIFF
--- a/src/DurableTask.Core/OrchestrationContext.cs
+++ b/src/DurableTask.Core/OrchestrationContext.cs
@@ -34,7 +34,7 @@ namespace DurableTask.Core
         /// <summary>
         /// Instance of the currently executing orchestration
         /// </summary>
-        public OrchestrationInstance OrchestrationInstance { get; internal set; }
+        public OrchestrationInstance OrchestrationInstance { get; internal protected set; }
 
         /// <summary>
         /// Replay-safe current UTC datetime
@@ -44,7 +44,7 @@ namespace DurableTask.Core
         /// <summary>
         ///     True if the code is currently replaying, False if code is truly executing for the first time.
         /// </summary>
-        public bool IsReplaying { get; internal set; }
+        public bool IsReplaying { get; internal protected set; }
 
         /// <summary>
         ///     Create a proxy client class to schedule remote TaskActivities via a strongly typed interface.


### PR DESCRIPTION
I could set them to internal protected to expose them to implementation of the abstract class, or I could make them both virtual.
It felt like `internal protected` is less intrusive, but I admit I do not fully understand why these two are not virtual.

#236 