### PR TITLE
Prevent value drift on PendingOrchestrationCount

### DIFF
--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -196,10 +196,8 @@ namespace DurableTask.AzureStorage.Messaging
         {
             lock (this.pendingMessageIds)
             {
-                if (this.pendingMessageIds.Remove(message.OriginalQueueMessage.Id))
-                {
-                    this.stats.PendingOrchestratorMessages.Decrement();
-                }
+                this.pendingMessageIds.Remove(message.OriginalQueueMessage.Id);
+                this.stats.PendingOrchestratorMessages.Decrement();
             }
 
             return base.AbandonMessageAsync(message, session);
@@ -209,10 +207,8 @@ namespace DurableTask.AzureStorage.Messaging
         {
             lock (this.pendingMessageIds)
             {
-                if (this.pendingMessageIds.Remove(message.OriginalQueueMessage.Id))
-                {
-                    this.stats.PendingOrchestratorMessages.Decrement();
-                }
+                this.pendingMessageIds.Remove(message.OriginalQueueMessage.Id);
+                this.stats.PendingOrchestratorMessages.Decrement();
             }
 
             return base.DeleteMessageAsync(message, session);

--- a/src/DurableTask.Core/Stats/Counter.cs
+++ b/src/DurableTask.Core/Stats/Counter.cs
@@ -32,7 +32,10 @@ namespace DurableTask.Core.Stats
         /// </summary>
         public void Increment()
         {
-            Interlocked.Increment(ref this.counterValue);
+            lock (this)
+            {
+                this.counterValue++;
+            }
         }
 
         /// <summary>
@@ -41,15 +44,24 @@ namespace DurableTask.Core.Stats
         /// <param name="value">The value to increment the counter by</param>
         public void Increment(long value)
         {
-            Interlocked.Add(ref this.counterValue, value);
+            lock (this)
+            {
+                this.counterValue += value;
+            }      
         }
 
         /// <summary>
-        /// Decrements the counter by 1
+        /// Decrements the counter by 1. Ensures that counter cannot go below 0.
         /// </summary>
         public void Decrement()
         {
-            Interlocked.Decrement(ref this.counterValue);
+            lock (this)
+            {
+                if (this.counterValue > 0)
+                {
+                    this.counterValue--;
+                }
+            }        
         }
 
         /// <summary>
@@ -58,7 +70,12 @@ namespace DurableTask.Core.Stats
         /// <returns>The value of the counter before it was reset</returns>
         public long Reset()
         {
-            return Interlocked.Exchange(ref this.counterValue, 0);
+            lock (this)
+            {
+                long previousValue = this.counterValue;
+                this.counterValue = 0;
+                return previousValue;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Currently, when a host lease is lost and reclaimed before its pending messages are processed, a new control queue is spun up, losing track of what messages it has already processed.

In an ideal solution, we would find some way to reclaim that old control queue. This commit tracks a more simple workaround in which we don't rely on the message id being present in the current control queues pending messages in order to decrement PendingOrchestrationCount. This may not fix all of the problems (i.e. duplicate messages may be still be double counted in the lease reaquire scenario). It would still be an improvement over the current scenario however.