### PR TITLE
Optimize Continue As New And Solve Missed Raised Events

### DIFF
--- a/Test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -542,13 +542,9 @@ namespace DurableTask.AzureStorage.Tests
                 // TODO: Sleeping to avoid a race condition where multiple ContinueAsNew messages
                 //       are processed by the same instance at the same time, resulting in a corrupt
                 //       storage failure in DTFx.
-                await Task.Delay(2000);
                 await client.RaiseEventAsync("operation", "incr");
-                await Task.Delay(2000);
                 await client.RaiseEventAsync("operation", "incr");
-                await Task.Delay(2000);
                 await client.RaiseEventAsync("operation", "decr");
-                await Task.Delay(2000);
                 await client.RaiseEventAsync("operation", "incr");
                 await Task.Delay(2000);
 
@@ -609,7 +605,7 @@ namespace DurableTask.AzureStorage.Tests
 
             // Ideally there would only be three blobs at the end of the test.
             // TODO: https://github.com/Azure/azure-functions-durable-extension/issues/509
-            Assert.AreEqual(9, blobCount);
+            Assert.AreEqual(3, blobCount);
 
             await client.PurgeInstanceHistoryByTimePeriod(
                 startDateTime,
@@ -1963,7 +1959,7 @@ namespace DurableTask.AzureStorage.Tests
                 public override void OnEvent(OrchestrationContext context, string name, string input)
                 {
                     Assert.AreEqual("operation", name, true, "Unknown signal recieved...");
-                    if (this.waitForOperationHandle != null)
+                    if (this.waitForOperationHandle != null && !this.waitForOperationHandle.Task.IsCompleted)
                     {
                         this.waitForOperationHandle.SetResult(input);
                     }

--- a/Test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -173,7 +173,7 @@ namespace DurableTask.AzureStorage.Tests
                 await host.StartAsync();
                 TestOrchestrationClient client = await host.StartOrchestrationAsync(typeof(Orchestrations.Factorial), 110, instanceId);
                 await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
-                
+
                 List<HistoryStateEvent> historyEvents = await client.GetOrchestrationHistoryAsync(instanceId);
                 Assert.IsTrue(historyEvents.Count > 0);
 
@@ -538,10 +538,6 @@ namespace DurableTask.AzureStorage.Tests
 
                 // Perform some operations
                 await client.RaiseEventAsync("operation", "incr");
-
-                // TODO: Sleeping to avoid a race condition where multiple ContinueAsNew messages
-                //       are processed by the same instance at the same time, resulting in a corrupt
-                //       storage failure in DTFx.
                 await client.RaiseEventAsync("operation", "incr");
                 await client.RaiseEventAsync("operation", "incr");
                 await client.RaiseEventAsync("operation", "decr");
@@ -603,8 +599,6 @@ namespace DurableTask.AzureStorage.Tests
 
             int blobCount = await this.GetBlobCount("test-largemessages", instanceId);
 
-            // Ideally there would only be three blobs at the end of the test.
-            // TODO: https://github.com/Azure/azure-functions-durable-extension/issues/509
             Assert.AreEqual(3, blobCount);
 
             await client.PurgeInstanceHistoryByTimePeriod(
@@ -643,7 +637,7 @@ namespace DurableTask.AzureStorage.Tests
 
                 // Need to wait for the instance to start before sending events to it.
                 // TODO: This requirement may not be ideal and should be revisited.
-                OrchestrationState orchestrationState = 
+                OrchestrationState orchestrationState =
                     await client.WaitForStartupAsync(TimeSpan.FromSeconds(10));
 
                 // Perform some operations
@@ -741,7 +735,7 @@ namespace DurableTask.AzureStorage.Tests
 
                 var client1 = await host.StartOrchestrationAsync(
                     typeof(Orchestrations.FactorialOrchestratorFail),
-                    input: 3, 
+                    input: 3,
                     instanceId: singletonInstanceId1);
 
                 var statusFail = await client1.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
@@ -755,7 +749,7 @@ namespace DurableTask.AzureStorage.Tests
                 input: "Catherine",
                 instanceId: singletonInstanceId2);
 
-                await client1.RewindAsync("Rewind failed orchestration only"); 
+                await client1.RewindAsync("Rewind failed orchestration only");
 
                 var statusRewind = await client1.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
@@ -1285,7 +1279,7 @@ namespace DurableTask.AzureStorage.Tests
                 string currentDirectory = Directory.GetCurrentDirectory();
                 string originalFilePath = Path.Combine(currentDirectory, originalFileName);
                 byte[] readBytes = File.ReadAllBytes(originalFilePath);
-                
+
                 var client = await host.StartOrchestrationAsync(typeof(Orchestrations.EchoBytes), readBytes);
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
 
@@ -1945,7 +1939,7 @@ namespace DurableTask.AzureStorage.Tests
                     }
 
                     return currentValue;
-                    
+
                 }
 
                 async Task<string> WaitForOperation()
@@ -1959,7 +1953,7 @@ namespace DurableTask.AzureStorage.Tests
                 public override void OnEvent(OrchestrationContext context, string name, string input)
                 {
                     Assert.AreEqual("operation", name, true, "Unknown signal recieved...");
-                    if (this.waitForOperationHandle != null && !this.waitForOperationHandle.Task.IsCompleted)
+                    if (this.waitForOperationHandle != null)
                     {
                         this.waitForOperationHandle.SetResult(input);
                     }
@@ -2224,7 +2218,7 @@ namespace DurableTask.AzureStorage.Tests
                 }
             }
 
-            internal class HelloFailMultipleActivity : TaskActivity<string, string> 
+            internal class HelloFailMultipleActivity : TaskActivity<string, string>
             {
                 public static bool ShouldFail1 = true;
                 public static bool ShouldFail2 = true;

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -845,6 +845,12 @@ namespace DurableTask.AzureStorage
             try
             {
                 session.ETag = await this.trackingStore.UpdateStateAsync(runtimeState, instanceId, executionId, session.ETag);
+
+                if(this.trackingStore is InstanceStoreBackedTrackingStore && workItem.OrchestrationRuntimeState != runtimeState){
+
+                    session.ETag = await this.trackingStore.UpdateStateAsync(workItem.OrchestrationRuntimeState, instanceId, workItem.OrchestrationRuntimeState.OrchestrationInstance.ExecutionId, session.ETag);
+
+                }
             }
             catch (Exception e)
             {

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -275,11 +275,11 @@ namespace DurableTask.AzureStorage
         }
 
         /// <summary>
-        ///  Will not carry over unexecuted raised events to the next iteration of an orchestration on ContinueAsNew
+        ///  Should we carry over unexecuted raised events to the next iteration of an orchestration on ContinueAsNew
         /// </summary>
-        public bool SkipEventsOnContinuation
+        public BehaviorOnContinueAsNew EventBehaviourForContinueAsNew
         {
-            get { return this.settings.SkipEventsOnContinuation; }
+            get { return this.settings.EventBehaviourForContinueAsNew; }
         }
 
         // We always leave the dispatcher counts at one unless we can find a customer workload that requires more.

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -67,7 +67,7 @@ namespace DurableTask.AzureStorage
         readonly TableEntityConverter tableEntityConverter;
 
         readonly ResettableLazy<Task> taskHubCreator;
-        readonly BlobLeaseManager leaseManager; 
+        readonly BlobLeaseManager leaseManager;
         readonly PartitionManager<BlobLease> partitionManager;
         readonly OrchestrationSessionManager orchestrationSessionManager;
         readonly object hubCreationLock;
@@ -363,9 +363,9 @@ namespace DurableTask.AzureStorage
         {
             if (recreateInstanceStore)
             {
-               await DeleteTrackingStore();
+                await DeleteTrackingStore();
 
-               this.taskHubCreator.Reset();
+                this.taskHubCreator.Reset();
             }
 
             await this.taskHubCreator.Value;
@@ -824,7 +824,7 @@ namespace DurableTask.AzureStorage
             }
 
             session.StartNewLogicalTraceScope();
-            OrchestrationRuntimeState runtimeState = newOrchestrationRuntimeState??workItem.OrchestrationRuntimeState;
+            OrchestrationRuntimeState runtimeState = newOrchestrationRuntimeState ?? workItem.OrchestrationRuntimeState;
 
             string instanceId = workItem.InstanceId;
             string executionId = runtimeState.OrchestrationInstance.ExecutionId;
@@ -1070,7 +1070,7 @@ namespace DurableTask.AzureStorage
                 // The context does not exist - possibly because it was already removed.
                 AnalyticsEventSource.Log.AssertFailure(
                     this.storageAccountName,
-                    this.settings.TaskHubName, 
+                    this.settings.TaskHubName,
                     $"Could not find context for work item with ID = {workItem.Id}.",
                     Utils.ExtensionVersion);
                 return;
@@ -1128,7 +1128,7 @@ namespace DurableTask.AzureStorage
                 // The context does not exist - possibly because it was already removed.
                 AnalyticsEventSource.Log.AssertFailure(
                     this.storageAccountName,
-                    this.settings.TaskHubName, 
+                    this.settings.TaskHubName,
                     $"Could not find context for work item with ID = {workItem.Id}.",
                     Utils.ExtensionVersion);
                 return;
@@ -1450,7 +1450,7 @@ namespace DurableTask.AzureStorage
             while (!cancellationToken.IsCancellationRequested && timeout > TimeSpan.Zero)
             {
                 OrchestrationState state = await this.GetOrchestrationStateAsync(instanceId, executionId);
-                if (state == null || 
+                if (state == null ||
                     state.OrchestrationStatus == OrchestrationStatus.Running ||
                     state.OrchestrationStatus == OrchestrationStatus.Pending ||
                     state.OrchestrationStatus == OrchestrationStatus.ContinuedAsNew)

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -274,6 +274,14 @@ namespace DurableTask.AzureStorage
             get { return this.settings.MaxConcurrentTaskActivityWorkItems; }
         }
 
+        /// <summary>
+        ///  Will not carry over unexecuted raised events to the next iteration of an orchestration on ContinueAsNew
+        /// </summary>
+        public bool SkipEventsOnContinuation
+        {
+            get { return this.settings.SkipEventsOnContinuation; }
+        }
+
         // We always leave the dispatcher counts at one unless we can find a customer workload that requires more.
         /// <inheritdoc />
         public int TaskActivityDispatcherCount { get; } = 1;
@@ -816,7 +824,7 @@ namespace DurableTask.AzureStorage
             }
 
             session.StartNewLogicalTraceScope();
-            OrchestrationRuntimeState runtimeState = workItem.OrchestrationRuntimeState;
+            OrchestrationRuntimeState runtimeState = newOrchestrationRuntimeState??workItem.OrchestrationRuntimeState;
 
             string instanceId = workItem.InstanceId;
             string executionId = runtimeState.OrchestrationInstance.ExecutionId;

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -844,13 +844,7 @@ namespace DurableTask.AzureStorage
             // will result in a duplicate replay of the orchestration with no side-effects.
             try
             {
-                session.ETag = await this.trackingStore.UpdateStateAsync(runtimeState, instanceId, executionId, session.ETag);
-
-                if(this.trackingStore is InstanceStoreBackedTrackingStore && workItem.OrchestrationRuntimeState != runtimeState){
-
-                    session.ETag = await this.trackingStore.UpdateStateAsync(workItem.OrchestrationRuntimeState, instanceId, workItem.OrchestrationRuntimeState.OrchestrationInstance.ExecutionId, session.ETag);
-
-                }
+                session.ETag = await this.trackingStore.UpdateStateAsync(runtimeState, workItem.OrchestrationRuntimeState, instanceId, executionId, session.ETag);
             }
             catch (Exception e)
             {

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -14,6 +14,7 @@
 namespace DurableTask.AzureStorage
 {
     using System;
+    using DurableTask.Core;
     using Microsoft.WindowsAzure.Storage.Queue;
     using Microsoft.WindowsAzure.Storage.Table;
 
@@ -141,8 +142,8 @@ namespace DurableTask.AzureStorage
         public StorageAccountDetails StorageAccountDetails { get; set; }
 
         /// <summary>
-        ///  Will not carry over unexecuted raised events to the next iteration of an orchestration on ContinueAsNew
+        ///  Should we carry over unexecuted raised events to the next iteration of an orchestration on ContinueAsNew
         /// </summary>
-        public bool SkipEventsOnContinuation { get; set; } = false;
+        public BehaviorOnContinueAsNew EventBehaviourForContinueAsNew { get; set; } = BehaviorOnContinueAsNew.Carryover;
     }
 }

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -139,5 +139,10 @@ namespace DurableTask.AzureStorage
         /// If provided, this is used to connect to Azure Storage
         /// </summary>
         public StorageAccountDetails StorageAccountDetails { get; set; }
+
+        /// <summary>
+        ///  Will not carry over unexecuted raised events to the next iteration of an orchestration on ContinueAsNew
+        /// </summary>
+        public bool SkipEventsOnContinuation { get; set; } = false;
     }
 }

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -852,6 +852,7 @@ namespace DurableTask.AzureStorage.Tracking
         /// <inheritdoc />
         public override async Task<string> UpdateStateAsync(
             OrchestrationRuntimeState runtimeState,
+            OrchestrationRuntimeState oldRuntimeState,
             string instanceId,
             string executionId,
             string eTagValue)

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -851,17 +851,17 @@ namespace DurableTask.AzureStorage.Tracking
 
         /// <inheritdoc />
         public override async Task<string> UpdateStateAsync(
-            OrchestrationRuntimeState runtimeState,
+            OrchestrationRuntimeState newRuntimeState,
             OrchestrationRuntimeState oldRuntimeState,
             string instanceId,
             string executionId,
             string eTagValue)
         {
             int estimatedBytes = 0;
-            IList<HistoryEvent> newEvents = runtimeState.NewEvents;
-            IList<HistoryEvent> allEvents = runtimeState.Events;
+            IList<HistoryEvent> newEvents = newRuntimeState.NewEvents;
+            IList<HistoryEvent> allEvents = newRuntimeState.Events;
 
-            int episodeNumber = Utils.GetEpisodeNumber(runtimeState);
+            int episodeNumber = Utils.GetEpisodeNumber(newRuntimeState);
 
             var newEventListBuffer = new StringBuilder(4000);
             var historyEventBatch = new TableBatchOperation();
@@ -872,7 +872,7 @@ namespace DurableTask.AzureStorage.Tracking
             {
                 Properties =
                 {
-                    ["CustomStatus"] = new EntityProperty(runtimeState.Status),
+                    ["CustomStatus"] = new EntityProperty(newRuntimeState.Status),
                     ["ExecutionId"] = new EntityProperty(executionId),
                     ["LastUpdatedTime"] = new EntityProperty(newEvents.Last().Timestamp),
                 }

--- a/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
@@ -64,12 +64,12 @@ namespace DurableTask.AzureStorage.Tracking
         /// <summary>
         /// Update State in the Tracking store for a particular orchestration instance and execution base on the new runtime state
         /// </summary>
-        /// <param name="runtimeState">The New RuntimeState</param>
+        /// <param name="newRuntimeState">The New RuntimeState</param>
         /// <param name="oldRuntimeState">The RuntimeState for an olderExecution</param>
         /// <param name="instanceId">InstanceId for the Orchestration Update</param>
         /// <param name="executionId">ExecutionId for the Orchestration Update</param>
         /// <param name="eTag">The ETag value to use for safe updates</param>
-        Task<string> UpdateStateAsync(OrchestrationRuntimeState runtimeState, OrchestrationRuntimeState oldRuntimeState, string instanceId, string executionId, string eTag);
+        Task<string> UpdateStateAsync(OrchestrationRuntimeState newRuntimeState, OrchestrationRuntimeState oldRuntimeState, string instanceId, string executionId, string eTag);
 
         /// <summary>
         /// Get The Orchestration State for the Latest or All Executions

--- a/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
@@ -65,10 +65,11 @@ namespace DurableTask.AzureStorage.Tracking
         /// Update State in the Tracking store for a particular orchestration instance and execution base on the new runtime state
         /// </summary>
         /// <param name="runtimeState">The New RuntimeState</param>
+        /// <param name="oldRuntimeState">The RuntimeState for an olderExecution</param>
         /// <param name="instanceId">InstanceId for the Orchestration Update</param>
         /// <param name="executionId">ExecutionId for the Orchestration Update</param>
         /// <param name="eTag">The ETag value to use for safe updates</param>
-        Task<string> UpdateStateAsync(OrchestrationRuntimeState runtimeState, string instanceId, string executionId, string eTag);
+        Task<string> UpdateStateAsync(OrchestrationRuntimeState runtimeState, OrchestrationRuntimeState oldRuntimeState, string instanceId, string executionId, string eTag);
 
         /// <summary>
         /// Get The Orchestration State for the Latest or All Executions

--- a/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
@@ -130,6 +130,8 @@ namespace DurableTask.AzureStorage.Tracking
         /// <inheritdoc />
         public override async Task<string> UpdateStateAsync(OrchestrationRuntimeState newRuntimeState, OrchestrationRuntimeState oldRuntimeState, string instanceId, string executionId, string eTag)
         {
+            //In case there is a runtime state for an older execution/iteration as well that needs to be committed, commit it.
+            //This may be the case if a ContinueAsNew was executed on the orchestration
             if (newRuntimeState != oldRuntimeState)
             {
                 eTag = await UpdateStateAsync(oldRuntimeState, instanceId, oldRuntimeState.OrchestrationInstance.ExecutionId, eTag);

--- a/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
@@ -128,14 +128,14 @@ namespace DurableTask.AzureStorage.Tracking
         }
 
         /// <inheritdoc />
-        public override async Task<string> UpdateStateAsync(OrchestrationRuntimeState runtimeState, OrchestrationRuntimeState oldRuntimeState, string instanceId, string executionId, string eTag)
+        public override async Task<string> UpdateStateAsync(OrchestrationRuntimeState newRuntimeState, OrchestrationRuntimeState oldRuntimeState, string instanceId, string executionId, string eTag)
         {
-            if (runtimeState != oldRuntimeState)
+            if (newRuntimeState != oldRuntimeState)
             {
                 eTag = await UpdateStateAsync(oldRuntimeState, instanceId, oldRuntimeState.OrchestrationInstance.ExecutionId, eTag);
             }
 
-            return await UpdateStateAsync(runtimeState, instanceId, executionId, eTag);
+            return await UpdateStateAsync(newRuntimeState, instanceId, executionId, eTag);
         }
 
         /// <inheritdoc />

--- a/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
@@ -128,7 +128,18 @@ namespace DurableTask.AzureStorage.Tracking
         }
 
         /// <inheritdoc />
-        public override async Task<string> UpdateStateAsync(OrchestrationRuntimeState runtimeState, string instanceId, string executionId, string eTag)
+        public override async Task<string> UpdateStateAsync(OrchestrationRuntimeState runtimeState, OrchestrationRuntimeState oldRuntimeState, string instanceId, string executionId, string eTag)
+        {
+            if (runtimeState != oldRuntimeState)
+            {
+                eTag = await UpdateStateAsync(oldRuntimeState, instanceId, oldRuntimeState.OrchestrationInstance.ExecutionId, eTag);
+            }
+
+            return await UpdateStateAsync(runtimeState, instanceId, executionId, eTag);
+        }
+
+        /// <inheritdoc />
+        private async Task<string> UpdateStateAsync(OrchestrationRuntimeState runtimeState, string instanceId, string executionId, string eTag)
         {
             int oldEventsCount = (runtimeState.Events.Count - runtimeState.NewEvents.Count);
             await instanceStore.WriteEntitiesAsync(runtimeState.NewEvents.Select((x, i) =>

--- a/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
+++ b/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
@@ -97,6 +97,6 @@ namespace DurableTask.AzureStorage.Tracking
         public abstract Task StartAsync();
 
         /// <inheritdoc />
-        public abstract Task<string> UpdateStateAsync(OrchestrationRuntimeState runtimeState, OrchestrationRuntimeState oldRuntimeState, string instanceId, string executionId, string eTag);
+        public abstract Task<string> UpdateStateAsync(OrchestrationRuntimeState newRuntimeState, OrchestrationRuntimeState oldRuntimeState, string instanceId, string executionId, string eTag);
     }
 }

--- a/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
+++ b/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
@@ -97,6 +97,6 @@ namespace DurableTask.AzureStorage.Tracking
         public abstract Task StartAsync();
 
         /// <inheritdoc />
-        public abstract Task<string> UpdateStateAsync(OrchestrationRuntimeState runtimeState, string instanceId, string executionId, string eTag);
+        public abstract Task<string> UpdateStateAsync(OrchestrationRuntimeState runtimeState, OrchestrationRuntimeState oldRuntimeState, string instanceId, string executionId, string eTag);
     }
 }

--- a/src/DurableTask.Core/Command/OrchestrationCompleteOrchestratorAction.cs
+++ b/src/DurableTask.Core/Command/OrchestrationCompleteOrchestratorAction.cs
@@ -11,10 +11,17 @@
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+using DurableTask.Core.History;
+
 namespace DurableTask.Core.Command
 {
     internal class OrchestrationCompleteOrchestratorAction : OrchestratorAction
     {
+        public OrchestrationCompleteOrchestratorAction()
+        {
+            CarryOverEvents = new List<HistoryEvent>();
+        }
         public OrchestrationStatus OrchestrationStatus;
 
         public override OrchestratorActionType OrchestratorActionType => OrchestratorActionType.OrchestrationComplete;
@@ -24,5 +31,7 @@ namespace DurableTask.Core.Command
         public string Details { get; set; }
 
         public string NewVersion { get; set; }
+
+        public IList<HistoryEvent> CarryOverEvents { get; set; }
     }
 }

--- a/src/DurableTask.Core/Command/OrchestrationCompleteOrchestratorAction.cs
+++ b/src/DurableTask.Core/Command/OrchestrationCompleteOrchestratorAction.cs
@@ -11,11 +11,12 @@
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
 
-using System.Collections.Generic;
-using DurableTask.Core.History;
-
 namespace DurableTask.Core.Command
 {
+
+    using System.Collections.Generic;
+    using DurableTask.Core.History;
+
     internal class OrchestrationCompleteOrchestratorAction : OrchestratorAction
     {
         public OrchestrationCompleteOrchestratorAction()
@@ -32,6 +33,6 @@ namespace DurableTask.Core.Command
 
         public string NewVersion { get; set; }
 
-        public IList<HistoryEvent> CarryOverEvents { get; set; }
+        public IList<HistoryEvent> CarryOverEvents { get; }
     }
 }

--- a/src/DurableTask.Core/EventHandlingOnContinueAsNew.cs
+++ b/src/DurableTask.Core/EventHandlingOnContinueAsNew.cs
@@ -11,28 +11,21 @@
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
 
-namespace DurableTask.Core.Command
+namespace DurableTask.Core
 {
-    using System.Collections.Generic;
-    using DurableTask.Core.History;
-
-    internal class OrchestrationCompleteOrchestratorAction : OrchestratorAction
+    /// <summary>
+    /// Specifies Behavior to be followed when dealing with unprocessed EventRaisedEvents when an orchestration continues as new
+    /// </summary>
+    public enum BehaviorOnContinueAsNew
     {
-        public OrchestrationCompleteOrchestratorAction()
-        {
-            CarryoverEvents = new List<HistoryEvent>();
-        }
+        /// <summary>
+        /// All pending EventRaisedEvents will be ignored
+        /// </summary>
+        Ignore,
 
-        public OrchestrationStatus OrchestrationStatus;
-
-        public override OrchestratorActionType OrchestratorActionType => OrchestratorActionType.OrchestrationComplete;
-
-        public string Result { get; set; }
-
-        public string Details { get; set; }
-
-        public string NewVersion { get; set; }
-
-        public IList<HistoryEvent> CarryoverEvents { get; }
+        /// <summary>
+        /// 
+        /// </summary>
+        Carryover,
     }
 }

--- a/src/DurableTask.Core/IOrchestrationService.cs
+++ b/src/DurableTask.Core/IOrchestrationService.cs
@@ -98,9 +98,9 @@ namespace DurableTask.Core
         int MaxConcurrentTaskOrchestrationWorkItems { get; }
 
         /// <summary>
-        ///  Will not carry over unexecuted raised events to the next iteration of an orchestration on ContinueAsNew
+        ///  Should we carry over unexecuted raised events to the next iteration of an orchestration on ContinueAsNew
         /// </summary>
-        bool SkipEventsOnContinuation { get; }
+        BehaviorOnContinueAsNew EventBehaviourForContinueAsNew { get; }
 
         /// <summary>
         ///     Wait for the next orchestration work item and return the orchestration work item

--- a/src/DurableTask.Core/IOrchestrationService.cs
+++ b/src/DurableTask.Core/IOrchestrationService.cs
@@ -98,6 +98,11 @@ namespace DurableTask.Core
         int MaxConcurrentTaskOrchestrationWorkItems { get; }
 
         /// <summary>
+        ///  Will not carry over unexecuted raised events to the next iteration of an orchestration on ContinueAsNew
+        /// </summary>
+        bool SkipEventsOnContinuation { get; }
+
+        /// <summary>
         ///     Wait for the next orchestration work item and return the orchestration work item
         /// </summary>
         Task<TaskOrchestrationWorkItem> LockNextTaskOrchestrationWorkItemAsync(TimeSpan receiveTimeout, CancellationToken cancellationToken);

--- a/src/DurableTask.Core/Settings/TaskOrchestrationDispatcherSettings.cs
+++ b/src/DurableTask.Core/Settings/TaskOrchestrationDispatcherSettings.cs
@@ -28,6 +28,7 @@ namespace DurableTask.Core.Settings
             DispatcherCount = FrameworkConstants.OrchestrationDefaultDispatcherCount;
             MaxConcurrentOrchestrations = FrameworkConstants.OrchestrationDefaultMaxConcurrentItems;
             CompressOrchestrationState = false;
+            SkipEventsOnContinuation = false;
         }
 
         /// <summary>
@@ -54,6 +55,11 @@ namespace DurableTask.Core.Settings
         ///     Compress the orchestration state to enable more complex orchestrations at the cost of throughput. Default is False.
         /// </summary>
         public bool CompressOrchestrationState { get; set; }
+
+        /// <summary>
+        ///  Will not carry over unexecuted raised events to the next iteration of an orchestration on ContinueAsNew
+        /// </summary>
+        public bool SkipEventsOnContinuation { get; set; }
 
         internal TaskOrchestrationDispatcherSettings Clone()
         {

--- a/src/DurableTask.Core/Settings/TaskOrchestrationDispatcherSettings.cs
+++ b/src/DurableTask.Core/Settings/TaskOrchestrationDispatcherSettings.cs
@@ -28,7 +28,7 @@ namespace DurableTask.Core.Settings
             DispatcherCount = FrameworkConstants.OrchestrationDefaultDispatcherCount;
             MaxConcurrentOrchestrations = FrameworkConstants.OrchestrationDefaultMaxConcurrentItems;
             CompressOrchestrationState = false;
-            SkipEventsOnContinuation = false;
+            EventBehaviourForContinueAsNew = BehaviorOnContinueAsNew.Carryover;
         }
 
         /// <summary>
@@ -57,9 +57,9 @@ namespace DurableTask.Core.Settings
         public bool CompressOrchestrationState { get; set; }
 
         /// <summary>
-        ///  Will not carry over unexecuted raised events to the next iteration of an orchestration on ContinueAsNew
+        ///  Should we carry over unexecuted raised events to the next iteration of an orchestration on ContinueAsNew
         /// </summary>
-        public bool SkipEventsOnContinuation { get; set; }
+        public BehaviorOnContinueAsNew EventBehaviourForContinueAsNew { get; set; }
 
         internal TaskOrchestrationDispatcherSettings Clone()
         {

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -35,6 +35,12 @@ namespace DurableTask.Core
         bool executionTerminated;
         int idCounter;
 
+        public bool HasContinueAsNew => continueAsNew != null;
+
+        public void AddEventToNextIteration(HistoryEvent he){
+            continueAsNew.CarryOverEvents.Add(he);
+        }
+
         public TaskOrchestrationContext(OrchestrationInstance orchestrationInstance, TaskScheduler taskScheduler)
         {
             Utils.UnusedParameter(taskScheduler);
@@ -54,6 +60,7 @@ namespace DurableTask.Core
         internal void ClearPendingActions()
         {
             this.orchestratorActionsMap.Clear();
+            continueAsNew = null;
         }
 
         public override async Task<TResult> ScheduleTask<TResult>(string name, string version,

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -39,7 +39,7 @@ namespace DurableTask.Core
 
         public void AddEventToNextIteration(HistoryEvent he)
         {
-            continueAsNew.CarryOverEvents.Add(he);
+            continueAsNew.CarryoverEvents.Add(he);
         }
 
         public TaskOrchestrationContext(OrchestrationInstance orchestrationInstance, TaskScheduler taskScheduler)

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -37,7 +37,8 @@ namespace DurableTask.Core
 
         public bool HasContinueAsNew => continueAsNew != null;
 
-        public void AddEventToNextIteration(HistoryEvent he){
+        public void AddEventToNextIteration(HistoryEvent he)
+        {
             continueAsNew.CarryOverEvents.Add(he);
         }
 

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -364,9 +364,11 @@ namespace DurableTask.Core
                                 "TaskOrchestrationDispatcher-UpdatingStateForContinuation",
                                 workItem.InstanceId,
                                 "Updating state for continuation");
+
                             runtimeState = new OrchestrationRuntimeState();
                             runtimeState.AddEvent(new OrchestratorStartedEvent(-1));
                             runtimeState.AddEvent(continueAsNewExecutionStarted);
+
                             if (carryOverEvents != null)
                             {
                                 foreach (var historyEvent in carryOverEvents)
@@ -374,19 +376,20 @@ namespace DurableTask.Core
                                     runtimeState.AddEvent(historyEvent);
                                 }
                             }
+
                             runtimeState.AddEvent(new OrchestratorCompletedEvent(-1));
                             workItem.OrchestrationRuntimeState = runtimeState;
 
                             TaskOrchestration orchestration = this.objectManager.GetObject(runtimeState.Name, continueAsNewExecutionStarted.Version);
-                            
+
                             workItem.Cursor = new OrchestrationExecutionCursor(runtimeState, orchestration, new TaskOrchestrationExecutor(runtimeState, workItem.Cursor.TaskOrchestration, orchestrationService.SkipEventsOnContinuation), null);
                             await orchestrationService.RenewTaskOrchestrationWorkItemLockAsync(workItem);
                         }
 
                         instanceState = Utils.BuildOrchestrationState(runtimeState);
                     }
-                }while (continuedAsNew);
-                
+                } while (continuedAsNew);
+
             }
 
             workItem.OrchestrationRuntimeState = oldOrchestrationRuntimeState;
@@ -402,7 +405,7 @@ namespace DurableTask.Core
 
             workItem.OrchestrationRuntimeState = runtimeState;
 
-            return isCompleted|| continuedAsNew || isInterrupted;
+            return isCompleted || continuedAsNew || isInterrupted;
         }
 
         async Task<OrchestrationExecutionCursor> ExecuteOrchestrationAsync(OrchestrationRuntimeState runtimeState)

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -379,7 +379,7 @@ namespace DurableTask.Core
 
                             TaskOrchestration orchestration = this.objectManager.GetObject(runtimeState.Name, continueAsNewExecutionStarted.Version);
                             
-                            workItem.Cursor = new OrchestrationExecutionCursor(runtimeState, orchestration, new TaskOrchestrationExecutor(runtimeState, workItem.Cursor.TaskOrchestration, false), null);
+                            workItem.Cursor = new OrchestrationExecutionCursor(runtimeState, orchestration, new TaskOrchestrationExecutor(runtimeState, workItem.Cursor.TaskOrchestration, orchestrationService.SkipEventsOnContinuation), null);
                             await orchestrationService.RenewTaskOrchestrationWorkItemLockAsync(workItem);
                         }
 
@@ -422,7 +422,7 @@ namespace DurableTask.Core
             dispatchContext.SetProperty(taskOrchestration);
             dispatchContext.SetProperty(runtimeState);
 
-            var executor = new TaskOrchestrationExecutor(runtimeState, taskOrchestration, false);
+            var executor = new TaskOrchestrationExecutor(runtimeState, taskOrchestration, orchestrationService.SkipEventsOnContinuation);
 
             IEnumerable<OrchestratorAction> decisions = null;
             await this.dispatchPipeline.RunAsync(dispatchContext, _ =>

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -192,10 +192,15 @@ namespace DurableTask.Core
 
             ExecutionStartedEvent continueAsNewExecutionStarted = null;
             TaskMessage continuedAsNewMessage = null;
+            IList<HistoryEvent> carryOverEvents = null;
 
             OrchestrationRuntimeState runtimeState = workItem.OrchestrationRuntimeState;
 
             runtimeState.AddEvent(new OrchestratorStartedEvent(-1));
+
+            OrchestrationRuntimeState oldOrchestrationRuntimeState = runtimeState;
+
+            OrchestrationState instanceState = null;
 
             if (!ReconcileMessagesWithState(workItem))
             {
@@ -209,169 +214,195 @@ namespace DurableTask.Core
             }
             else
             {
-                TraceHelper.TraceInstance(
+                do
+                {
+                    continuedAsNew = false;
+                    continuedAsNewMessage = null;
+
+                    TraceHelper.TraceInstance(
                     TraceEventType.Verbose,
                     "TaskOrchestrationDispatcher-ExecuteUserOrchestration-Begin",
                     runtimeState.OrchestrationInstance,
                     "Executing user orchestration: {0}",
                     DataConverter.Serialize(runtimeState.GetOrchestrationRuntimeStateDump(), true));
 
-                if (workItem.Cursor == null)
-                {
-                    workItem.Cursor = await ExecuteOrchestrationAsync(runtimeState);
-                }
-                else
-                {
-                    await ResumeOrchestrationAsync(workItem.Cursor);
-                }
-
-                IReadOnlyList<OrchestratorAction> decisions = workItem.Cursor.LatestDecisions.ToList();
-
-                TraceHelper.TraceInstance(
-                    TraceEventType.Information,
-                    "TaskOrchestrationDispatcher-ExecuteUserOrchestration-End",
-                    runtimeState.OrchestrationInstance,
-                    "Executed user orchestration. Received {0} orchestrator actions: {1}",
-                    decisions.Count,
-                    string.Join(", ", decisions.Select(d => d.Id + ":" + d.OrchestratorActionType)));
-
-                foreach (OrchestratorAction decision in decisions)
-                {
-                    TraceHelper.TraceInstance(
-                        TraceEventType.Information,
-                        "TaskOrchestrationDispatcher-ProcessOrchestratorAction",
-                        runtimeState.OrchestrationInstance,
-                        "Processing orchestrator action of type {0}",
-                        decision.OrchestratorActionType);
-                    switch (decision.OrchestratorActionType)
+                    if (workItem.Cursor == null)
                     {
-                        case OrchestratorActionType.ScheduleOrchestrator:
-                            messagesToSend.Add(
-                                ProcessScheduleTaskDecision((ScheduleTaskOrchestratorAction)decision, runtimeState,
-                                    IncludeParameters));
-                            break;
-                        case OrchestratorActionType.CreateTimer:
-                            var timerOrchestratorAction = (CreateTimerOrchestratorAction)decision;
-                            timerMessages.Add(ProcessCreateTimerDecision(timerOrchestratorAction, runtimeState));
-                            break;
-                        case OrchestratorActionType.CreateSubOrchestration:
-                            var createSubOrchestrationAction = (CreateSubOrchestrationAction)decision;
-                            subOrchestrationMessages.Add(
-                                ProcessCreateSubOrchestrationInstanceDecision(createSubOrchestrationAction,
-                                    runtimeState, IncludeParameters));
-                            break;
-                        case OrchestratorActionType.OrchestrationComplete:
-                            TaskMessage workflowInstanceCompletedMessage =
-                                ProcessWorkflowCompletedTaskDecision((OrchestrationCompleteOrchestratorAction)decision, runtimeState, IncludeDetails, out continuedAsNew);
-                            if (workflowInstanceCompletedMessage != null)
-                            {
-                                // Send complete message to parent workflow or to itself to start a new execution
-                                // Store the event so we can rebuild the state
-                                if (continuedAsNew)
-                                {
-                                    continuedAsNewMessage = workflowInstanceCompletedMessage;
-                                    continueAsNewExecutionStarted = workflowInstanceCompletedMessage.Event as ExecutionStartedEvent;
-                                }
-                                else
-                                {
-                                    subOrchestrationMessages.Add(workflowInstanceCompletedMessage);
-                                }
-                            }
-
-                            isCompleted = !continuedAsNew;
-                            break;
-                        default:
-                            throw TraceHelper.TraceExceptionInstance(
-                                TraceEventType.Error,
-                                "TaskOrchestrationDispatcher-UnsupportedDecisionType",
-                                runtimeState.OrchestrationInstance,
-                                new NotSupportedException("decision type not supported"));
+                        workItem.Cursor = await ExecuteOrchestrationAsync(runtimeState);
+                    }
+                    else
+                    {
+                        await ResumeOrchestrationAsync(workItem.Cursor);
                     }
 
-                    // Underlying orchestration service provider may have a limit of messages per call, to avoid the situation
-                    // we keep on asking the provider if message count is ok and stop processing new decisions if not.
-                    //
-                    // We also put in a fake timer to force next orchestration task for remaining messages
-                    int totalMessages = messagesToSend.Count + subOrchestrationMessages.Count + timerMessages.Count;
-                    if (this.orchestrationService.IsMaxMessageCountExceeded(totalMessages, runtimeState))
+                    IReadOnlyList<OrchestratorAction> decisions = workItem.Cursor.LatestDecisions.ToList();
+
+                    TraceHelper.TraceInstance(
+                        TraceEventType.Information,
+                        "TaskOrchestrationDispatcher-ExecuteUserOrchestration-End",
+                        runtimeState.OrchestrationInstance,
+                        "Executed user orchestration. Received {0} orchestrator actions: {1}",
+                        decisions.Count,
+                        string.Join(", ", decisions.Select(d => d.Id + ":" + d.OrchestratorActionType)));
+
+                    foreach (OrchestratorAction decision in decisions)
                     {
                         TraceHelper.TraceInstance(
                             TraceEventType.Information,
-                            "TaskOrchestrationDispatcher-MaxMessageCountReached",
+                            "TaskOrchestrationDispatcher-ProcessOrchestratorAction",
                             runtimeState.OrchestrationInstance,
-                            "MaxMessageCount reached.  Adding timer to process remaining events in next attempt.");
+                            "Processing orchestrator action of type {0}",
+                            decision.OrchestratorActionType);
+                        switch (decision.OrchestratorActionType)
+                        {
+                            case OrchestratorActionType.ScheduleOrchestrator:
+                                messagesToSend.Add(
+                                    ProcessScheduleTaskDecision((ScheduleTaskOrchestratorAction)decision, runtimeState,
+                                        IncludeParameters));
+                                break;
+                            case OrchestratorActionType.CreateTimer:
+                                var timerOrchestratorAction = (CreateTimerOrchestratorAction)decision;
+                                timerMessages.Add(ProcessCreateTimerDecision(timerOrchestratorAction, runtimeState));
+                                break;
+                            case OrchestratorActionType.CreateSubOrchestration:
+                                var createSubOrchestrationAction = (CreateSubOrchestrationAction)decision;
+                                subOrchestrationMessages.Add(
+                                    ProcessCreateSubOrchestrationInstanceDecision(createSubOrchestrationAction,
+                                        runtimeState, IncludeParameters));
+                                break;
+                            case OrchestratorActionType.OrchestrationComplete:
+                                OrchestrationCompleteOrchestratorAction completeDecision = (OrchestrationCompleteOrchestratorAction)decision;
+                                TaskMessage workflowInstanceCompletedMessage =
+                                    ProcessWorkflowCompletedTaskDecision(completeDecision, runtimeState, IncludeDetails, out continuedAsNew);
+                                if (workflowInstanceCompletedMessage != null)
+                                {
+                                    // Send complete message to parent workflow or to itself to start a new execution
+                                    // Store the event so we can rebuild the state
+                                    carryOverEvents = null;
+                                    if (continuedAsNew)
+                                    {
+                                        continuedAsNewMessage = workflowInstanceCompletedMessage;
+                                        continueAsNewExecutionStarted = workflowInstanceCompletedMessage.Event as ExecutionStartedEvent;
+                                        if (completeDecision.CarryOverEvents.Any())
+                                        {
+                                            carryOverEvents = completeDecision.CarryOverEvents.ToList();
+                                            completeDecision.CarryOverEvents.Clear();
+                                        }
+                                    }
+                                    else
+                                    {
+                                        subOrchestrationMessages.Add(workflowInstanceCompletedMessage);
+                                    }
+                                }
 
-                        if (isCompleted || continuedAsNew)
+                                isCompleted = !continuedAsNew;
+                                break;
+                            default:
+                                throw TraceHelper.TraceExceptionInstance(
+                                    TraceEventType.Error,
+                                    "TaskOrchestrationDispatcher-UnsupportedDecisionType",
+                                    runtimeState.OrchestrationInstance,
+                                    new NotSupportedException("decision type not supported"));
+                        }
+
+                        // Underlying orchestration service provider may have a limit of messages per call, to avoid the situation
+                        // we keep on asking the provider if message count is ok and stop processing new decisions if not.
+                        //
+                        // We also put in a fake timer to force next orchestration task for remaining messages
+                        int totalMessages = messagesToSend.Count + subOrchestrationMessages.Count + timerMessages.Count;
+                        if (this.orchestrationService.IsMaxMessageCountExceeded(totalMessages, runtimeState))
                         {
                             TraceHelper.TraceInstance(
                                 TraceEventType.Information,
-                                "TaskOrchestrationDispatcher-OrchestrationAlreadyCompleted",
+                                "TaskOrchestrationDispatcher-MaxMessageCountReached",
                                 runtimeState.OrchestrationInstance,
-                                "Orchestration already completed.  Skip adding timer for splitting messages.");
+                                "MaxMessageCount reached.  Adding timer to process remaining events in next attempt.");
+
+                            if (isCompleted || continuedAsNew)
+                            {
+                                TraceHelper.TraceInstance(
+                                    TraceEventType.Information,
+                                    "TaskOrchestrationDispatcher-OrchestrationAlreadyCompleted",
+                                    runtimeState.OrchestrationInstance,
+                                    "Orchestration already completed.  Skip adding timer for splitting messages.");
+                                break;
+                            }
+
+                            var dummyTimer = new CreateTimerOrchestratorAction
+                            {
+                                Id = FrameworkConstants.FakeTimerIdToSplitDecision,
+                                FireAt = DateTime.UtcNow
+                            };
+
+                            timerMessages.Add(ProcessCreateTimerDecision(dummyTimer, runtimeState));
+                            isInterrupted = true;
                             break;
                         }
-
-                        var dummyTimer = new CreateTimerOrchestratorAction
-                        {
-                            Id = FrameworkConstants.FakeTimerIdToSplitDecision,
-                            FireAt = DateTime.UtcNow
-                        };
-
-                        timerMessages.Add(ProcessCreateTimerDecision(dummyTimer, runtimeState));
-                        isInterrupted = true;
-                        break;
                     }
-                }
+
+                    // finish up processing of the work item
+                    if (!continuedAsNew)
+                    {
+                        runtimeState.AddEvent(new OrchestratorCompletedEvent(-1));
+                    }
+
+                    if (isCompleted)
+                    {
+                        TraceHelper.TraceSession(TraceEventType.Information, "TaskOrchestrationDispatcher-DeletingSessionState", workItem.InstanceId, "Deleting session state");
+                        if (runtimeState.ExecutionStartedEvent != null)
+                        {
+                            instanceState = Utils.BuildOrchestrationState(runtimeState);
+                        }
+                    }
+                    else
+                    {
+
+                        if (continuedAsNew)
+                        {
+                            TraceHelper.TraceSession(
+                                TraceEventType.Information,
+                                "TaskOrchestrationDispatcher-UpdatingStateForContinuation",
+                                workItem.InstanceId,
+                                "Updating state for continuation");
+                            runtimeState = new OrchestrationRuntimeState();
+                            runtimeState.AddEvent(new OrchestratorStartedEvent(-1));
+                            runtimeState.AddEvent(continueAsNewExecutionStarted);
+                            if (carryOverEvents != null)
+                            {
+                                foreach (var historyEvent in carryOverEvents)
+                                {
+                                    runtimeState.AddEvent(historyEvent);
+                                }
+                            }
+                            runtimeState.AddEvent(new OrchestratorCompletedEvent(-1));
+                            workItem.OrchestrationRuntimeState = runtimeState;
+
+                            TaskOrchestration orchestration = this.objectManager.GetObject(runtimeState.Name, continueAsNewExecutionStarted.Version);
+                            
+                            workItem.Cursor = new OrchestrationExecutionCursor(runtimeState, orchestration, new TaskOrchestrationExecutor(runtimeState, workItem.Cursor.TaskOrchestration, false), null);
+                            await orchestrationService.RenewTaskOrchestrationWorkItemLockAsync(workItem);
+                        }
+
+                        instanceState = Utils.BuildOrchestrationState(runtimeState);
+                    }
+                }while (continuedAsNew);
+                
             }
 
-            // finish up processing of the work item
-            if (!continuedAsNew)
-            {
-                runtimeState.AddEvent(new OrchestratorCompletedEvent(-1));
-            }
-
-            OrchestrationRuntimeState newOrchestrationRuntimeState = workItem.OrchestrationRuntimeState;
-
-            OrchestrationState instanceState = null;
-
-            if (isCompleted)
-            {
-                TraceHelper.TraceSession(TraceEventType.Information, "TaskOrchestrationDispatcher-DeletingSessionState", workItem.InstanceId, "Deleting session state");
-                if (newOrchestrationRuntimeState.ExecutionStartedEvent != null)
-                {
-                    instanceState = Utils.BuildOrchestrationState(newOrchestrationRuntimeState);
-                }
-
-                newOrchestrationRuntimeState = null;
-            }
-            else
-            {
-                instanceState = Utils.BuildOrchestrationState(newOrchestrationRuntimeState);
-
-                if (continuedAsNew)
-                {
-                    TraceHelper.TraceSession(
-                        TraceEventType.Information,
-                        "TaskOrchestrationDispatcher-UpdatingStateForContinuation",
-                        workItem.InstanceId,
-                        "Updating state for continuation");
-                    newOrchestrationRuntimeState = new OrchestrationRuntimeState();
-                    newOrchestrationRuntimeState.AddEvent(new OrchestratorStartedEvent(-1));
-                    newOrchestrationRuntimeState.AddEvent(continueAsNewExecutionStarted);
-                    newOrchestrationRuntimeState.AddEvent(new OrchestratorCompletedEvent(-1));
-                }
-            }
+            workItem.OrchestrationRuntimeState = oldOrchestrationRuntimeState;
 
             await this.orchestrationService.CompleteTaskOrchestrationWorkItemAsync(
                 workItem,
-                newOrchestrationRuntimeState,
+                runtimeState,
                 continuedAsNew ? null : messagesToSend,
                 subOrchestrationMessages,
                 continuedAsNew ? null : timerMessages,
                 continuedAsNewMessage,
                 instanceState);
 
-            return isCompleted || continuedAsNew || isInterrupted;
+            workItem.OrchestrationRuntimeState = runtimeState;
+
+            return isCompleted|| continuedAsNew || isInterrupted;
         }
 
         async Task<OrchestrationExecutionCursor> ExecuteOrchestrationAsync(OrchestrationRuntimeState runtimeState)
@@ -391,7 +422,7 @@ namespace DurableTask.Core
             dispatchContext.SetProperty(taskOrchestration);
             dispatchContext.SetProperty(runtimeState);
 
-            var executor = new TaskOrchestrationExecutor(runtimeState, taskOrchestration);
+            var executor = new TaskOrchestrationExecutor(runtimeState, taskOrchestration, false);
 
             IEnumerable<OrchestratorAction> decisions = null;
             await this.dispatchPipeline.RunAsync(dispatchContext, _ =>

--- a/src/DurableTask.Core/TaskOrchestrationExecutor.cs
+++ b/src/DurableTask.Core/TaskOrchestrationExecutor.cs
@@ -32,13 +32,13 @@ namespace DurableTask.Core
         Task<string> result;
 
         public TaskOrchestrationExecutor(OrchestrationRuntimeState orchestrationRuntimeState,
-            TaskOrchestration taskOrchestration, bool skipCarryOverEvents)
+            TaskOrchestration taskOrchestration, BehaviorOnContinueAsNew eventBehaviourForContinueAsNew)
         {
             this.decisionScheduler = new SynchronousTaskScheduler();
             this.context = new TaskOrchestrationContext(orchestrationRuntimeState.OrchestrationInstance, this.decisionScheduler);
             this.orchestrationRuntimeState = orchestrationRuntimeState;
             this.taskOrchestration = taskOrchestration;
-            this.skipCarryOverEvents = skipCarryOverEvents;
+            this.skipCarryOverEvents = eventBehaviourForContinueAsNew == BehaviorOnContinueAsNew.Ignore;
         }
 
         public bool IsCompleted => this.result != null && (this.result.IsCompleted || this.result.IsFaulted);

--- a/src/DurableTask.Core/TaskOrchestrationExecutor.cs
+++ b/src/DurableTask.Core/TaskOrchestrationExecutor.cs
@@ -28,15 +28,17 @@ namespace DurableTask.Core
         readonly TaskScheduler decisionScheduler;
         readonly OrchestrationRuntimeState orchestrationRuntimeState;
         readonly TaskOrchestration taskOrchestration;
+        readonly bool skipCarryOverEvents;
         Task<string> result;
 
         public TaskOrchestrationExecutor(OrchestrationRuntimeState orchestrationRuntimeState,
-            TaskOrchestration taskOrchestration)
+            TaskOrchestration taskOrchestration, bool skipCarryOverEvents)
         {
             this.decisionScheduler = new SynchronousTaskScheduler();
             this.context = new TaskOrchestrationContext(orchestrationRuntimeState.OrchestrationInstance, this.decisionScheduler);
             this.orchestrationRuntimeState = orchestrationRuntimeState;
             this.taskOrchestration = taskOrchestration;
+            this.skipCarryOverEvents = skipCarryOverEvents;
         }
 
         public bool IsCompleted => this.result != null && (this.result.IsCompleted || this.result.IsFaulted);
@@ -151,8 +153,15 @@ namespace DurableTask.Core
                     this.context.HandleTimerFiredEvent((TimerFiredEvent)historyEvent);
                     break;
                 case EventType.EventRaised:
-                    var eventRaisedEvent = (EventRaisedEvent)historyEvent;
-                    this.taskOrchestration.RaiseEvent(this.context, eventRaisedEvent.Name, eventRaisedEvent.Input);
+                    if (this.skipCarryOverEvents||!this.context.HasContinueAsNew)
+                    {
+                        var eventRaisedEvent = (EventRaisedEvent)historyEvent;
+                        this.taskOrchestration.RaiseEvent(this.context, eventRaisedEvent.Name, eventRaisedEvent.Input);
+                    }
+                    else
+                    {
+                        this.context.AddEventToNextIteration(historyEvent);
+                    }
                     break;
             }
         }

--- a/src/DurableTask.Core/TaskOrchestrationExecutor.cs
+++ b/src/DurableTask.Core/TaskOrchestrationExecutor.cs
@@ -153,7 +153,7 @@ namespace DurableTask.Core
                     this.context.HandleTimerFiredEvent((TimerFiredEvent)historyEvent);
                     break;
                 case EventType.EventRaised:
-                    if (this.skipCarryOverEvents||!this.context.HasContinueAsNew)
+                    if (this.skipCarryOverEvents || !this.context.HasContinueAsNew)
                     {
                         var eventRaisedEvent = (EventRaisedEvent)historyEvent;
                         this.taskOrchestration.RaiseEvent(this.context, eventRaisedEvent.Name, eventRaisedEvent.Input);

--- a/src/DurableTask.Emulator/LocalOrchestrationService.cs
+++ b/src/DurableTask.Emulator/LocalOrchestrationService.cs
@@ -503,6 +503,11 @@ namespace DurableTask.Emulator
         /// <inheritdoc />
         public int TaskActivityDispatcherCount => 1;
 
+        /// <summary>
+        ///  Will not carry over unexecuted raised events to the next iteration of an orchestration on ContinueAsNew
+        /// </summary>
+        public bool SkipEventsOnContinuation => false;
+
         /// <inheritdoc />
         public int MaxConcurrentTaskActivityWorkItems => this.MaxConcurrentWorkItems;
 

--- a/src/DurableTask.Emulator/LocalOrchestrationService.cs
+++ b/src/DurableTask.Emulator/LocalOrchestrationService.cs
@@ -504,9 +504,9 @@ namespace DurableTask.Emulator
         public int TaskActivityDispatcherCount => 1;
 
         /// <summary>
-        ///  Will not carry over unexecuted raised events to the next iteration of an orchestration on ContinueAsNew
+        ///  Should we carry over unexecuted raised events to the next iteration of an orchestration on ContinueAsNew
         /// </summary>
-        public bool SkipEventsOnContinuation => false;
+        public BehaviorOnContinueAsNew EventBehaviourForContinueAsNew => BehaviorOnContinueAsNew.Carryover;
 
         /// <inheritdoc />
         public int MaxConcurrentTaskActivityWorkItems => this.MaxConcurrentWorkItems;

--- a/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
+++ b/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
@@ -762,10 +762,10 @@ namespace DurableTask.ServiceBus
                         {
                             trackingMessages = await CreateTrackingMessagesAsync(newOrchestrationRuntimeState, sessionState.SequenceNumber);
                             TraceHelper.TraceInstance(
-                            TraceEventType.Information,
-                            "ServiceBusOrchestrationService-CompleteTaskOrchestrationWorkItem-TrackingMessages",
-                            newOrchestrationRuntimeState.OrchestrationInstance,
-                            "Created {0} tracking messages", trackingMessages.Count);
+                                TraceEventType.Information,
+                                "ServiceBusOrchestrationService-CompleteTaskOrchestrationWorkItem-TrackingMessages",
+                                newOrchestrationRuntimeState.OrchestrationInstance,
+                                "Created {0} tracking messages", trackingMessages.Count);
 
                             if (trackingMessages.Count > 0)
                             {

--- a/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
+++ b/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
@@ -456,9 +456,9 @@ namespace DurableTask.ServiceBus
         public int MaxConcurrentTaskOrchestrationWorkItems => this.Settings.TaskOrchestrationDispatcherSettings.MaxConcurrentOrchestrations;
 
         /// <summary>
-        ///  Will not carry over unexecuted raised events to the next iteration of an orchestration on ContinueAsNew
+        ///  Should we carry over unexecuted raised events to the next iteration of an orchestration on ContinueAsNew
         /// </summary>
-        public bool SkipEventsOnContinuation => this.Settings.TaskOrchestrationDispatcherSettings.SkipEventsOnContinuation;
+        public BehaviorOnContinueAsNew EventBehaviourForContinueAsNew => this.Settings.TaskOrchestrationDispatcherSettings.EventBehaviourForContinueAsNew;
 
         /// <summary>
         ///     Wait for the next orchestration work item and return the orchestration work item

--- a/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
+++ b/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
@@ -456,6 +456,11 @@ namespace DurableTask.ServiceBus
         public int MaxConcurrentTaskOrchestrationWorkItems => this.Settings.TaskOrchestrationDispatcherSettings.MaxConcurrentOrchestrations;
 
         /// <summary>
+        ///  Will not carry over unexecuted raised events to the next iteration of an orchestration on ContinueAsNew
+        /// </summary>
+        public bool SkipEventsOnContinuation => this.Settings.TaskOrchestrationDispatcherSettings.SkipEventsOnContinuation;
+
+        /// <summary>
         ///     Wait for the next orchestration work item and return the orchestration work item
         /// </summary>
         /// <param name="receiveTimeout">The timespan to wait for new messages before timing out</param>
@@ -739,7 +744,6 @@ namespace DurableTask.ServiceBus
                     if (this.InstanceStore != null)
                     {
                         List<MessageContainer> trackingMessages = await CreateTrackingMessagesAsync(runtimeState, sessionState.SequenceNumber);
-
                         TraceHelper.TraceInstance(
                             TraceEventType.Information,
                             "ServiceBusOrchestrationService-CompleteTaskOrchestrationWorkItem-TrackingMessages",
@@ -752,6 +756,24 @@ namespace DurableTask.ServiceBus
                             LogSentMessages(session, "Tracking messages", trackingMessages);
                             this.ServiceStats.TrackingDispatcherStats.MessageBatchesSent.Increment();
                             this.ServiceStats.TrackingDispatcherStats.MessagesSent.Increment(trackingMessages.Count);
+                        }
+
+                        if (newOrchestrationRuntimeState != null && runtimeState != newOrchestrationRuntimeState)
+                        {
+                            trackingMessages = await CreateTrackingMessagesAsync(newOrchestrationRuntimeState, sessionState.SequenceNumber);
+                            TraceHelper.TraceInstance(
+                            TraceEventType.Information,
+                            "ServiceBusOrchestrationService-CompleteTaskOrchestrationWorkItem-TrackingMessages",
+                            newOrchestrationRuntimeState.OrchestrationInstance,
+                            "Created {0} tracking messages", trackingMessages.Count);
+
+                            if (trackingMessages.Count > 0)
+                            {
+                                await this.trackingSender.SendBatchAsync(trackingMessages.Select(m => m.Message));
+                                LogSentMessages(session, "Tracking messages", trackingMessages);
+                                this.ServiceStats.TrackingDispatcherStats.MessageBatchesSent.Increment();
+                                this.ServiceStats.TrackingDispatcherStats.MessagesSent.Increment(trackingMessages.Count);
+                            }
                         }
                     }
                 }
@@ -1510,7 +1532,7 @@ namespace DurableTask.ServiceBus
 
             var isSessionSizeThresholdExceeded = false;
 
-            if (newOrchestrationRuntimeState == null)
+            if (newOrchestrationRuntimeState == null || newOrchestrationRuntimeState.OrchestrationStatus != OrchestrationStatus.Running)
             {
                 await session.SetStateAsync(null);
                 return true;

--- a/test/DurableTask.ServiceBus.Tests/ServiceBusOrchestrationServiceTests.cs
+++ b/test/DurableTask.ServiceBus.Tests/ServiceBusOrchestrationServiceTests.cs
@@ -20,6 +20,7 @@ namespace DurableTask.ServiceBus.Tests
     using DurableTask.Core.Exceptions;
     using DurableTask.Test.Orchestrations;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json.Linq;
 
     [TestClass]
     public class ServiceBusOrchestrationServiceTests
@@ -68,6 +69,55 @@ namespace DurableTask.ServiceBus.Tests
             Assert.IsTrue(isCompleted, TestHelpers.GetInstanceNotCompletedMessage(this.client, id, 60));
             Assert.AreEqual("Greeting send to Gabbar", SimplestGreetingsOrchestration.Result,
                 "Orchestration Result is wrong!!!");
+        }
+
+        [TestMethod]
+        public async Task ActorOrchestrationTest()
+        {
+            var sbService = (ServiceBusOrchestrationService)this.taskHub.orchestrationService;
+            string name = NameVersionHelper.GetDefaultName(typeof(CounterOrchestration));
+            string version = NameVersionHelper.GetDefaultVersion(typeof(CounterOrchestration));
+
+            await this.taskHub.AddTaskOrchestrations(typeof(CounterOrchestration))
+                .StartAsync();
+
+            int initialValue = 0;
+            OrchestrationInstance id = await this.client.CreateOrchestrationInstanceAsync(typeof(CounterOrchestration), initialValue);
+
+            // Need to wait for the instance to start before sending events to it.
+            // TODO: This requirement may not be ideal and should be revisited.
+            await TestHelpers.WaitForInstanceAsync(this.client, id, 10, waitForCompletion: false);
+
+            OrchestrationInstance temp = new OrchestrationInstance() { InstanceId = id.InstanceId };
+            // Perform some operations
+            await this.client.RaiseEventAsync(temp, "operation", "incr");
+
+            // TODO: Sleeping to avoid a race condition where multiple ContinueAsNew messages
+            //       are processed by the same instance at the same time, resulting in a corrupt
+            //       storage failure in DTFx.
+            await this.client.RaiseEventAsync(temp, "operation", "incr");
+            await this.client.RaiseEventAsync(temp, "operation", "decr");
+            await this.client.RaiseEventAsync(temp, "operation", "incr");
+            await this.client.RaiseEventAsync(temp, "operation", "incr");
+            await this.client.RaiseEventAsync(temp, "operation", "end");
+            await Task.Delay(4000);
+
+            // Make sure it's still running and didn't complete early (or fail).
+            var status = await client.GetOrchestrationStateAsync(id);
+            Assert.IsTrue(
+                status?.OrchestrationStatus == OrchestrationStatus.Running ||
+                status?.OrchestrationStatus == OrchestrationStatus.ContinuedAsNew);
+
+            // The end message will cause the actor to complete itself.
+            await this.client.RaiseEventAsync(temp, "operation", "end");
+
+            status = await client.WaitForOrchestrationAsync(temp, TimeSpan.FromSeconds(10));
+
+            Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
+            Assert.AreEqual(3, JToken.Parse(status?.Output));
+
+            // When using ContinueAsNew, the original input is discarded and replaced with the most recent state.
+            Assert.AreNotEqual(initialValue, JToken.Parse(status?.Input));
         }
 
         [TestMethod]

--- a/test/DurableTask.ServiceBus.Tests/ServiceBusOrchestrationServiceTests.cs
+++ b/test/DurableTask.ServiceBus.Tests/ServiceBusOrchestrationServiceTests.cs
@@ -91,10 +91,6 @@ namespace DurableTask.ServiceBus.Tests
             OrchestrationInstance temp = new OrchestrationInstance() { InstanceId = id.InstanceId };
             // Perform some operations
             await this.client.RaiseEventAsync(temp, "operation", "incr");
-
-            // TODO: Sleeping to avoid a race condition where multiple ContinueAsNew messages
-            //       are processed by the same instance at the same time, resulting in a corrupt
-            //       storage failure in DTFx.
             await this.client.RaiseEventAsync(temp, "operation", "incr");
             await this.client.RaiseEventAsync(temp, "operation", "decr");
             await this.client.RaiseEventAsync(temp, "operation", "incr");


### PR DESCRIPTION
This PR aims to optimize ContinueAsNew so that an orchestration continues in memory in the dispatcher if it can instead of enqueueing a new task message.

With this Events Raised After a continueAsNew has been executed will also be collected and carried over to the next iteration of the orchestration. This a feature that can be opted out of by specifying SkipEventsOnContinuation as true in the OrchestrationService.

