### PR TITLE
Improve speed of graceful shutdown, and remove race condition

### DIFF
--- a/src/DurableTask.Core/TaskHubWorker.cs
+++ b/src/DurableTask.Core/TaskHubWorker.cs
@@ -156,9 +156,14 @@ namespace DurableTask.Core
             {
                 if (this.isStarted)
                 {
-                    await this.orchestrationDispatcher.StopAsync(isForced);
-                    await this.activityDispatcher.StopAsync(isForced);
-                    await orchestrationService.StopAsync(isForced);
+                    var serviceShutdowns = new Task[]
+                    {
+                        this.orchestrationDispatcher.StopAsync(isForced),
+                        this.activityDispatcher.StopAsync(isForced),
+                        orchestrationService.StopAsync(isForced)
+                    };
+
+                    await Task.WhenAll(serviceShutdowns);
 
                     this.isStarted = false;
                 }

--- a/src/DurableTask.Core/TaskHubWorker.cs
+++ b/src/DurableTask.Core/TaskHubWorker.cs
@@ -156,14 +156,15 @@ namespace DurableTask.Core
             {
                 if (this.isStarted)
                 {
-                    var serviceShutdowns = new Task[]
+                    var dispatcherShutdowns = new Task[]
                     {
                         this.orchestrationDispatcher.StopAsync(isForced),
                         this.activityDispatcher.StopAsync(isForced),
-                        orchestrationService.StopAsync(isForced)
                     };
 
-                    await Task.WhenAll(serviceShutdowns);
+                    await Task.WhenAll(dispatcherShutdowns);
+
+                    await orchestrationService.StopAsync(isForced);
 
                     this.isStarted = false;
                 }

--- a/src/DurableTask.Core/WorkItemDispatcher.cs
+++ b/src/DurableTask.Core/WorkItemDispatcher.cs
@@ -173,7 +173,7 @@ namespace DurableTask.Core
                 if (!forced)
                 {
                     var retryCount = 7;
-                    while (this.AllWorkItemsCompleted() && retryCount-- >= 0)
+                    while (!this.AllWorkItemsCompleted() && retryCount-- >= 0)
                     {
                         TraceHelper.Trace(TraceEventType.Information, "WorkItemDispatcherStop-Waiting", $"WorkItemDispatcher('{this.name}') waiting to stop. Id {this.id}. WorkItemCount: {this.concurrentWorkItemCount}, ActiveFetchers: {this.activeFetchers}");
                         await Task.Delay(1000);

--- a/src/DurableTask.Core/WorkItemDispatcher.cs
+++ b/src/DurableTask.Core/WorkItemDispatcher.cs
@@ -173,11 +173,10 @@ namespace DurableTask.Core
                 if (!forced)
                 {
                     var retryCount = 7;
-                    //TODO: race condition in graceful shutdown.
-                    while ((this.concurrentWorkItemCount > 0 || this.activeFetchers > 0) && retryCount-- >= 0)
+                    while (this.AllWorkItemsCompleted() && retryCount-- >= 0)
                     {
                         TraceHelper.Trace(TraceEventType.Information, "WorkItemDispatcherStop-Waiting", $"WorkItemDispatcher('{this.name}') waiting to stop. Id {this.id}. WorkItemCount: {this.concurrentWorkItemCount}, ActiveFetchers: {this.activeFetchers}");
-                        await Task.Delay(4000);
+                        await Task.Delay(1000);
                     }
                 }
 
@@ -187,6 +186,28 @@ namespace DurableTask.Core
             {
                 this.initializationLock.Release();
             }
+        }
+
+        private bool AllWorkItemsCompleted()
+        {
+            if (this.isStarted == true)
+            {
+                // If we are still started, we can make no guarantees that there won't be
+                // more scheduled work items.
+                return false;
+            }
+
+            if (this.activeFetchers == 0)
+            {
+                // We can assume that no more active fetchers will be scheduled. Since there are no active
+                // fetchers, and no more can be scheduled, we can trust the concurrent work item count
+                if (this.concurrentWorkItemCount == 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         async Task DispatchAsync(string dispatcherId)


### PR DESCRIPTION
Improves graceful shutdown the following ways:

1. Stop the dispatchers and orchestration service in parallel to save time.
2. Reduce delay from 4 seconds to 1 second when waiting for inflight work items.
3. Fix race condition where we could accidentally mark a WorkItemDispatcher as stopped when there are in flight work items.