### PR TITLE
Update documentation to add details about Azure storage connection string for unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ https://www.nuget.org/packages/DurableTask
 
 To run unit tests, you must specify your Service Bus connection string for the tests to use. You can do this via the **ServiceBusConnectionString** app.config value in the test project, or by defining a **DurableTaskTestServiceBusConnectionString** environment variable. The benefit of the environment variable is that no temporary source changes are required. 
 
-Unit tests also require Azure storage, but by default Azure Storage Emulator is used. You can change this behaviour via the **StorageConnectionString** app.config value in the test project, or by defining a **DurableTaskTestStorageConnectionString** environment variable. 
+Unit tests also require [Azure Storage Emulator](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-emulator), so make sure it's installed and running. 
+
+> Note: While it's possible to use in tests a real Azure Storage account it is highly not recomended to do so because many tests will fail with a 409 Conflict error. This is because tests delete and quickly recreate the same storage tables, and Azure Storage doesn't do well in these conditions. If you really want to change Azure Storage connection string you can do so via the **StorageConnectionString** app.config value in the test project, or by defining a **DurableTaskTestStorageConnectionString** environment variable. 
 
 The associated wiki contains more details about the framework:
 https://github.com/Azure/durabletask/wiki

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ https://www.nuget.org/packages/DurableTask
 
 To run unit tests, you must specify your Service Bus connection string for the tests to use. You can do this via the **ServiceBusConnectionString** app.config value in the test project, or by defining a **DurableTaskTestServiceBusConnectionString** environment variable. The benefit of the environment variable is that no temporary source changes are required. 
 
+Unit tests also require Azure storage, but by default Azure Storage Emulator is used. You can change this behaviour via the **StorageConnectionString** app.config value in the test project, or by defining a **DurableTaskTestStorageConnectionString** environment variable. 
+
 The associated wiki contains more details about the framework:
 https://github.com/Azure/durabletask/wiki
 


### PR DESCRIPTION
Documentation in README file does mention only about Service Bus Connection string for unit tests. It would be good if Azure Storage configuration for unit tests is briefly described.

This pull request adds details about Azure Storage connection string configuration for unit tests.