### PR TITLE
Update System.DiagnosticSource for enabling W3C on Durable Functions

### DIFF
--- a/Test/DurableTask.AzureStorage.Tests/Correlation/CorrelationScenarioTest.cs
+++ b/Test/DurableTask.AzureStorage.Tests/Correlation/CorrelationScenarioTest.cs
@@ -33,8 +33,8 @@ namespace DurableTask.AzureStorage.Tests.Correlation
     public class CorrelationScenarioTest
     {
         [DataTestMethod]
-        [DataRow(Protocol.HttpCorrelationProtocol)]
         [DataRow(Protocol.W3CTraceContext)]
+        [DataRow(Protocol.HttpCorrelationProtocol)]
         public async Task SingleOrchestratorWithSingleActivityAsync(Protocol protocol)
         {
             CorrelationSettings.Current.Protocol = protocol;
@@ -634,12 +634,8 @@ namespace DurableTask.AzureStorage.Tests.Correlation
                     await host.StartAsync();
                     var activity = new Activity(TraceConstants.Client);
 
-                    if (CorrelationSettings.Current.Protocol == Protocol.W3CTraceContext)
-                    {
-#pragma warning disable 618 // GenerateW3CContext() is deprecated. However, it is required for W3C for this System.Diagnostics version.
-                        activity.GenerateW3CContext();
-#pragma warning restore 618
-                    }
+                    var idFormat = CorrelationSettings.Current.Protocol == Protocol.W3CTraceContext ? ActivityIdFormat.W3C : ActivityIdFormat.Hierarchical;
+                    activity.SetIdFormat(idFormat);
 
                     activity.Start();
                     Client = await host.StartOrchestrationAsync(orchestrationType, parameter);

--- a/Test/DurableTask.AzureStorage.Tests/Correlation/TelemetryActivator.cs
+++ b/Test/DurableTask.AzureStorage.Tests/Correlation/TelemetryActivator.cs
@@ -23,7 +23,6 @@ namespace DurableTask.AzureStorage.Tests.Correlation
     using Microsoft.ApplicationInsights.DependencyCollector;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
-    using Microsoft.ApplicationInsights.W3C;
 
     public class TelemetryActivator
     {

--- a/Test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
+++ b/Test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
@@ -48,4 +48,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.12.0" />
+  </ItemGroup>
+
 </Project>

--- a/samples/Correlation.Samples/Correlation.Samples.csproj
+++ b/samples/Correlation.Samples/Correlation.Samples.csproj
@@ -22,6 +22,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.12.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/samples/Correlation.Samples/Properties/launchSettings.json
+++ b/samples/Correlation.Samples/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "Correlation.Samples": {
       "commandName": "Project",
       "environmentVariables": {
-        "CorrelationProtocol": "HTTP"
+        "CorrelationProtocol": "W3C"
       }
     }
   }

--- a/samples/Correlation.Samples/ScenarioInvoker.cs
+++ b/samples/Correlation.Samples/ScenarioInvoker.cs
@@ -48,11 +48,11 @@ namespace Correlation.Samples
             {
                 case "HTTP":
                     CorrelationSettings.Current.Protocol = Protocol.HttpCorrelationProtocol;
+                    activity.SetIdFormat(ActivityIdFormat.Hierarchical);
                     return;
                 default:
-#pragma warning disable 618 // GenerateW3CContext() is deprecated. However, it is required for W3C for this version.
-                    activity.GenerateW3CContext();
-#pragma warning restore 618
+                    CorrelationSettings.Current.Protocol = Protocol.W3CTraceContext;
+                    activity.SetIdFormat(ActivityIdFormat.W3C);
                     return;
             }
         }

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -18,14 +18,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.0" />
     <PackageReference Include="System.Reactive.Core" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <!--TODO Planning to remove DenpendencyCollector once we can update DiagnosticSource to 4.6.0+. -->
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.8.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0" />
   </ItemGroup>
   
 </Project>

--- a/src/DurableTask.Core/HttpCorrelationProtocolTraceContext.cs
+++ b/src/DurableTask.Core/HttpCorrelationProtocolTraceContext.cs
@@ -43,6 +43,7 @@ namespace DurableTask.Core
         public override void SetParentAndStart(TraceContextBase parentTraceContext)
         {
             CurrentActivity = new Activity(this.OperationName);
+            CurrentActivity.SetIdFormat(ActivityIdFormat.Hierarchical);
 
             if (parentTraceContext is HttpCorrelationProtocolTraceContext)
             {
@@ -64,6 +65,7 @@ namespace DurableTask.Core
         public override void StartAsNew()
         {
             CurrentActivity = new Activity(this.OperationName);
+            CurrentActivity.SetIdFormat(ActivityIdFormat.Hierarchical);
             CurrentActivity.Start();
 
             ParentId = CurrentActivity.Id;

--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -21,7 +21,6 @@ namespace DurableTask.Core
     using System.Threading.Tasks;
     using DurableTask.Core.History;
     using DurableTask.Core.Serializing;
-    using Microsoft.ApplicationInsights.W3C;
 
     /// <summary>
     ///     Client used to manage and query orchestration instances

--- a/src/DurableTask.Core/TraceContextFactory.cs
+++ b/src/DurableTask.Core/TraceContextFactory.cs
@@ -19,9 +19,6 @@ namespace DurableTask.Core
     using System.Dynamic;
     using System.Text;
     using DurableTask.Core.Settings;
-    using Microsoft.ApplicationInsights.W3C;
-
-#pragma warning disable 618 // GetTraceparent(), GetTracestate() are deprecated. However, it is required for W3C for this System.Diagnostics version.
 
     /// <summary>
     /// Factory of TraceContext
@@ -82,9 +79,9 @@ namespace DurableTask.Core
                 {
                     OperationName = activity.OperationName,
                     StartTime = activity.StartTimeUtc,
-                    TraceParent = activity.GetTraceparent(),
-                    TraceState = activity.GetTracestate(),
-                    ParentSpanId = activity.GetParentSpanId(),
+                    TraceParent = activity.Id,
+                    TraceState = activity.TraceStateString,
+                    ParentSpanId = activity.ParentSpanId.ToHexString(),
                     // ParentId = activity.Id // TODO check if it necessary
                     CurrentActivity = activity
                 };


### PR DESCRIPTION
Hi @cgillum 

I update the System.Diagnostics.Source to 4.6.0 
The reason for this update is: 

* WebJobsHost SDK update the DiagnosticSource to 4.6.0 (See this commit: https://github.com/Azure/azure-webjobs-sdk/commit/5f1f62fa12979846346689e940efc37bb55f113f#diff-71ab67b70c446b3e5c0665fa1e119f0e) 
* We can remove the dependency of Application Insights from the DurableTask.Core
* Fix the problem of W3C tracing on Durable Functions. The 4.6.0 will cause breaking changes in the Activity interface. 
* Portal behavior change of W3C tracing.

For more details about breaking change, you can refer to this blog post. 
https://medium.com/@tsuyoshiushio/system-diagnostics-activity-update-and-distributed-tracing-in-c-f02428dcd050


 