### PR TITLE
Allow connection string for configuring StorageAccountDetails

### DIFF
--- a/src/DurableTask.AzureStorage/StorageAccountDetails.cs
+++ b/src/DurableTask.AzureStorage/StorageAccountDetails.cs
@@ -37,11 +37,30 @@ namespace DurableTask.AzureStorage
         public string EndpointSuffix { get; set; }
 
         /// <summary>
+        /// The storage account connection string.
+        /// </summary>
+        /// <remarks>
+        /// If specified, this value overrides any other settings.
+        /// </remarks>
+        public string ConnectionString { get; set; }
+
+        /// <summary>
         ///  Convert this to its equivalent CloudStorageAccount.
         /// </summary>
         public CloudStorageAccount ToCloudStorageAccount()
         {
-            return new CloudStorageAccount(this.StorageCredentials, this.AccountName, this.EndpointSuffix, true);
+            if (!string.IsNullOrEmpty(this.ConnectionString))
+            {
+                return CloudStorageAccount.Parse(this.ConnectionString);
+            }
+            else
+            {
+                return new CloudStorageAccount(
+                    this.StorageCredentials,
+                    this.AccountName,
+                    this.EndpointSuffix,
+                    useHttps: true);
+            }
         }
     }
 }


### PR DESCRIPTION
This PR makes it easier to configure the tracking store with a connection string.

@TsuyoshiUshio could you take a look? This is actually similar to what you tried originally. I thought maybe we shouldn't do this, but when I tried to use it in azure-functions-durable-extension, it was tricky and I realized trying to turn a connection string into a `StorageAccountDetails` object could be error prone in some cases. For that reason, I decided to add back the ability to configure with connection strings directly.