### PR TITLE
Prevent value drift on PendingOrchestrationMessages

### DIFF
--- a/src/DurableTask.AzureStorage/Monitoring/AzureStorageOrchestrationServiceStats.cs
+++ b/src/DurableTask.AzureStorage/Monitoring/AzureStorageOrchestrationServiceStats.cs
@@ -14,6 +14,7 @@
 namespace DurableTask.AzureStorage.Monitoring
 {
     using DurableTask.Core.Stats;
+    using System.Collections.Concurrent;
 
     class AzureStorageOrchestrationServiceStats
     {
@@ -31,6 +32,8 @@ namespace DurableTask.AzureStorage.Monitoring
 
         public Counter ActiveActivityExecutions { get; } = new Counter();
 
-        public Counter PendingOrchestratorMessages { get; } = new Counter();
+        // The standard library does not support a concurrent hashset, so use ConcurrentDictionary with the
+        // value as a byte, as the value does not matter.
+        public ConcurrentDictionary<string, byte> PendingOrchestratorMessages { get; } = new ConcurrentDictionary<string, byte>();
     }
 }

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -413,7 +413,7 @@ namespace DurableTask.AzureStorage
             lock (this.messageAndSessionLock)
             {
                 pendingOrchestratorInstances = this.pendingOrchestrationMessageBatches.Count;
-                pendingOrchestrationMessages = (int)this.stats.PendingOrchestratorMessages.Value;
+                pendingOrchestrationMessages = (int)this.stats.PendingOrchestratorMessages.Count;
                 activeOrchestrationSessions = this.activeOrchestrationSessions.Count;
             }
         }


### PR DESCRIPTION
Currently, when a host lease is lost and reclaimed before its pending messages are processed, a new control queue is spun up, losing track of what messages it has already processed.

This PR keeps track of pending messages in the shared AzureStorageOrchestrationServiceStats class, so that even when a new control queue is spun up, the pending messages from a previous iteration are still available.