### PR TITLE
Provide method for downloading blobs in AzureStorageOrchestrationService

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1523,12 +1523,11 @@ namespace DurableTask.AzureStorage
         }
 
         /// <summary>
-        /// Download status fields whose content was too large to be stored in the orchestration status,
-        /// such as the input or output, and for which the blob URI was stored instead.
+        /// Download content that was too large to be stored in table storage,
+        /// such as the input or output status fields, and for which the blob URI was stored instead.
         /// </summary>
-        /// <param name="blobUri"></param>
-        /// <returns></returns>
-        public Task<string> DownloadLargeStatusField(string blobUri)
+        /// <param name="blobUri">The URI of the blob.</param>
+        public Task<string> DownloadBlobAsync(string blobUri)
         {
             return this.messageManager.DownloadAndDecompressAsBytesAsync(new Uri(blobUri));
         }

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1522,6 +1522,17 @@ namespace DurableTask.AzureStorage
             return this.trackingStore.PurgeHistoryAsync(thresholdDateTimeUtc, timeRangeFilterType);
         }
 
+        /// <summary>
+        /// Download status fields whose content was too large to be stored in the orchestration status,
+        /// such as the input or output, and for which the blob URI was stored instead.
+        /// </summary>
+        /// <param name="blobUri"></param>
+        /// <returns></returns>
+        public Task<string> DownloadLargeStatusField(string blobUri)
+        {
+            return this.messageManager.DownloadAndDecompressAsBytesAsync(new Uri(blobUri));
+        }
+
         #endregion
 
         // TODO: Change this to a sticky assignment so that partition count changes can

--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -175,6 +175,17 @@ namespace DurableTask.AzureStorage
             await this.EnsureContainerAsync();
 
             CloudBlockBlob cloudBlockBlob = this.cloudBlobContainer.GetBlockBlobReference(blobName);
+            return await DownloadAndDecompressAsBytesAsync(cloudBlockBlob);
+        }
+
+        internal Task<string> DownloadAndDecompressAsBytesAsync(Uri blobUri)
+        {
+            CloudBlockBlob cloudBlockBlob = new CloudBlockBlob(blobUri, this.cloudBlobContainer.ServiceClient.Credentials);
+            return DownloadAndDecompressAsBytesAsync(cloudBlockBlob);
+        }
+
+        private async Task<string> DownloadAndDecompressAsBytesAsync(CloudBlockBlob cloudBlockBlob)
+        {
             Stream downloadBlobAsStream = await cloudBlockBlob.OpenReadAsync();
             ArraySegment<byte> decompressedSegment = this.Decompress(downloadBlobAsStream);
             return Encoding.UTF8.GetString(decompressedSegment.Array, 0, decompressedSegment.Count);


### PR DESCRIPTION
When using `AzureStorageOrchestrationService`, large status fields (input or output) are compressed and stored in blobs, which is difficult for clients to access (see issue #274).

This PR solves this problem by adding a public method for decompressing and downloading the content of such blobs. 