### PR TITLE
AzureTableTrackingStore fix for RewindHistoryAsync query

### DIFF
--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -360,8 +360,8 @@ namespace DurableTask.AzureStorage.Tracking
             rowsToUpdateFilterCondition.Append(PartitionKeyProperty).Append(" eq ").Append(Quote).Append(instanceId).Append(Quote);
             rowsToUpdateFilterCondition.Append(" and ExecutionId eq ").Append(Quote).Append(executionId).Append(Quote);
             rowsToUpdateFilterCondition.Append(" and (OrchestrationStatus eq ").Append(Quote).Append("Failed").Append(Quote);
-            rowsToUpdateFilterCondition.Append(" or EventType eq").Append(Quote).Append("TaskFailed").Append(Quote);
-            rowsToUpdateFilterCondition.Append(" or EventType eq").Append(Quote).Append("SubOrchestrationInstanceFailed").Append(Quote).Append(")");
+            rowsToUpdateFilterCondition.Append(" or EventType eq ").Append(Quote).Append("TaskFailed").Append(Quote);
+            rowsToUpdateFilterCondition.Append(" or EventType eq ").Append(Quote).Append("SubOrchestrationInstanceFailed").Append(Quote).Append(")");
 
             var entitiesToClear = await this.QueryHistoryAsync(rowsToUpdateFilterCondition.ToString(), instanceId, cancellationToken);
 


### PR DESCRIPTION
This PR fixes the query creation in `AzureTableTrackingStore.RewindHistoryAsync`. As far as I see there was a missing whitespace in there.

A note for the reviewer: I found not that much tests for AzureTableTrackingStore (only a few with a mocked `Instance` table) so maybe these are tested in some other way as well.