### PR TITLE
Fix incorrect out-of-order classifications for messages addressed for…

### DIFF
--- a/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
+++ b/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
@@ -119,6 +119,13 @@ namespace DurableTask.AzureStorage.Messaging
 
         internal bool IsOutOfOrderMessage(MessageData message)
         {
+            if (this.RuntimeState.Events.Count == 0 ||
+                this.RuntimeState.ExecutionStartedEvent == null)
+            {
+                // This message is for an instance which doesn't exist.
+                return false;
+            }
+
             int taskScheduledId = Utils.GetTaskEventId(message.TaskMessage.Event);
             if (taskScheduledId < 0)
             {


### PR DESCRIPTION
Resolves https://github.com/Azure/durabletask/issues/271.

Response messages for old orchestrations were stuck in an infinite loop because the out-of-order logic incorrectly flagged them as out-of-order messages. This fix should allow such messages to be correctly discarded.
