### PR TITLE
Use LastUpdatedTime in DurableTask.Emulator

### DIFF
--- a/src/DurableTask.Emulator/LocalOrchestrationService.cs
+++ b/src/DurableTask.Emulator/LocalOrchestrationService.cs
@@ -206,6 +206,7 @@ namespace DurableTask.Emulator
                         ExecutionId = creationMessage.OrchestrationInstance.ExecutionId,
                     },
                     CreatedTime = DateTime.UtcNow,
+                    LastUpdatedTime = DateTime.UtcNow,
                     OrchestrationStatus = OrchestrationStatus.Pending,
                     Version = ee.Version,
                     Name = ee.Name,


### PR DESCRIPTION
The Durable Functions tests have some assertions around the field LastUpdatedTime. When this field isn't set, the default values cause those assertions to fail when using DurableTask.Emulator as a storage provider.