### PR TITLE
Added Options to Configure Behavior When Starting a New Orchestrator With an Existing Instance Id

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -173,7 +173,7 @@ namespace DurableTask.AzureStorage
         public BehaviorOnContinueAsNew EventBehaviourForContinueAsNew { get; set; } = BehaviorOnContinueAsNew.Carryover;
 
         /// <summary>
-        ///  
+        ///  States to override an existing orchestrator when attempting to start a new orchestrator with the same instance Id
         /// </summary>
         public OverridableStates OverrideExistingInstanceStates { get; set; } = OverridableStates.AnyState;
 

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -173,6 +173,11 @@ namespace DurableTask.AzureStorage
         public BehaviorOnContinueAsNew EventBehaviourForContinueAsNew { get; set; } = BehaviorOnContinueAsNew.Carryover;
 
         /// <summary>
+        ///  
+        /// </summary>
+        public OverridableStates OverrideExistingInstanceStates { get; set; } = OverridableStates.AnyState;
+
+        /// <summary>
         /// Returns bool indicating is the TrackingStoreStorageAccount has been set.
         /// </summary>
         public  bool HasTrackingStoreStorageAccount => TrackingStoreStorageAccountDetails != null;

--- a/src/DurableTask.AzureStorage/OverridableStates.cs
+++ b/src/DurableTask.AzureStorage/OverridableStates.cs
@@ -1,21 +1,37 @@
-﻿using System;
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace DurableTask.AzureStorage
 {
     /// <summary>
-    /// 
+    /// Represents options for different states that an existing orchestrator can be in to be able to be overwritten by
+    /// an attempt to start a new instance with the same instance Id.
     /// </summary>
     public enum OverridableStates
     {
         /// <summary>
-        /// 
+        /// Option to start a new orchestrator instance with an existing instnace Id when the existing
+        /// instance is in any state.
         /// </summary>
         AnyState,
 
         /// <summary>
-        /// 
+        /// Option to only start a new orchestrator instance with an existing instance Id when the existing
+        /// instance is in a termincated, failed, or completed state.
         /// </summary>
         IfTerminatedFailedOrCompleted
     }

--- a/src/DurableTask.AzureStorage/OverridableStates.cs
+++ b/src/DurableTask.AzureStorage/OverridableStates.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DurableTask.AzureStorage
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public enum OverridableStates
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        AnyState,
+
+        /// <summary>
+        /// 
+        /// </summary>
+        IfTerminatedFailedOrCompleted
+    }
+}


### PR DESCRIPTION
Added options to configure which states you want to override an existing orchestrator instance id when attempting to start a new instance.

Fixes this issue in the azure-functions-durable-extension repository
https://github.com/Azure/azure-functions-durable-extension/issues/367