### PR TITLE
Use DownloadToStreamAsync(Stream) to download blob contents

### DIFF
--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -206,9 +206,14 @@ namespace DurableTask.AzureStorage
 
         private async Task<string> DownloadAndDecompressAsBytesAsync(CloudBlockBlob cloudBlockBlob)
         {
-            Stream downloadBlobAsStream = await cloudBlockBlob.OpenReadAsync();
-            ArraySegment<byte> decompressedSegment = this.Decompress(downloadBlobAsStream);
-            return Encoding.UTF8.GetString(decompressedSegment.Array, 0, decompressedSegment.Count);
+            using (MemoryStream memory = new MemoryStream(MaxStorageQueuePayloadSizeInBytes * 2))
+            {
+                await cloudBlockBlob.DownloadToStreamAsync(memory);
+                memory.Position = 0;
+
+                ArraySegment<byte> decompressedSegment = this.Decompress(memory);
+                return Encoding.UTF8.GetString(decompressedSegment.Array, 0, decompressedSegment.Count);
+            }
         }
 
         internal string GetBlobUrl(string blobName)


### PR DESCRIPTION
This change resolves [issue #1406](https://github.com/Azure/azure-functions-durable-extension/issues/1406) from the azure-function-durable-extension repo.

The current implementation to download contents from a blob (`OpenReadAsync()`) has a chance to result in a race condition, but switching to using the `DownloadToStreamAsync(Stream)` API would solve this issue.