### PR TITLE
SumofSquares sample broken -- Copy BagofNumbers.json to output.

### DIFF
--- a/samples/DurableTask.Samples/DurableTask.Samples.csproj
+++ b/samples/DurableTask.Samples/DurableTask.Samples.csproj
@@ -38,5 +38,9 @@
       <SubType>Form</SubType>
     </Compile>
   </ItemGroup>
-  
+  <ItemGroup>
+    <None Update="SumOfSquares\BagofNumbers.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
The `SumofSquares` sample is broken unless you copy the output of the `BagofNumbers.json` to build output.