### PR TITLE
Make HistoryEvent's IsPlayed and Timestamp properties settable

### DIFF
--- a/src/DurableTask.Core/History/HistoryEvent.cs
+++ b/src/DurableTask.Core/History/HistoryEvent.cs
@@ -70,13 +70,13 @@ namespace DurableTask.Core.History
         /// Gets the IsPlayed status
         /// </summary>
         [DataMember]
-        public bool IsPlayed { get; internal set; }
+        public bool IsPlayed { get; set; }
 
         /// <summary>
         /// Gets the event timestamp
         /// </summary>
         [DataMember]
-        public DateTime Timestamp { get; internal set; }
+        public DateTime Timestamp { get; set; }
 
         /// <summary>
         /// Gets the event type


### PR DESCRIPTION
Small change required for a DurableTask.SqlServer prototype that I'm working on.

The intent is to allow providers to load history events from storage without necessarily using serialization.