### PR TITLE
Make large message blob names unique

### DIFF
--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -267,9 +267,9 @@ namespace DurableTask.AzureStorage
         {
             string instanceId = message.TaskMessage.OrchestrationInstance.InstanceId;
             string eventType = message.TaskMessage.Event.EventType.ToString();
-            string sequenceNumber = message.SequenceNumber.ToString("X16");
+            string activityId = message.ActivityId.ToString("N");
 
-            return $"{instanceId}/message-{sequenceNumber}-{eventType}.json.gz".ToLowerInvariant();
+            return $"{instanceId}/message-{activityId}-{eventType}.json.gz".ToLowerInvariant();
         }
 
         internal async Task DeleteLargeMessageBlobs(string instanceId, AzureStorageOrchestrationServiceStats stats)


### PR DESCRIPTION
We previously generated "unique" blob names using the SequenceNumber
field of the MessageData object. However, these sequence numbers are
generated by the client, This means is no uniqueness guarantee for a given
instance id, as any VM running the application is allowed to send
messages. This meant it was possible for large messages sent from
different VMs to the same instance could overwrite each other.

We now use activity ids, as they are random guids that should
not conflict with other messages, regardless of which client they are
sent from.