### PR TITLE
Improve performance of the runtime state dump

### DIFF
--- a/src/DurableTask.Core/OrchestrationRuntimeState.cs
+++ b/src/DurableTask.Core/OrchestrationRuntimeState.cs
@@ -255,30 +255,16 @@ namespace DurableTask.Core
         }
 
         /// <summary>
-        /// Gets a statedump of the current list of events
+        /// Gets a statedump of the current list of events.
         /// </summary>
         /// <returns></returns>
         public OrchestrationRuntimeStateDump GetOrchestrationRuntimeStateDump()
         {
-            var runtimeStateDump = new OrchestrationRuntimeStateDump
+            return new OrchestrationRuntimeStateDump
             {
-                Events = new List<HistoryEvent>(),
-                NewEvents = new List<HistoryEvent>(),
+                EventCount = Events.Count,
+                NewEventsCount = NewEvents.Count,
             };
-
-            foreach (HistoryEvent evt in Events)
-            {
-                HistoryEvent abridgeEvent = GenerateAbridgedEvent(evt);
-                runtimeStateDump.Events.Add(abridgeEvent);
-            }
-
-            foreach (HistoryEvent evt in NewEvents)
-            {
-                HistoryEvent abridgeEvent = GenerateAbridgedEvent(evt);
-                runtimeStateDump.NewEvents.Add(abridgeEvent);
-            }
-
-            return runtimeStateDump;
         }
 
         HistoryEvent GenerateAbridgedEvent(HistoryEvent evt)

--- a/src/DurableTask.Core/OrchestrationRuntimeState.cs
+++ b/src/DurableTask.Core/OrchestrationRuntimeState.cs
@@ -260,11 +260,33 @@ namespace DurableTask.Core
         /// <returns></returns>
         public OrchestrationRuntimeStateDump GetOrchestrationRuntimeStateDump()
         {
+#if DEBUG
+            var runtimeStateDump = new OrchestrationRuntimeStateDump
+            {
+                Events = new List<HistoryEvent>(),
+                NewEvents = new List<HistoryEvent>(),
+            };
+
+            foreach (HistoryEvent evt in Events)
+            {
+                HistoryEvent abridgeEvent = GenerateAbridgedEvent(evt);
+                runtimeStateDump.Events.Add(abridgeEvent);
+            }
+
+            foreach (HistoryEvent evt in NewEvents)
+            {
+                HistoryEvent abridgeEvent = GenerateAbridgedEvent(evt);
+                runtimeStateDump.NewEvents.Add(abridgeEvent);
+            }
+
+            return runtimeStateDump;
+#else
             return new OrchestrationRuntimeStateDump
             {
                 EventCount = Events.Count,
                 NewEventsCount = NewEvents.Count,
             };
+#endif
         }
 
         HistoryEvent GenerateAbridgedEvent(HistoryEvent evt)

--- a/src/DurableTask.Core/OrchestrationRuntimeStateDump.cs
+++ b/src/DurableTask.Core/OrchestrationRuntimeStateDump.cs
@@ -13,22 +13,20 @@
 
 namespace DurableTask.Core
 {
-    using DurableTask.Core.History;
-    using System.Collections.Generic;
-
     /// <summary>
     /// A snapshot / state dump of an OrchestrationRuntimeState's events
     /// </summary>
     public class OrchestrationRuntimeStateDump
     {
         /// <summary>
-        /// List of all history events for this runtime state dump
+        /// The number of history events.
         /// </summary>
-        public IList<HistoryEvent> Events;
+        public int EventCount { get; set; }
 
         /// <summary>
-        /// List of new events added during an execution for this runtime state dump
+        /// The number of new events.
         /// </summary>
-        public IList<HistoryEvent> NewEvents;
+        public int NewEventsCount { get; set; }
+
     }
 }

--- a/src/DurableTask.Core/OrchestrationRuntimeStateDump.cs
+++ b/src/DurableTask.Core/OrchestrationRuntimeStateDump.cs
@@ -13,20 +13,32 @@
 
 namespace DurableTask.Core
 {
+    using DurableTask.Core.History;
+    using System.Collections.Generic;
+
     /// <summary>
     /// A snapshot / state dump of an OrchestrationRuntimeState's events
     /// </summary>
     public class OrchestrationRuntimeStateDump
     {
         /// <summary>
-        /// The number of history events.
+        /// The number of all history events for this runtime state dump.
         /// </summary>
         public int EventCount { get; set; }
 
         /// <summary>
-        /// The number of new events.
+        /// The number of new events added during an execution for this runtime state dump.
         /// </summary>
         public int NewEventsCount { get; set; }
 
+        /// <summary>
+        /// List of all history events for this runtime state dump
+        /// </summary>
+        public IList<HistoryEvent> Events;
+
+        /// <summary>
+        /// List of new events added during an execution for this runtime state dump
+        /// </summary>
+        public IList<HistoryEvent> NewEvents;
     }
 }


### PR DESCRIPTION
The actions of dumping the orchestration state for the telemetry event
type TaskOrchestrationDispatcher-ExecuteUserOrchestration-Begin is
expensive. It scales linearly with the number of events, meaning
orchestrations with large histories start to spend most of their time
writing this verbose telemetry item, which is not ideal.

Instead, we now just log the number of events, as this is a constant
time operation.