### PR TITLE
[ServiceFabric-V1] Enable an option to cleanup the orchestration from the store

### DIFF
--- a/src/DurableTask.ServiceFabric/FabricOrchestrationServiceClient.cs
+++ b/src/DurableTask.ServiceFabric/FabricOrchestrationServiceClient.cs
@@ -91,7 +91,7 @@ namespace DurableTask.ServiceFabric
                 throw new ArgumentException($"No execution id found for given instanceId {instanceId}, can only terminate the latest execution of a given orchestration");
             }
 
-            if (reason.Trim().StartsWith("CleanupStore", StringComparison.OrdinalIgnoreCase))
+            if (reason!= null && reason.Trim().StartsWith("CleanupStore", StringComparison.OrdinalIgnoreCase))
             {
                 using (var txn = this.stateManager.CreateTransaction())
                 {

--- a/src/DurableTask.ServiceFabric/FabricOrchestrationServiceClient.cs
+++ b/src/DurableTask.ServiceFabric/FabricOrchestrationServiceClient.cs
@@ -107,7 +107,6 @@ namespace DurableTask.ServiceFabric
             }
             else
             {
-
                 var taskMessage = new TaskMessage
                 {
                     OrchestrationInstance = new OrchestrationInstance { InstanceId = instanceId, ExecutionId = latestExecutionId },
@@ -123,7 +122,7 @@ namespace DurableTask.ServiceFabric
             var stateInstances = await this.instanceStore.GetOrchestrationStateAsync(instanceId, allExecutions);
 
             var result = new List<OrchestrationState>();
-            foreach(var stateInstance in stateInstances)
+            foreach (var stateInstance in stateInstances)
             {
                 if (stateInstance != null)
                 {

--- a/src/DurableTask.ServiceFabric/FabricOrchestrationServiceClient.cs
+++ b/src/DurableTask.ServiceFabric/FabricOrchestrationServiceClient.cs
@@ -91,7 +91,7 @@ namespace DurableTask.ServiceFabric
                 throw new ArgumentException($"No execution id found for given instanceId {instanceId}, can only terminate the latest execution of a given orchestration");
             }
 
-            if (reason!= null && reason.Trim().StartsWith("CleanupStore", StringComparison.OrdinalIgnoreCase))
+            if (reason?.Trim().StartsWith("CleanupStore", StringComparison.OrdinalIgnoreCase) == true)
             {
                 using (var txn = this.stateManager.CreateTransaction())
                 {

--- a/src/DurableTask.ServiceFabric/FabricOrchestrationServiceClient.cs
+++ b/src/DurableTask.ServiceFabric/FabricOrchestrationServiceClient.cs
@@ -95,7 +95,6 @@ namespace DurableTask.ServiceFabric
             {
                 using (var txn = this.stateManager.CreateTransaction())
                 {
-
                     // DropSession does 2 things (like mentioned in the comments above) - remove the row from sessions dictionary
                     // and delete the session messages dictionary. The second step is in a background thread and not part of transaction.
                     // However even if this transaction failed but we ended up deleting session messages dictionary, that's ok - at


### PR DESCRIPTION
This is change is specific to V1 implementation of Service Fabric provider. We needed to terminate orchestration from the store if the graceful cleanup fails.