### PR TITLE
Fix failing tests on the DurableTask.Emulator, fixing https://github.com/Azure/durabletask/issues/255

### DIFF
--- a/src/DurableTask.Emulator/LocalOrchestrationService.cs
+++ b/src/DurableTask.Emulator/LocalOrchestrationService.cs
@@ -412,10 +412,22 @@ namespace DurableTask.Emulator
         {
             lock (this.thisLock)
             {
+                byte[] newSessionState;
+
+                if (newOrchestrationRuntimeState == null ||
+                newOrchestrationRuntimeState.ExecutionStartedEvent == null ||
+                newOrchestrationRuntimeState.OrchestrationStatus != OrchestrationStatus.Running)
+                {
+                    newSessionState = null;
+                }
+                else
+                {
+                    newSessionState = SerializeOrchestrationRuntimeState(newOrchestrationRuntimeState);
+                }
+
                 this.orchestratorQueue.CompleteSession(
                     workItem.InstanceId,
-                    newOrchestrationRuntimeState != null ?
-                    SerializeOrchestrationRuntimeState(newOrchestrationRuntimeState) : null,
+                    newSessionState,
                     orchestratorMessages,
                     continuedAsNewMessage
                     );

--- a/src/DurableTask.Emulator/LocalOrchestrationService.cs
+++ b/src/DurableTask.Emulator/LocalOrchestrationService.cs
@@ -467,7 +467,7 @@ namespace DurableTask.Emulator
             return Task.FromResult(0);
         }
 
-        private Task CommitState(OrchestrationRuntimeState runtimeState, OrchestrationState state)
+        Task CommitState(OrchestrationRuntimeState runtimeState, OrchestrationState state)
         {
             if (!this.instanceStore.TryGetValue(runtimeState.OrchestrationInstance.InstanceId, out Dictionary<string, OrchestrationState> mapState))
             {

--- a/src/DurableTask.Emulator/LocalOrchestrationService.cs
+++ b/src/DurableTask.Emulator/LocalOrchestrationService.cs
@@ -455,12 +455,12 @@ namespace DurableTask.Emulator
                 if (workItem.OrchestrationRuntimeState != newOrchestrationRuntimeState)
                 {
                     var oldState = Utils.BuildOrchestrationState(workItem.OrchestrationRuntimeState);
-                    CommitState(workItem.OrchestrationRuntimeState, oldState).Wait();
+                    CommitState(workItem.OrchestrationRuntimeState, oldState).GetAwaiter().GetResult();
                 }
 
                 if (state != null)
                 {
-                    CommitState(newOrchestrationRuntimeState, state).Wait();
+                    CommitState(newOrchestrationRuntimeState, state).GetAwaiter().GetResult();
                 }
             }
 

--- a/test/DurableTask.Emulator.Tests/EmulatorFunctionalTests.cs
+++ b/test/DurableTask.Emulator.Tests/EmulatorFunctionalTests.cs
@@ -54,7 +54,6 @@ namespace DurableTask.Emulator.Tests
             await worker.StopAsync(true);
         }
 
-        [TestCategory("DisabledInCI")] // https://github.com/Azure/durabletask/issues/255
         [TestMethod]
         public async Task MockRecreateOrchestrationTest()
         {
@@ -143,7 +142,6 @@ namespace DurableTask.Emulator.Tests
             await worker.StopAsync(true);
         }
 
-        [TestCategory("DisabledInCI")] // https://github.com/Azure/durabletask/issues/255
         [TestMethod]
         public async Task MockGenerationTest()
         {


### PR DESCRIPTION
This Fixes Failing 
MockRecreateOrchestration Test:
This was failing as the emulator was not clearing its session state for a non-running orchestration similar tot he way it was being done in the service bus service.

MockGenerationTest:
This was failing as the Continue as the new state of a previous generation was not being saved to the instance store along with the new started ContinueAsNew state.

This fixes #255
