### PR TITLE
support for multiple histories in history table, and other bugfixes

### DIFF
--- a/Test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -592,6 +592,7 @@ namespace DurableTask.AzureStorage.Tests
                 await client.WaitForStartupAsync(TimeSpan.FromSeconds(10));
 
                 // Perform some operations
+                // (all the incr have the same effect but the number helps when debugging)
                 await client.RaiseEventAsync("operation", "incr1");
                 await client.RaiseEventAsync("operation", "incr2");
                 await client.RaiseEventAsync("operation", "incr3");
@@ -2053,6 +2054,8 @@ namespace DurableTask.AzureStorage.Tests
                 {
                     string operation = await this.WaitForOperation();
 
+                    // for easier debugging we support suffixing incr operations with a sequence
+                    // number. So here we strip off that suffix.
                     if (operation.StartsWith("incr"))
                     {
                         operation = "incr";

--- a/Test/DurableTask.AzureStorage.Tests/TestOrchestrationHost.cs
+++ b/Test/DurableTask.AzureStorage.Tests/TestOrchestrationHost.cs
@@ -43,6 +43,8 @@ namespace DurableTask.AzureStorage.Tests
 
         public string TaskHub => this.settings.TaskHubName;
 
+        public AzureStorageOrchestrationServiceSettings Settings => settings;
+
         public void Dispose()
         {
             this.worker.Dispose();

--- a/Test/DurableTask.AzureStorage.Tests/TestOrchestrationHost.cs
+++ b/Test/DurableTask.AzureStorage.Tests/TestOrchestrationHost.cs
@@ -43,7 +43,7 @@ namespace DurableTask.AzureStorage.Tests
 
         public string TaskHub => this.settings.TaskHubName;
 
-        public AzureStorageOrchestrationServiceSettings Settings => settings;
+        public AzureStorageOrchestrationServiceSettings Settings => this.settings;
 
         public void Dispose()
         {

--- a/src/DurableTask.AzureStorage/AsyncQueue.cs
+++ b/src/DurableTask.AzureStorage/AsyncQueue.cs
@@ -33,7 +33,7 @@ namespace DurableTask.AzureStorage
 
         public async Task<T> DequeueAsync(CancellationToken cancellationToken)
         {
-            while (true)
+            while (!cancellationToken.IsCancellationRequested)
             {
                 await this.semaphore.WaitAsync(cancellationToken);
 
@@ -42,6 +42,8 @@ namespace DurableTask.AzureStorage
                     return item;
                 }
             }
+
+            return default(T);
         }
 
         public void Dispose()

--- a/src/DurableTask.AzureStorage/AsyncQueue.cs
+++ b/src/DurableTask.AzureStorage/AsyncQueue.cs
@@ -33,7 +33,7 @@ namespace DurableTask.AzureStorage
 
         public async Task<T> DequeueAsync(CancellationToken cancellationToken)
         {
-            while (!cancellationToken.IsCancellationRequested)
+            while (true)
             {
                 await this.semaphore.WaitAsync(cancellationToken);
 
@@ -42,8 +42,6 @@ namespace DurableTask.AzureStorage
                     return item;
                 }
             }
-
-            return default(T);
         }
 
         public void Dispose()

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -48,6 +48,7 @@ namespace DurableTask.AzureStorage
             InstanceId = string.Empty,
             ExecutionId = string.Empty
         };
+        static readonly Task AlreadyCompletedTask = Task.FromResult<object>(null);
 
         readonly AzureStorageOrchestrationServiceSettings settings;
         readonly AzureStorageOrchestrationServiceStats stats;
@@ -769,7 +770,6 @@ namespace DurableTask.AzureStorage
                 var instanceId = newMessages[0].OrchestrationInstance.InstanceId;
 
                 if (instanceId.StartsWith("@") 
-                    && newMessages.Count > 0 
                     && newMessages[0].Event.EventType == EventType.EventRaised
                     && newMessages[0].OrchestrationInstance.ExecutionId == null)
                 {
@@ -843,7 +843,7 @@ namespace DurableTask.AzureStorage
             }
             else
             {
-                return null;
+                return AlreadyCompletedTask ;
             }
         }
 

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -895,7 +895,7 @@ namespace DurableTask.AzureStorage
             {
                 // as we could not commit the state (losing storage ownership) we need to abandon the messages
                 // so the new owner can receive them and process them
-                await this.AbandonSessionAsync(session);
+                await this.AbandonAndReleaseSessionAsync(session);
                 throw;
             }
             catch (Exception e)

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -173,6 +173,11 @@ namespace DurableTask.AzureStorage
         public BehaviorOnContinueAsNew EventBehaviourForContinueAsNew { get; set; } = BehaviorOnContinueAsNew.Carryover;
 
         /// <summary>
+        /// Number of execution histories retained. Must be at least 2, and at most 10.
+        /// </summary>
+        public int NumberOfRetainedExecutionHistories { get; set; } = 3;
+
+        /// <summary>
         /// Returns bool indicating is the TrackingStoreStorageAccount has been set.
         /// </summary>
         public  bool HasTrackingStoreStorageAccount => TrackingStoreStorageAccountDetails != null;

--- a/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
+++ b/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
@@ -103,7 +103,7 @@ namespace DurableTask.AzureStorage.Messaging
 
             lock (this.nextMessageBatch)
             {
-                this.CurrentMessageBatch = this.nextMessageBatch.ToArray();
+                this.CurrentMessageBatch = this.nextMessageBatch.ToList();
                 this.nextMessageBatch.Clear();
             }
 

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -152,8 +152,8 @@ namespace DurableTask.AzureStorage
                     // directly rather than adding it to the linked list. A null executionId value
                     // means that this is a management operation, like RaiseEvent or Terminate, which
                     // should be delivered to the current session.
-                    if (this.activeOrchestrationSessions.TryGetValue(instanceId, out OrchestrationSession session) &&
-                        (executionId == null || session.RuntimeState.ContainsExecution(executionId)))
+                    if (this.activeOrchestrationSessions.TryGetValue(instanceId, out OrchestrationSession session) &&                    
+                        (executionId == null || session.Instance.ExecutionId == executionId || session.RuntimeState.HasPreviousExecution(executionId)))
                     {
                         List<MessageData> pendingMessages;
                         if (!existingSessionMessages.TryGetValue(session, out pendingMessages))
@@ -335,7 +335,7 @@ namespace DurableTask.AzureStorage
                         return session;
                     }
                     else if (nextBatch.OrchestrationExecutionId == null 
-                        || existingSession.RuntimeState.ContainsExecution(nextBatch.OrchestrationExecutionId))
+                        || existingSession.Instance.ExecutionId == nextBatch.OrchestrationExecutionId || existingSession.RuntimeState.HasPreviousExecution(nextBatch.OrchestrationExecutionId))
                     {
                         // there is already an active session with the same execution id.
                         // The session might be waiting for more messages. If it is, signal them.

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -153,7 +153,7 @@ namespace DurableTask.AzureStorage
                     // means that this is a management operation, like RaiseEvent or Terminate, which
                     // should be delivered to the current session.
                     if (this.activeOrchestrationSessions.TryGetValue(instanceId, out OrchestrationSession session) &&
-                        (executionId == null || session.Instance.ExecutionId == executionId))
+                        (executionId == null || session.RuntimeState.ContainsExecution(executionId)))
                     {
                         List<MessageData> pendingMessages;
                         if (!existingSessionMessages.TryGetValue(session, out pendingMessages))

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -402,11 +402,14 @@ namespace DurableTask.AzureStorage
                     this.activeOrchestrationSessions.Remove(instanceId))
                 {
                     // Put any unprocessed messages back into the pending buffer.
-                    this.AddMessageToPendingOrchestration(
-                        session.ControlQueue,
-                        session.PendingMessages,
-                        session.TraceActivityId,
-                        cancellationToken);
+                    if (session.PendingMessages.Count > 0)
+                    {
+                        this.AddMessageToPendingOrchestration(
+                            session.ControlQueue,
+                            session.PendingMessages,
+                            session.TraceActivityId,
+                            cancellationToken);
+                    }
                 }
                 else
                 {

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -334,7 +334,8 @@ namespace DurableTask.AzureStorage
 
                         return session;
                     }
-                    else if (nextBatch.OrchestrationExecutionId == existingSession.Instance.ExecutionId)
+                    else if (nextBatch.OrchestrationExecutionId == null 
+                        || existingSession.RuntimeState.ContainsExecution(nextBatch.OrchestrationExecutionId))
                     {
                         // there is already an active session with the same execution id.
                         // The session might be waiting for more messages. If it is, signal them.

--- a/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
@@ -18,6 +18,7 @@ namespace DurableTask.AzureStorage.Tracking
     using System.Threading;
     using System.Threading.Tasks;
     using DurableTask.Core;
+    using DurableTask.Core.Exceptions;
     using DurableTask.Core.History;
 
     /// <summary>
@@ -65,11 +66,12 @@ namespace DurableTask.AzureStorage.Tracking
         /// Update State in the Tracking store for a particular orchestration instance and execution base on the new runtime state
         /// </summary>
         /// <param name="newRuntimeState">The New RuntimeState</param>
-        /// <param name="oldRuntimeState">The RuntimeState for an olderExecution</param>
         /// <param name="instanceId">InstanceId for the Orchestration Update</param>
-        /// <param name="executionId">ExecutionId for the Orchestration Update</param>
+        /// <param name="mostRecentExecutionId">ExecutionId for the Orchestration Update</param>
         /// <param name="eTag">The ETag value to use for safe updates</param>
-        Task<string> UpdateStateAsync(OrchestrationRuntimeState newRuntimeState, OrchestrationRuntimeState oldRuntimeState, string instanceId, string executionId, string eTag);
+        /// <param name="renewIfNeeded">The async function to call for renewing work items</param>
+        /// <exception cref="StorageConflictException">Indicates that the update failed because another participant already updated this history in storage.</exception>
+        Task<string> UpdateStateAsync(OrchestrationRuntimeState newRuntimeState, string instanceId, string mostRecentExecutionId, string eTag, Func<Task> renewIfNeeded);
 
         /// <summary>
         /// Get The Orchestration State for the Latest or All Executions

--- a/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
+++ b/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
@@ -102,6 +102,6 @@ namespace DurableTask.AzureStorage.Tracking
         public abstract Task StartAsync();
 
         /// <inheritdoc />
-        public abstract Task<string> UpdateStateAsync(OrchestrationRuntimeState newRuntimeState, OrchestrationRuntimeState oldRuntimeState, string instanceId, string executionId, string eTag);
+        public abstract Task<string> UpdateStateAsync(OrchestrationRuntimeState newRuntimeState, string instanceId, string mostRecentExecutionId, string eTag, Func<Task> renewIfNeeded);
     }
 }

--- a/src/DurableTask.Core/Exceptions/StorageConflictException.cs
+++ b/src/DurableTask.Core/Exceptions/StorageConflictException.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Text;
@@ -31,6 +44,16 @@ namespace DurableTask.Core.Exceptions
         /// <param name="innerException">The error that caused the exception.</param>
         public StorageConflictException(string message, Exception innerException)
             : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StorageConflictException" />  class with serialized data.
+        /// </summary>
+        /// <param name="info">The System.Runtime.Serialization.SerializationInfo that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The System.Runtime.Serialization.StreamingContext that contains contextual information about the source or destination.</param>
+        protected StorageConflictException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/DurableTask.Core/Exceptions/StorageConflictException.cs
+++ b/src/DurableTask.Core/Exceptions/StorageConflictException.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace DurableTask.Core.Exceptions
+{
+    /// <summary>
+    /// The exception thrown by when a storage update detects a conflict, such as an e-tag mismatch.
+    /// </summary>
+    [Serializable]
+    public class StorageConflictException : Exception
+    {
+        /// <summary>Initializes a new instance of the <see cref="StorageConflictException" /> class using default values.</summary>
+        public StorageConflictException()
+            : base()
+        {
+        }
+
+        /// <summary>Initializes a new instance of the 
+        /// <see cref="StorageConflictException" /> class using specified error message.</summary> 
+        /// <param name="message">The message associated with the error.</param>
+        public StorageConflictException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the 
+        /// <see cref="StorageConflictException" /> class using specified error message.</summary> 
+        /// <param name="message">The message associated with the error.</param>
+        /// <param name="innerException">The error that caused the exception.</param>
+        public StorageConflictException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/DurableTask.Core/OrchestrationRuntimeState.cs
+++ b/src/DurableTask.Core/OrchestrationRuntimeState.cs
@@ -265,10 +265,11 @@ namespace DurableTask.Core
         /// Checks if the given execution ID matches a current or past execution of this session.
         /// </summary>
         /// <returns></returns>
-        public bool ContainsExecution(string executionId)
+        public bool HasPreviousExecution(string executionId)
         {
-            return this.OrchestrationInstance.ExecutionId == executionId
-                   || this.PreviousExecution != null && this.PreviousExecution.ContainsExecution(executionId);
+            return this.PreviousExecution != null 
+                && (this.PreviousExecution.OrchestrationInstance?.ExecutionId == executionId
+                   || this.PreviousExecution.HasPreviousExecution(executionId));
         }
 
         bool IsDuplicateEvent(HistoryEvent historyEvent)

--- a/src/DurableTask.Core/OrchestrationRuntimeState.cs
+++ b/src/DurableTask.Core/OrchestrationRuntimeState.cs
@@ -56,7 +56,7 @@ namespace DurableTask.Core
         public string Status;
 
         /// <summary>
-        /// The previous execution. Is set when doing multiple executions in a row.
+        /// The previous execution. Is used to chain executions that end with a continue-as-new.
         /// </summary>
         public OrchestrationRuntimeState PreviousExecution { get; set; }
 
@@ -259,6 +259,16 @@ namespace DurableTask.Core
             }
 
             return current;
+        }
+
+        /// <summary>
+        /// Checks if the given execution ID matches a current or past execution of this session.
+        /// </summary>
+        /// <returns></returns>
+        public bool ContainsExecution(string executionId)
+        {
+            return this.OrchestrationInstance.ExecutionId == executionId
+                   || this.PreviousExecution != null && this.PreviousExecution.ContainsExecution(executionId);
         }
 
         bool IsDuplicateEvent(HistoryEvent historyEvent)

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -222,7 +222,7 @@ namespace DurableTask.Core
             }
             else
             {
-                var allowedNumberOfFastContinueAsNews = 1;
+                int allowedNumberOfFastContinueAsNews = 1;
 
                 do
                 {


### PR DESCRIPTION
Implements new features:
- partial commits (i.e. failure before committing the last batch of a work item) are correctly handled
- multiple histories per instance can be retained  in history table (defaults to 3)
- multiple histories are maintained in memory under fast continue as new
- fast continue as new has now a limited number of iterations (default to 1)
- storage precondition conflicts are wrapped in a backend-independent exception

And fixes some other bugs:
- remove infinite spin loop in async dequeue
- break out of extended session on storage conflict
- limit autostart situation to RaiseEvent only, not other history events
- max checkpoint batchsize removed, renew workitem between batches instead

_[Edit by Chris for book-keeping]_
Resolves https://github.com/Azure/azure-functions-durable-extension/issues/332.