### PR TITLE
Add support for fire-and-forget suborchestrations

### DIFF
--- a/Test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -166,15 +166,17 @@ namespace DurableTask.AzureStorage.Tests
         }
 
         [DataTestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
-        public async Task EventConversation(bool enableExtendedSessions)
+        [DataRow(false, false)]
+        [DataRow(true, false)]
+        [DataRow(false, true)]
+        [DataRow(true, true)]
+        public async Task EventConversation(bool enableExtendedSessions, bool useFireAndForget)
         {
             using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(enableExtendedSessions))
             {
                 await host.StartAsync();
 
-                var client = await host.StartOrchestrationAsync(typeof(Test.Orchestrations.EventConversationOrchestration), "");
+                var client = await host.StartOrchestrationAsync(typeof(Test.Orchestrations.EventConversationOrchestration), useFireAndForget.ToString());
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
@@ -183,7 +185,6 @@ namespace DurableTask.AzureStorage.Tests
                 await host.StopAsync();
             }
         }
-
 
         [DataTestMethod]
         [DataRow(false)]

--- a/Test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -176,7 +176,7 @@ namespace DurableTask.AzureStorage.Tests
             {
                 await host.StartAsync();
 
-                var client = await host.StartOrchestrationAsync(typeof(Test.Orchestrations.EventConversationOrchestration), useFireAndForget.ToString());
+                var client = await host.StartOrchestrationAsync(typeof(Test.Orchestrations.EventConversationOrchestration), useFireAndForget);
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);

--- a/src/DurableTask.Core/FrameworkConstants.cs
+++ b/src/DurableTask.Core/FrameworkConstants.cs
@@ -36,6 +36,13 @@ namespace DurableTask.Core
         /// </summary>
         public const string HistoryEventIndexPropertyName = "HistoryEventIndex";
 
+
+        /// <summary>
+        /// A special orchestration tag used for indicating that a suborchestration is fire-and-forget,
+        /// i.e. the parent orchestration does not wait for the result.
+        /// </summary>
+        public const string FireAndForgetOrchestrationTag = "FireAndForget";
+
         /// <summary>
         /// Id for a fake timer event
         /// </summary>

--- a/src/DurableTask.Core/FrameworkConstants.cs
+++ b/src/DurableTask.Core/FrameworkConstants.cs
@@ -36,13 +36,6 @@ namespace DurableTask.Core
         /// </summary>
         public const string HistoryEventIndexPropertyName = "HistoryEventIndex";
 
-
-        /// <summary>
-        /// A special orchestration tag used for indicating that a suborchestration is fire-and-forget,
-        /// i.e. the parent orchestration does not wait for the result.
-        /// </summary>
-        public const string FireAndForgetOrchestrationTag = "FireAndForget";
-
         /// <summary>
         /// Id for a fake timer event
         /// </summary>

--- a/src/DurableTask.Core/OrchestrationTags.cs
+++ b/src/DurableTask.Core/OrchestrationTags.cs
@@ -23,20 +23,17 @@ namespace DurableTask.Core
     /// properties that can be explicitly assigned when orchestrations or suborchestrations
     /// are created. A suborchestration automatically inherits the tags of its parent orchestration.
     /// </summary>
-    /// <remarks>
-    /// Tags are generally intended for application-specific purposes and ignored by the runtime,
-    /// except for the special fire-and-forget tag. The fire-and-forget tag, when assigned to a 
-    /// sub-orchestration, is interpreted by the runtime to indicate that the parent should not
-    /// wait for the result of the sub-orchestration, and the sub-orchestration need not send a
-    /// response to the parent. Unlike application-defined tags, the fire-and-forget tag is not 
-    /// automatically inherited by sub-orchestrations.
-    /// </remarks>
     public static class OrchestrationTags
     {
         /// <summary>
         /// A special orchestration tag used for indicating that a suborchestration is fire-and-forget,
         /// i.e. the parent orchestration does not wait for the result.
         /// </summary>
+        /// <remarks>
+        /// Tags are generally intended for application-specific purposes and ignored by the runtime,
+        /// except for this special tag. Unlike general application-defined tags, this tag is not 
+        /// automatically inherited by sub-orchestrations.
+        /// </remarks>
         public const string FireAndForget = "FireAndForget";
 
         /// <summary>

--- a/src/DurableTask.Core/OrchestrationTags.cs
+++ b/src/DurableTask.Core/OrchestrationTags.cs
@@ -1,0 +1,79 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace DurableTask.Core
+{
+    /// <summary>
+    /// Common code for dealing with orchestration tags. Orchestration tags are string-typed 
+    /// properties that can be explicitly assigned when orchestrations or suborchestrations
+    /// are created. A suborchestration automatically inherits the tags of its parent orchestration.
+    /// </summary>
+    /// <remarks>
+    /// Tags are generally intended for application-specific purposes and ignored by the runtime,
+    /// except for the special fire-and-forget tag. The fire-and-forget tag, when assigned to a 
+    /// sub-orchestration, is interpreted by the runtime to indicate that the parent should not
+    /// wait for the result of the sub-orchestration, and the sub-orchestration need not send a
+    /// response to the parent. Unlike application-defined tags, the fire-and-forget tag is not 
+    /// automatically inherited by sub-orchestrations.
+    /// </remarks>
+    public static class OrchestrationTags
+    {
+        /// <summary>
+        /// A special orchestration tag used for indicating that a suborchestration is fire-and-forget,
+        /// i.e. the parent orchestration does not wait for the result.
+        /// </summary>
+        public const string FireAndForget = "FireAndForget";
+
+        /// <summary>
+        /// Check whether the given tags contain the fire and forget tag
+        /// </summary>
+        /// <param name="tags"></param>
+        /// <returns></returns>
+        internal static bool IsTaggedAsFireAndForget(IDictionary<string, string> tags)
+        {
+            return tags != null && tags.ContainsKey(FireAndForget);
+        }
+
+        internal static IDictionary<string, string> MergeTags(
+            IDictionary<string, string> newTags,
+            IDictionary<string, string> existingTags)
+        {
+            if (existingTags == null)
+            {
+                return newTags;
+            }
+            else if (newTags != null)
+            {
+                // We merge the two dictionaries of tags, with new tags overriding existing tags
+                return newTags.Concat(
+                    existingTags.Where(k => !newTags.ContainsKey(k.Key) && k.Key != FireAndForget))
+                    .ToDictionary(x => x.Key, y => y.Value);
+            }
+            else if (!existingTags.ContainsKey(FireAndForget))
+            {
+                return existingTags;
+            }
+            else
+            {
+                return existingTags
+                    .Where(k => k.Key != FireAndForget)
+                    .ToDictionary(x => x.Key, y => y.Value);
+            }
+        }
+    }
+}

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -159,8 +159,7 @@ namespace DurableTask.Core
 
             this.orchestratorActionsMap.Add(id, action);
 
-            if (tags != null 
-                && tags.ContainsKey(FrameworkConstants.FireAndForgetOrchestrationTag))
+            if (OrchestrationTags.IsTaggedAsFireAndForget(tags))
             {
                 // this is a fire-and-forget orchestration, so we do not wait for a result.
                 return default(T);

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -159,12 +159,21 @@ namespace DurableTask.Core
 
             this.orchestratorActionsMap.Add(id, action);
 
-            var tcs = new TaskCompletionSource<string>();
-            this.openTasks.Add(id, new OpenTaskInfo { Name = name, Version = version, Result = tcs });
+            if (tags != null 
+                && tags.ContainsKey(FrameworkConstants.FireAndForgetOrchestrationTag))
+            {
+                // this is a fire-and-forget orchestration, so we do not wait for a result.
+                return default(T);
+            }
+            else
+            {
+                var tcs = new TaskCompletionSource<string>();
+                this.openTasks.Add(id, new OpenTaskInfo { Name = name, Version = version, Result = tcs });
 
-            string serializedResult = await tcs.Task;
+                string serializedResult = await tcs.Task;
 
-            return this.dataConverter.Deserialize<T>(serializedResult);
+                return this.dataConverter.Deserialize<T>(serializedResult);
+            }
         }
 
         public override void SendEvent(OrchestrationInstance orchestrationInstance, string eventName, object eventData)

--- a/test/DurableTask.ServiceBus.Tests/SampleScenarioTests.cs
+++ b/test/DurableTask.ServiceBus.Tests/SampleScenarioTests.cs
@@ -286,7 +286,7 @@ namespace DurableTask.ServiceBus.Tests
                                        typeof(Test.Orchestrations.EventConversationOrchestration.Responder))
                 .StartAsync();
 
-            OrchestrationInstance id = await this.client.CreateOrchestrationInstanceAsync(typeof(Test.Orchestrations.EventConversationOrchestration), "");
+            OrchestrationInstance id = await this.client.CreateOrchestrationInstanceAsync(typeof(Test.Orchestrations.EventConversationOrchestration), "false");
             bool isCompleted = await TestHelpers.WaitForInstanceAsync(this.client, id, 60);
             Assert.IsTrue(isCompleted, TestHelpers.GetInstanceNotCompletedMessage(this.client, id, 60));
             Assert.IsTrue(Test.Orchestrations.EventConversationOrchestration.OkResult, "Orchestration did not finish ok!!!");

--- a/test/DurableTask.Test.Orchestrations/SimpleOrchestrations.cs
+++ b/test/DurableTask.Test.Orchestrations/SimpleOrchestrations.cs
@@ -288,7 +288,7 @@ namespace DurableTask.Test.Orchestrations
     }
 
     [KnownType(typeof(EventConversationOrchestration.Responder))]
-    public sealed class EventConversationOrchestration : TaskOrchestration<string, string>
+    public sealed class EventConversationOrchestration : TaskOrchestration<string, bool>
     {
         private readonly TaskCompletionSource<string> tcs
             = new TaskCompletionSource<string>(TaskContinuationOptions.ExecuteSynchronously);
@@ -296,10 +296,8 @@ namespace DurableTask.Test.Orchestrations
         // HACK: This is just a hack to communicate result of orchestration back to test
         public static bool OkResult;
 
-        public async override Task<string> RunTask(OrchestrationContext context, string input)
+        public async override Task<string> RunTask(OrchestrationContext context, bool useFireAndForgetSubOrchestration)
         {
-            bool useFireAndForgetSubOrchestration = bool.Parse(input);
-
             // start a responder orchestration
             var responderId = "responderId";
             Task<string> responderOrchestration = null;
@@ -311,7 +309,7 @@ namespace DurableTask.Test.Orchestrations
             else
             {
                 var dummyTask = context.CreateSubOrchestrationInstance<object>(NameVersionHelper.GetDefaultName(typeof(Responder)), "", responderId, "Herkimer",
-                    new Dictionary<string, string>() { { FrameworkConstants.FireAndForgetOrchestrationTag, "" } });
+                    new Dictionary<string, string>() { { OrchestrationTags.FireAndForget, "" } });
 
                 if (!dummyTask.IsCompleted)
                 {


### PR DESCRIPTION
Implementation of a feature that allows sub-orchestrations to be launched as "fire-and-forget". For any such sub-orchestration, the parent orchestration continues immediately and does not wait for the result of the sub-orchestration.

We need this feature for allowing entities in DF to start new orchestrations (azure/azure-functions-durable-extension#715).

To keep this a non-breaking change to the API, and to avoid changing any serialized data formats, I used the existing `tags` data structure to indicate that an orchestration is fire-and-forget. So, one can simply set the `FrameworkConstants.FireAndForgetOrchestrationTag` in `tags`, when creating a sub-orchestration, and this then makes the sub-orchestration fire-and-forget. 

One somewhat subtle point is that I have to specifically remove this tag when merging existing orchestration tags with new orchestration tags when creating a suborchestration. This is because by default, tags are inherited, but this kind of tag should not be (since not all suborchestrations of a fire-and-forget suborchestrations are necessarily fire-and-forget on their own). 