### PR TITLE
DurableTask.AzureStorage: Make max queue polling interval configurable

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -29,7 +29,6 @@ namespace DurableTask.AzureStorage
     using DurableTask.Core;
     using DurableTask.Core.History;
     using Microsoft.WindowsAzure.Storage;
-    using Microsoft.WindowsAzure.Storage.Auth;
     using Microsoft.WindowsAzure.Storage.Blob;
     using Microsoft.WindowsAzure.Storage.Queue;
     using Newtonsoft.Json;
@@ -43,8 +42,6 @@ namespace DurableTask.AzureStorage
         IPartitionObserver<BlobLease>,
         IDisposable
     {
-        internal static readonly TimeSpan MaxQueuePollingDelay = TimeSpan.FromSeconds(30);
-
         static readonly HistoryEvent[] EmptyHistoryEventList = new HistoryEvent[0];
         static readonly OrchestrationInstance EmptySourceInstance = new OrchestrationInstance
         {

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -25,6 +25,8 @@ namespace DurableTask.AzureStorage
     {
         internal const int DefaultPartitionCount = 4;
 
+        internal static readonly TimeSpan DefaultMaxQueuePollingInterval = TimeSpan.FromSeconds(30);
+
         /// <summary>
         /// Gets or sets the number of messages to pull from the control queue at a time. The default is 32.
         /// The maximum batch size supported by Azure Storage Queues is 32.
@@ -134,6 +136,11 @@ namespace DurableTask.AzureStorage
         /// interval, it will cause it to expire and ownership of the partition will move to another worker instance.
         /// </summary>
         public TimeSpan LeaseInterval { get; set; } = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// Maximum interval for polling control and work-item queues.
+        /// </summary>
+        public TimeSpan MaxQueuePollingInterval { get; set; } = DefaultMaxQueuePollingInterval;
 
         /// <summary>
         /// Gets or sets the Azure Storage Account details

--- a/src/DurableTask.AzureStorage/BackoffPollingHelper.cs
+++ b/src/DurableTask.AzureStorage/BackoffPollingHelper.cs
@@ -121,8 +121,8 @@ namespace DurableTask.AzureStorage
                         this.CurrentInterval = this.maximumInterval;
                     }
                 }
-                // else do nothing and keep current interval equal to max
 
+                // else do nothing and keep current interval equal to max
                 return this.CurrentInterval;
             }
         }

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -49,7 +49,12 @@ namespace DurableTask.AzureStorage.Messaging
             this.messageManager = messageManager;
 
             TimeSpan minPollingDelay = TimeSpan.FromMilliseconds(50);
-            TimeSpan maxPollingDelay = AzureStorageOrchestrationService.MaxQueuePollingDelay;
+            TimeSpan maxPollingDelay = settings.MaxQueuePollingInterval;
+            if (maxPollingDelay < minPollingDelay)
+            {
+                maxPollingDelay = minPollingDelay;
+            }
+
             this.backoffHelper = new BackoffPollingHelper(minPollingDelay, maxPollingDelay);
         }
 


### PR DESCRIPTION
Makes the maximum queue polling interval configurable. Previously this was hardcoded to 30 seconds, which could be too long or too fast, depending on who you ask.

First step to resolving https://github.com/Azure/azure-functions-durable-extension/issues/618.
