### PR TITLE
Increment versions of AzureStorage and Redis nuget packages

### DIFF
--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <FileVersion>1.6.3</FileVersion>
+    <FileVersion>1.6.4</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <Version>$(FileVersion)</Version>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/DurableTask.Redis/DurableTask.Redis.csproj
+++ b/src/DurableTask.Redis/DurableTask.Redis.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RunCodeAnalysis>false</RunCodeAnalysis>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <FileVersion>0.1.0</FileVersion>
+    <FileVersion>0.1.1</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <Version>$(FileVersion)-alpha</Version>
     <IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
The latest DurableTask.Core (v2.1.3) package introduced breaking changes, making it incompatible with existing versions of DurableTask.AzureStorage and DurableTask.Redis. Need to update these packages to target the latest version of DurableTask.Core.

Durable Functions also needs this updated DurableTask.AzureStorage package because it enables us to use the new "fire-and-forget" support for sub-orchestrations.