### PR TITLE
Removed ToLower on blob storage path names

### DIFF
--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -269,7 +269,7 @@ namespace DurableTask.AzureStorage
             string eventType = message.TaskMessage.Event.EventType.ToString();
             string sequenceNumber = message.SequenceNumber.ToString("X16");
 
-            return $"{instanceId}/message-{sequenceNumber}-{eventType}.json.gz".ToLowerInvariant();
+            return $"{instanceId}/message-{sequenceNumber}-{eventType}.json.gz";
         }
 
         internal async Task DeleteLargeMessageBlobs(string instanceId, AzureStorageOrchestrationServiceStats stats)

--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -269,7 +269,7 @@ namespace DurableTask.AzureStorage
             string eventType = message.TaskMessage.Event.EventType.ToString();
             string activityId = message.ActivityId.ToString("N");
 
-            return $"{instanceId}/message-{sequenceNumber}-{eventType}.json.gz";
+            return $"{instanceId}/message-{activityId}-{eventType}.json.gz";
         }
 
         internal async Task DeleteLargeMessageBlobs(string instanceId, AzureStorageOrchestrationServiceStats stats)

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -1142,7 +1142,7 @@ namespace DurableTask.AzureStorage.Tracking
             string eventType = entity.Properties["EventType"].StringValue;
             string blobName = $"{instanceId}/history-{sequenceNumber}-{eventType}-{property}.json.gz";
 
-            return blobName.ToLowerInvariant();
+            return blobName;
         }
 
         async Task<string> UploadHistoryBatch(


### PR DESCRIPTION
Removed ToLower on blob storage path names that caused blobs to be stored with a lowercase instanceId.

Fixes azure-functions-durable-extension issue #755: 
https://github.com/Azure/azure-functions-durable-extension/issues/755