### PR TITLE
Fixing #368: NullReferenceException when Task returns void

### DIFF
--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -77,7 +77,7 @@ namespace DurableTask.Core
         {
             object result = await ScheduleTaskInternal(name, version, taskList, typeof(TResult), parameters);
 
-            return (TResult)result;
+            return (result == null) ? null : (TResult)result;
         }
 
         public async Task<object> ScheduleTaskInternal(string name, string version, string taskList, Type resultType,


### PR DESCRIPTION
Fixing #368: NullReferenceException when Task returns void