### PR TITLE
Fix pending orchestration race condition in Azure Storage Provider

### DIFF
--- a/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
+++ b/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
@@ -125,13 +125,13 @@ namespace DurableTask.AzureStorage.Messaging
 
         internal bool IsOutOfOrderMessage(MessageData message)
         {
-            if (this.IsNonexistantInstance() && message.OriginalQueueMessage.DequeueCount > 3)
+            if (this.IsNonexistantInstance() && message.OriginalQueueMessage.DequeueCount > 5)
             {
-                // The first three times a message for a nonexistant instance is dequeued, give the message the benefit
+                // The first five times a message for a nonexistant instance is dequeued, give the message the benefit
                 // of the doubt and assume that the instance hasn't had its history table populated yet. After the 
-                // third execution, the most likely scenario is that this is a zombie event for a previous iteration of 
-                // an orchestration that called ContinueAsNew(). Return false to let the zombie message continue on to be
-                // discarded so that we don't end up processing it indefinitely.
+                // fifth execution, 15 seconds have passed and the most likely scenario is that this is a zombie event. 
+                // This means the history table for the message's orchestration no longer exists, either due to an explicit 
+                // PurgeHistory request or due to a ContinueAsNew call cleaning the old execution's history.
                 return false;
             }
 

--- a/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
+++ b/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
@@ -129,7 +129,7 @@ namespace DurableTask.AzureStorage.Messaging
             {
                 // The first five times a message for a nonexistant instance is dequeued, give the message the benefit
                 // of the doubt and assume that the instance hasn't had its history table populated yet. After the 
-                // fifth execution, 15 seconds have passed and the most likely scenario is that this is a zombie event. 
+                // fifth execution, ~30 seconds have passed and the most likely scenario is that this is a zombie event. 
                 // This means the history table for the message's orchestration no longer exists, either due to an explicit 
                 // PurgeHistory request or due to a ContinueAsNew call cleaning the old execution's history.
                 return false;

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -216,7 +216,7 @@ namespace DurableTask.AzureStorage.Messaging
 
             try
             {
-                // We "abandon" the message by settings its visibility timeout to it's dequeue count + 1 seconds.
+                // We "abandon" the message by settings its visibility timeout to its dequeue count + 1 seconds.
                 // This allows it to be reprocessed on this node or another node.
                 await this.storageQueue.UpdateMessageAsync(
                     queueMessage,

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -196,6 +196,9 @@ namespace DurableTask.AzureStorage.Messaging
                 // The delay needs to be long enough to allow some progress to be made but
                 // short enough to allow for debugging.
                 visibilityDelay = TimeSpan.FromMinutes(10);
+            } else
+            {
+                visibilityDelay = TimeSpan.FromSeconds(queueMessage.DequeueCount+1);
             }
 
             AnalyticsEventSource.Log.AbandoningMessage(
@@ -213,7 +216,7 @@ namespace DurableTask.AzureStorage.Messaging
 
             try
             {
-                // We "abandon" the message by settings its visibility timeout to zero.
+                // We "abandon" the message by settings its visibility timeout to it's dequeue count + 1 seconds.
                 // This allows it to be reprocessed on this node or another node.
                 await this.storageQueue.UpdateMessageAsync(
                     queueMessage,

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -180,8 +180,11 @@ namespace DurableTask.AzureStorage.Messaging
             TaskMessage taskMessage = message.TaskMessage;
             OrchestrationInstance instance = taskMessage.OrchestrationInstance;
 
-            TimeSpan visibilityDelay = TimeSpan.Zero;
-            if (queueMessage.DequeueCount >= 100)
+            // Exponentially backoff a given queue message until a maximum visibility delay of 10 minutes.
+            // Once it hits the maximum, log the message as a poison message.
+            const int maxSecondsToWait = 600;
+            int numSecondsToWait = Math.Min((int) Math.Pow(2, queueMessage.DequeueCount), maxSecondsToWait);
+            if (numSecondsToWait == maxSecondsToWait)
             {
                 AnalyticsEventSource.Log.PoisonMessageDetected(
                     this.storageAccountName,
@@ -192,14 +195,8 @@ namespace DurableTask.AzureStorage.Messaging
                     this.storageQueue.Name,
                     queueMessage.DequeueCount,
                     Utils.ExtensionVersion);
-
-                // The delay needs to be long enough to allow some progress to be made but
-                // short enough to allow for debugging.
-                visibilityDelay = TimeSpan.FromMinutes(10);
-            } else
-            {
-                visibilityDelay = TimeSpan.FromSeconds(queueMessage.DequeueCount+1);
             }
+            TimeSpan visibilityDelay = TimeSpan.FromSeconds(numSecondsToWait);
 
             AnalyticsEventSource.Log.AbandoningMessage(
                 this.storageAccountName,
@@ -216,8 +213,8 @@ namespace DurableTask.AzureStorage.Messaging
 
             try
             {
-                // We "abandon" the message by settings its visibility timeout to its dequeue count + 1 seconds.
-                // This allows it to be reprocessed on this node or another node.
+                // We "abandon" the message by settings its visibility timeout using an exponential backoff algorithm.
+                // This allows it to be reprocessed on this node or another node at a later time, hopefully successfully.
                 await this.storageQueue.UpdateMessageAsync(
                     queueMessage,
                     visibilityDelay,


### PR DESCRIPTION
Adds progressively longer visibility delays for abandoned messages to
give history table time to populate.