### PR TITLE
Support for aborting orchestration and activity executions

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -917,15 +917,8 @@ namespace DurableTask.AzureStorage
                 // Precondition failure is expected to be handled internally and logged as a warning.
                 if ((e as StorageException)?.RequestInformation?.HttpStatusCode == (int)HttpStatusCode.PreconditionFailed)
                 {
-                    await this.AbandonTaskOrchestrationWorkItemAsync(workItem);
-
-                    // if running with extended session, terminate the session
-                    if (workItem.Session != null)
-                    {
-                        throw new SessionAbortedException();
-                    }
-
-                    return;
+                    // The orchestration dispatcher will handle this exception by abandoning the work item
+                    throw new SessionAbortedException();
                 }
                 else
                 {

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <FileVersion>1.7.0</FileVersion>
+    <FileVersion>1.7.1</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <Version>$(FileVersion)</Version>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/DurableTask.Core/Common/Utils.cs
+++ b/src/DurableTask.Core/Common/Utils.cs
@@ -243,6 +243,11 @@ namespace DurableTask.Core.Common
         }
 
         /// <summary>
+        /// Returns true if an exception represents an aborting execution; false otherwise.
+        /// </summary>
+        public static bool IsExecutionAborting(Exception exception) => exception is SessionAbortedException;
+
+        /// <summary>
         /// Executes the supplied action until successful or the supplied number of attempts is reached
         /// </summary>
         public static async Task ExecuteWithRetries(Func<Task> retryAction, string sessionId, string operation,

--- a/src/DurableTask.Core/Exceptions/SessionAbortedException.cs
+++ b/src/DurableTask.Core/Exceptions/SessionAbortedException.cs
@@ -17,20 +17,20 @@ namespace DurableTask.Core.Exceptions
     using System.Runtime.Serialization;
 
     /// <summary>
-    /// Thrown when a session was aborted, for example in a split-brain situation
+    /// Thrown when an orchestration or activity session is aborted, for example in split-brain situation or host shutdown situations.
     /// </summary>
     [Serializable]
     public class SessionAbortedException : InvalidOperationException
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="OrchestrationAlreadyExistsException"/> class.
+        /// Initializes a new instance of the <see cref="SessionAbortedException"/> class.
         /// </summary>
         public SessionAbortedException()
         {
         }
 
         /// <summary>
-        /// Initializes an new instance of the SessionAbortedException class with a specified error message
+        /// Initializes an new instance of the <see cref="SessionAbortedException"/> class with a specified error message
         /// </summary>
         /// <param name="message">The message that describes the error.</param>
         public SessionAbortedException(string message)
@@ -39,7 +39,7 @@ namespace DurableTask.Core.Exceptions
         }
 
         /// <summary>
-        /// Initializes an new instance of the SessionAbortedException class with a specified error message
+        /// Initializes an new instance of the <see cref="SessionAbortedException"/> class with a specified error message
         ///    and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The message that describes the error.</param>
@@ -50,7 +50,7 @@ namespace DurableTask.Core.Exceptions
         }
 
         /// <summary>
-        /// Initializes a new instance of the SessionAbortedException class with serialized data.
+        /// Initializes a new instance of the <see cref="SessionAbortedException"/> class with serialized data.
         /// </summary>
         /// <param name="info">The System.Runtime.Serialization.SerializationInfo that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The System.Runtime.Serialization.StreamingContext that contains contextual information about the source or destination.</param>

--- a/src/DurableTask.Core/Exceptions/SessionAbortedException.cs
+++ b/src/DurableTask.Core/Exceptions/SessionAbortedException.cs
@@ -26,6 +26,7 @@ namespace DurableTask.Core.Exceptions
         /// Initializes a new instance of the <see cref="SessionAbortedException"/> class.
         /// </summary>
         public SessionAbortedException()
+            : base("The current execution has been aborted.")
         {
         }
 

--- a/src/DurableTask.Core/TaskActivity.cs
+++ b/src/DurableTask.Core/TaskActivity.cs
@@ -133,7 +133,7 @@ namespace DurableTask.Core
             {
                 result = await ExecuteAsync(context, parameter);
             }
-            catch (Exception e) when (!Utils.IsFatal(e))
+            catch (Exception e) when (!Utils.IsFatal(e) && !Utils.IsExecutionAborting(e))
             {
                 string details = Utils.SerializeCause(e, DataConverter);
                 throw new TaskFailureException(e.Message, e, details);

--- a/src/DurableTask.Core/TaskOrchestration.cs
+++ b/src/DurableTask.Core/TaskOrchestration.cs
@@ -95,7 +95,7 @@ namespace DurableTask.Core
             {
                 result = await RunTask(context, parameter);
             }
-            catch (Exception e) when (!Utils.IsFatal(e))
+            catch (Exception e) when (!Utils.IsFatal(e) && !Utils.IsExecutionAborting(e))
             {
                 string details = Utils.SerializeCause(e, DataConverter);
                 throw new OrchestrationFailureException(e.Message, details);

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -178,9 +178,11 @@ namespace DurableTask.Core
                     }
                 }
             }
-            catch (SessionAbortedException)
+            catch (SessionAbortedException e)
             {
                 // Either the orchestration or the orchestration service abandoned the session as part of normal control flow.
+                OrchestrationInstance instance = workItem.OrchestrationRuntimeState?.OrchestrationInstance ?? new OrchestrationInstance { InstanceId = workItem.InstanceId };
+                TraceHelper.TraceInstance(TraceEventType.Warning, "TaskOrchestrationDispatcher-ExecutionAborted", instance, "{0}", e.Message);
                 await this.orchestrationService.AbandonTaskOrchestrationWorkItemAsync(workItem);
             }
         }

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -180,7 +180,7 @@ namespace DurableTask.Core
             }
             catch (SessionAbortedException e)
             {
-                // Either the orchestration or the orchestration service abandoned the session as part of normal control flow.
+                // Either the orchestration or the orchestration service explicitly abandoned the session.
                 OrchestrationInstance instance = workItem.OrchestrationRuntimeState?.OrchestrationInstance ?? new OrchestrationInstance { InstanceId = workItem.InstanceId };
                 TraceHelper.TraceInstance(TraceEventType.Warning, "TaskOrchestrationDispatcher-ExecutionAborted", instance, "{0}", e.Message);
                 await this.orchestrationService.AbandonTaskOrchestrationWorkItemAsync(workItem);

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -110,74 +110,78 @@ namespace DurableTask.Core
 
         async Task OnProcessWorkItemSessionAsync(TaskOrchestrationWorkItem workItem)
         {
-            if (workItem.Session == null)
-            {
-                // Legacy behavior
-                await OnProcessWorkItemAsync(workItem);
-                return;
-            }
-
-            var isExtendedSession = false;
-            var processCount = 0;
             try
             {
-                while (true)
+                if (workItem.Session == null)
                 {
-                    // If the provider provided work items, execute them.
-                    if (workItem.NewMessages?.Count > 0)
+                    // Legacy behavior
+                    await OnProcessWorkItemAsync(workItem);
+                    return;
+                }
+
+                var isExtendedSession = false;
+                var processCount = 0;
+                try
+                {
+                    while (true)
                     {
-                        bool isCompletedOrInterrupted = await OnProcessWorkItemAsync(workItem);
-                        if (isCompletedOrInterrupted)
+                        // If the provider provided work items, execute them.
+                        if (workItem.NewMessages?.Count > 0)
+                        {
+                            bool isCompletedOrInterrupted = await OnProcessWorkItemAsync(workItem);
+                            if (isCompletedOrInterrupted)
+                            {
+                                break;
+                            }
+
+                            processCount++;
+                        }
+
+                        // Fetches beyond the first require getting an extended session lock, used to prevent starvation.
+                        if (processCount > 0 && !isExtendedSession)
+                        {
+                            isExtendedSession = this.concurrentSessionLock.Acquire();
+                            if (!isExtendedSession)
+                            {
+                                TraceHelper.Trace(TraceEventType.Verbose, "OnProcessWorkItemSession-MaxOperations", "Failed to acquire concurrent session lock.");
+                                break;
+                            }
+                        }
+
+                        TraceHelper.Trace(TraceEventType.Verbose, "OnProcessWorkItemSession-StartFetch", "Starting fetch of existing session.");
+                        Stopwatch timer = Stopwatch.StartNew();
+
+                        // Wait for new messages to arrive for the session. This call is expected to block (asynchronously)
+                        // until either new messages are available or until a provider-specific timeout has expired.
+                        workItem.NewMessages = await workItem.Session.FetchNewOrchestrationMessagesAsync(workItem);
+                        if (workItem.NewMessages == null)
                         {
                             break;
                         }
 
-                        processCount++;
+                        TraceHelper.Trace(
+                            TraceEventType.Verbose,
+                            "OnProcessWorkItemSession-EndFetch",
+                            $"Fetched {workItem.NewMessages.Count} new message(s) after {timer.ElapsedMilliseconds} ms from existing session.");
+                        workItem.OrchestrationRuntimeState.NewEvents.Clear();
                     }
-
-                    // Fetches beyond the first require getting an extended session lock, used to prevent starvation.
-                    if (processCount > 0 && !isExtendedSession)
+                }
+                finally
+                {
+                    if (isExtendedSession)
                     {
-                        isExtendedSession = this.concurrentSessionLock.Acquire();
-                        if (!isExtendedSession)
-                        {
-                            TraceHelper.Trace(TraceEventType.Verbose, "OnProcessWorkItemSession-MaxOperations", "Failed to acquire concurrent session lock.");
-                            break;
-                        }
+                        TraceHelper.Trace(
+                            TraceEventType.Verbose,
+                            "OnProcessWorkItemSession-Release",
+                            $"Releasing extended session after {processCount} batch(es).");
+                        this.concurrentSessionLock.Release();
                     }
-
-                    TraceHelper.Trace(TraceEventType.Verbose, "OnProcessWorkItemSession-StartFetch", "Starting fetch of existing session.");
-                    Stopwatch timer = Stopwatch.StartNew();
-
-                    // Wait for new messages to arrive for the session. This call is expected to block (asynchronously)
-                    // until either new messages are available or until a provider-specific timeout has expired.
-                    workItem.NewMessages = await workItem.Session.FetchNewOrchestrationMessagesAsync(workItem);
-                    if (workItem.NewMessages == null)
-                    {
-                        break;
-                    }
-
-                    TraceHelper.Trace(
-                        TraceEventType.Verbose,
-                        "OnProcessWorkItemSession-EndFetch",
-                        $"Fetched {workItem.NewMessages.Count} new message(s) after {timer.ElapsedMilliseconds} ms from existing session.");
-                    workItem.OrchestrationRuntimeState.NewEvents.Clear();
                 }
             }
             catch (SessionAbortedException)
             {
-                // we catch this exception here so that the TaskOrchestrationDispatcher does not back off.
-            }
-            finally
-            {
-                if (isExtendedSession)
-                {
-                    TraceHelper.Trace(
-                        TraceEventType.Verbose,
-                        "OnProcessWorkItemSession-Release",
-                        $"Releasing extended session after {processCount} batch(es).");
-                    this.concurrentSessionLock.Release();
-                }
+                // Either the orchestration or the orchestration service abandoned the session as part of normal control flow.
+                await this.orchestrationService.AbandonTaskOrchestrationWorkItemAsync(workItem);
             }
         }
 

--- a/src/DurableTask.Core/TaskOrchestrationExecutor.cs
+++ b/src/DurableTask.Core/TaskOrchestrationExecutor.cs
@@ -17,6 +17,7 @@ namespace DurableTask.Core
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
+    using System.Runtime.ExceptionServices;
     using System.Threading;
     using System.Threading.Tasks;
     using DurableTask.Core.Command;
@@ -94,8 +95,8 @@ namespace DurableTask.Core
 
                                 if (Utils.IsExecutionAborting(exception))
                                 {
-                                    // Let this exception propogate out to be handled by the dispatcher
-                                    this.result.GetAwaiter().GetResult();
+                                    // Let this exception propagate out to be handled by the dispatcher
+                                    ExceptionDispatchInfo.Capture(exception).Throw();
                                 }
                                 
                                 this.context.FailOrchestration(exception);

--- a/src/DurableTask.Core/TaskOrchestrationExecutor.cs
+++ b/src/DurableTask.Core/TaskOrchestrationExecutor.cs
@@ -13,12 +13,14 @@
 
 namespace DurableTask.Core
 {
+    using System;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using DurableTask.Core.Command;
+    using DurableTask.Core.Common;
     using DurableTask.Core.Exceptions;
     using DurableTask.Core.History;
 
@@ -87,9 +89,16 @@ namespace DurableTask.Core
                         {
                             if (this.result.IsFaulted)
                             {
-                                Debug.Assert(this.result.Exception != null);
+                                Exception exception = this.result.Exception?.InnerExceptions.FirstOrDefault();
+                                Debug.Assert(exception != null);
 
-                                this.context.FailOrchestration(this.result.Exception.InnerExceptions.FirstOrDefault());
+                                if (Utils.IsExecutionAborting(exception))
+                                {
+                                    // Let this exception propogate out to be handled by the dispatcher
+                                    this.result.GetAwaiter().GetResult();
+                                }
+                                
+                                this.context.FailOrchestration(exception);
                             }
                             else
                             {

--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -43,9 +43,9 @@
   <!-- Nuget Package Settings -->
   <PropertyGroup>
     <PackageOutputPath>..\..\build_output\packages</PackageOutputPath>
-    <AssemblyVersion>2.2.0</AssemblyVersion>
-    <FileVersion>2.2.0</FileVersion>
-    <Version>2.2.0</Version>
+    <AssemblyVersion>2.2.1</AssemblyVersion>
+    <FileVersion>2.2.1</FileVersion>
+    <Version>2.2.1</Version>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
     <Product>Durable Task Framework</Product>


### PR DESCRIPTION
This is a followup item to help fix https://github.com/Azure/azure-functions-durable-extension/issues/472 but it also directly applies to https://github.com/Azure/azure-functions-durable-extension/issues/1133.

### Summary

The idea is to take the existing `SessionAbortedException` (added by Sebastian) and make it work for abandoning in-flight orchestrations and activities. Basically, if an orchestration or activity function throws this exception, the dispatcher will abandon the work item rather than failing the activity/orchestration. The work item can then be picked up by a healthy instance and immediately resumed.

### Purpose

The primary purpose of this feature is to enable correctly handling host shutdown scenarios. For example, in Durable Functions, when the Functions host shuts down in the middle of an activity execution that is potentially running for a long time, we may see `ObjectDisposedException` from WebJobs framework when attempting to invoke the function. With this feature, we can detect host shutdown and throw a `SessionAbortedException` to abandon the current execution and let it restart gracefully on another instance.  Previously errors related to shutdown caused the orchestration to go into a failed state, which is not the correct behavior.

### Example

The following example shows how this could be used:

```csharp
public class LongRunningActivity : TaskActivity<string, string>
{
    protected override string Execute(TaskContext context, string input)
    {
        // do some work
        // ...

        while (!done)
        {
            if (HostIsShuttingDown())
            {
                // abort the execution so we can restart on another worker
                throw new SessionAbortedException();
            }

            // continue to do work
            // ...
        }

        return "done";
    }
}
```

### Validation tasks
- [x] Validate activity usage
- [x] Validate orchestration usage w/extended sessions
- [x] Validate orchestration usage w/out extended sessions
- [x] Validate split-brain handling still works as expected