### PR TITLE
Fix bug in fast continueAsNew for DurableTask.AzureStorage (#285)

### DIFF
--- a/Test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -206,6 +206,25 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
+        [DataTestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public async Task ContinueAsNewThenTimer(bool enableExtendedSessions)
+        {
+            using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(enableExtendedSessions))
+            {
+                await host.StartAsync();
+
+                var client = await host.StartOrchestrationAsync(typeof(Test.Orchestrations.ContinueAsNewThenTimerOrchestration), 0);
+                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+
+                Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
+                Assert.AreEqual("OK", JToken.Parse(status?.Output));
+
+                await host.StopAsync();
+            }
+        }
+
         [TestMethod]
         public async Task PurgeInstanceHistoryForSingleInstanceWithoutLargeMessageBlobs()
         {

--- a/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
+++ b/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
@@ -55,7 +55,7 @@ namespace DurableTask.AzureStorage.Messaging
 
         public IList<MessageData> CurrentMessageBatch { get; private set; }
 
-        public OrchestrationRuntimeState RuntimeState { get; }
+        public OrchestrationRuntimeState RuntimeState { get; private set; }
 
         public string ETag { get; set; }
 
@@ -115,6 +115,12 @@ namespace DurableTask.AzureStorage.Messaging
             }
 
             return messages;
+        }
+
+        public void UpdateRuntimeState(OrchestrationRuntimeState runtimeState)
+        {
+            this.RuntimeState = runtimeState;
+            this.Instance = runtimeState.OrchestrationInstance;
         }
 
         internal bool IsOutOfOrderMessage(MessageData message)

--- a/src/DurableTask.AzureStorage/Messaging/Session.cs
+++ b/src/DurableTask.AzureStorage/Messaging/Session.cs
@@ -36,7 +36,7 @@ namespace DurableTask.AzureStorage.Messaging
             };
         }
 
-        public OrchestrationInstance Instance { get; }
+        public OrchestrationInstance Instance { get; protected set; }
 
         public OperationContext StorageOperationContext { get; }
 

--- a/src/DurableTask.Core/IOrchestrationSession.cs
+++ b/src/DurableTask.Core/IOrchestrationSession.cs
@@ -30,5 +30,10 @@ namespace DurableTask.Core
         /// and the dispatcher will shut down the session.
         /// </remarks>
         Task<IList<TaskMessage>> FetchNewOrchestrationMessagesAsync(TaskOrchestrationWorkItem workItem);
+
+        /// <summary>
+        /// Updates the in-memory session info.
+        /// </summary>
+        void UpdateRuntimeState(OrchestrationRuntimeState runtimeState);
     }
 }

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -426,6 +426,8 @@ namespace DurableTask.Core
 
             workItem.OrchestrationRuntimeState = runtimeState;
 
+            workItem.Session?.UpdateRuntimeState(runtimeState);
+
             return isCompleted || continuedAsNew || isInterrupted;
         }
 

--- a/test/DurableTask.Test.Orchestrations/SimpleOrchestrations.cs
+++ b/test/DurableTask.Test.Orchestrations/SimpleOrchestrations.cs
@@ -263,6 +263,29 @@ namespace DurableTask.Test.Orchestrations
         }
     }
 
+    public sealed class ContinueAsNewThenTimerOrchestration : TaskOrchestration<string,int>
+    {
+        public override async Task<string> RunTask(OrchestrationContext context, int input)
+        {
+            if (input == 0)
+            {
+                context.ContinueAsNew(1);
+
+                return "continue as new";
+            }
+            else if (input == 1)
+            {
+                await context.CreateTimer(context.CurrentUtcDateTime, 0);
+
+                return "OK";
+            }
+            else
+            {
+                throw new InvalidOperationException();
+            }
+        }
+    }
+
     [KnownType(typeof(EventConversationOrchestration.Responder))]
     public sealed class EventConversationOrchestration : TaskOrchestration<string, string>
     {


### PR DESCRIPTION
This is a fix for the bug described in #285.

- Added a test to repro the problem.
- Added code to update the Orchestration session after a continue as new changes the runtime state.
- Added code to handle the case where messages are dequeued for an already existing session.