### PR TITLE
DurableTask.AzureStorage: Stop throwing ArgNullException on invalid status

### DIFF
--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -495,7 +495,8 @@ namespace DurableTask.AzureStorage.Tracking
             var orchestrationState = new OrchestrationState();
             if (!Enum.TryParse(orchestrationInstanceStatus.RuntimeStatus, out orchestrationState.OrchestrationStatus))
             {
-                throw new ArgumentException($"{orchestrationInstanceStatus.RuntimeStatus} is not a valid OrchestrationStatus value.");
+                // This is not expected, but could happen if there is invalid data in the Instances table.
+                orchestrationState.OrchestrationStatus = (OrchestrationStatus)(-1);
             }
 
             orchestrationState.OrchestrationInstance = new OrchestrationInstance


### PR DESCRIPTION
This fix is required for https://github.com/Azure/azure-functions-durable-extension/issues/688