### PR TITLE
DurableTask.AzureStorage: Fix out-of-order regression in 1.4.0

### DIFF
--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -75,12 +75,13 @@ namespace DurableTask.AzureStorage
 #endif
         }
 
-        [Event(101, Level = EventLevel.Informational, Opcode = EventOpcode.Send, Task = Tasks.Enqueue, Version = 4)]
+        [Event(101, Level = EventLevel.Informational, Opcode = EventOpcode.Send, Task = Tasks.Enqueue, Version = 5)]
         public void SendingMessage(
             Guid relatedActivityId,
             string Account,
             string TaskHub,
             string EventType,
+            int TaskEventId,
             string InstanceId,
             string ExecutionId,
             long SizeInBytes,
@@ -98,6 +99,7 @@ namespace DurableTask.AzureStorage
                 Account,
                 TaskHub,
                 EventType,
+                TaskEventId,
                 InstanceId ?? string.Empty,
                 ExecutionId ?? string.Empty,
                 SizeInBytes,
@@ -109,12 +111,13 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(102, Level = EventLevel.Informational, Opcode = EventOpcode.Receive, Task = Tasks.Dequeue, Version = 4)]
+        [Event(102, Level = EventLevel.Informational, Opcode = EventOpcode.Receive, Task = Tasks.Dequeue, Version = 5)]
         public void ReceivedMessage(
             Guid relatedActivityId,
             string Account,
             string TaskHub,
             string EventType,
+            int TaskEventId,
             string InstanceId,
             string ExecutionId,
             string MessageId,
@@ -134,6 +137,7 @@ namespace DurableTask.AzureStorage
                 Account,
                 TaskHub,
                 EventType,
+                TaskEventId,
                 InstanceId,
                 ExecutionId ?? string.Empty,
                 MessageId,
@@ -147,11 +151,12 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(103, Level = EventLevel.Informational, Version = 3)]
+        [Event(103, Level = EventLevel.Informational, Version = 4)]
         public void DeletingMessage(
             string Account,
             string TaskHub,
             string EventType,
+            int TaskEventId,
             string MessageId,
             string InstanceId,
             string ExecutionId,
@@ -165,6 +170,7 @@ namespace DurableTask.AzureStorage
                 Account,
                 TaskHub,
                 EventType,
+                TaskEventId,
                 MessageId,
                 InstanceId,
                 ExecutionId ?? string.Empty,
@@ -173,11 +179,12 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(104, Level = EventLevel.Warning, Version = 4)]
+        [Event(104, Level = EventLevel.Warning, Version = 5)]
         public void AbandoningMessage(
             string Account,
             string TaskHub,
             string EventType,
+            int TaskEventId,
             string MessageId,
             string InstanceId,
             string ExecutionId,
@@ -192,6 +199,7 @@ namespace DurableTask.AzureStorage
                 Account,
                 TaskHub,
                 EventType,
+                TaskEventId,
                 MessageId,
                 InstanceId,
                 ExecutionId ?? string.Empty,
@@ -212,7 +220,7 @@ namespace DurableTask.AzureStorage
             this.WriteEvent(105, Account, TaskHub, Details, ExtensionVersion);
         }
 
-        [Event(106, Level = EventLevel.Warning, Version = 2)]
+        [Event(106, Level = EventLevel.Warning, Version = 3)]
         public void MessageGone(
             string Account,
             string TaskHub,
@@ -220,6 +228,8 @@ namespace DurableTask.AzureStorage
             string InstanceId,
             string ExecutionId,
             string PartitionId,
+            string EventType,
+            int TaskEventId,
             string Details,
             string ExtensionVersion)
         {
@@ -232,6 +242,8 @@ namespace DurableTask.AzureStorage
                 InstanceId,
                 ExecutionId ?? string.Empty,
                 PartitionId,
+                EventType,
+                TaskEventId,
                 Details,
                 ExtensionVersion);
         }
@@ -384,7 +396,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(113, Level = EventLevel.Informational)]
+        [Event(113, Level = EventLevel.Informational, Version = 2)]
         public void RenewingMessage(
             string Account,
             string TaskHub,
@@ -392,6 +404,7 @@ namespace DurableTask.AzureStorage
             string ExecutionId,
             string PartitionId,
             string EventType,
+            int TaskEventId,
             string MessageId,
             int VisibilityTimeoutSeconds,
             string ExtensionVersion)
@@ -405,19 +418,22 @@ namespace DurableTask.AzureStorage
                 ExecutionId ?? string.Empty,
                 PartitionId,
                 EventType,
+                TaskEventId,
                 MessageId,
                 VisibilityTimeoutSeconds,
                 ExtensionVersion);
         }
 
-        [Event(114, Level = EventLevel.Error)]
+        [Event(114, Level = EventLevel.Error, Version = 2)]
         public void MessageFailure(
             string Account,
             string TaskHub,
+            string MessageId,
             string InstanceId,
             string ExecutionId,
             string PartitionId,
             string EventType,
+            int TaskEventId,
             string Details,
             string ExtensionVersion)
         {
@@ -426,10 +442,12 @@ namespace DurableTask.AzureStorage
                 114,
                 Account,
                 TaskHub,
+                MessageId,
                 InstanceId,
                 ExecutionId ?? string.Empty,
                 PartitionId,
                 EventType,
+                TaskEventId,
                 Details,
                 ExtensionVersion);
         }
@@ -486,7 +504,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(118, Level = EventLevel.Warning)]
+        [Event(118, Level = EventLevel.Warning, Version = 2)]
         public void ReceivedOutOfOrderMessage(
             string Account,
             string TaskHub,
@@ -494,6 +512,7 @@ namespace DurableTask.AzureStorage
             string ExecutionId,
             string PartitionId,
             string EventType,
+            int TaskEventId,
             string MessageId,
             int Episode,
             string ExtensionVersion)
@@ -507,6 +526,7 @@ namespace DurableTask.AzureStorage
                 ExecutionId ?? string.Empty,
                 PartitionId,
                 EventType,
+                TaskEventId,
                 MessageId,
                 Episode,
                 ExtensionVersion);
@@ -789,7 +809,16 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             EnsureLogicalTraceActivityId();
-            this.WriteEvent(135, Account, TaskHub, InstanceId, ExecutionId ?? string.Empty, EventType, Episode, LatencyMs, ExtensionVersion);
+            this.WriteEvent(
+                135,
+                Account,
+                TaskHub,
+                InstanceId,
+                ExecutionId ?? string.Empty,
+                EventType,
+                Episode,
+                LatencyMs,
+                ExtensionVersion);
         }
 
         [Event(136, Level = EventLevel.Informational)]
@@ -866,12 +895,13 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(140, Level = EventLevel.Informational, Task = Tasks.Processing, Opcode = EventOpcode.Receive, Version = 3)]
+        [Event(140, Level = EventLevel.Informational, Task = Tasks.Processing, Opcode = EventOpcode.Receive, Version = 4)]
         public void ProcessingMessage(
             Guid relatedActivityId,
             string Account,
             string TaskHub,
             string EventType,
+            int TaskEventId,
             string InstanceId,
             string ExecutionId,
             string MessageId,
@@ -888,6 +918,7 @@ namespace DurableTask.AzureStorage
                 Account,
                 TaskHub,
                 EventType,
+                TaskEventId,
                 InstanceId,
                 ExecutionId ?? string.Empty,
                 MessageId,

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -615,6 +615,7 @@ namespace DurableTask.AzureStorage
                                 session.Instance.ExecutionId,
                                 session.ControlQueue.Name,
                                 message.TaskMessage.Event.EventType.ToString(),
+                                Utils.GetTaskEventId(message.TaskMessage.Event),
                                 message.OriginalQueueMessage.Id,
                                 message.Episode,
                                 Utils.ExtensionVersion);
@@ -731,6 +732,7 @@ namespace DurableTask.AzureStorage
                 storageAccountName,
                 taskHubName,
                 taskMessage.Event.EventType.ToString(),
+                Utils.GetTaskEventId(taskMessage.Event),
                 taskMessage.OrchestrationInstance.InstanceId,
                 taskMessage.OrchestrationInstance.ExecutionId,
                 queueMessage.Id,

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <FileVersion>1.4.0</FileVersion>
+    <FileVersion>1.4.1</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <Version>$(FileVersion)</Version>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -137,10 +137,12 @@ namespace DurableTask.AzureStorage.Messaging
                             AnalyticsEventSource.Log.MessageFailure(
                                 this.storageAccountName,
                                 this.settings.TaskHubName,
-                                string.Empty,
-                                string.Empty,
+                                string.Empty /* MessageId */,
+                                string.Empty /* InstanceId */,
+                                string.Empty /* ExecutionId */,
                                 this.storageQueue.Name,
-                                string.Empty,
+                                string.Empty /* EventType */,
+                                0 /* TaskEventId */,
                                 e.ToString(),
                                 Utils.ExtensionVersion);
 

--- a/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
+++ b/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
@@ -119,27 +119,7 @@ namespace DurableTask.AzureStorage.Messaging
 
         internal bool IsOutOfOrderMessage(MessageData message)
         {
-            int taskScheduledId = -1;
-            HistoryEvent messageEvent = message.TaskMessage.Event;
-            switch (messageEvent.EventType)
-            {
-                case EventType.TaskCompleted:
-                    taskScheduledId = ((TaskCompletedEvent)messageEvent).TaskScheduledId;
-                    break;
-                case EventType.TaskFailed:
-                    taskScheduledId = ((TaskFailedEvent)messageEvent).TaskScheduledId;
-                    break;
-                case EventType.SubOrchestrationInstanceCompleted:
-                    taskScheduledId = ((SubOrchestrationInstanceCompletedEvent)messageEvent).TaskScheduledId;
-                    break;
-                case EventType.SubOrchestrationInstanceFailed:
-                    taskScheduledId = ((SubOrchestrationInstanceFailedEvent)messageEvent).TaskScheduledId;
-                    break;
-                case EventType.TimerFired:
-                    taskScheduledId = ((TimerFiredEvent)messageEvent).TimerId;
-                    break;
-            }
-
+            int taskScheduledId = Utils.GetTaskEventId(message.TaskMessage.Event);
             if (taskScheduledId < 0)
             {
                 // This message does not require ordering (RaiseEvent, ExecutionStarted, Terminate, etc.).

--- a/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
+++ b/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
@@ -146,11 +146,12 @@ namespace DurableTask.AzureStorage.Messaging
                 return false;
             }
 
-            // This message is a response to a task. Make sure the event ID matches the range of the previously known
-            // scheduled events. We don't need to ensure the event types actually match because the core runtime
-            // will do that anyways and fail the orchestration if there is a non-matching event type.
-            HistoryEvent mostRecentTaskEvent = this.RuntimeState.Events.LastOrDefault(e => e.EventId >= 0);
-            if (mostRecentTaskEvent != null && taskScheduledId <= mostRecentTaskEvent.EventId)
+            // This message is a response to a task. Search the history to make sure that we've recorded the fact that
+            // this task was scheduled. We don't have the luxery of transactions between queues and tables, so queue
+            // messages are always written before we update the history in table storage. This means that in some
+            // cases the response message could get picked up before we're ready for it.
+            HistoryEvent mostRecentTaskEvent = this.RuntimeState.Events.LastOrDefault(e => e.EventId == taskScheduledId);
+            if (mostRecentTaskEvent != null)
             {
                 return false;
             }

--- a/src/DurableTask.AzureStorage/Messaging/Session.cs
+++ b/src/DurableTask.AzureStorage/Messaging/Session.cs
@@ -65,6 +65,7 @@ namespace DurableTask.AzureStorage.Messaging
                 this.storageAccountName,
                 this.taskHubName,
                 taskMessage.Event.EventType.ToString(),
+                Utils.GetTaskEventId(taskMessage.Event),
                 taskMessage.OrchestrationInstance.InstanceId,
                 taskMessage.OrchestrationInstance.ExecutionId,
                 queueMessage.Id,

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -108,6 +108,7 @@ namespace DurableTask.AzureStorage.Messaging
                     this.storageAccountName,
                     this.settings.TaskHubName,
                     taskMessage.Event.EventType.ToString(),
+                    Utils.GetTaskEventId(taskMessage.Event),
                     sourceInstance.InstanceId,
                     sourceInstance.ExecutionId,
                     Encoding.Unicode.GetByteCount(rawContent),
@@ -135,10 +136,12 @@ namespace DurableTask.AzureStorage.Messaging
                 AnalyticsEventSource.Log.MessageFailure(
                     this.storageAccountName,
                     this.settings.TaskHubName,
-                    string.Empty,
+                    string.Empty /* MessageId */,
                     sourceInstance.InstanceId,
                     sourceInstance.ExecutionId,
                     this.storageQueue.Name,
+                    taskMessage.Event.EventType.ToString(),
+                    Utils.GetTaskEventId(taskMessage.Event),
                     e.ToString(),
                     Utils.ExtensionVersion);
                 throw;
@@ -194,6 +197,7 @@ namespace DurableTask.AzureStorage.Messaging
                 this.storageAccountName,
                 this.settings.TaskHubName,
                 taskMessage.Event.EventType.ToString(),
+                Utils.GetTaskEventId(taskMessage.Event),
                 queueMessage.Id,
                 instance.InstanceId,
                 instance.ExecutionId,
@@ -218,7 +222,7 @@ namespace DurableTask.AzureStorage.Messaging
             catch (Exception e)
             {
                 // Message may have been processed and deleted already.
-                this.HandleMessagingExceptions(e, queueMessage.Id, session.Instance, $"Caller: {nameof(AbandonMessageAsync)}");
+                this.HandleMessagingExceptions(e, message, $"Caller: {nameof(AbandonMessageAsync)}");
             }
             finally
             {
@@ -239,6 +243,7 @@ namespace DurableTask.AzureStorage.Messaging
                 instance.ExecutionId,
                 this.storageQueue.Name,
                 message.TaskMessage.Event.EventType.ToString(),
+                Utils.GetTaskEventId(message.TaskMessage.Event),
                 queueMessage.Id,
                 (int)this.MessageVisibilityTimeout.TotalSeconds,
                 Utils.ExtensionVersion);
@@ -257,7 +262,7 @@ namespace DurableTask.AzureStorage.Messaging
             catch (Exception e)
             {
                 // Message may have been processed and deleted already.
-                this.HandleMessagingExceptions(e, queueMessage.Id, session.Instance, $"Caller: {nameof(RenewMessageAsync)}");
+                this.HandleMessagingExceptions(e, message, $"Caller: {nameof(RenewMessageAsync)}");
             }
             finally
             {
@@ -274,6 +279,7 @@ namespace DurableTask.AzureStorage.Messaging
                 this.storageAccountName,
                 this.settings.TaskHubName,
                 taskMessage.Event.EventType.ToString(),
+                Utils.GetTaskEventId(taskMessage.Event),
                 queueMessage.Id,
                 session.Instance.InstanceId,
                 session.Instance.ExecutionId,
@@ -290,7 +296,7 @@ namespace DurableTask.AzureStorage.Messaging
             }
             catch (Exception e)
             {
-                this.HandleMessagingExceptions(e, queueMessage.Id, session.Instance, $"Caller: {nameof(DeleteMessageAsync)}");
+                this.HandleMessagingExceptions(e, message, $"Caller: {nameof(DeleteMessageAsync)}");
             }
             finally
             {
@@ -298,7 +304,7 @@ namespace DurableTask.AzureStorage.Messaging
             }
         }
 
-        void HandleMessagingExceptions(Exception e, string messageId, OrchestrationInstance instance, string details)
+        void HandleMessagingExceptions(Exception e, MessageData message, string details)
         {
             StorageException storageException = e as StorageException;
             if (storageException?.RequestInformation?.HttpStatusCode == 404)
@@ -307,10 +313,12 @@ namespace DurableTask.AzureStorage.Messaging
                 AnalyticsEventSource.Log.MessageGone(
                     this.storageAccountName,
                     this.settings.TaskHubName,
-                    messageId,
-                    instance.InstanceId,
-                    instance.ExecutionId,
+                    message.OriginalQueueMessage.Id,
+                    message.TaskMessage.OrchestrationInstance.InstanceId,
+                    message.TaskMessage.OrchestrationInstance.ExecutionId,
                     this.storageQueue.Name,
+                    message.TaskMessage.Event.EventType.ToString(),
+                    Utils.GetTaskEventId(message.TaskMessage.Event),
                     details,
                     Utils.ExtensionVersion);
             }
@@ -319,10 +327,12 @@ namespace DurableTask.AzureStorage.Messaging
                 AnalyticsEventSource.Log.MessageFailure(
                     this.storageAccountName,
                     this.settings.TaskHubName,
-                    messageId,
-                    instance.InstanceId,
-                    instance.ExecutionId,
+                    message.OriginalQueueMessage.Id,
+                    message.TaskMessage.OrchestrationInstance.InstanceId,
+                    message.TaskMessage.OrchestrationInstance.ExecutionId,
                     this.storageQueue.Name,
+                    message.TaskMessage.Event.EventType.ToString(),
+                    Utils.GetTaskEventId(message.TaskMessage.Event),
                     e.ToString(),
                     Utils.ExtensionVersion);
 
@@ -351,10 +361,12 @@ namespace DurableTask.AzureStorage.Messaging
                 AnalyticsEventSource.Log.MessageFailure(
                     this.storageAccountName,
                     this.settings.TaskHubName,
-                    string.Empty /* messageId */,
-                    string.Empty /* instanceId */,
-                    string.Empty /* executionId */,
+                    string.Empty /* MessageId */,
+                    string.Empty /* InstanceId */,
+                    string.Empty /* ExecutionId */,
                     this.storageQueue.Name,
+                    string.Empty /* EventType */,
+                    0 /* TaskEventId */,
                     e.ToString(),
                     Utils.ExtensionVersion);
                 throw;
@@ -385,10 +397,12 @@ namespace DurableTask.AzureStorage.Messaging
                 AnalyticsEventSource.Log.MessageFailure(
                     this.storageAccountName,
                     this.settings.TaskHubName,
-                    string.Empty /* messageId */,
-                    string.Empty /* instanceId */,
-                    string.Empty /* executionId */,
+                    string.Empty /* MessageId */,
+                    string.Empty /* InstanceId */,
+                    string.Empty /* ExecutionId */,
                     this.storageQueue.Name,
+                    string.Empty /* EventType */,
+                    0 /* TaskEventId */,
                     e.ToString(),
                     Utils.ExtensionVersion);
                 throw;

--- a/src/DurableTask.AzureStorage/Messaging/WorkItemQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/WorkItemQueue.cs
@@ -70,10 +70,12 @@ namespace DurableTask.AzureStorage.Messaging
                         AnalyticsEventSource.Log.MessageFailure(
                             this.storageAccountName,
                             this.settings.TaskHubName,
+                            string.Empty /* MessageId */,
                             string.Empty /* InstanceId */,
                             string.Empty /* ExecutionId */,
                             this.storageQueue.Name,
                             string.Empty /* EventType */,
+                            0 /* TaskEventId */,
                             e.ToString(),
                             Utils.ExtensionVersion);
 

--- a/src/DurableTask.AzureStorage/Utils.cs
+++ b/src/DurableTask.AzureStorage/Utils.cs
@@ -83,5 +83,24 @@ namespace DurableTask.AzureStorage
             // DTFx core writes an "OrchestratorStarted" event at the start of each episode.
             return historyEvents.Count(e => e.EventType == EventType.OrchestratorStarted);
         }
+
+        public static int GetTaskEventId(HistoryEvent historyEvent)
+        {
+            switch (historyEvent.EventType)
+            {
+                case EventType.TaskCompleted:
+                    return ((TaskCompletedEvent)historyEvent).TaskScheduledId;
+                case EventType.TaskFailed:
+                    return ((TaskFailedEvent)historyEvent).TaskScheduledId;
+                case EventType.SubOrchestrationInstanceCompleted:
+                    return ((SubOrchestrationInstanceCompletedEvent)historyEvent).TaskScheduledId;
+                case EventType.SubOrchestrationInstanceFailed:
+                    return ((SubOrchestrationInstanceFailedEvent)historyEvent).TaskScheduledId;
+                case EventType.TimerFired:
+                    return ((TimerFiredEvent)historyEvent).TimerId;
+                default:
+                    return historyEvent.EventId;
+            }
+        }
     }
 }


### PR DESCRIPTION
Resolves #241 

The fix is to do a more thorough search through the orchestration history to see if a particular response message matches a known request message. The previous "out-of-order" detection made some bad assumptions about the order of history events (premature optimization...), causing false-positives.

There is potentially a CPU performance impact for orchestrations that do huge fan-outs since we may end up searching through a larger portion of the orchestration history. This is acceptable, though, since it's not expected to be common and reliability is a priority.