### PR TITLE
Fix instance status update race condition (for replace)

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1285,17 +1285,15 @@ namespace DurableTask.AzureStorage
             // Client operations will auto-create the task hub if it doesn't already exist.
             await this.EnsureTaskHubAsync();
 
-            OrchestrationState existingInstance = await this.trackingStore.GetStateAsync(
-                creationMessage.OrchestrationInstance.InstanceId,
-                executionId: null,
-                fetchInput: false);
+            InstanceStatus existingInstance = await this.trackingStore.FetchInstanceStatusAsync(
+                creationMessage.OrchestrationInstance.InstanceId);
 
-            if (existingInstance != null && dedupeStatuses != null && dedupeStatuses.Contains(existingInstance.OrchestrationStatus))
+            if (existingInstance?.State != null && dedupeStatuses != null && dedupeStatuses.Contains(existingInstance.State.OrchestrationStatus))
             {
                 // An instance in this state already exists.
-                if (settings.ThrowExceptionOnInvalidDedupeStatus)
+                if (this.settings.ThrowExceptionOnInvalidDedupeStatus)
                 {
-                    throw new InvalidOperationException($"An Orchestration instance with the status {existingInstance.OrchestrationStatus} already exists.");
+                    throw new InvalidOperationException($"An Orchestration instance with the status {existingInstance.State.OrchestrationStatus} already exists.");
                 }
 
                 return;
@@ -1307,18 +1305,12 @@ namespace DurableTask.AzureStorage
                 controlQueue,
                 creationMessage);
 
-            // The start message gets enqueued before we write to the instances table. It's possible that the orchestration
-            // will start and update the instances status before this call can do so. To account for that race condition
-            // we ignore updating the instance status if none already exists. The case where one exists already is
-            // when an existing instance is being overwritten.
-            bool ignoreExistingInstances = (existingInstance == null);
-
             // CompressedBlobName either has a blob path for large messages or is null.
             string inputStatusOverride = internalMessage.CompressedBlobName;
 
             await this.trackingStore.SetNewExecutionAsync(
                 executionStartedEvent,
-                ignoreExistingInstances,
+                existingInstance?.ETag,
                 inputStatusOverride);
         }
 

--- a/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
@@ -88,6 +88,13 @@ namespace DurableTask.AzureStorage.Tracking
         Task<OrchestrationState> GetStateAsync(string instanceId, string executionId, bool fetchInput);
 
         /// <summary>
+        /// Fetches the latest instance status of the specified orchestration instance.
+        /// </summary>
+        /// <param name="instanceId">The ID of the orchestration.</param>
+        /// <returns>Returns the instance status or <c>null</c> if none was found.</returns>
+        Task<InstanceStatus> FetchInstanceStatusAsync(string instanceId);
+
+        /// <summary>
         /// Get The Orchestration State for querying all orchestration instances
         /// </summary>
         /// <returns></returns>
@@ -129,10 +136,10 @@ namespace DurableTask.AzureStorage.Tracking
         /// Used to set a state in the tracking store whenever a new execution is initiated from the client
         /// </summary>
         /// <param name="executionStartedEvent">The Execution Started Event being queued</param>
-        /// <param name="ignoreExistingInstances">When <c>true</c>, this operation is a no-op if an execution with this ID already exists.</param>
+        /// <param name="eTag">The eTag value to use for optimistic concurrency or <c>null</c> to overwrite any existing execution status.</param>
         /// <param name="inputStatusOverride">An override value to use for the Input column. If not specified, uses <see cref="ExecutionStartedEvent.Input"/>.</param>
         /// <returns>Returns <c>true</c> if the record was created successfully; <c>false</c> otherwise.</returns>
-        Task<bool> SetNewExecutionAsync(ExecutionStartedEvent executionStartedEvent, bool ignoreExistingInstances, string inputStatusOverride);
+        Task<bool> SetNewExecutionAsync(ExecutionStartedEvent executionStartedEvent, string eTag, string inputStatusOverride);
 
         /// <summary>
         /// Used to update a state in the tracking store to pending whenever a rewind is initiated from the client

--- a/src/DurableTask.AzureStorage/Tracking/InstanceStatus.cs
+++ b/src/DurableTask.AzureStorage/Tracking/InstanceStatus.cs
@@ -1,0 +1,35 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+using System;
+using DurableTask.Core;
+
+namespace DurableTask.AzureStorage.Tracking
+{
+    class InstanceStatus
+    {
+        public InstanceStatus(OrchestrationState state)
+            : this(state, null)
+        { }
+
+        public InstanceStatus(OrchestrationState state, string eTag)
+        {
+            this.State = state ?? throw new ArgumentNullException(nameof(state));
+            this.ETag = eTag ?? "*";
+        }
+
+        public OrchestrationState State { get; }
+
+        public string ETag { get; }
+    }
+}

--- a/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
+++ b/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
@@ -46,6 +46,9 @@ namespace DurableTask.AzureStorage.Tracking
         }
 
         /// <inheritdoc />
+        public abstract Task<InstanceStatus> FetchInstanceStatusAsync(string instanceId);
+
+        /// <inheritdoc />
         public abstract Task<IList<OrchestrationState>> GetStateAsync(string instanceId, bool allExecutions, bool fetchInput);
         
         /// <inheritdoc />
@@ -90,7 +93,7 @@ namespace DurableTask.AzureStorage.Tracking
         }
 
         /// <inheritdoc />
-        public abstract Task<bool> SetNewExecutionAsync(ExecutionStartedEvent executionStartedEvent, bool ignoreExistingInstances, string inputStatusOverride);
+        public abstract Task<bool> SetNewExecutionAsync(ExecutionStartedEvent executionStartedEvent, string eTag, string inputStatusOverride);
 
         /// <inheritdoc />
         public virtual Task UpdateStatusForRewindAsync(string instanceId)


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-durable-extension/issues/1020.

We were already handling the race condition for setting the "Pending" status on a new instance.  However, we did not correctly handle the case where we were replacing an existing instance with a "Pending". This resulted in cases where orchestration instances completed successfully but had a "Pending" status in the instances table.

This fix handles the latter race condition (replacing an existing instance). After this, both cases should be handled, and we should never have a completed instance in the "Pending" status.