### PR TITLE
Added constructor to TaskHubClient with JsonDataConverter input

### DIFF
--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -44,14 +44,14 @@ namespace DurableTask.Core
         }
 
         /// <summary>
-        ///     Create a new TaskHubClient with the given OrchestrationServiceClient
+        ///     Create a new TaskHubClient with the given OrchestrationServiceClient and JsonDataConverter.
         /// </summary>
         /// <param name="serviceClient">Object implementing the <see cref="IOrchestrationServiceClient"/> interface </param>
-        /// <param name="dataConverter"></param>
+        /// <param name="dataConverter">The <see cref="JsonDataConverter"/> to use for message serialization.</param>
         public TaskHubClient(IOrchestrationServiceClient serviceClient, JsonDataConverter dataConverter)
         {
             ServiceClient = serviceClient ?? throw new ArgumentNullException(nameof(serviceClient));
-            this.defaultConverter = dataConverter;
+            this.defaultConverter = dataConverter ?? throw new ArgumentNullException(nameof(dataConverter));
         }
 
         /// <summary>

--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -44,6 +44,17 @@ namespace DurableTask.Core
         }
 
         /// <summary>
+        ///     Create a new TaskHubClient with the given OrchestrationServiceClient
+        /// </summary>
+        /// <param name="serviceClient">Object implementing the <see cref="IOrchestrationServiceClient"/> interface </param>
+        /// <param name="dataConverter"></param>
+        public TaskHubClient(IOrchestrationServiceClient serviceClient, JsonDataConverter dataConverter)
+        {
+            ServiceClient = serviceClient ?? throw new ArgumentNullException(nameof(serviceClient));
+            this.defaultConverter = dataConverter;
+        }
+
+        /// <summary>
         ///     Create a new orchestration of the specified type with an automatically generated instance id
         /// </summary>
         /// <param name="orchestrationType">Type that derives from TaskOrchestration</param>

--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -43,9 +43,9 @@
   <!-- Nuget Package Settings -->
   <PropertyGroup>
     <PackageOutputPath>..\..\build_output\packages</PackageOutputPath>
-    <AssemblyVersion>2.1.3</AssemblyVersion>
-    <FileVersion>2.1.3</FileVersion>
-    <Version>2.1.3</Version>
+    <AssemblyVersion>2.3.0</AssemblyVersion>
+    <FileVersion>2.1.4</FileVersion>
+    <Version>2.1.4</Version>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors> 
     <Product>Durable Task Framework</Product>

--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -43,7 +43,7 @@
   <!-- Nuget Package Settings -->
   <PropertyGroup>
     <PackageOutputPath>..\..\build_output\packages</PackageOutputPath>
-    <AssemblyVersion>2.3.0</AssemblyVersion>
+    <AssemblyVersion>2.1.4</AssemblyVersion>
     <FileVersion>2.1.4</FileVersion>
     <Version>2.1.4</Version>
     <Company>Microsoft</Company>

--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -43,9 +43,9 @@
   <!-- Nuget Package Settings -->
   <PropertyGroup>
     <PackageOutputPath>..\..\build_output\packages</PackageOutputPath>
-    <AssemblyVersion>2.1.4</AssemblyVersion>
-    <FileVersion>2.1.4</FileVersion>
-    <Version>2.1.4</Version>
+    <AssemblyVersion>2.2.0</AssemblyVersion>
+    <FileVersion>2.2.0</FileVersion>
+    <Version>2.2.0</Version>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors> 
     <Product>Durable Task Framework</Product>


### PR DESCRIPTION
Added second constructor to TaskHubClient to allow for a custom JsonDataConverter to allow for custom serialization settings.

Related to this issue in the azure-functions-durable-extension repository:
https://github.com/Azure/azure-functions-durable-extension/issues/65