### PR TITLE
Removed invalid .net core 3 reflection call.

### DIFF
--- a/src/DurableTask.Core/Common/DateTimeUtils.cs
+++ b/src/DurableTask.Core/Common/DateTimeUtils.cs
@@ -20,11 +20,6 @@ namespace DurableTask.Core.Common
     /// </summary>
     public static class DateTimeUtils
     {
-        static DateTimeUtils()
-        {
-            MinDateTime = DateTime.MinValue;
-        }
-
         /// <summary>
         /// Returns bool indicating is the datetime has a value set
         /// </summary>        

--- a/src/DurableTask.Core/Common/DateTimeUtils.cs
+++ b/src/DurableTask.Core/Common/DateTimeUtils.cs
@@ -31,7 +31,7 @@ namespace DurableTask.Core.Common
         /// <summary>
         /// Returns minimum allowable DateTime, allows overriding this for the storage emulator.
         /// The Storage emulator supports a min datetime or DateTime.FromFileTimeUtc(0)
-        /// Do not alter this value. Kept as field to have backward compatibility.
+        /// Do not alter this value. Kept as field to have backward compatibility(#319).
         /// </summary>  
         public static DateTime MinDateTime = DateTime.MinValue;
 

--- a/src/DurableTask.Core/Common/DateTimeUtils.cs
+++ b/src/DurableTask.Core/Common/DateTimeUtils.cs
@@ -20,26 +20,34 @@ namespace DurableTask.Core.Common
     /// </summary>
     public static class DateTimeUtils
     {
+        private static DateTime _minDataTime;
+
+        static DateTimeUtils()
+        {
+            _minDataTime = MinDateTime = DateTime.MinValue;
+        }
+
         /// <summary>
         /// Returns bool indicating is the datetime has a value set
         /// </summary>        
         public static bool IsSet(this DateTime dateTime)
         {
-            return !(dateTime == DateTime.MinValue || dateTime == MinDateTime);
+            return !(dateTime == DateTime.MinValue || dateTime == _minDataTime);
         }
 
         /// <summary>
         /// Returns minimum allowable DateTime, allows overriding this for the storage emulator.
         /// The Storage emulator supports a min datetime or DateTime.FromFileTimeUtc(0)
+        /// Setting this value will have no effect.
         /// </summary>  
-        public static DateTime MinDateTime { get; private set; } = DateTime.MinValue;
+        public static DateTime MinDateTime; //Keeping backward compatibility #319 #320
 
         /// <summary>
         /// Uses reflection to alter the static readonly MinDateTime value for tests
         /// </summary>  
         public static void SetMinDateTimeForStorageEmulator()
         {
-            MinDateTime = DateTime.FromFileTimeUtc(0);
+            _minDataTime = MinDateTime = DateTime.FromFileTimeUtc(0);
         }
     }
 }

--- a/src/DurableTask.Core/Common/DateTimeUtils.cs
+++ b/src/DurableTask.Core/Common/DateTimeUtils.cs
@@ -14,7 +14,6 @@
 namespace DurableTask.Core.Common
 {
     using System;
-    using System.Reflection;
 
     /// <summary>
     /// Extension methods for DateTime
@@ -33,17 +32,14 @@ namespace DurableTask.Core.Common
         /// Returns minimum allowable DateTime, allows overriding this for the storage emulator.
         /// The Storage emulator supports a min datetime or DateTime.FromFileTimeUtc(0)
         /// </summary>  
-        public static readonly DateTime MinDateTime = DateTime.MinValue;
+        public static DateTime MinDateTime { get; private set; } = DateTime.MinValue;
 
         /// <summary>
         /// Uses reflection to alter the static readonly MinDateTime value for tests
         /// </summary>  
         public static void SetMinDateTimeForStorageEmulator()
         {
-            BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.Static;
-            Type settingsType = typeof(DateTimeUtils);
-            FieldInfo field = settingsType.GetField(nameof(MinDateTime), flags);
-            field?.SetValue(settingsType, DateTime.FromFileTimeUtc(0));
+            MinDateTime = DateTime.FromFileTimeUtc(0);
         }
     }
 }

--- a/src/DurableTask.Core/Common/DateTimeUtils.cs
+++ b/src/DurableTask.Core/Common/DateTimeUtils.cs
@@ -20,11 +20,9 @@ namespace DurableTask.Core.Common
     /// </summary>
     public static class DateTimeUtils
     {
-        private static DateTime _minDataTime;
-
         static DateTimeUtils()
         {
-            _minDataTime = MinDateTime = DateTime.MinValue;
+            MinDateTime = DateTime.MinValue;
         }
 
         /// <summary>
@@ -32,22 +30,22 @@ namespace DurableTask.Core.Common
         /// </summary>        
         public static bool IsSet(this DateTime dateTime)
         {
-            return !(dateTime == DateTime.MinValue || dateTime == _minDataTime);
+            return !(dateTime == DateTime.MinValue || dateTime == MinDateTime);
         }
 
         /// <summary>
         /// Returns minimum allowable DateTime, allows overriding this for the storage emulator.
         /// The Storage emulator supports a min datetime or DateTime.FromFileTimeUtc(0)
-        /// Setting this value will have no effect.
+        /// Do not alter this value. Kept as field to have backward compatibility.
         /// </summary>  
-        public static DateTime MinDateTime; //Keeping backward compatibility #319 #320
+        public static DateTime MinDateTime = DateTime.MinValue;
 
         /// <summary>
         /// Uses reflection to alter the static readonly MinDateTime value for tests
         /// </summary>  
         public static void SetMinDateTimeForStorageEmulator()
         {
-            _minDataTime = MinDateTime = DateTime.FromFileTimeUtc(0);
+            MinDateTime = DateTime.FromFileTimeUtc(0);
         }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/Azure/durabletask/issues/319. 

In .net core 3.0, validation was added so readonly fields could not be set with reflection.