### PR TITLE
DurableTask.Core: Make all history event types public

### DIFF
--- a/src/DurableTask.Core/History/ContinueAsNewEvent.cs
+++ b/src/DurableTask.Core/History/ContinueAsNewEvent.cs
@@ -15,14 +15,25 @@ namespace DurableTask.Core.History
 {
     using System.Runtime.Serialization;
 
+    /// <summary>
+    /// A history event for continue-as-new
+    /// </summary>
     [DataContract]
-    internal class ContinueAsNewEvent : ExecutionCompletedEvent
+    public class ContinueAsNewEvent : ExecutionCompletedEvent
     {
+        /// <summary>
+        /// Creates a new ExecutionStartedEvent with the supplied parameters
+        /// </summary>
+        /// <param name="eventId">The event id of the history event</param>
+        /// <param name="input">The serialized orchestration input</param>
         public ContinueAsNewEvent(int eventId, string input)
             : base(eventId, input, OrchestrationStatus.ContinuedAsNew)
         {
         }
 
+        /// <summary>
+        /// Gets the event type
+        /// </summary>
         public override EventType EventType => EventType.ContinueAsNew;
     }
 }

--- a/src/DurableTask.Core/History/EventRaisedEvent.cs
+++ b/src/DurableTask.Core/History/EventRaisedEvent.cs
@@ -15,20 +15,37 @@ namespace DurableTask.Core.History
 {
     using System.Runtime.Serialization;
 
+    /// <summary>
+    /// A history event for event raised
+    /// </summary>
     [DataContract]
-    internal class EventRaisedEvent : HistoryEvent
+    public class EventRaisedEvent : HistoryEvent
     {
+        /// <summary>
+        /// Creates a new <see cref="EventRaisedEvent"/> with the supplied event id and input.
+        /// </summary>
+        /// <param name="eventId">The ID of the event.</param>
+        /// <param name="input">The serialized event payload.</param>
         public EventRaisedEvent(int eventId, string input)
             : base(eventId)
         {
             Input = input;
         }
 
+        /// <summary>
+        /// Gets the event type
+        /// </summary>
         public override EventType EventType => EventType.EventRaised;
 
+        /// <summary>
+        /// Gets or sets the orchestration name
+        /// </summary>
         [DataMember]
         public string Name { get; set; }
 
+        /// <summary>
+        /// Gets or sets the serialized payload of the event
+        /// </summary>
         [DataMember]
         public string Input { get; set; }
     }

--- a/src/DurableTask.Core/History/EventSentEvent.cs
+++ b/src/DurableTask.Core/History/EventSentEvent.cs
@@ -15,22 +15,41 @@ namespace DurableTask.Core.History
 {
     using System.Runtime.Serialization;
 
+    /// <summary>
+    /// A history event for event sent
+    /// </summary>
     [DataContract]
-    internal class EventSentEvent : HistoryEvent
+    public class EventSentEvent : HistoryEvent
     {
+        /// <summary>
+        /// Creates a new <see cref="EventSentEvent"/> with the supplied event id.
+        /// </summary>
+        /// <param name="eventId">The ID of the event.</param>
         public EventSentEvent(int eventId)
             : base(eventId)
         {
         }
 
+        /// <summary>
+        /// Gets the event type
+        /// </summary>
         public override EventType EventType => EventType.EventSent;
 
+        /// <summary>
+        /// The orchestration instance ID for this event
+        /// </summary>
         [DataMember]
         public string InstanceId { get; set; }
 
+        /// <summary>
+        /// Gets or sets the orchestration name
+        /// </summary>
         [DataMember]
         public string Name { get; set; }
 
+        /// <summary>
+        /// Gets or sets the serialized payload of the event
+        /// </summary>
         [DataMember]
         public string Input { get; set; }
     }

--- a/src/DurableTask.Core/History/OrchestratorCompletedEvent.cs
+++ b/src/DurableTask.Core/History/OrchestratorCompletedEvent.cs
@@ -15,14 +15,24 @@ namespace DurableTask.Core.History
 {
     using System.Runtime.Serialization;
 
+    /// <summary>
+    /// A history event for orchestrator completed
+    /// </summary>
     [DataContract]
-    internal class OrchestratorCompletedEvent : HistoryEvent
+    public class OrchestratorCompletedEvent : HistoryEvent
     {
+        /// <summary>
+        /// Creates a new <see cref="OrchestratorCompletedEvent"/> with the supplied parameters
+        /// </summary>
+        /// <param name="eventId">The event id of the history event</param>
         public OrchestratorCompletedEvent(int eventId)
             : base(eventId)
         {
         }
 
+        /// <summary>
+        /// Gets the event type
+        /// </summary>
         public override EventType EventType => EventType.OrchestratorCompleted;
     }
 }

--- a/src/DurableTask.Core/History/OrchestratorStartedEvent.cs
+++ b/src/DurableTask.Core/History/OrchestratorStartedEvent.cs
@@ -15,14 +15,24 @@ namespace DurableTask.Core.History
 {
     using System.Runtime.Serialization;
 
+    /// <summary>
+    /// A history event for orchestrator started
+    /// </summary>
     [DataContract]
-    internal class OrchestratorStartedEvent : HistoryEvent
+    public class OrchestratorStartedEvent : HistoryEvent
     {
+        /// <summary>
+        /// Creates a new <see cref="OrchestratorStartedEvent"/> with the supplied parameters
+        /// </summary>
+        /// <param name="eventId">The event id of the history event</param>
         public OrchestratorStartedEvent(int eventId)
             : base(eventId)
         {
         }
 
+        /// <summary>
+        /// Gets the event type
+        /// </summary>
         public override EventType EventType => EventType.OrchestratorStarted;
     }
 }

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -448,7 +448,7 @@ namespace DurableTask.Core
 
             var executor = new TaskOrchestrationExecutor(runtimeState, taskOrchestration, orchestrationService.EventBehaviourForContinueAsNew);
 
-            IEnumerable<OrchestratorAction> decisions = null;
+            IEnumerable<OrchestratorAction> decisions = Enumerable.Empty<OrchestratorAction>();
             await this.dispatchPipeline.RunAsync(dispatchContext, _ =>
             {
                 decisions = executor.Execute();
@@ -465,6 +465,7 @@ namespace DurableTask.Core
             dispatchContext.SetProperty(cursor.TaskOrchestration);
             dispatchContext.SetProperty(cursor.RuntimeState);
 
+            cursor.LatestDecisions = Enumerable.Empty<OrchestratorAction>();
             return this.dispatchPipeline.RunAsync(dispatchContext, _ =>
             {
                 cursor.LatestDecisions = cursor.OrchestrationExecutor.ExecuteNewEvents();

--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <!-- Sign assemblies if the snk file is present -->
-  <PropertyGroup Condition="Exists('$(SolutionDir)\tools\sign.snk')">
+  <PropertyGroup Condition="Exists('$(SolutionDir)\tools\sign.snk') And $(Configuration) == 'Release'">
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)\tools\sign.snk</AssemblyOriginatorKeyFile>
     <DefineConstants>$(DefineConstants);SIGN_ASSEMBLY</DefineConstants>

--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <!-- Sign assemblies if the snk file is present -->
-  <PropertyGroup Condition="Exists('$(SolutionDir)\tools\sign.snk') And $(Configuration) == 'Release'">
+  <PropertyGroup Condition="Exists('$(SolutionDir)\tools\sign.snk')">
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)\tools\sign.snk</AssemblyOriginatorKeyFile>
     <DefineConstants>$(DefineConstants);SIGN_ASSEMBLY</DefineConstants>
@@ -43,9 +43,9 @@
   <!-- Nuget Package Settings -->
   <PropertyGroup>
     <PackageOutputPath>..\..\build_output\packages</PackageOutputPath>
-    <AssemblyVersion>2.1.0</AssemblyVersion>
-    <FileVersion>2.1.0</FileVersion>
-    <Version>2.1.0</Version>
+    <AssemblyVersion>2.1.1</AssemblyVersion>
+    <FileVersion>2.1.1</FileVersion>
+    <Version>2.1.1</Version>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors> 
     <Product>Durable Task Framework</Product>


### PR DESCRIPTION
Many history event types in **DurableTask.Core** were already public, but a few were not. This PR makes all of them public. This is needed for some new feature work in Durable Functions.

This PR also contains a very minor change to avoid null-reference exceptions when middleware hijacks the orchestration execution code path.