### PR TITLE
Add optional parameter to remove some telemetry for performance reasons

### DIFF
--- a/src/DurableTask.Core/OrchestrationRuntimeState.cs
+++ b/src/DurableTask.Core/OrchestrationRuntimeState.cs
@@ -257,28 +257,40 @@ namespace DurableTask.Core
         /// <summary>
         /// Gets a statedump of the current list of events
         /// </summary>
+        /// <param name="abridgedDump">A full dump can be expensive, so this optional parameter just grabs the count of events.</param>
         /// <returns></returns>
-        public OrchestrationRuntimeStateDump GetOrchestrationRuntimeStateDump()
+        public OrchestrationRuntimeStateDump GetOrchestrationRuntimeStateDump(bool abridgedDump)
         {
-            var runtimeStateDump = new OrchestrationRuntimeStateDump
+            if (abridgedDump)
             {
-                Events = new List<HistoryEvent>(),
-                NewEvents = new List<HistoryEvent>(),
-            };
-
-            foreach (HistoryEvent evt in Events)
-            {
-                HistoryEvent abridgeEvent = GenerateAbridgedEvent(evt);
-                runtimeStateDump.Events.Add(abridgeEvent);
+                return new OrchestrationRuntimeStateDump
+                {
+                    EventCount = Events.Count,
+                    NewEventsCount = NewEvents.Count,
+                };
             }
-
-            foreach (HistoryEvent evt in NewEvents)
+            else
             {
-                HistoryEvent abridgeEvent = GenerateAbridgedEvent(evt);
-                runtimeStateDump.NewEvents.Add(abridgeEvent);
-            }
+                var runtimeStateDump = new OrchestrationRuntimeStateDump
+                {
+                    Events = new List<HistoryEvent>(),
+                    NewEvents = new List<HistoryEvent>(),
+                };
 
-            return runtimeStateDump;
+                foreach (HistoryEvent evt in Events)
+                {
+                    HistoryEvent abridgeEvent = GenerateAbridgedEvent(evt);
+                    runtimeStateDump.Events.Add(abridgeEvent);
+                }
+
+                foreach (HistoryEvent evt in NewEvents)
+                {
+                    HistoryEvent abridgeEvent = GenerateAbridgedEvent(evt);
+                    runtimeStateDump.NewEvents.Add(abridgeEvent);
+                }
+
+                return runtimeStateDump;
+            }
         }
 
         HistoryEvent GenerateAbridgedEvent(HistoryEvent evt)

--- a/src/DurableTask.Core/OrchestrationRuntimeStateDump.cs
+++ b/src/DurableTask.Core/OrchestrationRuntimeStateDump.cs
@@ -22,6 +22,16 @@ namespace DurableTask.Core
     public class OrchestrationRuntimeStateDump
     {
         /// <summary>
+        /// The number of history events. Used in the case where we use the lighter-weight dump.
+        /// </summary>
+        public int EventCount { get; set; }
+
+        /// <summary>
+        /// The number of new events. Used in the case where we use the lighter-weight dump.
+        /// </summary>
+        public int NewEventsCount { get; set; }
+
+        /// <summary>
         /// List of all history events for this runtime state dump
         /// </summary>
         public IList<HistoryEvent> Events;

--- a/src/DurableTask.Core/TaskHubWorker.cs
+++ b/src/DurableTask.Core/TaskHubWorker.cs
@@ -25,7 +25,7 @@ namespace DurableTask.Core
     /// </summary>
     public sealed class TaskHubWorker : IDisposable
     {
-        readonly bool efficientTelemetry
+        readonly bool efficientTelemetry;
         readonly INameVersionObjectManager<TaskActivity> activityManager;
         readonly INameVersionObjectManager<TaskOrchestration> orchestrationManager;
 

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -40,15 +40,18 @@ namespace DurableTask.Core
         readonly WorkItemDispatcher<TaskOrchestrationWorkItem> dispatcher;
         readonly DispatchMiddlewarePipeline dispatchPipeline;
         readonly NonBlockingCountdownLock concurrentSessionLock;
+        readonly bool efficientTelemetry;
 
         internal TaskOrchestrationDispatcher(
             IOrchestrationService orchestrationService,
             INameVersionObjectManager<TaskOrchestration> objectManager,
-            DispatchMiddlewarePipeline dispatchPipeline)
+            DispatchMiddlewarePipeline dispatchPipeline,
+            bool efficientTelemetry)
         {
             this.objectManager = objectManager ?? throw new ArgumentNullException(nameof(objectManager));
             this.orchestrationService = orchestrationService ?? throw new ArgumentNullException(nameof(orchestrationService));
             this.dispatchPipeline = dispatchPipeline ?? throw new ArgumentNullException(nameof(dispatchPipeline));
+            this.efficientTelemetry = efficientTelemetry;
 
             this.dispatcher = new WorkItemDispatcher<TaskOrchestrationWorkItem>(
                 "TaskOrchestrationDispatcher",
@@ -235,7 +238,7 @@ namespace DurableTask.Core
                         "TaskOrchestrationDispatcher-ExecuteUserOrchestration-Begin",
                         runtimeState.OrchestrationInstance,
                         "Executing user orchestration: {0}",
-                        DataConverter.Serialize(runtimeState.GetOrchestrationRuntimeStateDump(), true));
+                        DataConverter.Serialize(runtimeState.GetOrchestrationRuntimeStateDump(this.efficientTelemetry), true));
 
                     if (workItem.Cursor == null)
                     {


### PR DESCRIPTION
Add a flag to TaskHubWorker and some of its internal classes in order to
flag that we prefer performance over perfectly detailed telemetry.

Currently the only telemetry this field affects is the runtime state
dump. This is a linear operation with the size of the event history,
and even if you filter out trace/information level events, there is
still the computational cost of creating the dump. In efficient
telemetry mode, we only emit the number of events rather than the events
themselves.