### PR TITLE
Update DurableTask.AzureStorage and DurableTask.Redis package versions

### DIFF
--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <FileVersion>1.6.5</FileVersion>
+    <FileVersion>1.7.0</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <Version>$(FileVersion)</Version>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/DurableTask.Redis/DurableTask.Redis.csproj
+++ b/src/DurableTask.Redis/DurableTask.Redis.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RunCodeAnalysis>false</RunCodeAnalysis>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <FileVersion>0.1.1</FileVersion>
+    <FileVersion>0.1.2</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <Version>$(FileVersion)-alpha</Version>
     <IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
For our upcoming release of Durable Functions 2.1, we need to release
DurableTask.Core, DurableTask.Emulator, DurableTask.AzureStorage, and
DurableTask.Redis. DurableTask.Core and DurableTask.Emulator already had
their version incremented, so this PR increments the version for the
other packages.