### PR TITLE
Added FetchInput property to OrchestrationInstanceStatusQueryCondition

### DIFF
--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -491,7 +491,7 @@ namespace DurableTask.AzureStorage.Tracking
                 {
                     // Retrieve all columns except the input column
                     columnsToRetrieve.Remove(InputProperty);
-                }            
+                }
             }
 
             var stopwatch = new Stopwatch();

--- a/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
+++ b/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
@@ -54,6 +54,28 @@ namespace DurableTask.AzureStorage.Tracking
         /// </summary>
         public bool FetchInput { get; set; } = true;
 
+        private List<string> columnsWithoutInput;
+
+        private List<string> ColumnsWithoutInput
+        {
+            get
+            {
+                if (this.columnsWithoutInput == null)
+                {
+                    this.columnsWithoutInput = typeof(OrchestrationInstanceStatus).GetProperties()
+                        .Where(prop => !prop.Name.Equals(nameof(OrchestrationInstanceStatus.Input)))
+                        .Select(prop => prop.Name)
+                        .ToList();
+                }
+
+                return this.columnsWithoutInput;
+            }
+            set
+            {
+                this.columnsWithoutInput = value;
+            }
+        }
+
         /// <summary>
         /// Get the TableQuery object
         /// </summary>
@@ -71,8 +93,7 @@ namespace DurableTask.AzureStorage.Tracking
             {
                 if (!FetchInput)
                 {
-                    IList<string> columns = new List<string> { "ExecutionId", "Name", "Version", "Output", "CustomStatus", "CreatedTime", "LastUpdatedTime", "RuntimeStatus" };
-                    query.Select(columns);
+                    query.Select(columnsWithoutInput);
                 }
 
                 query.Where(this.GetConditions());

--- a/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
+++ b/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
@@ -50,6 +50,11 @@ namespace DurableTask.AzureStorage.Tracking
         public string InstanceIdPrefix { get; set; }
 
         /// <summary>
+        /// If true, the input will be returned with the query
+        /// </summary>
+        public bool FetchInput { get; set; } = true;
+
+        /// <summary>
         /// Get the TableQuery object
         /// </summary>
         /// <typeparam name="T"></typeparam>
@@ -64,6 +69,12 @@ namespace DurableTask.AzureStorage.Tracking
                 this.TaskHubNames == null &&
                 this.InstanceIdPrefix == null))
             {
+                if (!FetchInput)
+                {
+                    IList<string> columns = new List<string> { "ExecutionId", "Name", "Version", "Output", "CustomStatus", "CreatedTime", "LastUpdatedTime", "RuntimeStatus" };
+                    query.Select(columns);
+                }
+
                 query.Where(this.GetConditions());
             }
 

--- a/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
+++ b/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
@@ -50,7 +50,7 @@ namespace DurableTask.AzureStorage.Tracking
         public string InstanceIdPrefix { get; set; }
 
         /// <summary>
-        /// If true, the input will be returned with the query
+        /// If true, the input will be returned with the results. The default value is true.
         /// </summary>
         public bool FetchInput { get; set; } = true;
 
@@ -91,7 +91,7 @@ namespace DurableTask.AzureStorage.Tracking
                 this.TaskHubNames == null &&
                 this.InstanceIdPrefix == null))
             {
-                if (!FetchInput)
+                if (!this.FetchInput)
                 {
                     query.Select(columnsWithoutInput);
                 }

--- a/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
+++ b/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
@@ -24,6 +24,8 @@ namespace DurableTask.AzureStorage.Tracking
     /// </summary>
     public class OrchestrationInstanceStatusQueryCondition
     {
+        private List<string> columnsWithoutInput;
+
         /// <summary>
         /// RuntimeStatus
         /// </summary>
@@ -53,8 +55,6 @@ namespace DurableTask.AzureStorage.Tracking
         /// If true, the input will be returned with the results. The default value is true.
         /// </summary>
         public bool FetchInput { get; set; } = true;
-
-        private List<string> columnsWithoutInput;
 
         private List<string> ColumnsWithoutInput
         {


### PR DESCRIPTION
Added FetchInput property to allow to specify if the Input column should be selected in the query created with OrchestrationInstanceStatusQueryCondition.

Related to https://github.com/Azure/azure-functions-durable-extension/issues/997
to allow query of entities without selecting the input column.