### PR TITLE
Added InstanceIdPrefix to OrchestrationInstanceStatusQueryCondition

### DIFF
--- a/Test/DurableTask.AzureStorage.Tests/OrchestrationInstanceStatusQueryConditionTest.cs
+++ b/Test/DurableTask.AzureStorage.Tests/OrchestrationInstanceStatusQueryConditionTest.cs
@@ -165,5 +165,19 @@ namespace DurableTask.AzureStorage.Tests
             var query = condition.ToTableQuery<OrchestrationInstanceStatus>();
             Assert.AreEqual("RuntimeStatus eq 'Running'", query.FilterString);
         }
+
+        [TestMethod]
+        public void OrchestrationInstanceQuery_InstanceIdPrefix()
+        {
+            var condition = new OrchestrationInstanceStatusQueryCondition
+            {
+                InstanceIdPrefix = "aaab",
+            };
+
+            var result = condition.ToTableQuery<OrchestrationInstanceStatus>().FilterString;
+            Assert.AreEqual(
+                "(InstanceId ge 'aaab') and (InstanceId lt 'aaac')",
+                condition.ToTableQuery<OrchestrationInstanceStatus>().FilterString);
+        }
     }
 }

--- a/Test/DurableTask.AzureStorage.Tests/OrchestrationInstanceStatusQueryConditionTest.cs
+++ b/Test/DurableTask.AzureStorage.Tests/OrchestrationInstanceStatusQueryConditionTest.cs
@@ -176,7 +176,7 @@ namespace DurableTask.AzureStorage.Tests
 
             var result = condition.ToTableQuery<OrchestrationInstanceStatus>().FilterString;
             Assert.AreEqual(
-                "(InstanceId ge 'aaab') and (InstanceId lt 'aaac')",
+                "(PartitionKey ge 'aaab') and (PartitionKey lt 'aaac')",
                 condition.ToTableQuery<OrchestrationInstanceStatus>().FilterString);
         }
     }

--- a/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
+++ b/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
@@ -61,7 +61,8 @@ namespace DurableTask.AzureStorage.Tracking
             if (!((this.RuntimeStatus == null || (!this.RuntimeStatus.Any())) && 
                 this.CreatedTimeFrom == default(DateTime) && 
                 this.CreatedTimeTo == default(DateTime) &&
-                this.TaskHubNames == null))
+                this.TaskHubNames == null &&
+                InstanceIdPrefix == null))
             {
                 query.Where(this.GetConditions());
             }

--- a/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
+++ b/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
@@ -45,6 +45,11 @@ namespace DurableTask.AzureStorage.Tracking
         public IEnumerable<string> TaskHubNames { get; set; }
 
         /// <summary>
+        /// InstanceIdPrefix
+        /// </summary>
+        public string InstanceIdPrefix { get; set; }
+
+        /// <summary>
         /// Get the TableQuery object
         /// </summary>
         /// <typeparam name="T"></typeparam>
@@ -96,6 +101,19 @@ namespace DurableTask.AzureStorage.Tracking
                 {
                     conditions.Add(taskHubCondition);
                 }
+            }
+
+            if (this.InstanceIdPrefix != null)
+            {
+                var length = InstanceIdPrefix.Length - 1;
+                var nextChar = InstanceIdPrefix[length] + 1;
+
+                var biggerSubstring = InstanceIdPrefix.Substring(0, length) + (char)nextChar;
+
+                conditions.Add(TableQuery.CombineFilters(
+                    TableQuery.GenerateFilterCondition("InstanceId", QueryComparisons.GreaterThanOrEqual, InstanceIdPrefix), 
+                    TableOperators.And, 
+                    TableQuery.GenerateFilterCondition("InstanceId", QueryComparisons.LessThan, biggerSubstring)));
             }
 
             return conditions.Count == 1 ? 

--- a/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
+++ b/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
@@ -62,7 +62,7 @@ namespace DurableTask.AzureStorage.Tracking
                 this.CreatedTimeFrom == default(DateTime) && 
                 this.CreatedTimeTo == default(DateTime) &&
                 this.TaskHubNames == null &&
-                InstanceIdPrefix == null))
+                this.InstanceIdPrefix == null))
             {
                 query.Where(this.GetConditions());
             }
@@ -106,15 +106,15 @@ namespace DurableTask.AzureStorage.Tracking
 
             if (this.InstanceIdPrefix != null)
             {
-                var length = InstanceIdPrefix.Length - 1;
-                var nextChar = InstanceIdPrefix[length] + 1;
+                int length = InstanceIdPrefix.Length - 1;
+                int incrementedLastChar = InstanceIdPrefix[length] + 1;
 
-                var biggerSubstring = InstanceIdPrefix.Substring(0, length) + (char)nextChar;
+                string greaterThanPrefix = InstanceIdPrefix.Substring(0, length) + (char)incrementedLastChar;
 
                 conditions.Add(TableQuery.CombineFilters(
                     TableQuery.GenerateFilterCondition("InstanceId", QueryComparisons.GreaterThanOrEqual, InstanceIdPrefix), 
                     TableOperators.And, 
-                    TableQuery.GenerateFilterCondition("InstanceId", QueryComparisons.LessThan, biggerSubstring)));
+                    TableQuery.GenerateFilterCondition("InstanceId", QueryComparisons.LessThan, greaterThanPrefix)));
             }
 
             return conditions.Count == 1 ? 

--- a/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
+++ b/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
@@ -104,17 +104,17 @@ namespace DurableTask.AzureStorage.Tracking
                 }
             }
 
-            if (this.InstanceIdPrefix != null)
+            if (!string.IsNullOrEmpty(this.InstanceIdPrefix))
             {
-                int length = InstanceIdPrefix.Length - 1;
-                int incrementedLastChar = InstanceIdPrefix[length] + 1;
+                int length = this.InstanceIdPrefix.Length - 1;
+                char incrementedLastChar = (char)(this.InstanceIdPrefix[length] + 1);
 
-                string greaterThanPrefix = InstanceIdPrefix.Substring(0, length) + (char)incrementedLastChar;
+                string greaterThanPrefix = this.InstanceIdPrefix.Substring(0, length) + incrementedLastChar;
 
                 conditions.Add(TableQuery.CombineFilters(
-                    TableQuery.GenerateFilterCondition("InstanceId", QueryComparisons.GreaterThanOrEqual, InstanceIdPrefix), 
+                    TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThanOrEqual, InstanceIdPrefix), 
                     TableOperators.And, 
-                    TableQuery.GenerateFilterCondition("InstanceId", QueryComparisons.LessThan, greaterThanPrefix)));
+                    TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.LessThan, greaterThanPrefix)));
             }
 
             return conditions.Count == 1 ? 


### PR DESCRIPTION
Added InstanceIdPrefix to allow query of an instance only given the first part of the instanceId. For example, with Entities, this allows query of EntityName (where instance id is composed of EntityName and EntityKey).

Related to issue https://github.com/Azure/azure-functions-durable-extension/issues/997
In the azure-functions-durable-extension repository.