### PR TITLE
Fix ETag retrieval for orchestrations with multiple executions

### DIFF
--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -184,7 +184,7 @@ namespace DurableTask.AzureStorage.Tracking
                         break;
                     }
 
-                    // The sentinal row does not contain any history events, so save it for later
+                    // The sentinel row does not contain any history events, so save it for later
                     // and continue
                     if (entity.RowKey == SentinelRowKey)
                     {
@@ -207,8 +207,8 @@ namespace DurableTask.AzureStorage.Tracking
             }
 
             // Read the checkpoint completion time from the sentinel row, which should always be the last row.
-            // The only time a sentinel won't exist is if no instance of this ID has ever existed.
-            // The IsCheckpointCompleteProperty was newly added _after_ v1.6.4.
+            // A sentinel won't exist only if no instance of this ID has ever existed or the instance history
+            // was purged.The IsCheckpointCompleteProperty was newly added _after_ v1.6.4.
             DateTime checkpointCompletionTime = DateTime.MinValue;
             sentinel = sentinel ?? tableEntities.LastOrDefault(e => e.RowKey == SentinelRowKey);
             string eTagValue = sentinel?.ETag;


### PR DESCRIPTION
It is possible for the history table to get into a state where the
latest execution history is first, followed by the previous execution
history, with the last entry for an instance id being the sentinal row.
The previous history parsing logic stopped processing as soon as it saw
a new execution id, meaning it failed to grab the ETag from the sentinal
row.

This, in combination with changes made when the ETag were not present,
caused UpdateState calls to fail, meaning queue messages for Activities
were being scheduled without recording that we did schedule them. This
leads to duplicate Activity executions until we retrieve the history
with an execution id (i.e. after an activity function successfully
executes).

This fix makes our ETag retrieval logic more robust.