### PR TITLE
Hotfix for DTFX logging issue

### DIFF
--- a/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
+++ b/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>net461</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Microsoft.Azure.DurableTask.AzureServiceFabric</PackageId>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
   </PropertyGroup>

--- a/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
+++ b/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>net461</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Microsoft.Azure.DurableTask.AzureServiceFabric</PackageId>
-    <Version>2.4.0</Version>
+    <Version>2.3.1</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
   </PropertyGroup>

--- a/src/DurableTask.AzureServiceFabric/Remote/RemoteOrchestrationServiceClient.cs
+++ b/src/DurableTask.AzureServiceFabric/Remote/RemoteOrchestrationServiceClient.cs
@@ -270,7 +270,7 @@ namespace DurableTask.AzureServiceFabric.Remote
 
             if (!result.IsSuccessStatusCode)
             {
-                var content = await result.Content.ReadAsStringAsync();
+                var content = await result.Content?.ReadAsStringAsync();
                 throw new RemoteServiceException($"CreateTaskOrchestrationAsync failed with status code {result.StatusCode}: {content}", result.StatusCode);
             }
         }

--- a/src/DurableTask.AzureServiceFabric/Remote/RemoteOrchestrationServiceClient.cs
+++ b/src/DurableTask.AzureServiceFabric/Remote/RemoteOrchestrationServiceClient.cs
@@ -270,7 +270,7 @@ namespace DurableTask.AzureServiceFabric.Remote
 
             if (!result.IsSuccessStatusCode)
             {
-                throw new RemoteServiceException("CreateTaskOrchestrationAsync failed", result.StatusCode);
+                throw new RemoteServiceException($"CreateTaskOrchestrationAsync failed with status code {result.StatusCode}: {result.ToString()}", result.StatusCode);
             }
         }
 

--- a/src/DurableTask.AzureServiceFabric/Remote/RemoteOrchestrationServiceClient.cs
+++ b/src/DurableTask.AzureServiceFabric/Remote/RemoteOrchestrationServiceClient.cs
@@ -270,7 +270,8 @@ namespace DurableTask.AzureServiceFabric.Remote
 
             if (!result.IsSuccessStatusCode)
             {
-                throw new RemoteServiceException($"CreateTaskOrchestrationAsync failed with status code {result.StatusCode}: {result.ToString()}", result.StatusCode);
+                var content = await result.Content.ReadAsStringAsync();
+                throw new RemoteServiceException($"CreateTaskOrchestrationAsync failed with status code {result.StatusCode}: {content}", result.StatusCode);
             }
         }
 

--- a/src/DurableTask.AzureServiceFabric/Service/ActivityLoggingMessageHandler.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/ActivityLoggingMessageHandler.cs
@@ -26,13 +26,13 @@ namespace DurableTask.AzureServiceFabric.Service
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             string requestMethod = request.Method.ToString();
-            string requestUri = request.RequestUri.AbsolutePath;
+            string requestUri = request.RequestUri.ToString();
             ServiceFabricProviderEventSource.Tracing.LogProxyServiceRequestInformation($"Proxy service incoming request {requestUri} with method {requestMethod}");
             HttpResponseMessage response = null;
             try
             {
                 response = await base.SendAsync(request, cancellationToken);
-                ServiceFabricProviderEventSource.Tracing.LogProxyServiceRequestInformation($"Proxy service responding request {requestUri} with method {requestMethod}");
+                ServiceFabricProviderEventSource.Tracing.LogProxyServiceRequestInformation($"Proxy service responding request {requestUri} with method {requestMethod} with status code {response.StatusCode}");
             }
             catch (Exception exception)
             {

--- a/src/DurableTask.AzureServiceFabric/Service/Startup.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/Startup.cs
@@ -56,6 +56,7 @@ namespace DurableTask.AzureServiceFabric.Service
             HttpConfiguration config = new HttpConfiguration();
             config.MapHttpAttributeRoutes();
             config.DependencyResolver = new DefaultDependencyResolver(GenerateServiceProvider());
+            config.MessageHandlers.Add(new ActivityLoggingMessageHandler());
             config.IncludeErrorDetailPolicy = IncludeErrorDetailPolicy.Always;
             config.Formatters.Remove(config.Formatters.XmlFormatter);
             config.Formatters.Remove(config.Formatters.FormUrlEncodedFormatter);


### PR DESCRIPTION
1. Logging response code and reponse content details when Create Orchestration Failed
2. Register ActivityLoggingMessageHandler as logging provider and provide full uri & reponse code & details
3. Bump up version