### PR TITLE
Implement auto-start support in AzureStorageOrchestrationService

### DIFF
--- a/Test/DurableTask.AzureStorage.Tests/AutoStartOrchestrationCreator.cs
+++ b/Test/DurableTask.AzureStorage.Tests/AutoStartOrchestrationCreator.cs
@@ -1,0 +1,65 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureStorage.Tests
+{
+    using DurableTask.Core;
+    using System;
+
+    /// <summary>
+    /// Autostart-Orchestration instance creator for a type, prefixes type name with '@'
+    /// </summary>
+    /// <typeparam name="T">Type of Orchestration</typeparam>
+    public class AutoStartOrchestrationCreator : ObjectCreator<TaskOrchestration>
+    {
+        readonly TaskOrchestration instance;
+        readonly Type prototype;
+
+        /// <summary>
+        /// Creates a new AutoStartOrchestrationCreator of supplied type
+        /// </summary>
+        /// <param name="type">Type to use for the creator</param>
+        public AutoStartOrchestrationCreator(Type type)
+        {
+            this.prototype = type;
+            Initialize(type);
+        }
+
+        /// <summary>
+        /// Creates a new AutoStartOrchestrationCreator using type of supplied object instance
+        /// </summary>
+        /// <param name="instance">Object instances to infer the type from</param>
+        public AutoStartOrchestrationCreator(TaskOrchestration instance)
+        {
+            this.instance = instance;
+            Initialize(instance);
+        }
+
+        ///<inheritdoc/>
+        public override TaskOrchestration Create()
+        {
+            if (this.prototype != null)
+            {
+                return (TaskOrchestration)Activator.CreateInstance(this.prototype);
+            }
+
+            return this.instance;
+        }
+
+        void Initialize(object obj)
+        {
+            Name = $"@{NameVersionHelper.GetDefaultName(obj)}";
+            Version = NameVersionHelper.GetDefaultVersion(obj);
+        }
+    }
+}

--- a/Test/DurableTask.AzureStorage.Tests/TestOrchestrationHost.cs
+++ b/Test/DurableTask.AzureStorage.Tests/TestOrchestrationHost.cs
@@ -58,6 +58,12 @@ namespace DurableTask.AzureStorage.Tests
             return this.worker.StopAsync(isForced: true);
         }
 
+        public void AddAutoStartOrchestrator(Type type)
+        {
+            this.worker.AddTaskOrchestrations(new AutoStartOrchestrationCreator(type));
+            this.addedOrchestrationTypes.Add(type);
+        }
+
         public async Task<TestOrchestrationClient> StartOrchestrationAsync(
             Type orchestrationType,
             object input,


### PR DESCRIPTION
This implements the auto-start feature needed for the durable actors project, for the AzureStorageOrchestrationService.

To avoid headaches with versioning, I made no changes to DurableTask.Core. Instead, this is just a semantic (functional) change to how the AzureStorageOrchestrationService back end deals with events delivered to  non-existing instances.

The new behavior is: when trying to deliver an event to a not-already-existing instance, instead of just throwing an error, first check if the instance id starts with the special character "@" . If so, insert an ExecutionStartedEvent for that instance, using an orchestration name equal to the instance id.

This could break existing code for users that are using their own instance ids and those instance ids start with '@', which is unlikely to be an issue but probably need to document it somewhere.

This PR is related to https://github.com/Azure/azure-functions-durable-extension/issues/21 and https://github.com/Azure/azure-functions-durable-extension/issues/22.