### PR TITLE
fixes for handling timers and extended sessions

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -906,9 +906,9 @@ namespace DurableTask.AzureStorage
                 if (session.DeferredMessages.Count > 0
                     && executionId != workItem.OrchestrationRuntimeState.OrchestrationInstance?.ExecutionId)
                 {
-                    var messages = session.DeferredMessages.ToArray();
+                    var messages = session.DeferredMessages.ToList();
                     session.DeferredMessages.Clear();
-                    this.orchestrationSessionManager.AddMessageToPendingOrchestration(session.ControlQueue, messages, default(Guid), CancellationToken.None);
+                    this.orchestrationSessionManager.AddMessageToPendingOrchestration(session.ControlQueue, messages, session.TraceActivityId, CancellationToken.None);
                 }
             }
             catch (Exception e)

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -801,7 +801,9 @@ namespace DurableTask.AzureStorage
             {
                 var instanceId = newMessages[0].OrchestrationInstance.InstanceId;
 
-                if (instanceId.StartsWith("@"))
+                if (instanceId.StartsWith("@")
+                    && newMessages[0].Event.EventType == EventType.EventRaised
+                    && newMessages[0].OrchestrationInstance.ExecutionId == null)
                 {
                     // automatically start this instance
                     var orchestrationInstance = new OrchestrationInstance
@@ -896,6 +898,18 @@ namespace DurableTask.AzureStorage
             try
             {
                 session.ETag = await this.trackingStore.UpdateStateAsync(runtimeState, workItem.OrchestrationRuntimeState, instanceId, executionId, session.ETag);
+
+                // update the runtime state and execution id stored in the session
+                session.UpdateRuntimeState(runtimeState);
+
+                // if we deferred some messages, and the execution id of this instance has changed, redeliver them
+                if (session.DeferredMessages.Count > 0
+                    && executionId != workItem.OrchestrationRuntimeState.OrchestrationInstance?.ExecutionId)
+                {
+                    var messages = session.DeferredMessages.ToArray();
+                    session.DeferredMessages.Clear();
+                    this.orchestrationSessionManager.AddMessageToPendingOrchestration(session.ControlQueue, messages, default(Guid), CancellationToken.None);
+                }
             }
             catch (Exception e)
             {

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -130,7 +130,7 @@ namespace DurableTask.AzureStorage
             }
         }
 
-        void AddMessageToPendingOrchestration(
+        internal void AddMessageToPendingOrchestration(
             ControlQueue controlQueue,
             IEnumerable<MessageData> queueMessages,
             Guid traceActivityId,

--- a/src/DurableTask.Core/IOrchestrationSession.cs
+++ b/src/DurableTask.Core/IOrchestrationSession.cs
@@ -30,10 +30,5 @@ namespace DurableTask.Core
         /// and the dispatcher will shut down the session.
         /// </remarks>
         Task<IList<TaskMessage>> FetchNewOrchestrationMessagesAsync(TaskOrchestrationWorkItem workItem);
-
-        /// <summary>
-        /// Updates the in-memory session info.
-        /// </summary>
-        void UpdateRuntimeState(OrchestrationRuntimeState runtimeState);
     }
 }

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -426,8 +426,6 @@ namespace DurableTask.Core
 
             workItem.OrchestrationRuntimeState = runtimeState;
 
-            workItem.Session?.UpdateRuntimeState(runtimeState);
-
             return isCompleted || continuedAsNew || isInterrupted;
         }
 


### PR DESCRIPTION
Fixes two bugs in how timers are handled. These fixes are necessary for implementing the entity reminder feature azure/azure-functions-durable-extension#716.

- the `DeferredMessages` mechanism introduced in #331 was not functioning correctly with extended sessions, as the deferred messages, even if ready to deliver, would just sit in the session until the session times out. I updated the code in `CompleteTaskOrchestrationWorkItemAsync` so that it redelivers deferred messages whenever the execution id of the session changed.

- I limited the autostart mechanism so it applies only to events. Otherwise, a timer message to a not-yet-existing execution of an entity can autostart a new one, causing unnecessary and harmful conflicts. This bug was already fixed in #327 but the latter PR is currently on ice, so I copied the fix into this PR.

Also, I slightly simplified the code by moving the `UpdateRuntimeState` call into `CompleteTaskOrchestrationWorkItemAsync`. This makes more sense to me and means we don't have to expose it through the `IOrchestrationSession` interface.