### PR TITLE
Downgrade DurableTask.SqlServer.Tests to netcore2.1

### DIFF
--- a/test/DurableTask.SqlServer.Tests/DurableTask.SqlServer.Tests.csproj
+++ b/test/DurableTask.SqlServer.Tests/DurableTask.SqlServer.Tests.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/DurableTask.SqlServer.Tests/DurableTask.SqlServer.Tests.csproj
+++ b/test/DurableTask.SqlServer.Tests/DurableTask.SqlServer.Tests.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Tests were written in netcore2.2, which is EOL, so it is no longer
supported by the latest version of the .NET SDK used in the CI pipeline.
We have to downgrading to 2.1, as 3.1 is not supported on our VS2017 agents.