### PR TITLE
New persistence order for azure storage

### DIFF
--- a/DurableTask.sln
+++ b/DurableTask.sln
@@ -41,9 +41,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DurableTask.AzureStorage", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DurableTask.AzureStorage.Tests", "Test\DurableTask.AzureStorage.Tests\DurableTask.AzureStorage.Tests.csproj", "{7CD147F9-1BB9-41FD-A310-BCA07447A6B9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DurableTask.Redis", "src\DurableTask.Redis\DurableTask.Redis.csproj", "{BDA5B320-5282-49FE-B0A7-1F8A0F06862C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DurableTask.Redis", "src\DurableTask.Redis\DurableTask.Redis.csproj", "{BDA5B320-5282-49FE-B0A7-1F8A0F06862C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DurableTask.Redis.Tests", "Test\DurableTask.Redis.Tests\DurableTask.Redis.Tests.csproj", "{B1C3B554-A098-47F8-8FA9-C28B5BBF35B1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DurableTask.Redis.Tests", "Test\DurableTask.Redis.Tests\DurableTask.Redis.Tests.csproj", "{B1C3B554-A098-47F8-8FA9-C28B5BBF35B1}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DurableTask.AzureServiceFabric", "src\DurableTask.AzureServiceFabric\DurableTask.AzureServiceFabric.csproj", "{3C10169F-4ACB-4FF6-A12B-B74569613E81}"
 EndProject
@@ -153,16 +153,24 @@ Global
 		{7CD147F9-1BB9-41FD-A310-BCA07447A6B9}.Debug|x64.Build.0 = Debug|Any CPU
 		{7CD147F9-1BB9-41FD-A310-BCA07447A6B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7CD147F9-1BB9-41FD-A310-BCA07447A6B9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BDA5B320-5282-49FE-B0A7-1F8A0F06862C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BDA5B320-5282-49FE-B0A7-1F8A0F06862C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BDA5B320-5282-49FE-B0A7-1F8A0F06862C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BDA5B320-5282-49FE-B0A7-1F8A0F06862C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B1C3B554-A098-47F8-8FA9-C28B5BBF35B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B1C3B554-A098-47F8-8FA9-C28B5BBF35B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B1C3B554-A098-47F8-8FA9-C28B5BBF35B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B1C3B554-A098-47F8-8FA9-C28B5BBF35B1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7CD147F9-1BB9-41FD-A310-BCA07447A6B9}.Release|x64.ActiveCfg = Release|Any CPU
 		{7CD147F9-1BB9-41FD-A310-BCA07447A6B9}.Release|x64.Build.0 = Release|Any CPU
+		{BDA5B320-5282-49FE-B0A7-1F8A0F06862C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BDA5B320-5282-49FE-B0A7-1F8A0F06862C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BDA5B320-5282-49FE-B0A7-1F8A0F06862C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BDA5B320-5282-49FE-B0A7-1F8A0F06862C}.Debug|x64.Build.0 = Debug|Any CPU
+		{BDA5B320-5282-49FE-B0A7-1F8A0F06862C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BDA5B320-5282-49FE-B0A7-1F8A0F06862C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BDA5B320-5282-49FE-B0A7-1F8A0F06862C}.Release|x64.ActiveCfg = Release|Any CPU
+		{BDA5B320-5282-49FE-B0A7-1F8A0F06862C}.Release|x64.Build.0 = Release|Any CPU
+		{B1C3B554-A098-47F8-8FA9-C28B5BBF35B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1C3B554-A098-47F8-8FA9-C28B5BBF35B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1C3B554-A098-47F8-8FA9-C28B5BBF35B1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B1C3B554-A098-47F8-8FA9-C28B5BBF35B1}.Debug|x64.Build.0 = Debug|Any CPU
+		{B1C3B554-A098-47F8-8FA9-C28B5BBF35B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1C3B554-A098-47F8-8FA9-C28B5BBF35B1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1C3B554-A098-47F8-8FA9-C28B5BBF35B1}.Release|x64.ActiveCfg = Release|Any CPU
+		{B1C3B554-A098-47F8-8FA9-C28B5BBF35B1}.Release|x64.Build.0 = Release|Any CPU
 		{3C10169F-4ACB-4FF6-A12B-B74569613E81}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3C10169F-4ACB-4FF6-A12B-B74569613E81}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3C10169F-4ACB-4FF6-A12B-B74569613E81}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -238,7 +246,7 @@ Global
 		{1D52F94E-933C-411F-96C4-4960B423586F} = {C53918E6-667A-4930-837C-0018C5D6E374}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {2D63A120-9394-48D9-8CA9-1184364FB854}
 		EnterpriseLibraryConfigurationToolBinariesPath = packages\TransientFaultHandling.Core.5.1.1209.1\lib\NET4
+		SolutionGuid = {2D63A120-9394-48D9-8CA9-1184364FB854}
 	EndGlobalSection
 EndGlobal

--- a/src/DurableTask.AzureStorage/MessageData.cs
+++ b/src/DurableTask.AzureStorage/MessageData.cs
@@ -66,6 +66,12 @@ namespace DurableTask.AzureStorage
         public long SequenceNumber { get; set; }
 
         /// <summary>
+        /// Whether this message uses the new algorithm, i.e. was sent after being persisted in history.
+        /// </summary>
+        [DataMember]
+        public bool NewPersistenceOrder { get; set; }
+
+        /// <summary>
         /// The episode number of the orchestration which created this message.
         /// </summary>
         /// <remarks>
@@ -84,6 +90,7 @@ namespace DurableTask.AzureStorage
         internal long TotalMessageSizeBytes { get; set; }
 
         internal MessageFormatFlags MessageFormat { get; set; }
+
     }
 
     /// <summary>

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -105,6 +105,9 @@ namespace DurableTask.AzureStorage.Messaging
                     session?.GetCurrentEpisode() ?? 0);
                 data.SequenceNumber = Interlocked.Increment(ref messageSequenceNumber);
 
+                // mark that this message was sent using the new version of the algorithm
+                data.NewPersistenceOrder = true;
+
                 string rawContent = await messageManager.SerializeMessageDataAsync(data);
                 CloudQueueMessage queueMessage = new CloudQueueMessage(rawContent);
 

--- a/src/DurableTask.Core/Common/Utils.cs
+++ b/src/DurableTask.Core/Common/Utils.cs
@@ -151,6 +151,63 @@ namespace DurableTask.Core.Common
         }
 
         /// <summary>
+        /// Compute an FNV hash from two strings and a long.
+        /// </summary>
+        /// <param name="str1">The first string.</param>
+        /// <param name="str2">The second string.</param>
+        /// <param name="number">The number.</param>
+        /// <returns></returns>
+        public static long ComputeLongHash(string str1, string str2, uint number)
+        {
+            unchecked
+            {
+                var hash = 0xcbf29ce484222325ul; // FNV_offset_basis
+                var prime = 0x100000001b3ul; // FNV_prime
+
+                if (str1 != null)
+                {
+                    for (int i = 0; i < str1.Length; i++)
+                    {
+                        hash ^= str1[i];
+                        hash *= prime;
+                    }
+                }
+                if (str2 != null)
+                {
+                    for (int i = 0; i < str2.Length; i++)
+                    {
+                        hash ^= str2[i];
+                        hash *= prime;
+                    }
+                }
+
+                hash ^= number & 0xFF;
+                hash *= prime;
+                number >>= 8;
+                hash ^= number & 0xFF;
+                hash *= prime;
+                number >>= 8;
+                hash ^= number & 0xFF;
+                hash *= prime;
+                number >>= 8;
+                hash ^= number & 0xFF;
+                hash *= prime;
+
+                return (long)hash;
+            }
+        }
+
+        /// <summary>
+        /// Compute a random long.
+        /// </summary>
+        /// <returns></returns>
+        public static long RandomLong()
+        {
+            var random = new Random();
+            return (long)(((ulong)((uint)random.Next()) << 32) | (uint)random.Next());
+        }
+
+        /// <summary>
         /// Returns true or false whether the supplied stream is a compressed stream
         /// </summary>
         public static bool IsGzipStream(Stream stream)

--- a/src/DurableTask.Core/History/ContinueAsNewEvent.cs
+++ b/src/DurableTask.Core/History/ContinueAsNewEvent.cs
@@ -32,6 +32,18 @@ namespace DurableTask.Core.History
         }
 
         /// <summary>
+        /// Gets or sets the execution id for the next execution of this workflow.
+        /// </summary>
+        [DataMember]
+        public string ExecutionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version for the next execution of this workflow.
+        /// </summary>
+        [DataMember]
+        public string NewVersion { get; set; }
+
+        /// <summary>
         /// Gets the event type
         /// </summary>
         public override EventType EventType => EventType.ContinueAsNew;

--- a/src/DurableTask.Core/History/EventRaisedEvent.cs
+++ b/src/DurableTask.Core/History/EventRaisedEvent.cs
@@ -48,5 +48,13 @@ namespace DurableTask.Core.History
         /// </summary>
         [DataMember]
         public string Input { get; set; }
+
+        /// <summary>
+        /// Gets or sets the fingerprint of the event. The fingerprint is used to detect duplicate delivery of events
+        /// within an orchestration history. Collision probability is sufficiently low (less than 1 in a billion for
+        /// histories with less than 100,000 entries).
+        /// </summary>
+        [DataMember]
+        public long FingerPrint { get; set; }
     }
 }

--- a/src/DurableTask.Core/History/EventSentEvent.cs
+++ b/src/DurableTask.Core/History/EventSentEvent.cs
@@ -52,5 +52,11 @@ namespace DurableTask.Core.History
         /// </summary>
         [DataMember]
         public string Input { get; set; }
+
+        /// <summary>
+        /// Gets or sets the sub orchestration's execution id
+        /// </summary>
+        [DataMember]
+        public string ExecutionId { get; set; }
     }
 }

--- a/src/DurableTask.Core/History/ExecutionCompletedEvent.cs
+++ b/src/DurableTask.Core/History/ExecutionCompletedEvent.cs
@@ -50,5 +50,11 @@ namespace DurableTask.Core.History
         /// </summary>
         [DataMember]
         public string Result { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the details
+        /// </summary>
+        [DataMember]
+        public string Details { get; set; }
     }
 }

--- a/src/DurableTask.Core/History/SubOrchestrationInstanceCreatedEvent.cs
+++ b/src/DurableTask.Core/History/SubOrchestrationInstanceCreatedEvent.cs
@@ -13,6 +13,7 @@
 
 namespace DurableTask.Core.History
 {
+    using System.Collections.Generic;
     using System.Runtime.Serialization;
 
     /// <summary>
@@ -58,5 +59,17 @@ namespace DurableTask.Core.History
         /// </summary>
         [DataMember]
         public string Input { get; set; }
+
+        /// <summary>
+        /// Gets or sets the sub orchestration's execution id
+        /// </summary>
+        [DataMember]
+        public string ExecutionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a dictionary of tags of string, string
+        /// </summary>
+        [DataMember]
+        public IDictionary<string, string> Tags { get; set; }
     }
 }

--- a/src/DurableTask.Core/IOrchestrationSession.cs
+++ b/src/DurableTask.Core/IOrchestrationSession.cs
@@ -29,11 +29,6 @@ namespace DurableTask.Core
         /// or until an internal wait period has expired. In either case, <c>null</c> can be returned
         /// and the dispatcher will shut down the session.
         /// </remarks>
-        Task<IList<TaskMessage>> FetchNewOrchestrationMessagesAsync(TaskOrchestrationWorkItem workItem);
-
-        /// <summary>
-        /// Updates the in-memory session info.
-        /// </summary>
-        void UpdateRuntimeState(OrchestrationRuntimeState runtimeState);
+        Task<IList<TaskMessage>> FetchNewOrchestrationMessagesAsync(TaskOrchestrationWorkItem workItem, IOrchestrationService orchestrationService);
     }
 }

--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -511,7 +511,11 @@ namespace DurableTask.Core
             var taskMessage = new TaskMessage
             {
                 OrchestrationInstance = orchestrationInstance,
-                Event = new EventRaisedEvent(-1, serializedInput) { Name = eventName }
+                Event = new EventRaisedEvent(-1, serializedInput)
+                {
+                    Name = eventName,
+                    FingerPrint = Common.Utils.RandomLong(),
+                }
             };
 
             await ServiceClient.SendTaskOrchestrationMessageAsync(taskMessage);


### PR DESCRIPTION
Draft of new algorithm for persisting queue / history in opposite order than before (first persist history, then persist queue messages).

This requires adding more state to some of the events in the history, so it is possible to resend the exact same messages simply by looking at the history.