### PR TITLE
Configuration to throw an exception when an orchestration is in an existing dedupe state

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1242,6 +1242,11 @@ namespace DurableTask.AzureStorage
             if (existingInstance != null && dedupeStatuses != null && dedupeStatuses.Contains(existingInstance.OrchestrationStatus))
             {
                 // An instance in this state already exists.
+                if (settings.ThrowExceptionOnInvalidDedupeStatus)
+                {
+                    throw new InvalidOperationException($"An Orchestration instance in the state {existingInstance.OrchestrationStatus} already exists.");
+                }
+
                 return;
             }
 

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1244,7 +1244,7 @@ namespace DurableTask.AzureStorage
                 // An instance in this state already exists.
                 if (settings.ThrowExceptionOnInvalidDedupeStatus)
                 {
-                    throw new InvalidOperationException($"An Orchestration instance in the state {existingInstance.OrchestrationStatus} already exists.");
+                    throw new InvalidOperationException($"An Orchestration instance with the status {existingInstance.OrchestrationStatus} already exists.");
                 }
 
                 return;

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -173,6 +173,11 @@ namespace DurableTask.AzureStorage
         public BehaviorOnContinueAsNew EventBehaviourForContinueAsNew { get; set; } = BehaviorOnContinueAsNew.Carryover;
 
         /// <summary>
+        /// When true, will throw an exception when attempting to create an orchestration with an existing dedupe status.
+        /// </summary>
+        public bool ThrowExceptionOnInvalidDedupeStatus { get; set; } = false;
+
+        /// <summary>
         /// Returns bool indicating is the TrackingStoreStorageAccount has been set.
         /// </summary>
         public  bool HasTrackingStoreStorageAccount => TrackingStoreStorageAccountDetails != null;


### PR DESCRIPTION
Allowed configuration to throw an exception when attempting to create an orchestration instance in an existing dedupe status.

Related to this issue in azure-functions-durable-extension
https://github.com/Azure/azure-functions-durable-extension/issues/367