### PR TITLE
Handle null continuation tokens properly in paginated GetInstances API

### DIFF
--- a/Test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -23,6 +23,7 @@ namespace DurableTask.AzureStorage.Tests
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
+    using DurableTask.AzureStorage.Tracking;
     using DurableTask.Core;
     using DurableTask.Core.Exceptions;
     using DurableTask.Core.History;
@@ -162,6 +163,23 @@ namespace DurableTask.AzureStorage.Tests
                 Assert.IsNotNull(results.SingleOrDefault(r => r.Output == "\"Hello, world one!\""));
                 Assert.IsNotNull(results.SingleOrDefault(r => r.Output == "\"Hello, world two!\""));
 
+                await host.StopAsync();
+            }
+        }
+
+        [TestMethod]
+        public async Task NoInstancesGetAllOrchestrationStatusesNullContinuationToken()
+        {
+            using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(enableExtendedSessions: false))
+            {
+                // Execute the orchestrator twice. Orchestrator will be replied. However instances might be two.
+                await host.StartAsync();
+                var queryResult = await host.service.GetOrchestrationStateAsync(
+                    new OrchestrationInstanceStatusQueryCondition(),
+                    100,
+                    null);
+
+                Assert.IsNull(queryResult.ContinuationToken);
                 await host.StopAsync();
             }
         }

--- a/Test/DurableTask.AzureStorage.Tests/TestOrchestrationHost.cs
+++ b/Test/DurableTask.AzureStorage.Tests/TestOrchestrationHost.cs
@@ -22,6 +22,8 @@ namespace DurableTask.AzureStorage.Tests
 
     internal sealed class TestOrchestrationHost : IDisposable
     {
+        internal readonly AzureStorageOrchestrationService service;
+
         readonly AzureStorageOrchestrationServiceSettings settings;
         readonly TaskHubWorker worker;
         readonly TaskHubClient client;
@@ -30,8 +32,8 @@ namespace DurableTask.AzureStorage.Tests
 
         public TestOrchestrationHost(AzureStorageOrchestrationServiceSettings settings)
         {
-            var service = new AzureStorageOrchestrationService(settings);
-            service.CreateAsync().GetAwaiter().GetResult();
+            this.service = new AzureStorageOrchestrationService(settings);
+            this.service.CreateAsync().GetAwaiter().GetResult();
 
             this.settings = settings;
 

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -624,7 +624,7 @@ namespace DurableTask.AzureStorage.Tracking
 
             if (segment.ContinuationToken != null)
             {
-                string tokenJson = JsonConvert.SerializeObject(token);
+                string tokenJson = JsonConvert.SerializeObject(segment.ContinuationToken);
                 queryResult.ContinuationToken = Convert.ToBase64String(Encoding.UTF8.GetBytes(tokenJson));
             }
 

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -617,13 +617,18 @@ namespace DurableTask.AzureStorage.Tracking
             this.stats.StorageRequests.Increment();
             this.stats.TableEntitiesRead.Increment(orchestrationStates.Count);
 
-            token = segment.ContinuationToken;
-            var tokenJson = JsonConvert.SerializeObject(token);
-            return new DurableStatusQueryResult()
+            var queryResult = new DurableStatusQueryResult()
             {
                 OrchestrationState = orchestrationStates,
-                ContinuationToken = Convert.ToBase64String(Encoding.UTF8.GetBytes(tokenJson))
             };
+
+            if (segment.ContinuationToken != null)
+            {
+                string tokenJson = JsonConvert.SerializeObject(token);
+                queryResult.ContinuationToken = Convert.ToBase64String(Encoding.UTF8.GetBytes(tokenJson));
+            }
+
+            return queryResult;
         }
 
         async Task<IList<OrchestrationState>> QueryStateAsync(TableQuery<OrchestrationInstanceStatus> query, CancellationToken cancellationToken)


### PR DESCRIPTION
Previously, when there is a null continuation token in the paginated
GetInstances API call for DurableTask.AzureStorage, we return the base64
encoded value of "null", instead of null.

We now return null properly in this case.