### PR TITLE
DurableTask.AzureStorage: Orchestration message counting fixes

### DIFF
--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -183,9 +183,12 @@ namespace DurableTask.AzureStorage.Messaging
 
         public override Task AbandonMessageAsync(MessageData message, SessionBase session)
         {
-            if (this.pendingMessageIds.Remove(message.OriginalQueueMessage.Id))
+            lock (this.pendingMessageIds)
             {
-                this.stats.PendingOrchestratorMessages.Decrement();
+                if (this.pendingMessageIds.Remove(message.OriginalQueueMessage.Id))
+                {
+                    this.stats.PendingOrchestratorMessages.Decrement();
+                }
             }
 
             return base.AbandonMessageAsync(message, session);
@@ -193,9 +196,12 @@ namespace DurableTask.AzureStorage.Messaging
 
         public override Task DeleteMessageAsync(MessageData message, SessionBase session)
         {
-            if (this.pendingMessageIds.Remove(message.OriginalQueueMessage.Id))
+            lock (this.pendingMessageIds)
             {
-                this.stats.PendingOrchestratorMessages.Decrement();
+                if (this.pendingMessageIds.Remove(message.OriginalQueueMessage.Id))
+                {
+                    this.stats.PendingOrchestratorMessages.Decrement();
+                }
             }
 
             return base.DeleteMessageAsync(message, session);

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -26,6 +26,7 @@ namespace DurableTask.AzureStorage.Messaging
     {
         static readonly List<MessageData> EmptyMessageList = new List<MessageData>();
 
+        readonly HashSet<string> pendingMessageIds;
         readonly CancellationTokenSource releaseTokenSource;
         readonly CancellationToken releaseCancellationToken;
 
@@ -36,6 +37,7 @@ namespace DurableTask.AzureStorage.Messaging
             MessageManager messageManager)
             : base(storageQueue, settings, stats, messageManager)
         {
+            this.pendingMessageIds = new HashSet<string>();
             this.releaseTokenSource = new CancellationTokenSource();
             this.releaseCancellationToken = this.releaseTokenSource.Token;
         }
@@ -113,6 +115,29 @@ namespace DurableTask.AzureStorage.Messaging
                                 queueMessage,
                                 this.storageQueue.Name);
 
+                            // Check to see whether we've already dequeued this message.
+                            lock (this.pendingMessageIds)
+                            {
+                                if (this.pendingMessageIds.Add(queueMessage.Id))
+                                {
+                                    this.stats.PendingOrchestratorMessages.Increment();
+                                }
+                                else
+                                {
+                                    // This message is already loaded in memory and is therefore a duplicate.
+                                    // We will continue to process it because we need the updated pop receipt.
+                                    AnalyticsEventSource.Log.DuplicateMessageDetected(
+                                        this.storageAccountName,
+                                        this.settings.TaskHubName,
+                                        queueMessage.Id,
+                                        messageData.TaskMessage.OrchestrationInstance.InstanceId,
+                                        messageData.TaskMessage.OrchestrationInstance.ExecutionId,
+                                        this.Name,
+                                        queueMessage.DequeueCount,
+                                        Utils.ExtensionVersion);
+                                }
+                            }
+
                             batchMessages.Add(messageData);
                         });
 
@@ -154,6 +179,26 @@ namespace DurableTask.AzureStorage.Messaging
                 this.IsReleased = true;
                 return EmptyMessageList;
             }
+        }
+
+        public override Task AbandonMessageAsync(MessageData message, SessionBase session)
+        {
+            if (this.pendingMessageIds.Remove(message.OriginalQueueMessage.Id))
+            {
+                this.stats.PendingOrchestratorMessages.Decrement();
+            }
+
+            return base.AbandonMessageAsync(message, session);
+        }
+
+        public override Task DeleteMessageAsync(MessageData message, SessionBase session)
+        {
+            if (this.pendingMessageIds.Remove(message.OriginalQueueMessage.Id))
+            {
+                this.stats.PendingOrchestratorMessages.Decrement();
+            }
+
+            return base.DeleteMessageAsync(message, session);
         }
 
         public void Release()

--- a/src/DurableTask.AzureStorage/Messaging/MessageCollection.cs
+++ b/src/DurableTask.AzureStorage/Messaging/MessageCollection.cs
@@ -19,9 +19,9 @@ namespace DurableTask.AzureStorage.Messaging
     class MessageCollection : List<MessageData>
     {
         /// <summary>
-        /// Adds or replaces a message in the list based on the message ID. Returns true for adds, false for replaces.
+        /// Adds or replaces a message in the list based on the message ID.
         /// </summary>
-        public bool AddOrReplace(MessageData message)
+        public void AddOrReplace(MessageData message)
         {
             // If a message has been sitting in the buffer for too long, the invisibility timeout may expire and 
             // it may get dequeued a second time. In such cases, we should replace the existing copy of the message
@@ -32,12 +32,10 @@ namespace DurableTask.AzureStorage.Messaging
                 if (existingMessage.Id == message.OriginalQueueMessage.Id)
                 {
                     this[i] = message;
-                    return false;
                 }
             }
 
             this.Add(message);
-            return true;
         }
     }
 }

--- a/src/DurableTask.AzureStorage/Messaging/MessageCollection.cs
+++ b/src/DurableTask.AzureStorage/Messaging/MessageCollection.cs
@@ -32,6 +32,7 @@ namespace DurableTask.AzureStorage.Messaging
                 if (existingMessage.Id == message.OriginalQueueMessage.Id)
                 {
                     this[i] = message;
+                    return;
                 }
             }
 

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -174,7 +174,7 @@ namespace DurableTask.AzureStorage.Messaging
             return initialVisibilityDelay;
         }
 
-        public async Task AbandonMessageAsync(MessageData message, SessionBase session)
+        public virtual async Task AbandonMessageAsync(MessageData message, SessionBase session)
         {
             CloudQueueMessage queueMessage = message.OriginalQueueMessage;
             TaskMessage taskMessage = message.TaskMessage;
@@ -275,7 +275,7 @@ namespace DurableTask.AzureStorage.Messaging
             }
         }
 
-        public async Task DeleteMessageAsync(MessageData message, SessionBase session)
+        public virtual async Task DeleteMessageAsync(MessageData message, SessionBase session)
         {
             CloudQueueMessage queueMessage = message.OriginalQueueMessage;
             TaskMessage taskMessage = message.TaskMessage;


### PR DESCRIPTION
Resolves #328 

This PR greatly simplifies the message counting logic to avoid message-piling problems when many messages are sent to an active instance. I'm keeping a list of all message IDs that we read from the queue and removing from that list when we abandon or delete those messages. This solution should be much more accurate than the previous method while also fixing the pile-up problem.