### PR TITLE
Accept StorageCredentials to create AzureStorageOrchestrationService

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -170,16 +170,6 @@ namespace DurableTask.AzureStorage
                 this.trackingStore);
         }
 
-        private static CloudStorageAccount GetCloudStorageAccount(string storageConnectionString)
-        {
-            return CloudStorageAccount.Parse(storageConnectionString);
-        }
-
-        private static CloudStorageAccount GetCloudStorageAccount(StorageAccountDetails storageAccountDetails)
-        {
-            return storageAccountDetails != null ? new CloudStorageAccount(storageAccountDetails.StorageCredentials, storageAccountDetails.AccountName, storageAccountDetails.EndpointSuffix, true) : null;
-        }
-
         internal string WorkerId => this.settings.WorkerId;
 
         internal IEnumerable<ControlQueue> AllControlQueues => this.allControlQueues.Values;

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -61,7 +61,6 @@ namespace DurableTask.AzureStorage
         readonly WorkItemQueue workItemQueue;
         readonly ConcurrentDictionary<string, ActivitySession> activeActivitySessions;
         readonly MessageManager messageManager;
-        readonly StorageAccountDetails storageAccountDetails;
 
         readonly ITrackingStore trackingStore;
 
@@ -101,11 +100,10 @@ namespace DurableTask.AzureStorage
 
             this.settings = settings;
             this.tableEntityConverter = new TableEntityConverter();
-            this.storageAccountDetails = settings.StorageAccountDetails;
 
-            CloudStorageAccount account = this.storageAccountDetails == null
+            CloudStorageAccount account = settings.StorageAccountDetails == null
                 ? CloudStorageAccount.Parse(settings.StorageConnectionString)
-                : new CloudStorageAccount(this.storageAccountDetails.StorageCredentials, this.storageAccountDetails.AccountName, this.storageAccountDetails.EndpointSuffix, true);
+                : new CloudStorageAccount(settings.StorageAccountDetails.StorageCredentials, settings.StorageAccountDetails.AccountName, settings.StorageAccountDetails.EndpointSuffix, true);
             this.storageAccountName = account.Credentials.AccountName;
             this.stats = new AzureStorageOrchestrationServiceStats();
             this.queueClient = account.CreateCloudQueueClient();

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -133,5 +133,11 @@ namespace DurableTask.AzureStorage
         /// interval, it will cause it to expire and ownership of the partition will move to another worker instance.
         /// </summary>
         public TimeSpan LeaseInterval { get; set; } = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// Gets or sets the Azure Storage Account details
+        /// If provided, this is used to connect to Azure Storage
+        /// </summary>
+        public StorageAccountDetails StorageAccountDetails { get; set; }
     }
 }

--- a/src/DurableTask.AzureStorage/StorageAccountDetails.cs
+++ b/src/DurableTask.AzureStorage/StorageAccountDetails.cs
@@ -1,0 +1,38 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureStorage
+{
+    using Microsoft.WindowsAzure.Storage.Auth;
+
+    /// <summary>
+    /// Connection details of the Azure Storage account
+    /// </summary>
+    public sealed class StorageAccountDetails
+    {
+        /// <summary>
+        /// The storage account credentials
+        /// </summary>
+        public StorageCredentials StorageCredentials { get; set; }
+
+        /// <summary>
+        /// The storage account name
+        /// </summary>
+        public string AccountName { get; set; }
+
+        /// <summary>
+        /// The storage account endpoint suffix
+        /// </summary>
+        public string EndpointSuffix { get; set; }
+    }
+}

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -67,7 +67,8 @@ namespace DurableTask.AzureStorage.Tracking
         public AzureTableTrackingStore(
             AzureStorageOrchestrationServiceSettings settings,
             MessageManager messageManager,
-            AzureStorageOrchestrationServiceStats stats)
+            AzureStorageOrchestrationServiceStats stats,
+            CloudStorageAccount account)
         {
             this.settings = settings;
             this.messageManager = messageManager;
@@ -75,7 +76,6 @@ namespace DurableTask.AzureStorage.Tracking
             this.tableEntityConverter = new TableEntityConverter();
             this.taskHubName = settings.TaskHubName;
 
-            CloudStorageAccount account = CloudStorageAccount.Parse(settings.StorageConnectionString);
             this.storageAccountName = account.Credentials.AccountName;
 
             CloudTableClient tableClient = account.CreateCloudTableClient();


### PR DESCRIPTION
#243 
- Adding a new constructor for AzureStorageOrchestrationService to accept StorageCredentials. This will help support Managed Service Identity for DurableTask.AzureStorage ([https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/tutorial-vm-windows-access-storage#get-an-access-token-and-use-it-to-call-azure-storage]) 
- Currently Azure Storage does not accept TokenProvider authentication for TableClient. But I tested this by using account name and key to create Storage Credentials.
- No unit test updates yet as I was unable to use StorageCredentials (account name and key) to access Storage Emulator as I couldn't find a place to provide the blob, queue and table endpoints (to point them to the localhost emulator endpoint). Any help/suggestions appreciated for this.