### PR TITLE
Fixes to unblock official build

### DIFF
--- a/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
+++ b/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
@@ -89,21 +89,22 @@ namespace DurableTask.AzureStorage.Tracking
         {
             var conditions = new List<string>();
 
-            if (default(DateTime) != this.CreatedTimeFrom)
+            if (this.CreatedTimeFrom > DateTime.MinValue)
             {
                 conditions.Add(TableQuery.GenerateFilterConditionForDate("CreatedTime", QueryComparisons.GreaterThanOrEqual, new DateTimeOffset(this.CreatedTimeFrom)));
             }
 
-            if (default(DateTime) != this.CreatedTimeTo)
+            if (this.CreatedTimeTo != default(DateTime) && this.CreatedTimeTo < DateTime.MaxValue)
             {
                 conditions.Add(TableQuery.GenerateFilterConditionForDate("CreatedTime", QueryComparisons.LessThanOrEqual, new DateTimeOffset(this.CreatedTimeTo)));
             }
 
             if (this.RuntimeStatus != null && this.RuntimeStatus.Any())
             {
-                string runtimeCondition = this.RuntimeStatus.Select(x => TableQuery.GenerateFilterCondition("RuntimeStatus", QueryComparisons.Equal, x.ToString()))
-                                    .Aggregate((a, b) => TableQuery.CombineFilters(a, TableOperators.Or, b));
-                if (runtimeCondition.Count() != 0)
+                string runtimeCondition = this.RuntimeStatus
+                    .Select(x => TableQuery.GenerateFilterCondition("RuntimeStatus", QueryComparisons.Equal, x.ToString()))
+                    .Aggregate((a, b) => TableQuery.CombineFilters(a, TableOperators.Or, b));
+                if (runtimeCondition.Length > 0)
                 {
                     conditions.Add(runtimeCondition);
                 }
@@ -111,7 +112,8 @@ namespace DurableTask.AzureStorage.Tracking
 
             if (this.TaskHubNames != null)
             {
-                string taskHubCondition = this.TaskHubNames.Select(x => TableQuery.GenerateFilterCondition("TaskHubName", QueryComparisons.Equal, x.ToString()))
+                string taskHubCondition = this.TaskHubNames
+                    .Select(x => TableQuery.GenerateFilterCondition("TaskHubName", QueryComparisons.Equal, x.ToString()))
                     .Aggregate((a, b) => TableQuery.CombineFilters(a, TableOperators.Or, b));
                 if (taskHubCondition.Count() != 0)
                 {

--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -20,15 +20,10 @@
     <DebugType>embedded</DebugType>
     <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
-  
+
   <!-- SourceLink Dependency for GitHub-->
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.*" PrivateAssets="All" />
-  </ItemGroup>
-
-  <!-- Nuget package icon -->
-  <ItemGroup>
-    <None Include="..\..\logo.png" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
   <!-- Sign assemblies if the snk file is present -->
@@ -52,14 +47,14 @@
     <FileVersion>2.2.0</FileVersion>
     <Version>2.2.0</Version>
     <Company>Microsoft</Company>
-    <Authors>Microsoft</Authors> 
+    <Authors>Microsoft</Authors>
     <Product>Durable Task Framework</Product>
     <Description>This package provides a C# based durable task framework for writing long running applications.</Description>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageProjectUrl>https://github.com/Azure/durabletask/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Azure/durabletask/</RepositoryUrl>
-    <PackageIcon>logo.png</PackageIcon>
+    <PackageIconUrl>https://github.com/Azure/durabletask/blob/master/logo.png?raw=true</PackageIconUrl>
     <PackageTags>ServiceBus Azure Task Durable Orchestration Workflow Activity Reliable</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
     <IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
The license change broke the official build in Azure DevOps - reverting
Also reverting the icon change to avoid potential issues
Sneaking in one additional fix for DurableTask.AzureStorage instance queries