### PR TITLE
Support for delayed entity messages and improved split brain handling

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -27,6 +27,7 @@ namespace DurableTask.AzureStorage
     using DurableTask.AzureStorage.Partitioning;
     using DurableTask.AzureStorage.Tracking;
     using DurableTask.Core;
+    using DurableTask.Core.Exceptions;
     using DurableTask.Core.History;
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Blob;
@@ -917,6 +918,13 @@ namespace DurableTask.AzureStorage
                 if ((e as StorageException)?.RequestInformation?.HttpStatusCode == (int)HttpStatusCode.PreconditionFailed)
                 {
                     await this.AbandonTaskOrchestrationWorkItemAsync(workItem);
+
+                    // if running with extended session, terminate the session
+                    if (workItem.Session != null)
+                    {
+                        throw new SessionAbortedException();
+                    }
+
                     return;
                 }
                 else

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -1205,7 +1205,7 @@ namespace DurableTask.AzureStorage.Tracking
             }
             else
             {
-                historyEventBatch.InsertOrReplace(sentinelEntity);
+                historyEventBatch.Insert(sentinelEntity);
             }
 
             Stopwatch stopwatch = Stopwatch.StartNew();

--- a/src/DurableTask.Core/Exceptions/SessionAbortedException.cs
+++ b/src/DurableTask.Core/Exceptions/SessionAbortedException.cs
@@ -1,0 +1,62 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core.Exceptions
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// Thrown when a session was aborted, for example in a split-brain situation
+    /// </summary>
+    [Serializable]
+    public class SessionAbortedException : InvalidOperationException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrchestrationAlreadyExistsException"/> class.
+        /// </summary>
+        public SessionAbortedException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes an new instance of the SessionAbortedException class with a specified error message
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public SessionAbortedException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes an new instance of the SessionAbortedException class with a specified error message
+        ///    and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+        public SessionAbortedException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the SessionAbortedException class with serialized data.
+        /// </summary>
+        /// <param name="info">The System.Runtime.Serialization.SerializationInfo that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The System.Runtime.Serialization.StreamingContext that contains contextual information about the source or destination.</param>
+        protected SessionAbortedException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -164,6 +164,10 @@ namespace DurableTask.Core
                     workItem.OrchestrationRuntimeState.NewEvents.Clear();
                 }
             }
+            catch (SessionAbortedException)
+            {
+                // we catch this exception here so that the TaskOrchestrationDispatcher does not back off.
+            }
             finally
             {
                 if (isExtendedSession)


### PR DESCRIPTION
This PR adds support for delayed entity messages, by recognizing a specially encoded delay parameter in event names, and setting the visibility timeout. This affects only entity messages, and does not require changes to core, only to the Azure table storage provider.

This PR also improves split brain handling in two cases:
- detects conflict on concurrent creation of an instance
- terminates extended session when conflict is detected

The latter required changing `DurableTask.Core` because the exception that terminates the extended session needs to be caught, so the work item scheduler does not back off. 