### PR TITLE
Update Microsoft.Azure.ServiceBus to 4.1.3

### DIFF
--- a/src/DurableTask.ServiceBus/Common/Abstraction/ServiceBusAbstraction.cs
+++ b/src/DurableTask.ServiceBus/Common/Abstraction/ServiceBusAbstraction.cs
@@ -468,6 +468,12 @@ namespace DurableTask.ServiceBus.Common.Abstraction
         {
         }
 
+        public ServiceBusConnection(string namespaceConnectionString, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null)
+            : base(namespaceConnectionString, retryPolicy)
+        {
+        }
+
+        [Obsolete]
         public ServiceBusConnection(string namespaceConnectionString, TimeSpan operationTimeout, Microsoft.Azure.ServiceBus.RetryPolicy retryPolicy = null)
             : base(namespaceConnectionString, operationTimeout, retryPolicy)
         {

--- a/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
+++ b/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.3.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
   </ItemGroup>
 

--- a/test/DurableTask.ServiceBus.Tests/DurableTask.ServiceBus.Tests.csproj
+++ b/test/DurableTask.ServiceBus.Tests/DurableTask.ServiceBus.Tests.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.3.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />

--- a/test/DurableTask.Stress.Tests/DurableTask.Stress.Tests.csproj
+++ b/test/DurableTask.Stress.Tests/DurableTask.Stress.Tests.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
 	  <PackageReference Include="CommandLineParser" Version="2.4.3" />
-	  <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.3.0" />
+	  <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
 	  <PackageReference Include="Microsoft.Diagnostics.EventFlow.Core" Version="1.5.6" />
 	  <PackageReference Include="Microsoft.Diagnostics.EventFlow.Inputs.EventSource" Version="1.4.3" />
 	  <PackageReference Include="Microsoft.Diagnostics.EventFlow.Outputs.StdOutput" Version="1.4.0" />


### PR DESCRIPTION
Issue: DurableTask.ServiceBus prevents using the latest `Microsoft.IdentityModel.Clients.ActiveDirectory` package as it causes a dependency on < 5.0.0 due to its usage of `Microsoft.Azure.ServiceBus, 3.3.0` in netstandard. Updating this package removes this conflict.

The only significant change in this update is the deprecation of a constructor, which I added a new one for and marked the current one `[Obsolete]`