### PR TITLE
Change Azure Storage SDK back to previous version

### DIFF
--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -30,7 +30,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <!--Change the Storage SDK version with extreme caution, otherwise may break Durable Functions usage with Azure Storage Extension. -->
-    <PackageReference Include="WindowsAzure.Storage" version="8.6.0" />
+    <PackageReference Include="WindowsAzure.Storage" version="9.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -29,7 +29,8 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="WindowsAzure.Storage" version="9.3.3" />
+    <!--Change the Storage SDK version with extreme caution, otherwise may break Durable Functions usage with Azure Storage Extension. -->
+    <PackageReference Include="WindowsAzure.Storage" version="8.6.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
A previous change upgraded the Azure Storage SDK from 8.6 to 9.3.3. This
changes the version to 9.3.1, as 9.3.3 broke compatibility between the Durable
Functions extension and the Azure Storage extension. This PR also adds a
comment next to the dependency in the csproj to warn against changing
this in the future.