### PR TITLE
Structured and extensible logging

### DIFF
--- a/samples/DurableTask.Samples/DurableTask.Samples.csproj
+++ b/samples/DurableTask.Samples/DurableTask.Samples.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net451</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -16,6 +16,7 @@ namespace DurableTask.AzureStorage
     using System;
     using System.Diagnostics.Tracing;
     using System.Threading;
+    using DurableTask.AzureStorage.Logging;
 
     /// <summary>
     /// ETW Event Provider for the DurableTask.AzureStorage provider extension.
@@ -41,7 +42,7 @@ namespace DurableTask.AzureStorage
             SetCurrentThreadActivityId(activityId);
         }
 
-        [Event(101, Level = EventLevel.Informational, Opcode = EventOpcode.Send, Task = Tasks.Enqueue, Version = 5)]
+        [Event(EventIds.SendingMessage, Level = EventLevel.Informational, Opcode = EventOpcode.Send, Task = Tasks.Enqueue, Version = 5)]
         public void SendingMessage(
             Guid relatedActivityId,
             string Account,
@@ -59,7 +60,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEventWithRelatedActivityId(
-                101,
+                EventIds.SendingMessage,
                 relatedActivityId,
                 Account,
                 TaskHub,
@@ -76,7 +77,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(102, Level = EventLevel.Informational, Opcode = EventOpcode.Receive, Task = Tasks.Dequeue, Version = 5)]
+        [Event(EventIds.ReceivedMessage, Level = EventLevel.Informational, Opcode = EventOpcode.Receive, Task = Tasks.Dequeue, Version = 5)]
         public void ReceivedMessage(
             Guid relatedActivityId,
             string Account,
@@ -96,7 +97,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEventWithRelatedActivityId(
-                102,
+                EventIds.ReceivedMessage,
                 relatedActivityId,
                 Account,
                 TaskHub,
@@ -115,7 +116,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(103, Level = EventLevel.Informational, Version = 4)]
+        [Event(EventIds.DeletingMessage, Level = EventLevel.Informational, Version = 4)]
         public void DeletingMessage(
             string Account,
             string TaskHub,
@@ -129,7 +130,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                103,
+                EventIds.DeletingMessage,
                 Account,
                 TaskHub,
                 EventType,
@@ -142,7 +143,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(104, Level = EventLevel.Warning, Version = 5)]
+        [Event(EventIds.AbandoningMessage, Level = EventLevel.Warning, Version = 5)]
         public void AbandoningMessage(
             string Account,
             string TaskHub,
@@ -157,7 +158,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                104,
+                EventIds.AbandoningMessage,
                 Account,
                 TaskHub,
                 EventType,
@@ -171,31 +172,31 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(105, Level = EventLevel.Warning, Message = "An unexpected condition was detected: {2}")]
+        [Event(EventIds.AssertFailure, Level = EventLevel.Warning, Message = "An unexpected condition was detected: {2}")]
         public void AssertFailure(
             string Account,
             string TaskHub,
             string Details,
             string ExtensionVersion)
         {
-            this.WriteEvent(105, Account, TaskHub, Details, ExtensionVersion);
+            this.WriteEvent(EventIds.AssertFailure, Account, TaskHub, Details, ExtensionVersion);
         }
 
-        [Event(106, Level = EventLevel.Warning, Version = 3)]
+        [Event(EventIds.MessageGone, Level = EventLevel.Warning, Version = 4)]
         public void MessageGone(
             string Account,
             string TaskHub,
+            string EventType,
+            int TaskEventId,
             string MessageId,
             string InstanceId,
             string ExecutionId,
             string PartitionId,
-            string EventType,
-            int TaskEventId,
             string Details,
             string ExtensionVersion)
         {
             this.WriteEvent(
-                106,
+                EventIds.MessageGone,
                 Account,
                 TaskHub,
                 MessageId,
@@ -208,16 +209,18 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(107, Level = EventLevel.Error)]
+        [Event(EventIds.GeneralError, Level = EventLevel.Error)]
         public void GeneralError(string Account, string TaskHub, string Details, string ExtensionVersion)
         {
-            this.WriteEvent(107, Account, TaskHub, Details, ExtensionVersion);
+            this.WriteEvent(EventIds.GeneralError, Account, TaskHub, Details, ExtensionVersion);
         }
 
-        [Event(108, Level = EventLevel.Warning, Version = 2, Message = "A duplicate message was detected. This can indicate a potential performance problem. Message ID = '{2}'. DequeueCount = {3}.")]
+        [Event(EventIds.DuplicateMessageDetected, Level = EventLevel.Warning, Version = 3, Message = "A duplicate message was detected. This can indicate a potential performance problem. Message ID = '{4}'. DequeueCount = {8}.")]
         public void DuplicateMessageDetected(
             string Account,
             string TaskHub,
+            string EventType,
+            int TaskEventId,
             string MessageId,
             string InstanceId,
             string ExecutionId,
@@ -226,9 +229,11 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                108,
+                EventIds.DuplicateMessageDetected,
                 Account,
                 TaskHub,
+                EventType,
+                TaskEventId,
                 MessageId,
                 InstanceId,
                 ExecutionId ?? string.Empty,
@@ -237,10 +242,12 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(109, Level = EventLevel.Warning, Message = "A poison message was detected! Message ID = '{2}'. DequeueCount = {6}.")]
+        [Event(EventIds.PoisonMessageDetected, Level = EventLevel.Warning, Message = "A poison message was detected! Message ID = '{4}'. DequeueCount = {8}.")]
         public void PoisonMessageDetected(
             string Account,
             string TaskHub,
+            string EventType,
+            int TaskEventId,
             string MessageId,
             string InstanceId,
             string ExecutionId,
@@ -249,9 +256,11 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                109,
+                EventIds.PoisonMessageDetected,
                 Account,
                 TaskHub,
+                EventType,
+                TaskEventId,
                 MessageId,
                 InstanceId,
                 ExecutionId ?? string.Empty,
@@ -260,7 +269,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(110, Level = EventLevel.Informational, Version = 3)]
+        [Event(EventIds.FetchedInstanceHistory, Level = EventLevel.Informational, Version = 3)]
         public void FetchedInstanceHistory(
             string Account,
             string TaskHub,
@@ -275,7 +284,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                110,
+                EventIds.FetchedInstanceHistory,
                 Account,
                 TaskHub,
                 InstanceId,
@@ -289,7 +298,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(111, Level = EventLevel.Informational, Version = 4)]
+        [Event(EventIds.AppendedInstanceHistory, Level = EventLevel.Informational, Version = 4)]
         public void AppendedInstanceHistory(
             string Account,
             string TaskHub,
@@ -306,7 +315,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                111,
+                EventIds.AppendedInstanceHistory,
                 Account,
                 TaskHub,
                 InstanceId,
@@ -322,7 +331,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(112, Level = EventLevel.Informational)]
+        [Event(EventIds.OrchestrationServiceStats, Level = EventLevel.Informational)]
         public void OrchestrationServiceStats(
             string Account,
             string TaskHub,
@@ -339,7 +348,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                112,
+                EventIds.OrchestrationServiceStats,
                 Account,
                 TaskHub,
                 StorageRequests,
@@ -355,7 +364,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(113, Level = EventLevel.Informational, Version = 2)]
+        [Event(EventIds.RenewingMessage, Level = EventLevel.Informational, Version = 2)]
         public void RenewingMessage(
             string Account,
             string TaskHub,
@@ -369,7 +378,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                113,
+                EventIds.RenewingMessage,
                 Account,
                 TaskHub,
                 InstanceId,
@@ -382,7 +391,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(114, Level = EventLevel.Error, Version = 2)]
+        [Event(EventIds.MessageFailure, Level = EventLevel.Error, Version = 2)]
         public void MessageFailure(
             string Account,
             string TaskHub,
@@ -396,7 +405,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                114,
+                EventIds.MessageFailure,
                 Account,
                 TaskHub,
                 MessageId,
@@ -409,7 +418,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(115, Level = EventLevel.Error)]
+        [Event(EventIds.OrchestrationProcessingFailure, Level = EventLevel.Error)]
         public void OrchestrationProcessingFailure(
             string Account,
             string TaskHub,
@@ -419,7 +428,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                115,
+                EventIds.OrchestrationProcessingFailure,
                 Account,
                 TaskHub,
                 InstanceId,
@@ -428,7 +437,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(116, Level = EventLevel.Informational, Version = 2)]
+        [Event(EventIds.PendingOrchestratorMessageLimitReached, Level = EventLevel.Informational, Version = 2)]
         public void PendingOrchestratorMessageLimitReached(
             string Account,
             string TaskHub,
@@ -437,7 +446,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                116,
+                EventIds.PendingOrchestratorMessageLimitReached,
                 Account,
                 TaskHub,
                 PartitionId,
@@ -445,7 +454,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(117, Level = EventLevel.Informational)]
+        [Event(EventIds.WaitingForMoreMessages, Level = EventLevel.Informational)]
         public void WaitingForMoreMessages(
             string Account,
             string TaskHub,
@@ -453,14 +462,14 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                117,
+                EventIds.WaitingForMoreMessages,
                 Account,
                 TaskHub,
                 PartitionId,
                 ExtensionVersion);
         }
 
-        [Event(118, Level = EventLevel.Warning, Version = 3)]
+        [Event(EventIds.ReceivedOutOfOrderMessage, Level = EventLevel.Warning, Version = 3)]
         public void ReceivedOutOfOrderMessage(
             string Account,
             string TaskHub,
@@ -475,7 +484,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                118,
+                EventIds.ReceivedOutOfOrderMessage,
                 Account,
                 TaskHub,
                 InstanceId,
@@ -489,7 +498,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(120, Level = EventLevel.Informational, Version = 2)]
+        [Event(EventIds.PartitionManagerInfo, Level = EventLevel.Informational, Version = 2)]
         public void PartitionManagerInfo(
             string Account,
             string TaskHub,
@@ -498,10 +507,17 @@ namespace DurableTask.AzureStorage
             string Details,
             string ExtensionVersion)
         {
-            this.WriteEvent(120, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, Details, ExtensionVersion);
+            this.WriteEvent(
+                EventIds.PartitionManagerInfo,
+                Account,
+                TaskHub,
+                WorkerName ?? string.Empty,
+                PartitionId ?? string.Empty,
+                Details,
+                ExtensionVersion);
         }
 
-        [Event(121, Level = EventLevel.Warning, Version = 2)]
+        [Event(EventIds.PartitionManagerWarning, Level = EventLevel.Warning, Version = 2)]
         public void PartitionManagerWarning(
             string Account,
             string TaskHub,
@@ -510,7 +526,14 @@ namespace DurableTask.AzureStorage
             string Details,
             string ExtensionVersion)
         {
-            this.WriteEvent(121, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, Details ?? string.Empty, ExtensionVersion);
+            this.WriteEvent(
+                EventIds.PartitionManagerWarning,
+                Account,
+                TaskHub,
+                WorkerName ?? string.Empty,
+                PartitionId ?? string.Empty,
+                Details ?? string.Empty,
+                ExtensionVersion);
         }
 
         [NonEvent]
@@ -525,7 +548,7 @@ namespace DurableTask.AzureStorage
             this.PartitionManagerError(account, taskHub, workerName, partitionId, exception.ToString(), ExtensionVersion);
         }
 
-        [Event(122, Level = EventLevel.Error, Version = 2)]
+        [Event(EventIds.PartitionManagerError, Level = EventLevel.Error, Version = 2)]
         public void PartitionManagerError(
             string Account,
             string TaskHub,
@@ -534,10 +557,17 @@ namespace DurableTask.AzureStorage
             string Details,
             string ExtensionVersion)
         {
-            this.WriteEvent(122, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, Details ?? string.Empty, ExtensionVersion);
+            this.WriteEvent(
+                EventIds.PartitionManagerError,
+                Account,
+                TaskHub,
+                WorkerName ?? string.Empty,
+                PartitionId ?? string.Empty,
+                Details ?? string.Empty,
+                ExtensionVersion);
         }
 
-        [Event(123, Level = EventLevel.Verbose, Message = "Host '{2}' renewing lease for PartitionId '{3}' with lease token '{4}'.")]
+        [Event(EventIds.StartingLeaseRenewal, Level = EventLevel.Verbose, Message = "Host '{2}' renewing lease for PartitionId '{3}' with lease token '{4}'.")]
         public void StartingLeaseRenewal(
             string Account,
             string TaskHub,
@@ -547,7 +577,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                123,
+                EventIds.StartingLeaseRenewal,
                 Account,
                 TaskHub,
                 WorkerName ?? string.Empty,
@@ -556,7 +586,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(124, Level = EventLevel.Verbose)]
+        [Event(EventIds.LeaseRenewalResult, Level = EventLevel.Verbose)]
         public void LeaseRenewalResult(
             string Account,
             string TaskHub,
@@ -568,7 +598,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                124,
+                EventIds.LeaseRenewalResult,
                 Account,
                 TaskHub,
                 WorkerName ?? string.Empty,
@@ -579,7 +609,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(125, Level = EventLevel.Informational)]
+        [Event(EventIds.LeaseRenewalFailed, Level = EventLevel.Informational)]
         public void LeaseRenewalFailed(
             string Account,
             string TaskHub,
@@ -590,7 +620,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                125,
+                EventIds.LeaseRenewalFailed,
                 Account,
                 TaskHub,
                 WorkerName ?? string.Empty,
@@ -600,7 +630,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(126, Level = EventLevel.Informational, Message = "Host '{2}' attempting to take lease for PartitionId '{3}'.")]
+        [Event(EventIds.LeaseAcquisitionStarted, Level = EventLevel.Informational, Message = "Host '{2}' attempting to take lease for PartitionId '{3}'.")]
         public void LeaseAcquisitionStarted(
             string Account,
             string TaskHub,
@@ -608,10 +638,16 @@ namespace DurableTask.AzureStorage
             string PartitionId,
             string ExtensionVersion)
         {
-            this.WriteEvent(126, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, ExtensionVersion);
+            this.WriteEvent(
+                EventIds.LeaseAcquisitionStarted,
+                Account,
+                TaskHub,
+                WorkerName ?? string.Empty,
+                PartitionId ?? string.Empty,
+                ExtensionVersion);
         }
 
-        [Event(127, Level = EventLevel.Informational, Message = "Host '{2}' successfully acquired lease for PartitionId '{3}'.")]
+        [Event(EventIds.LeaseAcquisitionSucceeded, Level = EventLevel.Informational, Message = "Host '{2}' successfully acquired lease for PartitionId '{3}'.")]
         public void LeaseAcquisitionSucceeded(
             string Account,
             string TaskHub,
@@ -619,10 +655,16 @@ namespace DurableTask.AzureStorage
             string PartitionId,
             string ExtensionVersion)
         {
-            this.WriteEvent(127, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, ExtensionVersion);
+            this.WriteEvent(
+                EventIds.LeaseAcquisitionSucceeded,
+                Account,
+                TaskHub,
+                WorkerName ?? string.Empty,
+                PartitionId ?? string.Empty,
+                ExtensionVersion);
         }
 
-        [Event(128, Level = EventLevel.Informational, Message = "Host '{2}' failed to acquire lease for PartitionId '{3}' due to conflict.")]
+        [Event(EventIds.LeaseAcquisitionFailed, Level = EventLevel.Informational, Message = "Host '{2}' failed to acquire lease for PartitionId '{3}' due to conflict.")]
         public void LeaseAcquisitionFailed(
             string Account,
             string TaskHub,
@@ -630,10 +672,16 @@ namespace DurableTask.AzureStorage
             string PartitionId,
             string ExtensionVersion)
         {
-            this.WriteEvent(128, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, ExtensionVersion);
+            this.WriteEvent(
+                EventIds.LeaseAcquisitionFailed,
+                Account,
+                TaskHub,
+                WorkerName ?? string.Empty,
+                PartitionId ?? string.Empty,
+                ExtensionVersion);
         }
 
-        [Event(129, Level = EventLevel.Informational, Message = "Host '{2} is attempting to steal a lease from '{3}' for PartitionId '{4}'.")]
+        [Event(EventIds.AttemptingToStealLease, Level = EventLevel.Informational, Message = "Host '{2} is attempting to steal a lease from '{3}' for PartitionId '{4}'.")]
         public void AttemptingToStealLease(
             string Account,
             string TaskHub,
@@ -643,7 +691,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                129,
+                EventIds.AttemptingToStealLease,
                 Account,
                 TaskHub,
                 WorkerName ?? string.Empty,
@@ -652,7 +700,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(130, Level = EventLevel.Informational, Message = "Host '{2}' stole lease from '{3}' for PartitionId '{4}'.")]
+        [Event(EventIds.LeaseStealingSucceeded, Level = EventLevel.Informational, Message = "Host '{2}' stole lease from '{3}' for PartitionId '{4}'.")]
         public void LeaseStealingSucceeded(
             string Account,
             string TaskHub,
@@ -662,7 +710,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                130,
+                EventIds.LeaseStealingSucceeded,
                 Account,
                 TaskHub,
                 WorkerName ?? string.Empty,
@@ -671,7 +719,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(131, Level = EventLevel.Informational, Message = "Host '{2}' failed to steal lease for PartitionId '{3}' due to conflict.")]
+        [Event(EventIds.LeaseStealingFailed, Level = EventLevel.Informational, Message = "Host '{2}' failed to steal lease for PartitionId '{3}' due to conflict.")]
         public void LeaseStealingFailed(
             string Account,
             string TaskHub,
@@ -679,10 +727,16 @@ namespace DurableTask.AzureStorage
             string PartitionId,
             string ExtensionVersion)
         {
-            this.WriteEvent(131, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, ExtensionVersion);
+            this.WriteEvent(
+                EventIds.LeaseStealingFailed,
+                Account,
+                TaskHub,
+                WorkerName ?? string.Empty,
+                PartitionId ?? string.Empty,
+                ExtensionVersion);
         }
 
-        [Event(132, Level = EventLevel.Informational, Message = "Host '{2}' successfully removed PartitionId '{3}' with lease token '{4}' from currently owned partitions.")]
+        [Event(EventIds.PartitionRemoved, Level = EventLevel.Informational, Message = "Host '{2}' successfully removed PartitionId '{3}' with lease token '{4}' from currently owned partitions.")]
         public void PartitionRemoved(
             string Account,
             string TaskHub,
@@ -692,7 +746,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                132,
+                EventIds.PartitionRemoved,
                 Account,
                 TaskHub,
                 WorkerName ?? string.Empty,
@@ -701,7 +755,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(133, Level = EventLevel.Informational, Message = "Host '{2}' successfully released lease on PartitionId '{3}' with lease token '{4}'")]
+        [Event(EventIds.LeaseRemoved, Level = EventLevel.Informational, Message = "Host '{2}' successfully released lease on PartitionId '{3}' with lease token '{4}'")]
         public void LeaseRemoved(
             string Account,
             string TaskHub,
@@ -711,7 +765,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                133,
+                EventIds.LeaseRemoved,
                 Account,
                 TaskHub,
                 WorkerName ?? string.Empty,
@@ -720,7 +774,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(134, Level = EventLevel.Warning, Message = "Host '{2}' failed to release lease for PartitionId '{3}' with lease token '{4}' due to conflict.")]
+        [Event(EventIds.LeaseRemovalFailed, Level = EventLevel.Warning, Message = "Host '{2}' failed to release lease for PartitionId '{3}' with lease token '{4}' due to conflict.")]
         public void LeaseRemovalFailed(
             string Account,
             string TaskHub,
@@ -730,7 +784,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                134,
+                EventIds.LeaseRemovalFailed,
                 Account,
                 TaskHub,
                 WorkerName ?? string.Empty,
@@ -739,7 +793,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(135, Level = EventLevel.Informational, Version = 2)]
+        [Event(EventIds.InstanceStatusUpdate, Level = EventLevel.Informational, Version = 2)]
         public void InstanceStatusUpdate(
             string Account,
             string TaskHub,
@@ -751,7 +805,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                135,
+                EventIds.InstanceStatusUpdate,
                 Account,
                 TaskHub,
                 InstanceId,
@@ -762,7 +816,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(136, Level = EventLevel.Informational)]
+        [Event(EventIds.FetchedInstanceStatus, Level = EventLevel.Informational)]
         public void FetchedInstanceStatus(
             string Account,
             string TaskHub,
@@ -771,16 +825,23 @@ namespace DurableTask.AzureStorage
             long LatencyMs,
             string ExtensionVersion)
         {
-            this.WriteEvent(136, Account, TaskHub, InstanceId, ExecutionId ?? string.Empty, LatencyMs, ExtensionVersion);
+            this.WriteEvent(
+                EventIds.FetchedInstanceStatus,
+                Account,
+                TaskHub,
+                InstanceId,
+                ExecutionId ?? string.Empty,
+                LatencyMs,
+                ExtensionVersion);
         }
 
-        [Event(137, Level = EventLevel.Warning)]
+        [Event(EventIds.GeneralWarning, Level = EventLevel.Warning)]
         public void GeneralWarning(string Account, string TaskHub, string Details, string ExtensionVersion)
         {
-            this.WriteEvent(137, Account, TaskHub, Details, ExtensionVersion);
+            this.WriteEvent(EventIds.GeneralWarning, Account, TaskHub, Details, ExtensionVersion);
         }
 
-        [Event(138, Level = EventLevel.Warning)]
+        [Event(EventIds.SplitBrainDetected, Level = EventLevel.Warning)]
         public void SplitBrainDetected(
             string Account,
             string TaskHub,
@@ -794,7 +855,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                138,
+                EventIds.SplitBrainDetected,
                 Account,
                 TaskHub,
                 InstanceId,
@@ -807,7 +868,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(139, Level = EventLevel.Warning)]
+        [Event(EventIds.DiscardingWorkItem, Level = EventLevel.Warning)]
         public void DiscardingWorkItem(
             string Account,
             string TaskHub,
@@ -820,7 +881,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                139,
+                EventIds.DiscardingWorkItem,
                 Account,
                 TaskHub,
                 InstanceId,
@@ -832,7 +893,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(140, Level = EventLevel.Informational, Task = Tasks.Processing, Opcode = EventOpcode.Receive, Version = 4)]
+        [Event(EventIds.ProcessingMessage, Level = EventLevel.Informational, Task = Tasks.Processing, Opcode = EventOpcode.Receive, Version = 4)]
         public void ProcessingMessage(
             Guid relatedActivityId,
             string Account,
@@ -849,7 +910,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEventWithRelatedActivityId(
-                140,
+                EventIds.ProcessingMessage,
                 relatedActivityId,
                 Account,
                 TaskHub,
@@ -865,7 +926,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(141, Level = EventLevel.Informational, Version = 2)]
+        [Event(EventIds.PurgeInstanceHistory, Level = EventLevel.Informational, Version = 2)]
         public void PurgeInstanceHistory(
             string Account,
             string TaskHub,
@@ -878,7 +939,7 @@ namespace DurableTask.AzureStorage
             string ExtensionVersion)
         {
             this.WriteEvent(
-                141,
+                EventIds.PurgeInstanceHistory,
                 Account,
                 TaskHub,
                 InstanceId,

--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -331,7 +331,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(EventIds.OrchestrationServiceStats, Level = EventLevel.Informational)]
+        [Event(EventIds.OrchestrationServiceStats, Level = EventLevel.Verbose, Version = 2)]
         public void OrchestrationServiceStats(
             string Account,
             string TaskHub,
@@ -408,11 +408,11 @@ namespace DurableTask.AzureStorage
                 EventIds.MessageFailure,
                 Account,
                 TaskHub,
-                MessageId,
-                InstanceId,
+                MessageId ?? string.Empty,
+                InstanceId ?? string.Empty,
                 ExecutionId ?? string.Empty,
                 PartitionId,
-                EventType,
+                EventType ?? string.Empty,
                 TaskEventId,
                 Details,
                 ExtensionVersion);
@@ -793,13 +793,13 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(EventIds.InstanceStatusUpdate, Level = EventLevel.Informational, Version = 2)]
+        [Event(EventIds.InstanceStatusUpdate, Level = EventLevel.Informational, Version = 3)]
         public void InstanceStatusUpdate(
             string Account,
             string TaskHub,
             string InstanceId,
             string ExecutionId,
-            string EventType,
+            string RuntimeStatus,
             int Episode,
             long LatencyMs,
             string ExtensionVersion)
@@ -810,7 +810,7 @@ namespace DurableTask.AzureStorage
                 TaskHub,
                 InstanceId,
                 ExecutionId ?? string.Empty,
-                EventType,
+                RuntimeStatus ?? string.Empty,
                 Episode,
                 LatencyMs,
                 ExtensionVersion);

--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -926,7 +926,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(EventIds.PurgeInstanceHistory, Level = EventLevel.Informational, Version = 2)]
+        [Event(EventIds.PurgeInstanceHistory, Level = EventLevel.Informational, Version = 3)]
         public void PurgeInstanceHistory(
             string Account,
             string TaskHub,
@@ -935,6 +935,7 @@ namespace DurableTask.AzureStorage
             string CreatedTimeTo,
             string RuntimeStatus,
             int RequestCount,
+            int InstanceCount,
             long LatencyMs,
             string ExtensionVersion)
         {
@@ -942,11 +943,12 @@ namespace DurableTask.AzureStorage
                 EventIds.PurgeInstanceHistory,
                 Account,
                 TaskHub,
-                InstanceId,
+                InstanceId ?? string.Empty,
                 CreatedTimeFrom,
                 CreatedTimeTo,
-                RuntimeStatus,
+                RuntimeStatus ?? string.Empty,
                 RequestCount,
+                InstanceCount,
                 LatencyMs,
                 ExtensionVersion);
         }

--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -41,16 +41,6 @@ namespace DurableTask.AzureStorage
             SetCurrentThreadActivityId(activityId);
         }
 
-        [NonEvent]
-        private static void EnsureLogicalTraceActivityId()
-        {
-            Guid currentActivityId = ActivityIdState.Value;
-            if (currentActivityId != CurrentThreadActivityId)
-            {
-                SetCurrentThreadActivityId(currentActivityId);
-            }
-        }
-
         [Event(101, Level = EventLevel.Informational, Opcode = EventOpcode.Send, Task = Tasks.Enqueue, Version = 5)]
         public void SendingMessage(
             Guid relatedActivityId,
@@ -68,7 +58,6 @@ namespace DurableTask.AzureStorage
             int Episode,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEventWithRelatedActivityId(
                 101,
                 relatedActivityId,
@@ -106,7 +95,6 @@ namespace DurableTask.AzureStorage
             int Episode,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEventWithRelatedActivityId(
                 102,
                 relatedActivityId,
@@ -140,7 +128,6 @@ namespace DurableTask.AzureStorage
             long SequenceNumber,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 103,
                 Account,
@@ -169,7 +156,6 @@ namespace DurableTask.AzureStorage
             int VisibilityTimeoutSeconds,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 104,
                 Account,
@@ -192,7 +178,6 @@ namespace DurableTask.AzureStorage
             string Details,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(105, Account, TaskHub, Details, ExtensionVersion);
         }
 
@@ -209,7 +194,6 @@ namespace DurableTask.AzureStorage
             string Details,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 106,
                 Account,
@@ -227,7 +211,6 @@ namespace DurableTask.AzureStorage
         [Event(107, Level = EventLevel.Error)]
         public void GeneralError(string Account, string TaskHub, string Details, string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(107, Account, TaskHub, Details, ExtensionVersion);
         }
 
@@ -242,7 +225,6 @@ namespace DurableTask.AzureStorage
             int DequeueCount,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 108,
                 Account,
@@ -266,7 +248,6 @@ namespace DurableTask.AzureStorage
             int DequeueCount,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 109,
                 Account,
@@ -293,7 +274,6 @@ namespace DurableTask.AzureStorage
             DateTime LastCheckpointTime,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 110,
                 Account,
@@ -325,7 +305,6 @@ namespace DurableTask.AzureStorage
             bool IsCheckpointComplete,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 111,
                 Account,
@@ -389,7 +368,6 @@ namespace DurableTask.AzureStorage
             int VisibilityTimeoutSeconds,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 113,
                 Account,
@@ -417,7 +395,6 @@ namespace DurableTask.AzureStorage
             string Details,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 114,
                 Account,
@@ -441,7 +418,6 @@ namespace DurableTask.AzureStorage
             string Details,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 115,
                 Account,
@@ -460,7 +436,6 @@ namespace DurableTask.AzureStorage
             long PendingOrchestratorMessages,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 116,
                 Account,
@@ -477,7 +452,6 @@ namespace DurableTask.AzureStorage
             string PartitionId,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 117,
                 Account,
@@ -500,7 +474,6 @@ namespace DurableTask.AzureStorage
             DateTime LastCheckpointTime,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 118,
                 Account,
@@ -525,7 +498,6 @@ namespace DurableTask.AzureStorage
             string Details,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(120, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, Details, ExtensionVersion);
         }
 
@@ -538,7 +510,6 @@ namespace DurableTask.AzureStorage
             string Details,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(121, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, Details ?? string.Empty, ExtensionVersion);
         }
 
@@ -563,7 +534,6 @@ namespace DurableTask.AzureStorage
             string Details,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(122, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, Details ?? string.Empty, ExtensionVersion);
         }
 
@@ -576,7 +546,6 @@ namespace DurableTask.AzureStorage
             string Token,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 123,
                 Account,
@@ -598,7 +567,6 @@ namespace DurableTask.AzureStorage
             string Details,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 124,
                 Account,
@@ -621,7 +589,6 @@ namespace DurableTask.AzureStorage
             string Details,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 125,
                 Account,
@@ -641,7 +608,6 @@ namespace DurableTask.AzureStorage
             string PartitionId,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(126, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, ExtensionVersion);
         }
 
@@ -653,7 +619,6 @@ namespace DurableTask.AzureStorage
             string PartitionId,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(127, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, ExtensionVersion);
         }
 
@@ -665,7 +630,6 @@ namespace DurableTask.AzureStorage
             string PartitionId,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(128, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, ExtensionVersion);
         }
 
@@ -678,7 +642,6 @@ namespace DurableTask.AzureStorage
             string PartitionId,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 129,
                 Account,
@@ -698,7 +661,6 @@ namespace DurableTask.AzureStorage
             string PartitionId,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 130,
                 Account,
@@ -717,7 +679,6 @@ namespace DurableTask.AzureStorage
             string PartitionId,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(131, Account, TaskHub, WorkerName ?? string.Empty, PartitionId ?? string.Empty, ExtensionVersion);
         }
 
@@ -730,7 +691,6 @@ namespace DurableTask.AzureStorage
             string Token,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 132,
                 Account,
@@ -750,7 +710,6 @@ namespace DurableTask.AzureStorage
             string Token,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 133,
                 Account,
@@ -770,7 +729,6 @@ namespace DurableTask.AzureStorage
             string Token,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 134,
                 Account,
@@ -792,7 +750,6 @@ namespace DurableTask.AzureStorage
             long LatencyMs,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 135,
                 Account,
@@ -814,14 +771,12 @@ namespace DurableTask.AzureStorage
             long LatencyMs,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(136, Account, TaskHub, InstanceId, ExecutionId ?? string.Empty, LatencyMs, ExtensionVersion);
         }
 
         [Event(137, Level = EventLevel.Warning)]
         public void GeneralWarning(string Account, string TaskHub, string Details, string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(137, Account, TaskHub, Details, ExtensionVersion);
         }
 
@@ -838,7 +793,6 @@ namespace DurableTask.AzureStorage
             string ETag,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 138,
                 Account,
@@ -865,7 +819,6 @@ namespace DurableTask.AzureStorage
             string Details,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 139,
                 Account,
@@ -895,7 +848,6 @@ namespace DurableTask.AzureStorage
             bool IsExtendedSession,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEventWithRelatedActivityId(
                 140,
                 relatedActivityId,
@@ -913,27 +865,26 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(141, Level = EventLevel.Informational)]
+        [Event(141, Level = EventLevel.Informational, Version = 2)]
         public void PurgeInstanceHistory(
             string Account,
             string TaskHub,
             string InstanceId,
-            string createdTimeFrom,
-            string createdTimeTo,
-            string runtimeStatus,
+            string CreatedTimeFrom,
+            string CreatedTimeTo,
+            string RuntimeStatus,
             int RequestCount,
             long LatencyMs,
             string ExtensionVersion)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 141,
                 Account,
                 TaskHub,
                 InstanceId,
-                createdTimeFrom,
-                createdTimeTo,
-                runtimeStatus,
+                CreatedTimeFrom,
+                CreatedTimeTo,
+                RuntimeStatus,
                 RequestCount,
                 LatencyMs,
                 ExtensionVersion);

--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -42,7 +42,7 @@ namespace DurableTask.AzureStorage
             SetCurrentThreadActivityId(activityId);
         }
 
-        [Event(EventIds.SendingMessage, Level = EventLevel.Informational, Opcode = EventOpcode.Send, Task = Tasks.Enqueue, Version = 5)]
+        [Event(EventIds.SendingMessage, Level = EventLevel.Informational, Opcode = EventOpcode.Send, Task = Tasks.Enqueue, Version = 6)]
         public void SendingMessage(
             Guid relatedActivityId,
             string Account,
@@ -57,6 +57,7 @@ namespace DurableTask.AzureStorage
             string TargetExecutionId,
             long SequenceNumber,
             int Episode,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEventWithRelatedActivityId(
@@ -74,10 +75,11 @@ namespace DurableTask.AzureStorage
                 TargetExecutionId ?? string.Empty,
                 SequenceNumber,
                 Episode,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.ReceivedMessage, Level = EventLevel.Informational, Opcode = EventOpcode.Receive, Task = Tasks.Dequeue, Version = 5)]
+        [Event(EventIds.ReceivedMessage, Level = EventLevel.Informational, Opcode = EventOpcode.Receive, Task = Tasks.Dequeue, Version = 6)]
         public void ReceivedMessage(
             Guid relatedActivityId,
             string Account,
@@ -94,6 +96,7 @@ namespace DurableTask.AzureStorage
             string PartitionId,
             long SequenceNumber,
             int Episode,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEventWithRelatedActivityId(
@@ -113,10 +116,11 @@ namespace DurableTask.AzureStorage
                 PartitionId,
                 SequenceNumber,
                 Episode,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.DeletingMessage, Level = EventLevel.Informational, Version = 4)]
+        [Event(EventIds.DeletingMessage, Level = EventLevel.Informational, Version = 5)]
         public void DeletingMessage(
             string Account,
             string TaskHub,
@@ -127,6 +131,7 @@ namespace DurableTask.AzureStorage
             string ExecutionId,
             string PartitionId,
             long SequenceNumber,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -140,10 +145,11 @@ namespace DurableTask.AzureStorage
                 ExecutionId ?? string.Empty,
                 PartitionId,
                 SequenceNumber,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.AbandoningMessage, Level = EventLevel.Warning, Version = 5)]
+        [Event(EventIds.AbandoningMessage, Level = EventLevel.Warning, Version = 6)]
         public void AbandoningMessage(
             string Account,
             string TaskHub,
@@ -155,6 +161,7 @@ namespace DurableTask.AzureStorage
             string PartitionId,
             long SequenceNumber,
             int VisibilityTimeoutSeconds,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -169,17 +176,19 @@ namespace DurableTask.AzureStorage
                 PartitionId,
                 SequenceNumber,
                 VisibilityTimeoutSeconds,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.AssertFailure, Level = EventLevel.Warning, Message = "An unexpected condition was detected: {2}")]
+        [Event(EventIds.AssertFailure, Level = EventLevel.Warning, Message = "An unexpected condition was detected: {2}", Version = 2)]
         public void AssertFailure(
             string Account,
             string TaskHub,
             string Details,
+            string AppName,
             string ExtensionVersion)
         {
-            this.WriteEvent(EventIds.AssertFailure, Account, TaskHub, Details, ExtensionVersion);
+            this.WriteEvent(EventIds.AssertFailure, Account, TaskHub, Details, AppName, ExtensionVersion);
         }
 
         [Event(EventIds.MessageGone, Level = EventLevel.Warning, Version = 4)]
@@ -193,6 +202,7 @@ namespace DurableTask.AzureStorage
             string ExecutionId,
             string PartitionId,
             string Details,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -206,16 +216,17 @@ namespace DurableTask.AzureStorage
                 EventType,
                 TaskEventId,
                 Details,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.GeneralError, Level = EventLevel.Error)]
-        public void GeneralError(string Account, string TaskHub, string Details, string ExtensionVersion)
+        [Event(EventIds.GeneralError, Level = EventLevel.Error, Version = 2)]
+        public void GeneralError(string Account, string TaskHub, string Details, string AppName, string ExtensionVersion)
         {
-            this.WriteEvent(EventIds.GeneralError, Account, TaskHub, Details, ExtensionVersion);
+            this.WriteEvent(EventIds.GeneralError, Account, TaskHub, Details, AppName, ExtensionVersion);
         }
 
-        [Event(EventIds.DuplicateMessageDetected, Level = EventLevel.Warning, Version = 3, Message = "A duplicate message was detected. This can indicate a potential performance problem. Message ID = '{4}'. DequeueCount = {8}.")]
+        [Event(EventIds.DuplicateMessageDetected, Level = EventLevel.Warning, Version = 3)]
         public void DuplicateMessageDetected(
             string Account,
             string TaskHub,
@@ -226,6 +237,7 @@ namespace DurableTask.AzureStorage
             string ExecutionId,
             string PartitionId,
             int DequeueCount,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -239,10 +251,11 @@ namespace DurableTask.AzureStorage
                 ExecutionId ?? string.Empty,
                 PartitionId,
                 DequeueCount,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.PoisonMessageDetected, Level = EventLevel.Warning, Message = "A poison message was detected! Message ID = '{4}'. DequeueCount = {8}.")]
+        [Event(EventIds.PoisonMessageDetected, Level = EventLevel.Warning, Version = 3)]
         public void PoisonMessageDetected(
             string Account,
             string TaskHub,
@@ -253,6 +266,7 @@ namespace DurableTask.AzureStorage
             string ExecutionId,
             string PartitionId,
             int DequeueCount,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -266,10 +280,11 @@ namespace DurableTask.AzureStorage
                 ExecutionId ?? string.Empty,
                 PartitionId,
                 DequeueCount,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.FetchedInstanceHistory, Level = EventLevel.Informational, Version = 3)]
+        [Event(EventIds.FetchedInstanceHistory, Level = EventLevel.Informational, Version = 4)]
         public void FetchedInstanceHistory(
             string Account,
             string TaskHub,
@@ -281,6 +296,7 @@ namespace DurableTask.AzureStorage
             long LatencyMs,
             string ETag,
             DateTime LastCheckpointTime,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -295,10 +311,11 @@ namespace DurableTask.AzureStorage
                 LatencyMs,
                 ETag ?? string.Empty,
                 LastCheckpointTime,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.AppendedInstanceHistory, Level = EventLevel.Informational, Version = 4)]
+        [Event(EventIds.AppendedInstanceHistory, Level = EventLevel.Informational, Version = 5)]
         public void AppendedInstanceHistory(
             string Account,
             string TaskHub,
@@ -312,6 +329,7 @@ namespace DurableTask.AzureStorage
             int SizeInBytes,
             string ETag,
             bool IsCheckpointComplete,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -328,10 +346,11 @@ namespace DurableTask.AzureStorage
                 SizeInBytes,
                 ETag ?? string.Empty,
                 IsCheckpointComplete,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.OrchestrationServiceStats, Level = EventLevel.Verbose, Version = 2)]
+        [Event(EventIds.OrchestrationServiceStats, Level = EventLevel.Verbose, Version = 3)]
         public void OrchestrationServiceStats(
             string Account,
             string TaskHub,
@@ -345,6 +364,7 @@ namespace DurableTask.AzureStorage
             long PendingOrchestratorMessages,
             long ActiveOrchestrators,
             long ActiveActivities,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -361,10 +381,11 @@ namespace DurableTask.AzureStorage
                 PendingOrchestratorMessages,
                 ActiveOrchestrators,
                 ActiveActivities,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.RenewingMessage, Level = EventLevel.Informational, Version = 2)]
+        [Event(EventIds.RenewingMessage, Level = EventLevel.Informational, Version = 3)]
         public void RenewingMessage(
             string Account,
             string TaskHub,
@@ -375,6 +396,7 @@ namespace DurableTask.AzureStorage
             int TaskEventId,
             string MessageId,
             int VisibilityTimeoutSeconds,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -388,10 +410,11 @@ namespace DurableTask.AzureStorage
                 TaskEventId,
                 MessageId,
                 VisibilityTimeoutSeconds,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.MessageFailure, Level = EventLevel.Error, Version = 2)]
+        [Event(EventIds.MessageFailure, Level = EventLevel.Error, Version = 3)]
         public void MessageFailure(
             string Account,
             string TaskHub,
@@ -402,6 +425,7 @@ namespace DurableTask.AzureStorage
             string EventType,
             int TaskEventId,
             string Details,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -415,16 +439,18 @@ namespace DurableTask.AzureStorage
                 EventType ?? string.Empty,
                 TaskEventId,
                 Details,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.OrchestrationProcessingFailure, Level = EventLevel.Error)]
+        [Event(EventIds.OrchestrationProcessingFailure, Level = EventLevel.Error, Version = 2)]
         public void OrchestrationProcessingFailure(
             string Account,
             string TaskHub,
             string InstanceId,
             string ExecutionId,
             string Details,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -434,15 +460,17 @@ namespace DurableTask.AzureStorage
                 InstanceId,
                 ExecutionId ?? string.Empty,
                 Details,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.PendingOrchestratorMessageLimitReached, Level = EventLevel.Informational, Version = 2)]
+        [Event(EventIds.PendingOrchestratorMessageLimitReached, Level = EventLevel.Informational, Version = 3)]
         public void PendingOrchestratorMessageLimitReached(
             string Account,
             string TaskHub,
             string PartitionId,
             long PendingOrchestratorMessages,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -451,14 +479,16 @@ namespace DurableTask.AzureStorage
                 TaskHub,
                 PartitionId,
                 PendingOrchestratorMessages,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.WaitingForMoreMessages, Level = EventLevel.Informational)]
+        [Event(EventIds.WaitingForMoreMessages, Level = EventLevel.Informational, Version = 2)]
         public void WaitingForMoreMessages(
             string Account,
             string TaskHub,
             string PartitionId,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -466,10 +496,11 @@ namespace DurableTask.AzureStorage
                 Account,
                 TaskHub,
                 PartitionId,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.ReceivedOutOfOrderMessage, Level = EventLevel.Warning, Version = 3)]
+        [Event(EventIds.ReceivedOutOfOrderMessage, Level = EventLevel.Warning, Version = 4)]
         public void ReceivedOutOfOrderMessage(
             string Account,
             string TaskHub,
@@ -481,6 +512,7 @@ namespace DurableTask.AzureStorage
             string MessageId,
             int Episode,
             DateTime LastCheckpointTime,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -495,16 +527,18 @@ namespace DurableTask.AzureStorage
                 MessageId,
                 Episode,
                 LastCheckpointTime,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.PartitionManagerInfo, Level = EventLevel.Informational, Version = 2)]
+        [Event(EventIds.PartitionManagerInfo, Level = EventLevel.Informational, Version = 3)]
         public void PartitionManagerInfo(
             string Account,
             string TaskHub,
             string WorkerName,
             string PartitionId,
             string Details,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -514,16 +548,18 @@ namespace DurableTask.AzureStorage
                 WorkerName ?? string.Empty,
                 PartitionId ?? string.Empty,
                 Details,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.PartitionManagerWarning, Level = EventLevel.Warning, Version = 2)]
+        [Event(EventIds.PartitionManagerWarning, Level = EventLevel.Warning, Version = 3)]
         public void PartitionManagerWarning(
             string Account,
             string TaskHub,
             string WorkerName,
             string PartitionId,
             string Details,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -533,6 +569,7 @@ namespace DurableTask.AzureStorage
                 WorkerName ?? string.Empty,
                 PartitionId ?? string.Empty,
                 Details ?? string.Empty,
+                AppName,
                 ExtensionVersion);
         }
 
@@ -545,16 +582,24 @@ namespace DurableTask.AzureStorage
             Exception exception,
             string ExtensionVersion)
         {
-            this.PartitionManagerError(account, taskHub, workerName, partitionId, exception.ToString(), ExtensionVersion);
+            this.PartitionManagerError(
+                account,
+                taskHub,
+                workerName,
+                partitionId,
+                exception.ToString(),
+                Utils.AppName,
+                ExtensionVersion);
         }
 
-        [Event(EventIds.PartitionManagerError, Level = EventLevel.Error, Version = 2)]
+        [Event(EventIds.PartitionManagerError, Level = EventLevel.Error, Version = 3)]
         public void PartitionManagerError(
             string Account,
             string TaskHub,
             string WorkerName,
             string PartitionId,
             string Details,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -564,16 +609,18 @@ namespace DurableTask.AzureStorage
                 WorkerName ?? string.Empty,
                 PartitionId ?? string.Empty,
                 Details ?? string.Empty,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.StartingLeaseRenewal, Level = EventLevel.Verbose, Message = "Host '{2}' renewing lease for PartitionId '{3}' with lease token '{4}'.")]
+        [Event(EventIds.StartingLeaseRenewal, Level = EventLevel.Verbose, Version = 2)]
         public void StartingLeaseRenewal(
             string Account,
             string TaskHub,
             string WorkerName,
             string PartitionId,
             string Token,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -583,10 +630,11 @@ namespace DurableTask.AzureStorage
                 WorkerName ?? string.Empty,
                 PartitionId ?? string.Empty,
                 Token ?? string.Empty,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.LeaseRenewalResult, Level = EventLevel.Verbose)]
+        [Event(EventIds.LeaseRenewalResult, Level = EventLevel.Verbose, Version = 2)]
         public void LeaseRenewalResult(
             string Account,
             string TaskHub,
@@ -595,6 +643,7 @@ namespace DurableTask.AzureStorage
             bool Success,
             string Token,
             string Details,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -606,10 +655,11 @@ namespace DurableTask.AzureStorage
                 Success,
                 Token ?? string.Empty,
                 Details ?? string.Empty,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.LeaseRenewalFailed, Level = EventLevel.Informational)]
+        [Event(EventIds.LeaseRenewalFailed, Level = EventLevel.Informational, Version = 2)]
         public void LeaseRenewalFailed(
             string Account,
             string TaskHub,
@@ -617,6 +667,7 @@ namespace DurableTask.AzureStorage
             string PartitionId,
             string Token,
             string Details,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -627,15 +678,17 @@ namespace DurableTask.AzureStorage
                 PartitionId ?? string.Empty,
                 Token ?? string.Empty,
                 Details ?? string.Empty,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.LeaseAcquisitionStarted, Level = EventLevel.Informational, Message = "Host '{2}' attempting to take lease for PartitionId '{3}'.")]
+        [Event(EventIds.LeaseAcquisitionStarted, Level = EventLevel.Informational, Version = 2)]
         public void LeaseAcquisitionStarted(
             string Account,
             string TaskHub,
             string WorkerName,
             string PartitionId,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -644,15 +697,17 @@ namespace DurableTask.AzureStorage
                 TaskHub,
                 WorkerName ?? string.Empty,
                 PartitionId ?? string.Empty,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.LeaseAcquisitionSucceeded, Level = EventLevel.Informational, Message = "Host '{2}' successfully acquired lease for PartitionId '{3}'.")]
+        [Event(EventIds.LeaseAcquisitionSucceeded, Level = EventLevel.Informational, Version = 2)]
         public void LeaseAcquisitionSucceeded(
             string Account,
             string TaskHub,
             string WorkerName,
             string PartitionId,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -661,15 +716,17 @@ namespace DurableTask.AzureStorage
                 TaskHub,
                 WorkerName ?? string.Empty,
                 PartitionId ?? string.Empty,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.LeaseAcquisitionFailed, Level = EventLevel.Informational, Message = "Host '{2}' failed to acquire lease for PartitionId '{3}' due to conflict.")]
+        [Event(EventIds.LeaseAcquisitionFailed, Level = EventLevel.Informational, Version = 2)]
         public void LeaseAcquisitionFailed(
             string Account,
             string TaskHub,
             string WorkerName,
             string PartitionId,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -678,16 +735,18 @@ namespace DurableTask.AzureStorage
                 TaskHub,
                 WorkerName ?? string.Empty,
                 PartitionId ?? string.Empty,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.AttemptingToStealLease, Level = EventLevel.Informational, Message = "Host '{2} is attempting to steal a lease from '{3}' for PartitionId '{4}'.")]
+        [Event(EventIds.AttemptingToStealLease, Level = EventLevel.Informational, Version = 2)]
         public void AttemptingToStealLease(
             string Account,
             string TaskHub,
             string WorkerName,
             string FromWorkerName,
             string PartitionId,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -697,16 +756,18 @@ namespace DurableTask.AzureStorage
                 WorkerName ?? string.Empty,
                 FromWorkerName ?? string.Empty,
                 PartitionId ?? string.Empty,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.LeaseStealingSucceeded, Level = EventLevel.Informational, Message = "Host '{2}' stole lease from '{3}' for PartitionId '{4}'.")]
+        [Event(EventIds.LeaseStealingSucceeded, Level = EventLevel.Informational, Version = 2)]
         public void LeaseStealingSucceeded(
             string Account,
             string TaskHub,
             string WorkerName,
             string FromWorkerName,
             string PartitionId,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -716,15 +777,17 @@ namespace DurableTask.AzureStorage
                 WorkerName ?? string.Empty,
                 FromWorkerName ?? string.Empty,
                 PartitionId ?? string.Empty,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.LeaseStealingFailed, Level = EventLevel.Informational, Message = "Host '{2}' failed to steal lease for PartitionId '{3}' due to conflict.")]
+        [Event(EventIds.LeaseStealingFailed, Level = EventLevel.Informational, Version = 2)]
         public void LeaseStealingFailed(
             string Account,
             string TaskHub,
             string WorkerName,
             string PartitionId,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -733,16 +796,18 @@ namespace DurableTask.AzureStorage
                 TaskHub,
                 WorkerName ?? string.Empty,
                 PartitionId ?? string.Empty,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.PartitionRemoved, Level = EventLevel.Informational, Message = "Host '{2}' successfully removed PartitionId '{3}' with lease token '{4}' from currently owned partitions.")]
+        [Event(EventIds.PartitionRemoved, Level = EventLevel.Informational, Version = 2)]
         public void PartitionRemoved(
             string Account,
             string TaskHub,
             string WorkerName,
             string PartitionId,
             string Token,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -752,16 +817,18 @@ namespace DurableTask.AzureStorage
                 WorkerName ?? string.Empty,
                 PartitionId ?? string.Empty,
                 Token ?? string.Empty,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.LeaseRemoved, Level = EventLevel.Informational, Message = "Host '{2}' successfully released lease on PartitionId '{3}' with lease token '{4}'")]
+        [Event(EventIds.LeaseRemoved, Level = EventLevel.Informational, Version = 2)]
         public void LeaseRemoved(
             string Account,
             string TaskHub,
             string WorkerName,
             string PartitionId,
             string Token,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -771,16 +838,18 @@ namespace DurableTask.AzureStorage
                 WorkerName ?? string.Empty,
                 PartitionId ?? string.Empty,
                 Token ?? string.Empty,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.LeaseRemovalFailed, Level = EventLevel.Warning, Message = "Host '{2}' failed to release lease for PartitionId '{3}' with lease token '{4}' due to conflict.")]
+        [Event(EventIds.LeaseRemovalFailed, Level = EventLevel.Warning, Version = 2)]
         public void LeaseRemovalFailed(
             string Account,
             string TaskHub,
             string WorkerName,
             string PartitionId,
             string Token,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -790,10 +859,11 @@ namespace DurableTask.AzureStorage
                 WorkerName ?? string.Empty,
                 PartitionId ?? string.Empty,
                 Token ?? string.Empty,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.InstanceStatusUpdate, Level = EventLevel.Informational, Version = 3)]
+        [Event(EventIds.InstanceStatusUpdate, Level = EventLevel.Informational, Version = 4)]
         public void InstanceStatusUpdate(
             string Account,
             string TaskHub,
@@ -802,6 +872,7 @@ namespace DurableTask.AzureStorage
             string RuntimeStatus,
             int Episode,
             long LatencyMs,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -813,16 +884,18 @@ namespace DurableTask.AzureStorage
                 RuntimeStatus ?? string.Empty,
                 Episode,
                 LatencyMs,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.FetchedInstanceStatus, Level = EventLevel.Informational)]
+        [Event(EventIds.FetchedInstanceStatus, Level = EventLevel.Informational, Version = 2)]
         public void FetchedInstanceStatus(
             string Account,
             string TaskHub,
             string InstanceId,
             string ExecutionId,
             long LatencyMs,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -832,16 +905,17 @@ namespace DurableTask.AzureStorage
                 InstanceId,
                 ExecutionId ?? string.Empty,
                 LatencyMs,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.GeneralWarning, Level = EventLevel.Warning)]
-        public void GeneralWarning(string Account, string TaskHub, string Details, string ExtensionVersion)
+        [Event(EventIds.GeneralWarning, Level = EventLevel.Warning, Version = 2)]
+        public void GeneralWarning(string Account, string TaskHub, string Details, string AppName, string ExtensionVersion)
         {
-            this.WriteEvent(EventIds.GeneralWarning, Account, TaskHub, Details, ExtensionVersion);
+            this.WriteEvent(EventIds.GeneralWarning, Account, TaskHub, Details, AppName, ExtensionVersion);
         }
 
-        [Event(EventIds.SplitBrainDetected, Level = EventLevel.Warning)]
+        [Event(EventIds.SplitBrainDetected, Level = EventLevel.Warning, Version = 2)]
         public void SplitBrainDetected(
             string Account,
             string TaskHub,
@@ -852,6 +926,7 @@ namespace DurableTask.AzureStorage
             string NewEvents,
             long LatencyMs,
             string ETag,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -865,10 +940,11 @@ namespace DurableTask.AzureStorage
                 NewEvents,
                 LatencyMs,
                 ETag ?? string.Empty,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.DiscardingWorkItem, Level = EventLevel.Warning)]
+        [Event(EventIds.DiscardingWorkItem, Level = EventLevel.Warning, Version = 2)]
         public void DiscardingWorkItem(
             string Account,
             string TaskHub,
@@ -878,6 +954,7 @@ namespace DurableTask.AzureStorage
             int TotalEventCount,
             string NewEvents,
             string Details,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -890,10 +967,11 @@ namespace DurableTask.AzureStorage
                 TotalEventCount,
                 NewEvents,
                 Details,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.ProcessingMessage, Level = EventLevel.Informational, Task = Tasks.Processing, Opcode = EventOpcode.Receive, Version = 4)]
+        [Event(EventIds.ProcessingMessage, Level = EventLevel.Informational, Task = Tasks.Processing, Opcode = EventOpcode.Receive, Version = 5)]
         public void ProcessingMessage(
             Guid relatedActivityId,
             string Account,
@@ -907,6 +985,7 @@ namespace DurableTask.AzureStorage
             long SequenceNumber,
             int Episode,
             bool IsExtendedSession,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEventWithRelatedActivityId(
@@ -923,10 +1002,11 @@ namespace DurableTask.AzureStorage
                 SequenceNumber,
                 Episode,
                 IsExtendedSession,
+                AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.PurgeInstanceHistory, Level = EventLevel.Informational, Version = 3)]
+        [Event(EventIds.PurgeInstanceHistory, Level = EventLevel.Informational, Version = 4)]
         public void PurgeInstanceHistory(
             string Account,
             string TaskHub,
@@ -937,6 +1017,7 @@ namespace DurableTask.AzureStorage
             int RequestCount,
             int InstanceCount,
             long LatencyMs,
+            string AppName,
             string ExtensionVersion)
         {
             this.WriteEvent(
@@ -950,6 +1031,7 @@ namespace DurableTask.AzureStorage
                 RequestCount,
                 InstanceCount,
                 LatencyMs,
+                AppName,
                 ExtensionVersion);
         }
 

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -16,6 +16,7 @@ namespace DurableTask.AzureStorage
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Diagnostics.Tracing;
     using System.Linq;
     using System.Net;
     using System.Runtime.ExceptionServices;
@@ -62,8 +63,6 @@ namespace DurableTask.AzureStorage
 
         readonly ITrackingStore trackingStore;
 
-        readonly TableEntityConverter tableEntityConverter;
-
         readonly ResettableLazy<Task> taskHubCreator;
         readonly BlobLeaseManager leaseManager;
         readonly PartitionManager<BlobLease> partitionManager;
@@ -97,7 +96,6 @@ namespace DurableTask.AzureStorage
             ValidateSettings(settings);
 
             this.settings = settings;
-            this.tableEntityConverter = new TableEntityConverter();
  
             CloudStorageAccount account = settings.StorageAccountDetails == null
                 ? CloudStorageAccount.Parse(settings.StorageConnectionString)
@@ -149,15 +147,12 @@ namespace DurableTask.AzureStorage
                 LazyThreadSafetyMode.ExecutionAndPublication);
 
             this.leaseManager = GetBlobLeaseManager(
-                settings.TaskHubName,
-                settings.WorkerId,
+                settings,
                 account,
-                settings.LeaseInterval,
-                settings.LeaseRenewInterval,
                 this.stats);
             this.partitionManager = new PartitionManager<BlobLease>(
+                this.settings,
                 this.storageAccountName,
-                this.settings.TaskHubName,
                 settings.WorkerId,
                 this.leaseManager,
                 new PartitionManagerOptions
@@ -228,22 +223,16 @@ namespace DurableTask.AzureStorage
         }
 
         static BlobLeaseManager GetBlobLeaseManager(
-            string taskHub,
-            string workerName,
+            AzureStorageOrchestrationServiceSettings settings,
             CloudStorageAccount account,
-            TimeSpan leaseInterval,
-            TimeSpan renewalInterval,
             AzureStorageOrchestrationServiceStats stats)
         {
             return new BlobLeaseManager(
-                taskHubName: taskHub,
-                workerName: workerName,
-                leaseContainerName: taskHub.ToLowerInvariant() + "-leases",
+                settings,
+                leaseContainerName: settings.TaskHubName.ToLowerInvariant() + "-leases",
                 blobPrefix: string.Empty,
                 consumerGroupName: "default",
                 storageClient: account.CreateCloudBlobClient(),
-                leaseInterval: leaseInterval,
-                renewInterval: renewalInterval,
                 skipBlobContainerCreation: false,
                 stats: stats);
         }
@@ -321,11 +310,10 @@ namespace DurableTask.AzureStorage
             }
             catch (Exception e)
             {
-                AnalyticsEventSource.Log.GeneralError(
+                this.settings.Logger.GeneralError(
                     this.storageAccountName,
                     this.settings.TaskHubName,
-                    $"Failed to create the task hub: {e}",
-                    Utils.ExtensionVersion);
+                    $"Failed to create the task hub: {e}");
 
                 // Don't want to cache the failed task
                 this.taskHubCreator.Reset();
@@ -481,11 +469,10 @@ namespace DurableTask.AzureStorage
                 }
                 catch (Exception e)
                 {
-                    AnalyticsEventSource.Log.GeneralError(
+                    this.settings.Logger.GeneralError(
                         this.storageAccountName,
                         this.settings.TaskHubName,
-                        $"Unexpected error in {nameof(ReportStatsLoop)}: {e}",
-                        Utils.ExtensionVersion);
+                        $"Unexpected error in {nameof(ReportStatsLoop)}: {e}");
                 }
             }
 
@@ -509,7 +496,7 @@ namespace DurableTask.AzureStorage
                 out int pendingOrchestrationMessages,
                 out int activeOrchestrationSessions);
 
-            AnalyticsEventSource.Log.OrchestrationServiceStats(
+            this.settings.Logger.OrchestrationServiceStats(
                 this.storageAccountName,
                 this.settings.TaskHubName,
                 storageRequests,
@@ -521,8 +508,7 @@ namespace DurableTask.AzureStorage
                 pendingOrchestratorInstances,
                 pendingOrchestrationMessages,
                 activeOrchestrationSessions,
-                this.stats.ActiveActivityExecutions.Value,
-                Utils.ExtensionVersion);
+                this.stats.ActiveActivityExecutions.Value);
         }
 
         async Task IPartitionObserver<BlobLease>.OnPartitionAcquiredAsync(BlobLease lease)
@@ -551,7 +537,7 @@ namespace DurableTask.AzureStorage
 
         internal static async Task<CloudQueue[]> GetControlQueuesAsync(
             CloudStorageAccount account,
-            string taskHub,
+            AzureStorageOrchestrationServiceSettings settings,
             int defaultPartitionCount)
         {
             if (account == null)
@@ -559,12 +545,13 @@ namespace DurableTask.AzureStorage
                 throw new ArgumentNullException(nameof(account));
             }
 
-            if (taskHub == null)
+            if (settings.TaskHubName == null)
             {
-                throw new ArgumentNullException(nameof(taskHub));
+                throw new ArgumentNullException(nameof(settings.TaskHubName));
             }
 
-            BlobLeaseManager inactiveLeaseManager = GetBlobLeaseManager(taskHub, "n/a", account, TimeSpan.Zero, TimeSpan.Zero, null);
+            string taskHub = settings.TaskHubName;
+            BlobLeaseManager inactiveLeaseManager = GetBlobLeaseManager(settings, account, null);
             TaskHubInfo hubInfo = await inactiveLeaseManager.GetOrCreateTaskHubInfoAsync(
                 GetTaskHubInfo(taskHub, defaultPartitionCount));
 
@@ -592,7 +579,7 @@ namespace DurableTask.AzureStorage
             TimeSpan receiveTimeout,
             CancellationToken cancellationToken)
         {
-            Guid traceActivityId = StartNewLogicalTraceScope();
+            Guid traceActivityId = StartNewLogicalTraceScope(useExisting: true);
 
             await this.EnsureTaskHubAsync();
 
@@ -632,7 +619,7 @@ namespace DurableTask.AzureStorage
                             // This can happen if a lease change occurs and a new node receives a message for an 
                             // orchestration that has not yet checkpointed its history. We abandon such messages
                             // so that they can be reprocessed after the history checkpoint has completed.
-                            AnalyticsEventSource.Log.ReceivedOutOfOrderMessage(
+                            this.settings.Logger.ReceivedOutOfOrderMessage(
                                 this.storageAccountName,
                                 this.settings.TaskHubName,
                                 session.Instance.InstanceId,
@@ -642,8 +629,7 @@ namespace DurableTask.AzureStorage
                                 Utils.GetTaskEventId(message.TaskMessage.Event),
                                 message.OriginalQueueMessage.Id,
                                 message.Episode.GetValueOrDefault(-1),
-                                session.LastCheckpointTime,
-                                Utils.ExtensionVersion);
+                                session.LastCheckpointTime);
                             outOfOrderMessages.Add(message);
                         }
                         else
@@ -714,7 +700,7 @@ namespace DurableTask.AzureStorage
                             eventListBuilder.Append(msg.TaskMessage.Event.EventType.ToString()).Append(',');
                         }
 
-                        AnalyticsEventSource.Log.DiscardingWorkItem(
+                        this.settings.Logger.DiscardingWorkItem(
                             this.storageAccountName,
                             this.settings.TaskHubName,
                             session.Instance.InstanceId,
@@ -722,8 +708,7 @@ namespace DurableTask.AzureStorage
                             orchestrationWorkItem.NewMessages.Count,
                             session.RuntimeState.Events.Count,
                             eventListBuilder.ToString(0, eventListBuilder.Length - 1) /* remove trailing comma */,
-                            warningMessage,
-                            Utils.ExtensionVersion);
+                            warningMessage);
 
                         // The instance has already completed or never existed. Delete this message batch.
                         await this.DeleteMessageBatchAsync(session, messagesToDiscard);
@@ -745,13 +730,12 @@ namespace DurableTask.AzureStorage
                 }
                 catch (Exception e)
                 {
-                    AnalyticsEventSource.Log.OrchestrationProcessingFailure(
+                    this.settings.Logger.OrchestrationProcessingFailure(
                         this.storageAccountName,
                         this.settings.TaskHubName,
                         session?.Instance.InstanceId ?? string.Empty,
                         session?.Instance.ExecutionId ?? string.Empty,
-                        e.ToString(),
-                        Utils.ExtensionVersion);
+                        e.ToString());
 
                     if (orchestrationWorkItem != null)
                     {
@@ -764,18 +748,33 @@ namespace DurableTask.AzureStorage
             }
         }
 
-        internal static Guid StartNewLogicalTraceScope()
+        internal static Guid StartNewLogicalTraceScope(bool useExisting)
         {
-            // This call sets the activity trace ID both on the current thread context
-            // and on the logical call context. AnalyticsEventSource will use this 
-            // activity ID for all trace operations.
-            Guid traceActivityId = Guid.NewGuid();
+            // Starting in DurableTask.Core v2.4.0, a new trace activity will already be
+            // started and we don't need to start one ourselves.
+            // TODO: When distributed correlation is merged, use that instead.
+            Guid traceActivityId;
+            if (useExisting && EventSource.CurrentThreadActivityId != Guid.Empty)
+            {
+                traceActivityId = EventSource.CurrentThreadActivityId;
+            }
+            else
+            {
+                // No ambient trace activity ID was found or doesn't apply - create a new one
+                traceActivityId = Guid.NewGuid();
+            }
+
             AnalyticsEventSource.SetLogicalTraceActivityId(traceActivityId);
             return traceActivityId;
         }
 
-        internal static void TraceMessageReceived(MessageData data, string storageAccountName, string taskHubName)
+        internal static void TraceMessageReceived(AzureStorageOrchestrationServiceSettings settings, MessageData data, string storageAccountName)
         {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
             if (data == null)
             {
                 throw new ArgumentNullException(nameof(data));
@@ -784,10 +783,10 @@ namespace DurableTask.AzureStorage
             TaskMessage taskMessage = data.TaskMessage;
             CloudQueueMessage queueMessage = data.OriginalQueueMessage;
 
-            AnalyticsEventSource.Log.ReceivedMessage(
+            settings.Logger.ReceivedMessage(
                 data.ActivityId,
                 storageAccountName,
-                taskHubName,
+                settings.TaskHubName,
                 taskMessage.Event.EventType.ToString(),
                 Utils.GetTaskEventId(taskMessage.Event),
                 taskMessage.OrchestrationInstance.InstanceId,
@@ -799,8 +798,7 @@ namespace DurableTask.AzureStorage
                 data.TotalMessageSizeBytes,
                 data.QueueName /* PartitionId */,
                 data.SequenceNumber,
-                data.Episode.GetValueOrDefault(-1),
-                Utils.ExtensionVersion);
+                data.Episode.GetValueOrDefault(-1));
         }
 
         bool IsExecutableInstance(OrchestrationRuntimeState runtimeState, IList<TaskMessage> newMessages, out string message)
@@ -876,11 +874,10 @@ namespace DurableTask.AzureStorage
             OrchestrationSession session;
             if (!this.orchestrationSessionManager.TryGetExistingSession(workItem.InstanceId, out session))
             {
-                AnalyticsEventSource.Log.AssertFailure(
+                this.settings.Logger.AssertFailure(
                     this.storageAccountName,
                     this.settings.TaskHubName,
-                    $"{nameof(CompleteTaskOrchestrationWorkItemAsync)}: Session for instance {workItem.InstanceId} was not found!",
-                    Utils.ExtensionVersion);
+                    $"{nameof(CompleteTaskOrchestrationWorkItemAsync)}: Session for instance {workItem.InstanceId} was not found!");
                 return;
             }
 
@@ -932,13 +929,12 @@ namespace DurableTask.AzureStorage
                     // TODO: https://github.com/Azure/azure-functions-durable-extension/issues/332
                     //       It's possible that history updates may have been partially committed at this point.
                     //       If so, what are the implications of this as far as DurableTask.Core are concerned?
-                    AnalyticsEventSource.Log.OrchestrationProcessingFailure(
+                    this.settings.Logger.OrchestrationProcessingFailure(
                         this.storageAccountName,
                         this.settings.TaskHubName,
                         instanceId,
                         executionId,
-                        e.ToString(),
-                        Utils.ExtensionVersion);
+                        e.ToString());
                 }
 
                 throw;
@@ -1016,11 +1012,10 @@ namespace DurableTask.AzureStorage
             OrchestrationSession session;
             if (!this.orchestrationSessionManager.TryGetExistingSession(workItem.InstanceId, out session))
             {
-                AnalyticsEventSource.Log.AssertFailure(
+                this.settings.Logger.AssertFailure(
                     this.storageAccountName,
                     this.settings.TaskHubName,
-                    $"{nameof(RenewTaskOrchestrationWorkItemLockAsync)}: Session for instance {workItem.InstanceId} was not found!",
-                    Utils.ExtensionVersion);
+                    $"{nameof(RenewTaskOrchestrationWorkItemLockAsync)}: Session for instance {workItem.InstanceId} was not found!");
                 return;
             }
 
@@ -1042,11 +1037,10 @@ namespace DurableTask.AzureStorage
             OrchestrationSession session;
             if (!this.orchestrationSessionManager.TryGetExistingSession(workItem.InstanceId, out session))
             {
-                AnalyticsEventSource.Log.AssertFailure(
+                this.settings.Logger.AssertFailure(
                     this.storageAccountName,
                     this.settings.TaskHubName,
-                    $"{nameof(AbandonTaskOrchestrationWorkItemAsync)}: Session for instance {workItem.InstanceId} was not found!",
-                    Utils.ExtensionVersion);
+                    $"{nameof(AbandonTaskOrchestrationWorkItemAsync)}: Session for instance {workItem.InstanceId} was not found!");
                 return Utils.CompletedTask;
             }
 
@@ -1115,20 +1109,19 @@ namespace DurableTask.AzureStorage
                 }
 
                 Guid traceActivityId = Guid.NewGuid();
-                var session = new ActivitySession(this.storageAccountName, this.settings.TaskHubName, message, traceActivityId);
+                var session = new ActivitySession(this.settings, this.storageAccountName, message, traceActivityId);
                 session.StartNewLogicalTraceScope();
-                TraceMessageReceived(session.MessageData, this.storageAccountName, this.settings.TaskHubName);
+                TraceMessageReceived(this.settings, session.MessageData, this.storageAccountName);
                 session.TraceProcessingMessage(message, isExtendedSession: false);
 
                 if (!this.activeActivitySessions.TryAdd(message.Id, session))
                 {
                     // This means we're already processing this message. This is never expected since the message
                     // should be kept invisible via background calls to RenewTaskActivityWorkItemLockAsync.
-                    AnalyticsEventSource.Log.AssertFailure(
+                    this.settings.Logger.AssertFailure(
                         this.storageAccountName,
                         this.settings.TaskHubName,
-                        $"Work item queue message with ID = {message.Id} is being processed multiple times concurrently.",
-                        Utils.ExtensionVersion);
+                        $"Work item queue message with ID = {message.Id} is being processed multiple times concurrently.");
                     return null;
                 }
 
@@ -1150,11 +1143,10 @@ namespace DurableTask.AzureStorage
             if (!this.activeActivitySessions.TryGetValue(workItem.Id, out session))
             {
                 // The context does not exist - possibly because it was already removed.
-                AnalyticsEventSource.Log.AssertFailure(
+                this.settings.Logger.AssertFailure(
                     this.storageAccountName,
                     this.settings.TaskHubName,
-                    $"Could not find context for work item with ID = {workItem.Id}.",
-                    Utils.ExtensionVersion);
+                    $"Could not find context for work item with ID = {workItem.Id}.");
                 return;
             }
 
@@ -1208,11 +1200,10 @@ namespace DurableTask.AzureStorage
             if (!this.activeActivitySessions.TryGetValue(workItem.Id, out session))
             {
                 // The context does not exist - possibly because it was already removed.
-                AnalyticsEventSource.Log.AssertFailure(
+                this.settings.Logger.AssertFailure(
                     this.storageAccountName,
                     this.settings.TaskHubName,
-                    $"Could not find context for work item with ID = {workItem.Id}.",
-                    Utils.ExtensionVersion);
+                    $"Could not find context for work item with ID = {workItem.Id}.");
                 return;
             }
 

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -14,8 +14,10 @@
 namespace DurableTask.AzureStorage
 {
     using System;
+    using DurableTask.AzureStorage.Logging;
     using DurableTask.Core;
     using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
     using Microsoft.WindowsAzure.Storage.Queue;
     using Microsoft.WindowsAzure.Storage.Table;
 
@@ -27,6 +29,8 @@ namespace DurableTask.AzureStorage
         internal const int DefaultPartitionCount = 4;
 
         internal static readonly TimeSpan DefaultMaxQueuePollingInterval = TimeSpan.FromSeconds(30);
+
+        LogHelper logHelper;
 
         /// <summary>
         /// Gets or sets the number of messages to pull from the control queue at a time. The default is 32.
@@ -181,7 +185,7 @@ namespace DurableTask.AzureStorage
         /// <summary>
         /// Gets or sets the optional <see cref="ILoggerFactory"/> to use for diagnostic logging.
         /// </summary>
-        public ILoggerFactory LoggerFactory { get; set; }
+        public ILoggerFactory LoggerFactory { get; set; } = NullLoggerFactory.Instance;
 
         /// <summary>
         /// Returns bool indicating is the TrackingStoreStorageAccount has been set.
@@ -191,5 +195,18 @@ namespace DurableTask.AzureStorage
         internal string HistoryTableName => this.HasTrackingStoreStorageAccount ? $"{this.TrackingStoreNamePrefix}History" : $"{this.TaskHubName}History";
 
         internal string InstanceTableName => this.HasTrackingStoreStorageAccount ? $"{this.TrackingStoreNamePrefix}Instances" : $"{this.TaskHubName}Instances";
+
+        internal LogHelper Logger
+        {
+            get
+            {
+                if (this.logHelper == null)
+                {
+                    this.logHelper = new LogHelper(this.LoggerFactory.CreateLogger("DurableTask.Core"));
+                }
+
+                return this.logHelper;
+            }
+        }
     }
 }

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -196,13 +196,16 @@ namespace DurableTask.AzureStorage
 
         internal string InstanceTableName => this.HasTrackingStoreStorageAccount ? $"{this.TrackingStoreNamePrefix}Instances" : $"{this.TaskHubName}Instances";
 
+        /// <summary>
+        /// Gets an instance of <see cref="LogHelper"/> that can be used for writing structured logs.
+        /// </summary>
         internal LogHelper Logger
         {
             get
             {
                 if (this.logHelper == null)
                 {
-                    this.logHelper = new LogHelper(this.LoggerFactory.CreateLogger("DurableTask.Core"));
+                    this.logHelper = new LogHelper(this.LoggerFactory.CreateLogger("DurableTask.AzureStorage"));
                 }
 
                 return this.logHelper;

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -15,6 +15,7 @@ namespace DurableTask.AzureStorage
 {
     using System;
     using DurableTask.Core;
+    using Microsoft.Extensions.Logging;
     using Microsoft.WindowsAzure.Storage.Queue;
     using Microsoft.WindowsAzure.Storage.Table;
 
@@ -178,9 +179,14 @@ namespace DurableTask.AzureStorage
         public bool ThrowExceptionOnInvalidDedupeStatus { get; set; } = false;
 
         /// <summary>
+        /// Gets or sets the optional <see cref="ILoggerFactory"/> to use for diagnostic logging.
+        /// </summary>
+        public ILoggerFactory LoggerFactory { get; set; }
+
+        /// <summary>
         /// Returns bool indicating is the TrackingStoreStorageAccount has been set.
         /// </summary>
-        public  bool HasTrackingStoreStorageAccount => TrackingStoreStorageAccountDetails != null;
+        public  bool HasTrackingStoreStorageAccount => this.TrackingStoreStorageAccountDetails != null;
 
         internal string HistoryTableName => this.HasTrackingStoreStorageAccount ? $"{this.TrackingStoreNamePrefix}History" : $"{this.TaskHubName}History";
 

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -2,9 +2,9 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <FileVersion>1.7.7</FileVersion>
+    <FileVersion>1.8.0</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <Version>$(FileVersion)</Version>
     <IncludeSymbols>true</IncludeSymbols>
@@ -19,10 +19,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.5" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.*" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
     <PackageReference Include="WindowsAzure.Storage" version="7.2.1" />
   </ItemGroup>

--- a/src/DurableTask.AzureStorage/Logging/EventIds.cs
+++ b/src/DurableTask.AzureStorage/Logging/EventIds.cs
@@ -1,0 +1,46 @@
+﻿namespace DurableTask.AzureStorage.Logging
+{
+    static class EventIds
+    {
+        public const int SendingMessage = 101;
+        public const int ReceivedMessage = 102;
+        public const int DeletingMessage = 103;
+        public const int AbandoningMessage = 104;
+        public const int AssertFailure = 105;
+        public const int MessageGone = 106;
+        public const int GeneralError = 107;
+        public const int DuplicateMessageDetected = 108;
+        public const int PoisonMessageDetected = 109;
+        public const int FetchedInstanceHistory = 110;
+        public const int AppendedInstanceHistory = 111;
+        public const int OrchestrationServiceStats = 112;
+        public const int RenewingMessage = 113;
+        public const int MessageFailure = 114;
+        public const int OrchestrationProcessingFailure = 115;
+        public const int PendingOrchestratorMessageLimitReached = 116;
+        public const int WaitingForMoreMessages = 117;
+        public const int ReceivedOutOfOrderMessage = 118;
+        public const int PartitionManagerInfo = 120;
+        public const int PartitionManagerWarning = 121;
+        public const int PartitionManagerError = 122;
+        public const int StartingLeaseRenewal = 123;
+        public const int LeaseRenewalResult = 124;
+        public const int LeaseRenewalFailed = 125;
+        public const int LeaseAcquisitionStarted = 126;
+        public const int LeaseAcquisitionSucceeded = 127;
+        public const int LeaseAcquisitionFailed = 128;
+        public const int AttemptingToStealLease = 129;
+        public const int LeaseStealingSucceeded = 130;
+        public const int LeaseStealingFailed = 131;
+        public const int PartitionRemoved = 132;
+        public const int LeaseRemoved = 133;
+        public const int LeaseRemovalFailed = 134;
+        public const int InstanceStatusUpdate = 135;
+        public const int FetchedInstanceStatus = 136;
+        public const int GeneralWarning = 137;
+        public const int SplitBrainDetected = 138;
+        public const int DiscardingWorkItem = 139;
+        public const int ProcessingMessage = 140;
+        public const int PurgeInstanceHistory = 141;
+    }
+}

--- a/src/DurableTask.AzureStorage/Logging/EventIds.cs
+++ b/src/DurableTask.AzureStorage/Logging/EventIds.cs
@@ -1,4 +1,17 @@
-﻿namespace DurableTask.AzureStorage.Logging
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureStorage.Logging
 {
     static class EventIds
     {

--- a/src/DurableTask.AzureStorage/Logging/LogEvents.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogEvents.cs
@@ -714,7 +714,7 @@
                 long latencyMs,
                 int sizeInBytes,
                 string eTag,
-                Boolean isCheckpointComplete)
+                bool isCheckpointComplete)
             {
                 this.Account = account;
                 this.TaskHub = taskHub;
@@ -764,7 +764,7 @@
             public string ETag { get; }
 
             [StructuredLogField]
-            public Boolean IsCheckpointComplete { get; }
+            public bool IsCheckpointComplete { get; }
 
             public override EventId EventId => new EventId(
                 EventIds.AppendedInstanceHistory,
@@ -1427,7 +1427,7 @@
                 string taskHub,
                 string workerName,
                 string partitionId,
-                Boolean success,
+                bool success,
                 string token,
                 string details)
             {
@@ -1453,7 +1453,7 @@
             public string PartitionId { get; }
 
             [StructuredLogField]
-            public Boolean Success { get; }
+            public bool Success { get; }
 
             [StructuredLogField]
             public string Token { get; }
@@ -2238,7 +2238,7 @@
                 int age,
                 long sequenceNumber,
                 int episode,
-                Boolean isExtendedSession)
+                bool isExtendedSession)
             {
                 this.RelatedActivityId = relatedActivityId;
                 this.Account = account;
@@ -2287,7 +2287,7 @@
             public int Episode { get; }
 
             [StructuredLogField]
-            public Boolean IsExtendedSession { get; }
+            public bool IsExtendedSession { get; }
 
             public override EventId EventId => new EventId(
                 EventIds.ProcessingMessage,

--- a/src/DurableTask.AzureStorage/Logging/LogEvents.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogEvents.cs
@@ -1,0 +1,2382 @@
+﻿namespace DurableTask.AzureStorage.Logging
+{
+    using System;
+    using DurableTask.Core.Logging;
+    using Microsoft.Extensions.Logging;
+
+    static class LogEvents
+    {
+        internal class SendingMessage : StructuredLogEvent, IEventSourceEvent
+        {
+            public SendingMessage(
+                Guid relatedActivityId,
+                string account,
+                string taskHub,
+                string eventType,
+                int taskEventId,
+                string instanceId,
+                string executionId,
+                long sizeInBytes,
+                string partitionId,
+                string targetInstanceId,
+                string targetExecutionId,
+                long sequenceNumber,
+                int episode)
+            {
+                this.RelatedActivityId = relatedActivityId;
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.EventType = eventType;
+                this.TaskEventId = taskEventId;
+                this.InstanceId = instanceId;
+                this.ExecutionId = executionId;
+                this.SizeInBytes = sizeInBytes;
+                this.PartitionId = partitionId;
+                this.TargetInstanceId = targetInstanceId;
+                this.TargetExecutionId = targetExecutionId;
+                this.SequenceNumber = sequenceNumber;
+                this.Episode = episode;
+            }
+
+            public Guid RelatedActivityId { get; }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string EventType { get; }
+
+            [StructuredLogField]
+            public int TaskEventId { get; }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public long SizeInBytes { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            [StructuredLogField]
+            public string TargetInstanceId { get; }
+
+            [StructuredLogField]
+            public string TargetExecutionId { get; }
+
+            [StructuredLogField]
+            public long SequenceNumber { get; }
+
+            [StructuredLogField]
+            public int Episode { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.SendingMessage,
+                nameof(EventIds.SendingMessage));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.SendingMessage(
+                this.RelatedActivityId,
+                this.Account,
+                this.TaskHub,
+                this.EventType,
+                this.TaskEventId,
+                this.InstanceId,
+                this.ExecutionId,
+                this.SizeInBytes,
+                this.PartitionId,
+                this.TargetInstanceId,
+                this.TargetExecutionId,
+                this.SequenceNumber,
+                this.Episode,
+                Utils.ExtensionVersion);
+        }
+
+        internal class ReceivedMessage : StructuredLogEvent, IEventSourceEvent
+        {
+            public ReceivedMessage(
+                Guid relatedActivityId,
+                string account,
+                string taskHub,
+                string eventType,
+                int taskEventId,
+                string instanceId,
+                string executionId,
+                string messageId,
+                int age,
+                int dequeueCount,
+                string nextVisibleTime,
+                long sizeInBytes,
+                string partitionId,
+                long sequenceNumber,
+                int episode)
+            {
+                this.RelatedActivityId = relatedActivityId;
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.EventType = eventType;
+                this.TaskEventId = taskEventId;
+                this.InstanceId = instanceId;
+                this.ExecutionId = executionId;
+                this.MessageId = messageId;
+                this.Age = age;
+                this.DequeueCount = dequeueCount;
+                this.NextVisibleTime = nextVisibleTime;
+                this.SizeInBytes = sizeInBytes;
+                this.PartitionId = partitionId;
+                this.SequenceNumber = sequenceNumber;
+                this.Episode = episode;
+            }
+
+            public Guid RelatedActivityId { get; }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string EventType { get; }
+
+            [StructuredLogField]
+            public int TaskEventId { get; }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string MessageId { get; }
+
+            [StructuredLogField]
+            public int Age { get; }
+
+            [StructuredLogField]
+            public int DequeueCount { get; }
+
+            [StructuredLogField]
+            public string NextVisibleTime { get; }
+
+            [StructuredLogField]
+            public long SizeInBytes { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            [StructuredLogField]
+            public long SequenceNumber { get; }
+
+            [StructuredLogField]
+            public int Episode { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.ReceivedMessage,
+                nameof(EventIds.ReceivedMessage));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.ReceivedMessage(
+                this.RelatedActivityId,
+                this.Account,
+                this.TaskHub,
+                this.EventType,
+                this.TaskEventId,
+                this.InstanceId,
+                this.ExecutionId,
+                this.MessageId,
+                this.Age,
+                this.DequeueCount,
+                this.NextVisibleTime,
+                this.SizeInBytes,
+                this.PartitionId,
+                this.SequenceNumber,
+                this.Episode,
+                Utils.ExtensionVersion);
+        }
+
+        internal class DeletingMessage : StructuredLogEvent, IEventSourceEvent
+        {
+            public DeletingMessage(
+                string account,
+                string taskHub,
+                string eventType,
+                int taskEventId,
+                string messageId,
+                string instanceId,
+                string executionId,
+                string partitionId,
+                long sequenceNumber)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.EventType = eventType;
+                this.TaskEventId = taskEventId;
+                this.MessageId = messageId;
+                this.InstanceId = instanceId;
+                this.ExecutionId = executionId;
+                this.PartitionId = partitionId;
+                this.SequenceNumber = sequenceNumber;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string EventType { get; }
+
+            [StructuredLogField]
+            public int TaskEventId { get; }
+
+            [StructuredLogField]
+            public string MessageId { get; }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            [StructuredLogField]
+            public long SequenceNumber { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.DeletingMessage,
+                nameof(EventIds.DeletingMessage));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.DeletingMessage(
+                this.Account,
+                this.TaskHub,
+                this.EventType,
+                this.TaskEventId,
+                this.MessageId,
+                this.InstanceId,
+                this.ExecutionId,
+                this.PartitionId,
+                this.SequenceNumber,
+                Utils.ExtensionVersion);
+        }
+
+        internal class AbandoningMessage : StructuredLogEvent, IEventSourceEvent
+        {
+            public AbandoningMessage(
+                string account,
+                string taskHub,
+                string eventType,
+                int taskEventId,
+                string messageId,
+                string instanceId,
+                string executionId,
+                string partitionId,
+                long sequenceNumber,
+                int visibilityTimeoutSeconds)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.EventType = eventType;
+                this.TaskEventId = taskEventId;
+                this.MessageId = messageId;
+                this.InstanceId = instanceId;
+                this.ExecutionId = executionId;
+                this.PartitionId = partitionId;
+                this.SequenceNumber = sequenceNumber;
+                this.VisibilityTimeoutSeconds = visibilityTimeoutSeconds;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string EventType { get; }
+
+            [StructuredLogField]
+            public int TaskEventId { get; }
+
+            [StructuredLogField]
+            public string MessageId { get; }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            [StructuredLogField]
+            public long SequenceNumber { get; }
+
+            [StructuredLogField]
+            public int VisibilityTimeoutSeconds { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.AbandoningMessage,
+                nameof(EventIds.AbandoningMessage));
+
+            public override LogLevel Level => LogLevel.Warning;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.AbandoningMessage(
+                this.Account,
+                this.TaskHub,
+                this.EventType,
+                this.TaskEventId,
+                this.MessageId,
+                this.InstanceId,
+                this.ExecutionId,
+                this.PartitionId,
+                this.SequenceNumber,
+                this.VisibilityTimeoutSeconds,
+                Utils.ExtensionVersion);
+        }
+
+        internal class AssertFailure : StructuredLogEvent, IEventSourceEvent
+        {
+            public AssertFailure(
+                string account,
+                string taskHub,
+                string details)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.Details = details;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.AssertFailure,
+                nameof(EventIds.AssertFailure));
+
+            public override LogLevel Level => LogLevel.Warning;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.AssertFailure(
+                this.Account,
+                this.TaskHub,
+                this.Details,
+                Utils.ExtensionVersion);
+        }
+
+        internal class MessageGone : StructuredLogEvent, IEventSourceEvent
+        {
+            public MessageGone(
+                string account,
+                string taskHub,
+                string messageId,
+                string instanceId,
+                string executionId,
+                string partitionId,
+                string eventType,
+                int taskEventId,
+                string details)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.MessageId = messageId;
+                this.InstanceId = instanceId;
+                this.ExecutionId = executionId;
+                this.PartitionId = partitionId;
+                this.EventType = eventType;
+                this.TaskEventId = taskEventId;
+                this.Details = details;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string MessageId { get; }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            [StructuredLogField]
+            public string EventType { get; }
+
+            [StructuredLogField]
+            public int TaskEventId { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.MessageGone,
+                nameof(EventIds.MessageGone));
+
+            public override LogLevel Level => LogLevel.Warning;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.MessageGone(
+                this.Account,
+                this.TaskHub,
+                this.MessageId,
+                this.InstanceId,
+                this.ExecutionId,
+                this.PartitionId,
+                this.EventType,
+                this.TaskEventId,
+                this.Details,
+                Utils.ExtensionVersion);
+        }
+
+        internal class GeneralError : StructuredLogEvent, IEventSourceEvent
+        {
+            public GeneralError(
+                string account,
+                string taskHub,
+                string details)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.Details = details;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.GeneralError,
+                nameof(EventIds.GeneralError));
+
+            public override LogLevel Level => LogLevel.Error;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.GeneralError(
+                this.Account,
+                this.TaskHub,
+                this.Details,
+                Utils.ExtensionVersion);
+        }
+
+        internal class DuplicateMessageDetected : StructuredLogEvent, IEventSourceEvent
+        {
+            public DuplicateMessageDetected(
+                string account,
+                string taskHub,
+                string messageId,
+                string instanceId,
+                string executionId,
+                string partitionId,
+                int dequeueCount)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.MessageId = messageId;
+                this.InstanceId = instanceId;
+                this.ExecutionId = executionId;
+                this.PartitionId = partitionId;
+                this.DequeueCount = dequeueCount;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string MessageId { get; }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            [StructuredLogField]
+            public int DequeueCount { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.DuplicateMessageDetected,
+                nameof(EventIds.DuplicateMessageDetected));
+
+            public override LogLevel Level => LogLevel.Warning;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.DuplicateMessageDetected(
+                this.Account,
+                this.TaskHub,
+                this.MessageId,
+                this.InstanceId,
+                this.ExecutionId,
+                this.PartitionId,
+                this.DequeueCount,
+                Utils.ExtensionVersion);
+        }
+
+        internal class PoisonMessageDetected : StructuredLogEvent, IEventSourceEvent
+        {
+            public PoisonMessageDetected(
+                string account,
+                string taskHub,
+                string messageId,
+                string instanceId,
+                string executionId,
+                string partitionId,
+                int dequeueCount)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.MessageId = messageId;
+                this.InstanceId = instanceId;
+                this.ExecutionId = executionId;
+                this.PartitionId = partitionId;
+                this.DequeueCount = dequeueCount;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string MessageId { get; }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            [StructuredLogField]
+            public int DequeueCount { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.PoisonMessageDetected,
+                nameof(EventIds.PoisonMessageDetected));
+
+            public override LogLevel Level => LogLevel.Warning;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.PoisonMessageDetected(
+                this.Account,
+                this.TaskHub,
+                this.MessageId,
+                this.InstanceId,
+                this.ExecutionId,
+                this.PartitionId,
+                this.DequeueCount,
+                Utils.ExtensionVersion);
+        }
+
+        internal class FetchedInstanceHistory : StructuredLogEvent, IEventSourceEvent
+        {
+            public FetchedInstanceHistory(
+                string account,
+                string taskHub,
+                string instanceId,
+                string executionId,
+                int eventCount,
+                int episode,
+                int requestCount,
+                long latencyMs,
+                string eTag,
+                DateTime lastCheckpointTime)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.InstanceId = instanceId;
+                this.ExecutionId = executionId;
+                this.EventCount = eventCount;
+                this.Episode = episode;
+                this.RequestCount = requestCount;
+                this.LatencyMs = latencyMs;
+                this.ETag = eTag;
+                this.LastCheckpointTime = lastCheckpointTime;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public int EventCount { get; }
+
+            [StructuredLogField]
+            public int Episode { get; }
+
+            [StructuredLogField]
+            public int RequestCount { get; }
+
+            [StructuredLogField]
+            public long LatencyMs { get; }
+
+            [StructuredLogField]
+            public string ETag { get; }
+
+            [StructuredLogField]
+            public DateTime LastCheckpointTime { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.FetchedInstanceHistory,
+                nameof(EventIds.FetchedInstanceHistory));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.FetchedInstanceHistory(
+                this.Account,
+                this.TaskHub,
+                this.InstanceId,
+                this.ExecutionId,
+                this.EventCount,
+                this.Episode,
+                this.RequestCount,
+                this.LatencyMs,
+                this.ETag,
+                this.LastCheckpointTime,
+                Utils.ExtensionVersion);
+        }
+
+        internal class AppendedInstanceHistory : StructuredLogEvent, IEventSourceEvent
+        {
+            public AppendedInstanceHistory(
+                string account,
+                string taskHub,
+                string instanceId,
+                string executionId,
+                int newEventCount,
+                int totalEventCount,
+                string newEvents,
+                int episode,
+                long latencyMs,
+                int sizeInBytes,
+                string eTag,
+                Boolean isCheckpointComplete)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.InstanceId = instanceId;
+                this.ExecutionId = executionId;
+                this.NewEventCount = newEventCount;
+                this.TotalEventCount = totalEventCount;
+                this.NewEvents = newEvents;
+                this.Episode = episode;
+                this.LatencyMs = latencyMs;
+                this.SizeInBytes = sizeInBytes;
+                this.ETag = eTag;
+                this.IsCheckpointComplete = isCheckpointComplete;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public int NewEventCount { get; }
+
+            [StructuredLogField]
+            public int TotalEventCount { get; }
+
+            [StructuredLogField]
+            public string NewEvents { get; }
+
+            [StructuredLogField]
+            public int Episode { get; }
+
+            [StructuredLogField]
+            public long LatencyMs { get; }
+
+            [StructuredLogField]
+            public int SizeInBytes { get; }
+
+            [StructuredLogField]
+            public string ETag { get; }
+
+            [StructuredLogField]
+            public Boolean IsCheckpointComplete { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.AppendedInstanceHistory,
+                nameof(EventIds.AppendedInstanceHistory));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.AppendedInstanceHistory(
+                this.Account,
+                this.TaskHub,
+                this.InstanceId,
+                this.ExecutionId,
+                this.NewEventCount,
+                this.TotalEventCount,
+                this.NewEvents,
+                this.Episode,
+                this.LatencyMs,
+                this.SizeInBytes,
+                this.ETag,
+                this.IsCheckpointComplete,
+                Utils.ExtensionVersion);
+        }
+
+        internal class OrchestrationServiceStats : StructuredLogEvent, IEventSourceEvent
+        {
+            public OrchestrationServiceStats(
+                string account,
+                string taskHub,
+                long storageRequests,
+                long messagesSent,
+                long messagesRead,
+                long messagesUpdated,
+                long tableEntitiesWritten,
+                long tableEntitiesRead,
+                long pendingOrchestrators,
+                long pendingOrchestratorMessages,
+                long activeOrchestrators,
+                long activeActivities)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.StorageRequests = storageRequests;
+                this.MessagesSent = messagesSent;
+                this.MessagesRead = messagesRead;
+                this.MessagesUpdated = messagesUpdated;
+                this.TableEntitiesWritten = tableEntitiesWritten;
+                this.TableEntitiesRead = tableEntitiesRead;
+                this.PendingOrchestrators = pendingOrchestrators;
+                this.PendingOrchestratorMessages = pendingOrchestratorMessages;
+                this.ActiveOrchestrators = activeOrchestrators;
+                this.ActiveActivities = activeActivities;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public long StorageRequests { get; }
+
+            [StructuredLogField]
+            public long MessagesSent { get; }
+
+            [StructuredLogField]
+            public long MessagesRead { get; }
+
+            [StructuredLogField]
+            public long MessagesUpdated { get; }
+
+            [StructuredLogField]
+            public long TableEntitiesWritten { get; }
+
+            [StructuredLogField]
+            public long TableEntitiesRead { get; }
+
+            [StructuredLogField]
+            public long PendingOrchestrators { get; }
+
+            [StructuredLogField]
+            public long PendingOrchestratorMessages { get; }
+
+            [StructuredLogField]
+            public long ActiveOrchestrators { get; }
+
+            [StructuredLogField]
+            public long ActiveActivities { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.OrchestrationServiceStats,
+                nameof(EventIds.OrchestrationServiceStats));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.OrchestrationServiceStats(
+                this.Account,
+                this.TaskHub,
+                this.StorageRequests,
+                this.MessagesSent,
+                this.MessagesRead,
+                this.MessagesUpdated,
+                this.TableEntitiesWritten,
+                this.TableEntitiesRead,
+                this.PendingOrchestrators,
+                this.PendingOrchestratorMessages,
+                this.ActiveOrchestrators,
+                this.ActiveActivities,
+                Utils.ExtensionVersion);
+        }
+
+        internal class RenewingMessage : StructuredLogEvent, IEventSourceEvent
+        {
+            public RenewingMessage(
+                string account,
+                string taskHub,
+                string instanceId,
+                string executionId,
+                string partitionId,
+                string eventType,
+                int taskEventId,
+                string messageId,
+                int visibilityTimeoutSeconds)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.InstanceId = instanceId;
+                this.ExecutionId = executionId;
+                this.PartitionId = partitionId;
+                this.EventType = eventType;
+                this.TaskEventId = taskEventId;
+                this.MessageId = messageId;
+                this.VisibilityTimeoutSeconds = visibilityTimeoutSeconds;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            [StructuredLogField]
+            public string EventType { get; }
+
+            [StructuredLogField]
+            public int TaskEventId { get; }
+
+            [StructuredLogField]
+            public string MessageId { get; }
+
+            [StructuredLogField]
+            public int VisibilityTimeoutSeconds { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.RenewingMessage,
+                nameof(EventIds.RenewingMessage));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.RenewingMessage(
+                this.Account,
+                this.TaskHub,
+                this.InstanceId,
+                this.ExecutionId,
+                this.PartitionId,
+                this.EventType,
+                this.TaskEventId,
+                this.MessageId,
+                this.VisibilityTimeoutSeconds,
+                Utils.ExtensionVersion);
+        }
+
+        internal class MessageFailure : StructuredLogEvent, IEventSourceEvent
+        {
+            public MessageFailure(
+                string account,
+                string taskHub,
+                string messageId,
+                string instanceId,
+                string executionId,
+                string partitionId,
+                string eventType,
+                int taskEventId,
+                string details)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.MessageId = messageId;
+                this.InstanceId = instanceId;
+                this.ExecutionId = executionId;
+                this.PartitionId = partitionId;
+                this.EventType = eventType;
+                this.TaskEventId = taskEventId;
+                this.Details = details;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string MessageId { get; }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            [StructuredLogField]
+            public string EventType { get; }
+
+            [StructuredLogField]
+            public int TaskEventId { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.MessageFailure,
+                nameof(EventIds.MessageFailure));
+
+            public override LogLevel Level => LogLevel.Error;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.MessageFailure(
+                this.Account,
+                this.TaskHub,
+                this.MessageId,
+                this.InstanceId,
+                this.ExecutionId,
+                this.PartitionId,
+                this.EventType,
+                this.TaskEventId,
+                this.Details,
+                Utils.ExtensionVersion);
+        }
+
+        internal class OrchestrationProcessingFailure : StructuredLogEvent, IEventSourceEvent
+        {
+            public OrchestrationProcessingFailure(
+                string account,
+                string taskHub,
+                string instanceId,
+                string executionId,
+                string details)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.InstanceId = instanceId;
+                this.ExecutionId = executionId;
+                this.Details = details;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.OrchestrationProcessingFailure,
+                nameof(EventIds.OrchestrationProcessingFailure));
+
+            public override LogLevel Level => LogLevel.Error;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.OrchestrationProcessingFailure(
+                this.Account,
+                this.TaskHub,
+                this.InstanceId,
+                this.ExecutionId,
+                this.Details,
+                Utils.ExtensionVersion);
+        }
+
+        internal class PendingOrchestratorMessageLimitReached : StructuredLogEvent, IEventSourceEvent
+        {
+            public PendingOrchestratorMessageLimitReached(
+                string account,
+                string taskHub,
+                string partitionId,
+                long pendingOrchestratorMessages)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.PartitionId = partitionId;
+                this.PendingOrchestratorMessages = pendingOrchestratorMessages;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            [StructuredLogField]
+            public long PendingOrchestratorMessages { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.PendingOrchestratorMessageLimitReached,
+                nameof(EventIds.PendingOrchestratorMessageLimitReached));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.PendingOrchestratorMessageLimitReached(
+                this.Account,
+                this.TaskHub,
+                this.PartitionId,
+                this.PendingOrchestratorMessages,
+                Utils.ExtensionVersion);
+        }
+
+        internal class WaitingForMoreMessages : StructuredLogEvent, IEventSourceEvent
+        {
+            public WaitingForMoreMessages(
+                string account,
+                string taskHub,
+                string partitionId)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.PartitionId = partitionId;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.WaitingForMoreMessages,
+                nameof(EventIds.WaitingForMoreMessages));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.WaitingForMoreMessages(
+                this.Account,
+                this.TaskHub,
+                this.PartitionId,
+                Utils.ExtensionVersion);
+        }
+
+        internal class ReceivedOutOfOrderMessage : StructuredLogEvent, IEventSourceEvent
+        {
+            public ReceivedOutOfOrderMessage(
+                string account,
+                string taskHub,
+                string instanceId,
+                string executionId,
+                string partitionId,
+                string eventType,
+                int taskEventId,
+                string messageId,
+                int episode,
+                DateTime lastCheckpointTime)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.InstanceId = instanceId;
+                this.ExecutionId = executionId;
+                this.PartitionId = partitionId;
+                this.EventType = eventType;
+                this.TaskEventId = taskEventId;
+                this.MessageId = messageId;
+                this.Episode = episode;
+                this.LastCheckpointTime = lastCheckpointTime;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            [StructuredLogField]
+            public string EventType { get; }
+
+            [StructuredLogField]
+            public int TaskEventId { get; }
+
+            [StructuredLogField]
+            public string MessageId { get; }
+
+            [StructuredLogField]
+            public int Episode { get; }
+
+            [StructuredLogField]
+            public DateTime LastCheckpointTime { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.ReceivedOutOfOrderMessage,
+                nameof(EventIds.ReceivedOutOfOrderMessage));
+
+            public override LogLevel Level => LogLevel.Warning;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.ReceivedOutOfOrderMessage(
+                this.Account,
+                this.TaskHub,
+                this.InstanceId,
+                this.ExecutionId,
+                this.PartitionId,
+                this.EventType,
+                this.TaskEventId,
+                this.MessageId,
+                this.Episode,
+                this.LastCheckpointTime,
+                Utils.ExtensionVersion);
+        }
+
+        internal class PartitionManagerInfo : StructuredLogEvent, IEventSourceEvent
+        {
+            public PartitionManagerInfo(
+                string account,
+                string taskHub,
+                string workerName,
+                string partitionId,
+                string details)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.WorkerName = workerName;
+                this.PartitionId = partitionId;
+                this.Details = details;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string WorkerName { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.PartitionManagerInfo,
+                nameof(EventIds.PartitionManagerInfo));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.PartitionManagerInfo(
+                this.Account,
+                this.TaskHub,
+                this.WorkerName,
+                this.PartitionId,
+                this.Details,
+                Utils.ExtensionVersion);
+        }
+
+        internal class PartitionManagerWarning : StructuredLogEvent, IEventSourceEvent
+        {
+            public PartitionManagerWarning(
+                string account,
+                string taskHub,
+                string workerName,
+                string partitionId,
+                string details)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.WorkerName = workerName;
+                this.PartitionId = partitionId;
+                this.Details = details;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string WorkerName { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.PartitionManagerWarning,
+                nameof(EventIds.PartitionManagerWarning));
+
+            public override LogLevel Level => LogLevel.Warning;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.PartitionManagerWarning(
+                this.Account,
+                this.TaskHub,
+                this.WorkerName,
+                this.PartitionId,
+                this.Details,
+                Utils.ExtensionVersion);
+        }
+
+        internal class PartitionManagerError : StructuredLogEvent, IEventSourceEvent
+        {
+            public PartitionManagerError(
+                string account,
+                string taskHub,
+                string workerName,
+                string partitionId,
+                string details)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.WorkerName = workerName;
+                this.PartitionId = partitionId;
+                this.Details = details;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string WorkerName { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.PartitionManagerError,
+                nameof(EventIds.PartitionManagerError));
+
+            public override LogLevel Level => LogLevel.Error;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.PartitionManagerError(
+                this.Account,
+                this.TaskHub,
+                this.WorkerName,
+                this.PartitionId,
+                this.Details,
+                Utils.ExtensionVersion);
+        }
+
+        internal class StartingLeaseRenewal : StructuredLogEvent, IEventSourceEvent
+        {
+            public StartingLeaseRenewal(
+                string account,
+                string taskHub,
+                string workerName,
+                string partitionId,
+                string token)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.WorkerName = workerName;
+                this.PartitionId = partitionId;
+                this.Token = token;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string WorkerName { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            [StructuredLogField]
+            public string Token { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.StartingLeaseRenewal,
+                nameof(EventIds.StartingLeaseRenewal));
+
+            public override LogLevel Level => LogLevel.Debug;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.StartingLeaseRenewal(
+                this.Account,
+                this.TaskHub,
+                this.WorkerName,
+                this.PartitionId,
+                this.Token,
+                Utils.ExtensionVersion);
+        }
+
+        internal class LeaseRenewalResult : StructuredLogEvent, IEventSourceEvent
+        {
+            public LeaseRenewalResult(
+                string account,
+                string taskHub,
+                string workerName,
+                string partitionId,
+                Boolean success,
+                string token,
+                string details)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.WorkerName = workerName;
+                this.PartitionId = partitionId;
+                this.Success = success;
+                this.Token = token;
+                this.Details = details;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string WorkerName { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            [StructuredLogField]
+            public Boolean Success { get; }
+
+            [StructuredLogField]
+            public string Token { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.LeaseRenewalResult,
+                nameof(EventIds.LeaseRenewalResult));
+
+            public override LogLevel Level => LogLevel.Debug;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseRenewalResult(
+                this.Account,
+                this.TaskHub,
+                this.WorkerName,
+                this.PartitionId,
+                this.Success,
+                this.Token,
+                this.Details,
+                Utils.ExtensionVersion);
+        }
+
+        internal class LeaseRenewalFailed : StructuredLogEvent, IEventSourceEvent
+        {
+            public LeaseRenewalFailed(
+                string account,
+                string taskHub,
+                string workerName,
+                string partitionId,
+                string token,
+                string details)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.WorkerName = workerName;
+                this.PartitionId = partitionId;
+                this.Token = token;
+                this.Details = details;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string WorkerName { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            [StructuredLogField]
+            public string Token { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.LeaseRenewalFailed,
+                nameof(EventIds.LeaseRenewalFailed));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseRenewalFailed(
+                this.Account,
+                this.TaskHub,
+                this.WorkerName,
+                this.PartitionId,
+                this.Token,
+                this.Details,
+                Utils.ExtensionVersion);
+        }
+
+        internal class LeaseAcquisitionStarted : StructuredLogEvent, IEventSourceEvent
+        {
+            public LeaseAcquisitionStarted(
+                string account,
+                string taskHub,
+                string workerName,
+                string partitionId)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.WorkerName = workerName;
+                this.PartitionId = partitionId;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string WorkerName { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.LeaseAcquisitionStarted,
+                nameof(EventIds.LeaseAcquisitionStarted));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseAcquisitionStarted(
+                this.Account,
+                this.TaskHub,
+                this.WorkerName,
+                this.PartitionId,
+                Utils.ExtensionVersion);
+        }
+
+        internal class LeaseAcquisitionSucceeded : StructuredLogEvent, IEventSourceEvent
+        {
+            public LeaseAcquisitionSucceeded(
+                string account,
+                string taskHub,
+                string workerName,
+                string partitionId)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.WorkerName = workerName;
+                this.PartitionId = partitionId;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string WorkerName { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.LeaseAcquisitionSucceeded,
+                nameof(EventIds.LeaseAcquisitionSucceeded));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseAcquisitionSucceeded(
+                this.Account,
+                this.TaskHub,
+                this.WorkerName,
+                this.PartitionId,
+                Utils.ExtensionVersion);
+        }
+
+        internal class LeaseAcquisitionFailed : StructuredLogEvent, IEventSourceEvent
+        {
+            public LeaseAcquisitionFailed(
+                string account,
+                string taskHub,
+                string workerName,
+                string partitionId)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.WorkerName = workerName;
+                this.PartitionId = partitionId;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string WorkerName { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.LeaseAcquisitionFailed,
+                nameof(EventIds.LeaseAcquisitionFailed));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseAcquisitionFailed(
+                this.Account,
+                this.TaskHub,
+                this.WorkerName,
+                this.PartitionId,
+                Utils.ExtensionVersion);
+        }
+
+        internal class AttemptingToStealLease : StructuredLogEvent, IEventSourceEvent
+        {
+            public AttemptingToStealLease(
+                string account,
+                string taskHub,
+                string workerName,
+                string fromWorkerName,
+                string partitionId)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.WorkerName = workerName;
+                this.FromWorkerName = fromWorkerName;
+                this.PartitionId = partitionId;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string WorkerName { get; }
+
+            [StructuredLogField]
+            public string FromWorkerName { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.AttemptingToStealLease,
+                nameof(EventIds.AttemptingToStealLease));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.AttemptingToStealLease(
+                this.Account,
+                this.TaskHub,
+                this.WorkerName,
+                this.FromWorkerName,
+                this.PartitionId,
+                Utils.ExtensionVersion);
+        }
+
+        internal class LeaseStealingSucceeded : StructuredLogEvent, IEventSourceEvent
+        {
+            public LeaseStealingSucceeded(
+                string account,
+                string taskHub,
+                string workerName,
+                string fromWorkerName,
+                string partitionId)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.WorkerName = workerName;
+                this.FromWorkerName = fromWorkerName;
+                this.PartitionId = partitionId;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string WorkerName { get; }
+
+            [StructuredLogField]
+            public string FromWorkerName { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.LeaseStealingSucceeded,
+                nameof(EventIds.LeaseStealingSucceeded));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseStealingSucceeded(
+                this.Account,
+                this.TaskHub,
+                this.WorkerName,
+                this.FromWorkerName,
+                this.PartitionId,
+                Utils.ExtensionVersion);
+        }
+
+        internal class LeaseStealingFailed : StructuredLogEvent, IEventSourceEvent
+        {
+            public LeaseStealingFailed(
+                string account,
+                string taskHub,
+                string workerName,
+                string partitionId)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.WorkerName = workerName;
+                this.PartitionId = partitionId;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string WorkerName { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.LeaseStealingFailed,
+                nameof(EventIds.LeaseStealingFailed));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseStealingFailed(
+                this.Account,
+                this.TaskHub,
+                this.WorkerName,
+                this.PartitionId,
+                Utils.ExtensionVersion);
+        }
+
+        internal class PartitionRemoved : StructuredLogEvent, IEventSourceEvent
+        {
+            public PartitionRemoved(
+                string account,
+                string taskHub,
+                string workerName,
+                string partitionId,
+                string token)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.WorkerName = workerName;
+                this.PartitionId = partitionId;
+                this.Token = token;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string WorkerName { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            [StructuredLogField]
+            public string Token { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.PartitionRemoved,
+                nameof(EventIds.PartitionRemoved));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.PartitionRemoved(
+                this.Account,
+                this.TaskHub,
+                this.WorkerName,
+                this.PartitionId,
+                this.Token,
+                Utils.ExtensionVersion);
+        }
+
+        internal class LeaseRemoved : StructuredLogEvent, IEventSourceEvent
+        {
+            public LeaseRemoved(
+                string account,
+                string taskHub,
+                string workerName,
+                string partitionId,
+                string token)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.WorkerName = workerName;
+                this.PartitionId = partitionId;
+                this.Token = token;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string WorkerName { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            [StructuredLogField]
+            public string Token { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.LeaseRemoved,
+                nameof(EventIds.LeaseRemoved));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseRemoved(
+                this.Account,
+                this.TaskHub,
+                this.WorkerName,
+                this.PartitionId,
+                this.Token,
+                Utils.ExtensionVersion);
+        }
+
+        internal class LeaseRemovalFailed : StructuredLogEvent, IEventSourceEvent
+        {
+            public LeaseRemovalFailed(
+                string account,
+                string taskHub,
+                string workerName,
+                string partitionId,
+                string token)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.WorkerName = workerName;
+                this.PartitionId = partitionId;
+                this.Token = token;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string WorkerName { get; }
+
+            [StructuredLogField]
+            public string PartitionId { get; }
+
+            [StructuredLogField]
+            public string Token { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.LeaseRemovalFailed,
+                nameof(EventIds.LeaseRemovalFailed));
+
+            public override LogLevel Level => LogLevel.Warning;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseRemovalFailed(
+                this.Account,
+                this.TaskHub,
+                this.WorkerName,
+                this.PartitionId,
+                this.Token,
+                Utils.ExtensionVersion);
+        }
+
+        internal class InstanceStatusUpdate : StructuredLogEvent, IEventSourceEvent
+        {
+            public InstanceStatusUpdate(
+                string account,
+                string taskHub,
+                string instanceId,
+                string executionId,
+                string eventType,
+                int episode,
+                long latencyMs)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.InstanceId = instanceId;
+                this.ExecutionId = executionId;
+                this.EventType = eventType;
+                this.Episode = episode;
+                this.LatencyMs = latencyMs;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string EventType { get; }
+
+            [StructuredLogField]
+            public int Episode { get; }
+
+            [StructuredLogField]
+            public long LatencyMs { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.InstanceStatusUpdate,
+                nameof(EventIds.InstanceStatusUpdate));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.InstanceStatusUpdate(
+                this.Account,
+                this.TaskHub,
+                this.InstanceId,
+                this.ExecutionId,
+                this.EventType,
+                this.Episode,
+                this.LatencyMs,
+                Utils.ExtensionVersion);
+        }
+
+        internal class FetchedInstanceStatus : StructuredLogEvent, IEventSourceEvent
+        {
+            public FetchedInstanceStatus(
+                string account,
+                string taskHub,
+                string instanceId,
+                string executionId,
+                long latencyMs)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.InstanceId = instanceId;
+                this.ExecutionId = executionId;
+                this.LatencyMs = latencyMs;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public long LatencyMs { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.FetchedInstanceStatus,
+                nameof(EventIds.FetchedInstanceStatus));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.FetchedInstanceStatus(
+                this.Account,
+                this.TaskHub,
+                this.InstanceId,
+                this.ExecutionId,
+                this.LatencyMs,
+                Utils.ExtensionVersion);
+        }
+
+        internal class GeneralWarning : StructuredLogEvent, IEventSourceEvent
+        {
+            public GeneralWarning(
+                string account,
+                string taskHub,
+                string details)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.Details = details;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.GeneralWarning,
+                nameof(EventIds.GeneralWarning));
+
+            public override LogLevel Level => LogLevel.Warning;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.GeneralWarning(
+                this.Account,
+                this.TaskHub,
+                this.Details,
+                Utils.ExtensionVersion);
+        }
+
+        internal class SplitBrainDetected : StructuredLogEvent, IEventSourceEvent
+        {
+            public SplitBrainDetected(
+                string account,
+                string taskHub,
+                string instanceId,
+                string executionId,
+                int newEventCount,
+                int totalEventCount,
+                string newEvents,
+                long latencyMs,
+                string eTag)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.InstanceId = instanceId;
+                this.ExecutionId = executionId;
+                this.NewEventCount = newEventCount;
+                this.TotalEventCount = totalEventCount;
+                this.NewEvents = newEvents;
+                this.LatencyMs = latencyMs;
+                this.ETag = eTag;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public int NewEventCount { get; }
+
+            [StructuredLogField]
+            public int TotalEventCount { get; }
+
+            [StructuredLogField]
+            public string NewEvents { get; }
+
+            [StructuredLogField]
+            public long LatencyMs { get; }
+
+            [StructuredLogField]
+            public string ETag { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.SplitBrainDetected,
+                nameof(EventIds.SplitBrainDetected));
+
+            public override LogLevel Level => LogLevel.Warning;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.SplitBrainDetected(
+                this.Account,
+                this.TaskHub,
+                this.InstanceId,
+                this.ExecutionId,
+                this.NewEventCount,
+                this.TotalEventCount,
+                this.NewEvents,
+                this.LatencyMs,
+                this.ETag,
+                Utils.ExtensionVersion);
+        }
+
+        internal class DiscardingWorkItem : StructuredLogEvent, IEventSourceEvent
+        {
+            public DiscardingWorkItem(
+                string account,
+                string taskHub,
+                string instanceId,
+                string executionId,
+                int newEventCount,
+                int totalEventCount,
+                string newEvents,
+                string details)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.InstanceId = instanceId;
+                this.ExecutionId = executionId;
+                this.NewEventCount = newEventCount;
+                this.TotalEventCount = totalEventCount;
+                this.NewEvents = newEvents;
+                this.Details = details;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public int NewEventCount { get; }
+
+            [StructuredLogField]
+            public int TotalEventCount { get; }
+
+            [StructuredLogField]
+            public string NewEvents { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.DiscardingWorkItem,
+                nameof(EventIds.DiscardingWorkItem));
+
+            public override LogLevel Level => LogLevel.Warning;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.DiscardingWorkItem(
+                this.Account,
+                this.TaskHub,
+                this.InstanceId,
+                this.ExecutionId,
+                this.NewEventCount,
+                this.TotalEventCount,
+                this.NewEvents,
+                this.Details,
+                Utils.ExtensionVersion);
+        }
+
+        internal class ProcessingMessage : StructuredLogEvent, IEventSourceEvent
+        {
+            public ProcessingMessage(
+                Guid relatedActivityId,
+                string account,
+                string taskHub,
+                string eventType,
+                int taskEventId,
+                string instanceId,
+                string executionId,
+                string messageId,
+                int age,
+                long sequenceNumber,
+                int episode,
+                Boolean isExtendedSession)
+            {
+                this.RelatedActivityId = relatedActivityId;
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.EventType = eventType;
+                this.TaskEventId = taskEventId;
+                this.InstanceId = instanceId;
+                this.ExecutionId = executionId;
+                this.MessageId = messageId;
+                this.Age = age;
+                this.SequenceNumber = sequenceNumber;
+                this.Episode = episode;
+                this.IsExtendedSession = isExtendedSession;
+            }
+
+            public Guid RelatedActivityId { get; }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string EventType { get; }
+
+            [StructuredLogField]
+            public int TaskEventId { get; }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string MessageId { get; }
+
+            [StructuredLogField]
+            public int Age { get; }
+
+            [StructuredLogField]
+            public long SequenceNumber { get; }
+
+            [StructuredLogField]
+            public int Episode { get; }
+
+            [StructuredLogField]
+            public Boolean IsExtendedSession { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.ProcessingMessage,
+                nameof(EventIds.ProcessingMessage));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.ProcessingMessage(
+                this.RelatedActivityId,
+                this.Account,
+                this.TaskHub,
+                this.EventType,
+                this.TaskEventId,
+                this.InstanceId,
+                this.ExecutionId,
+                this.MessageId,
+                this.Age,
+                this.SequenceNumber,
+                this.Episode,
+                this.IsExtendedSession,
+                Utils.ExtensionVersion);
+        }
+
+        internal class PurgeInstanceHistory : StructuredLogEvent, IEventSourceEvent
+        {
+            public PurgeInstanceHistory(
+                string account,
+                string taskHub,
+                string instanceId,
+                string createdTimeFrom,
+                string createdTimeTo,
+                string runtimeStatus,
+                int requestCount,
+                long latencyMs)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.InstanceId = instanceId;
+                this.CreatedTimeFrom = createdTimeFrom;
+                this.CreatedTimeTo = createdTimeTo;
+                this.RuntimeStatus = runtimeStatus;
+                this.RequestCount = requestCount;
+                this.LatencyMs = latencyMs;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string CreatedTimeFrom { get; }
+
+            [StructuredLogField]
+            public string CreatedTimeTo { get; }
+
+            [StructuredLogField]
+            public string RuntimeStatus { get; }
+
+            [StructuredLogField]
+            public int RequestCount { get; }
+
+            [StructuredLogField]
+            public long LatencyMs { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.PurgeInstanceHistory,
+                nameof(EventIds.PurgeInstanceHistory));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"TODO: Add formatted message here";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.PurgeInstanceHistory(
+                this.Account,
+                this.TaskHub,
+                this.InstanceId,
+                this.CreatedTimeFrom,
+                this.CreatedTimeTo,
+                this.RuntimeStatus,
+                this.RequestCount,
+                this.LatencyMs,
+                Utils.ExtensionVersion);
+        }
+    }
+}

--- a/src/DurableTask.AzureStorage/Logging/LogEvents.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogEvents.cs
@@ -117,6 +117,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.TargetExecutionId,
                 this.SequenceNumber,
                 this.Episode,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -229,6 +230,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.PartitionId,
                 this.SequenceNumber,
                 this.Episode,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -305,6 +307,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.ExecutionId,
                 this.PartitionId,
                 this.SequenceNumber,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -388,6 +391,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.PartitionId,
                 this.SequenceNumber,
                 this.VisibilityTimeoutSeconds,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -424,6 +428,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.Account,
                 this.TaskHub,
                 this.Details,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -500,6 +505,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.ExecutionId,
                 this.PartitionId,
                 this.Details,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -536,6 +542,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.Account,
                 this.TaskHub,
                 this.Details,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -614,6 +621,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.ExecutionId,
                 this.PartitionId,
                 this.DequeueCount,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -691,6 +699,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.ExecutionId,
                 this.PartitionId,
                 this.DequeueCount,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -772,6 +781,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.LatencyMs,
                 this.ETag,
                 this.LastCheckpointTime,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -863,6 +873,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.SizeInBytes,
                 this.ETag,
                 this.IsCheckpointComplete,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -954,6 +965,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.PendingOrchestratorMessages,
                 this.ActiveOrchestrators,
                 this.ActiveActivities,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -1031,6 +1043,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.TaskEventId,
                 this.MessageId,
                 this.VisibilityTimeoutSeconds,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -1113,6 +1126,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.EventType,
                 this.TaskEventId,
                 this.Details,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -1162,6 +1176,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.InstanceId,
                 this.ExecutionId,
                 this.Details,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -1206,6 +1221,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.TaskHub,
                 this.PartitionId,
                 this.PendingOrchestratorMessages,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -1243,6 +1259,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.Account,
                 this.TaskHub,
                 this.PartitionId,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -1325,6 +1342,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.MessageId,
                 this.Episode,
                 this.LastCheckpointTime,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -1374,6 +1392,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.WorkerName,
                 this.PartitionId,
                 this.Details,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -1423,6 +1442,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.WorkerName,
                 this.PartitionId,
                 this.Details,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -1472,6 +1492,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.WorkerName,
                 this.PartitionId,
                 this.Details,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -1521,6 +1542,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.WorkerName,
                 this.PartitionId,
                 this.Token,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -1582,6 +1604,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.Success,
                 this.Token,
                 this.Details,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -1637,6 +1660,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.PartitionId,
                 this.Token,
                 this.Details,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -1679,6 +1703,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.TaskHub,
                 this.WorkerName,
                 this.PartitionId,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -1721,6 +1746,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.TaskHub,
                 this.WorkerName,
                 this.PartitionId,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -1763,6 +1789,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.TaskHub,
                 this.WorkerName,
                 this.PartitionId,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -1812,6 +1839,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.WorkerName,
                 this.FromWorkerName,
                 this.PartitionId,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -1861,6 +1889,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.WorkerName,
                 this.FromWorkerName,
                 this.PartitionId,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -1903,6 +1932,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.TaskHub,
                 this.WorkerName,
                 this.PartitionId,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -1951,6 +1981,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.WorkerName,
                 this.PartitionId,
                 this.Token,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -1999,6 +2030,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.WorkerName,
                 this.PartitionId,
                 this.Token,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -2048,6 +2080,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.WorkerName,
                 this.PartitionId,
                 this.Token,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -2109,6 +2142,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.RuntimeStatus,
                 this.Episode,
                 this.LatencyMs,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -2157,6 +2191,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.InstanceId,
                 this.ExecutionId,
                 this.LatencyMs,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -2193,6 +2228,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.Account,
                 this.TaskHub,
                 this.Details,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -2266,6 +2302,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.NewEvents,
                 this.LatencyMs,
                 this.ETag,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -2333,6 +2370,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.TotalEventCount,
                 this.NewEvents,
                 this.Details,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -2423,6 +2461,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.SequenceNumber,
                 this.Episode,
                 this.IsExtendedSession,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
 
@@ -2498,6 +2537,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.RequestCount,
                 this.InstanceCount,
                 this.LatencyMs,
+                Utils.AppName,
                 Utils.ExtensionVersion);
         }
     }

--- a/src/DurableTask.AzureStorage/Logging/LogEvents.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogEvents.cs
@@ -753,7 +753,8 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => 
+                $"Fetched {this.EventCount} history events for instance '{this.InstanceId}'";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.FetchedInstanceHistory(
                 this.Account,
@@ -841,7 +842,8 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => 
+                $"Saved {this.NewEventCount} new events to the history table for instance '{this.InstanceId}'; total events = {this.TotalEventCount}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.AppendedInstanceHistory(
                 this.Account,
@@ -931,7 +933,8 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => 
+                $"There are currently {this.ActiveOrchestrators + this.PendingOrchestrators} orchestration and {this.ActiveActivities} activities loaded into memory on this worker";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.OrchestrationServiceStats(
                 this.Account,
@@ -1006,7 +1009,12 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => string.Format(
+                "Renewing {0} message from {1} for instance '{2}' for an additional {3} seconds",
+                GetHistoryEventDescription(this.EventType, this.TaskEventId),
+                this.PartitionId,
+                this.InstanceId,
+                this.VisibilityTimeoutSeconds);
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.RenewingMessage(
                 this.Account,
@@ -1078,7 +1086,11 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Error;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => string.Format(
+                "An error occurred while processing message {0} for instance '{1}': {2}",
+                GetHistoryEventDescription(this.EventType, this.TaskEventId),
+                this.InstanceId,
+                this.Details);
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.MessageFailure(
                 this.Account,
@@ -1130,7 +1142,8 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Error;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => 
+                $"An unexpected failure occurred while processing instance '{this.InstanceId}': {this.Details}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.OrchestrationProcessingFailure(
                 this.Account,
@@ -1173,7 +1186,9 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => 
+                $"The maximum orchestration message prefetch limit of {this.PendingOrchestratorMessages} has been reached; " +
+                $"fetching from {this.PartitionId} will be temporarily suspended until existing messages are consumed";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.PendingOrchestratorMessageLimitReached(
                 this.Account,
@@ -1210,7 +1225,8 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => 
+                $"No messages were found on {this.PartitionId}; backing off to reduce polling transaction costs";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.WaitingForMoreMessages(
                 this.Account,
@@ -1281,7 +1297,11 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Warning;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => string.Format(
+                "Message {0} for instance '{1}' was received out of order; returning it back to {2}",
+                GetHistoryEventDescription(this.EventType, this.TaskEventId),
+                this.InstanceId,
+                this.PartitionId);
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.ReceivedOutOfOrderMessage(
                 this.Account,
@@ -1334,7 +1354,7 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => $"{this.PartitionId}: {this.Details}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.PartitionManagerInfo(
                 this.Account,
@@ -1382,7 +1402,7 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Warning;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => $"{this.PartitionId}: {this.Details}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.PartitionManagerWarning(
                 this.Account,
@@ -1430,7 +1450,7 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Error;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => $"{this.PartitionId}: {this.Details}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.PartitionManagerError(
                 this.Account,
@@ -1478,7 +1498,7 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Debug;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => $"Starting lease renewal for {this.PartitionId}; token = {this.Token}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.StartingLeaseRenewal(
                 this.Account,
@@ -1536,7 +1556,7 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Debug;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => $"Lease renewal result for {this.PartitionId}: Success = {this.Success}; token = {this.Token}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseRenewalResult(
                 this.Account,
@@ -1591,7 +1611,7 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => $"Failed to renew lease for {this.PartitionId}: {this.Details}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseRenewalFailed(
                 this.Account,
@@ -1635,7 +1655,7 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => $"Attempting to acquire lease for {this.PartitionId}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseAcquisitionStarted(
                 this.Account,
@@ -1677,7 +1697,7 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => $"Successfully acquired lease for {this.PartitionId}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseAcquisitionSucceeded(
                 this.Account,
@@ -1719,7 +1739,7 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => $"Failed to acquire lease for {this.PartitionId}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseAcquisitionFailed(
                 this.Account,
@@ -1766,7 +1786,7 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => $"Attempting to steal lease for {this.PartitionId} from {this.FromWorkerName}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.AttemptingToStealLease(
                 this.Account,
@@ -1814,7 +1834,7 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => $"Successfully stole lease for {this.PartitionId} from {this.FromWorkerName}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseStealingSucceeded(
                 this.Account,
@@ -1857,7 +1877,7 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => $"Failed to steal lease for {this.PartitionId}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseStealingFailed(
                 this.Account,
@@ -1904,7 +1924,7 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => $"Stopped processing messages for partition {this.PartitionId}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.PartitionRemoved(
                 this.Account,
@@ -1952,7 +1972,7 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => $"Released lease for {this.PartitionId}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseRemoved(
                 this.Account,
@@ -2000,7 +2020,7 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Warning;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => $"Failed to release lease for {this.PartitionId} due to a conflict";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseRemovalFailed(
                 this.Account,
@@ -2058,7 +2078,10 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() =>
+                string.IsNullOrEmpty(this.EventType) ?
+                    $"Updated instance status for {this.InstanceId}" :
+                    $"Updated instance status for {this.InstanceId} with a {this.EventType} runtime status";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.InstanceStatusUpdate(
                 this.Account,
@@ -2108,7 +2131,7 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => $"Fetched instance status for {this.InstanceId}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.FetchedInstanceStatus(
                 this.Account,
@@ -2146,7 +2169,7 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Warning;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => $"WARNING: {this.Details}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.GeneralWarning(
                 this.Account,
@@ -2212,7 +2235,8 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Warning;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() =>
+                $"Split brain was detected for {this.InstanceId} and {this.NewEventCount} new history events need to be abandoned";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.SplitBrainDetected(
                 this.Account,
@@ -2279,7 +2303,8 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Warning;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => 
+                $"A work item for '{this.InstanceId}' with {this.NewEventCount} history event(s) is being discarded: {this.Details}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.DiscardingWorkItem(
                 this.Account,
@@ -2364,7 +2389,10 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() => string.Format(
+                "Starting to process the {0} message for instance '{1}'",
+                GetHistoryEventDescription(this.EventType, this.TaskEventId),
+                this.InstanceId);
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.ProcessingMessage(
                 this.RelatedActivityId,
@@ -2392,6 +2420,7 @@ namespace DurableTask.AzureStorage.Logging
                 string createdTimeTo,
                 string runtimeStatus,
                 int requestCount,
+                int instanceCount,
                 long latencyMs)
             {
                 this.Account = account;
@@ -2401,6 +2430,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.CreatedTimeTo = createdTimeTo;
                 this.RuntimeStatus = runtimeStatus;
                 this.RequestCount = requestCount;
+                this.InstanceCount = instanceCount;
                 this.LatencyMs = latencyMs;
             }
 
@@ -2426,6 +2456,9 @@ namespace DurableTask.AzureStorage.Logging
             public int RequestCount { get; }
 
             [StructuredLogField]
+            public int InstanceCount { get; }
+
+            [StructuredLogField]
             public long LatencyMs { get; }
 
             public override EventId EventId => new EventId(
@@ -2434,7 +2467,10 @@ namespace DurableTask.AzureStorage.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() => $"TODO: Add formatted message here";
+            public override string GetLogMessage() =>
+                !string.IsNullOrEmpty(this.InstanceId) ?
+                    $"Purged instance history data for instance '{this.InstanceId}' in {this.LatencyMs / 1000.0:F} seconds" :
+                    $"Purged instance history data for {this.InstanceCount} instance(s) in {this.LatencyMs / 1000.0:F} seconds";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.PurgeInstanceHistory(
                 this.Account,
@@ -2444,6 +2480,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.CreatedTimeTo,
                 this.RuntimeStatus,
                 this.RequestCount,
+                this.InstanceCount,
                 this.LatencyMs,
                 Utils.ExtensionVersion);
         }

--- a/src/DurableTask.AzureStorage/Logging/LogHelper.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogHelper.cs
@@ -812,6 +812,7 @@ namespace DurableTask.AzureStorage.Logging
             string createdTimeTo,
             string runtimeStatus,
             int requestCount,
+            int instanceCount,
             long latencyMs)
         {
             var logEvent = new LogEvents.PurgeInstanceHistory(
@@ -822,6 +823,7 @@ namespace DurableTask.AzureStorage.Logging
                 createdTimeTo,
                 runtimeStatus,
                 requestCount,
+                instanceCount,
                 latencyMs);
             this.WriteStructuredLog(logEvent);
         }

--- a/src/DurableTask.AzureStorage/Logging/LogHelper.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogHelper.cs
@@ -1,0 +1,826 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureStorage.Logging
+{
+    using System;
+    using DurableTask.Core.Logging;
+    using Microsoft.Extensions.Logging;
+
+    class LogHelper
+    {
+        readonly ILogger log;
+
+        public LogHelper(ILogger log)
+        {
+            this.log = log;
+        }
+
+        internal void SendingMessage(
+            Guid relatedActivityId,
+            string account,
+            string taskHub,
+            string eventType,
+            int taskEventId,
+            string instanceId,
+            string executionId,
+            long sizeInBytes,
+            string partitionId,
+            string targetInstanceId,
+            string targetExecutionId,
+            long sequenceNumber,
+            int episode)
+        {
+            var logEvent = new LogEvents.SendingMessage(
+                relatedActivityId,
+                account,
+                taskHub,
+                eventType,
+                taskEventId,
+                instanceId,
+                executionId,
+                sizeInBytes,
+                partitionId,
+                targetInstanceId,
+                targetExecutionId,
+                sequenceNumber,
+                episode);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void ReceivedMessage(
+            Guid relatedActivityId,
+            string account,
+            string taskHub,
+            string eventType,
+            int taskEventId,
+            string instanceId,
+            string executionId,
+            string messageId,
+            int age,
+            int dequeueCount,
+            string nextVisibleTime,
+            long sizeInBytes,
+            string partitionId,
+            long sequenceNumber,
+            int episode)
+        {
+            var logEvent = new LogEvents.ReceivedMessage(
+                relatedActivityId,
+                account,
+                taskHub,
+                eventType,
+                taskEventId,
+                instanceId,
+                executionId,
+                messageId,
+                age,
+                dequeueCount,
+                nextVisibleTime,
+                sizeInBytes,
+                partitionId,
+                sequenceNumber,
+                episode);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void DeletingMessage(
+            string account,
+            string taskHub,
+            string eventType,
+            int taskEventId,
+            string messageId,
+            string instanceId,
+            string executionId,
+            string partitionId,
+            long sequenceNumber)
+        {
+            var logEvent = new LogEvents.DeletingMessage(
+                account,
+                taskHub,
+                eventType,
+                taskEventId,
+                messageId,
+                instanceId,
+                executionId,
+                partitionId,
+                sequenceNumber);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void AbandoningMessage(
+            string account,
+            string taskHub,
+            string eventType,
+            int taskEventId,
+            string messageId,
+            string instanceId,
+            string executionId,
+            string partitionId,
+            long sequenceNumber,
+            int visibilityTimeoutSeconds)
+        {
+            var logEvent = new LogEvents.AbandoningMessage(
+                account,
+                taskHub,
+                eventType,
+                taskEventId,
+                messageId,
+                instanceId,
+                executionId,
+                partitionId,
+                sequenceNumber,
+                visibilityTimeoutSeconds);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void AssertFailure(
+            string account,
+            string taskHub,
+            string details)
+        {
+            var logEvent = new LogEvents.AssertFailure(
+                account,
+                taskHub,
+                details);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void MessageGone(
+            string account,
+            string taskHub,
+            string messageId,
+            string instanceId,
+            string executionId,
+            string partitionId,
+            string eventType,
+            int taskEventId,
+            string details)
+        {
+            var logEvent = new LogEvents.MessageGone(
+                account,
+                taskHub,
+                messageId,
+                instanceId,
+                executionId,
+                partitionId,
+                eventType,
+                taskEventId,
+                details);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void GeneralError(
+            string account,
+            string taskHub,
+            string details)
+        {
+            var logEvent = new LogEvents.GeneralError(
+                account,
+                taskHub,
+                details);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void DuplicateMessageDetected(
+            string account,
+            string taskHub,
+            string messageId,
+            string instanceId,
+            string executionId,
+            string partitionId,
+            int dequeueCount)
+        {
+            var logEvent = new LogEvents.DuplicateMessageDetected(
+                account,
+                taskHub,
+                messageId,
+                instanceId,
+                executionId,
+                partitionId,
+                dequeueCount);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void PoisonMessageDetected(
+            string account,
+            string taskHub,
+            string messageId,
+            string instanceId,
+            string executionId,
+            string partitionId,
+            int dequeueCount)
+        {
+            var logEvent = new LogEvents.PoisonMessageDetected(
+                account,
+                taskHub,
+                messageId,
+                instanceId,
+                executionId,
+                partitionId,
+                dequeueCount);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void FetchedInstanceHistory(
+            string account,
+            string taskHub,
+            string instanceId,
+            string executionId,
+            int eventCount,
+            int episode,
+            int requestCount,
+            long latencyMs,
+            string eTag,
+            DateTime lastCheckpointTime)
+        {
+            var logEvent = new LogEvents.FetchedInstanceHistory(
+                account,
+                taskHub,
+                instanceId,
+                executionId,
+                eventCount,
+                episode,
+                requestCount,
+                latencyMs,
+                eTag,
+                lastCheckpointTime);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void AppendedInstanceHistory(
+            string account,
+            string taskHub,
+            string instanceId,
+            string executionId,
+            int newEventCount,
+            int totalEventCount,
+            string newEvents,
+            int episode,
+            long latencyMs,
+            int sizeInBytes,
+            string eTag,
+            bool isCheckpointComplete)
+        {
+            var logEvent = new LogEvents.AppendedInstanceHistory(
+                account,
+                taskHub,
+                instanceId,
+                executionId,
+                newEventCount,
+                totalEventCount,
+                newEvents,
+                episode,
+                latencyMs,
+                sizeInBytes,
+                eTag,
+                isCheckpointComplete);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void OrchestrationServiceStats(
+            string account,
+            string taskHub,
+            long storageRequests,
+            long messagesSent,
+            long messagesRead,
+            long messagesUpdated,
+            long tableEntitiesWritten,
+            long tableEntitiesRead,
+            long pendingOrchestrators,
+            long pendingOrchestratorMessages,
+            long activeOrchestrators,
+            long activeActivities)
+        {
+            var logEvent = new LogEvents.OrchestrationServiceStats(
+                account,
+                taskHub,
+                storageRequests,
+                messagesSent,
+                messagesRead,
+                messagesUpdated,
+                tableEntitiesWritten,
+                tableEntitiesRead,
+                pendingOrchestrators,
+                pendingOrchestratorMessages,
+                activeOrchestrators,
+                activeActivities);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void RenewingMessage(
+            string account,
+            string taskHub,
+            string instanceId,
+            string executionId,
+            string partitionId,
+            string eventType,
+            int taskEventId,
+            string messageId,
+            int visibilityTimeoutSeconds)
+        {
+            var logEvent = new LogEvents.RenewingMessage(
+                account,
+                taskHub,
+                instanceId,
+                executionId,
+                partitionId,
+                eventType,
+                taskEventId,
+                messageId,
+                visibilityTimeoutSeconds);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void MessageFailure(
+            string account,
+            string taskHub,
+            string messageId,
+            string instanceId,
+            string executionId,
+            string partitionId,
+            string eventType,
+            int taskEventId,
+            string details)
+        {
+            var logEvent = new LogEvents.MessageFailure(
+                account,
+                taskHub,
+                messageId,
+                instanceId,
+                executionId,
+                partitionId,
+                eventType,
+                taskEventId,
+                details);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void OrchestrationProcessingFailure(
+            string account,
+            string taskHub,
+            string instanceId,
+            string executionId,
+            string details)
+        {
+            var logEvent = new LogEvents.OrchestrationProcessingFailure(
+                account,
+                taskHub,
+                instanceId,
+                executionId,
+                details);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void PendingOrchestratorMessageLimitReached(
+            string account,
+            string taskHub,
+            string partitionId,
+            long pendingOrchestratorMessages)
+        {
+            var logEvent = new LogEvents.PendingOrchestratorMessageLimitReached(
+                account,
+                taskHub,
+                partitionId,
+                pendingOrchestratorMessages);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void WaitingForMoreMessages(
+            string account,
+            string taskHub,
+            string partitionId)
+        {
+            var logEvent = new LogEvents.WaitingForMoreMessages(
+                account,
+                taskHub,
+                partitionId);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void ReceivedOutOfOrderMessage(
+            string account,
+            string taskHub,
+            string instanceId,
+            string executionId,
+            string partitionId,
+            string eventType,
+            int taskEventId,
+            string messageId,
+            int episode,
+            DateTime lastCheckpointTime)
+        {
+            var logEvent = new LogEvents.ReceivedOutOfOrderMessage(
+                account,
+                taskHub,
+                instanceId,
+                executionId,
+                partitionId,
+                eventType,
+                taskEventId,
+                messageId,
+                episode,
+                lastCheckpointTime);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void PartitionManagerInfo(
+            string account,
+            string taskHub,
+            string workerName,
+            string partitionId,
+            string details)
+        {
+            var logEvent = new LogEvents.PartitionManagerInfo(
+                account,
+                taskHub,
+                workerName,
+                partitionId,
+                details);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void PartitionManagerWarning(
+            string account,
+            string taskHub,
+            string workerName,
+            string partitionId,
+            string details)
+        {
+            var logEvent = new LogEvents.PartitionManagerWarning(
+                account,
+                taskHub,
+                workerName,
+                partitionId,
+                details);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void PartitionManagerError(
+            string account,
+            string taskHub,
+            string workerName,
+            string partitionId,
+            string details)
+        {
+            var logEvent = new LogEvents.PartitionManagerError(
+                account,
+                taskHub,
+                workerName,
+                partitionId,
+                details);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void StartingLeaseRenewal(
+            string account,
+            string taskHub,
+            string workerName,
+            string partitionId,
+            string token)
+        {
+            var logEvent = new LogEvents.StartingLeaseRenewal(
+                account,
+                taskHub,
+                workerName,
+                partitionId,
+                token);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void LeaseRenewalResult(
+            string account,
+            string taskHub,
+            string workerName,
+            string partitionId,
+            bool success,
+            string token,
+            string details)
+        {
+            var logEvent = new LogEvents.LeaseRenewalResult(
+                account,
+                taskHub,
+                workerName,
+                partitionId,
+                success,
+                token,
+                details);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void LeaseRenewalFailed(
+            string account,
+            string taskHub,
+            string workerName,
+            string partitionId,
+            string token,
+            string details)
+        {
+            var logEvent = new LogEvents.LeaseRenewalFailed(
+                account,
+                taskHub,
+                workerName,
+                partitionId,
+                token,
+                details);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void LeaseAcquisitionStarted(
+            string account,
+            string taskHub,
+            string workerName,
+            string partitionId)
+        {
+            var logEvent = new LogEvents.LeaseAcquisitionStarted(
+                account,
+                taskHub,
+                workerName,
+                partitionId);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void LeaseAcquisitionSucceeded(
+            string account,
+            string taskHub,
+            string workerName,
+            string partitionId)
+        {
+            var logEvent = new LogEvents.LeaseAcquisitionSucceeded(
+                account,
+                taskHub,
+                workerName,
+                partitionId);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void LeaseAcquisitionFailed(
+            string account,
+            string taskHub,
+            string workerName,
+            string partitionId)
+        {
+            var logEvent = new LogEvents.LeaseAcquisitionFailed(
+                account,
+                taskHub,
+                workerName,
+                partitionId);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void AttemptingToStealLease(
+            string account,
+            string taskHub,
+            string workerName,
+            string fromWorkerName,
+            string partitionId)
+        {
+            var logEvent = new LogEvents.AttemptingToStealLease(
+                account,
+                taskHub,
+                workerName,
+                fromWorkerName,
+                partitionId);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void LeaseStealingSucceeded(
+            string account,
+            string taskHub,
+            string workerName,
+            string fromWorkerName,
+            string partitionId)
+        {
+            var logEvent = new LogEvents.LeaseStealingSucceeded(
+                account,
+                taskHub,
+                workerName,
+                fromWorkerName,
+                partitionId);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void LeaseStealingFailed(
+            string account,
+            string taskHub,
+            string workerName,
+            string partitionId)
+        {
+            var logEvent = new LogEvents.LeaseStealingFailed(
+                account,
+                taskHub,
+                workerName,
+                partitionId);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void PartitionRemoved(
+            string account,
+            string taskHub,
+            string workerName,
+            string partitionId,
+            string token)
+        {
+            var logEvent = new LogEvents.PartitionRemoved(
+                account,
+                taskHub,
+                workerName,
+                partitionId,
+                token);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void LeaseRemoved(
+            string account,
+            string taskHub,
+            string workerName,
+            string partitionId,
+            string token)
+        {
+            var logEvent = new LogEvents.LeaseRemoved(
+                account,
+                taskHub,
+                workerName,
+                partitionId,
+                token);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void LeaseRemovalFailed(
+            string account,
+            string taskHub,
+            string workerName,
+            string partitionId,
+            string token)
+        {
+            var logEvent = new LogEvents.LeaseRemovalFailed(
+                account,
+                taskHub,
+                workerName,
+                partitionId,
+                token);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void InstanceStatusUpdate(
+            string account,
+            string taskHub,
+            string instanceId,
+            string executionId,
+            string eventType,
+            int episode,
+            long latencyMs)
+        {
+            var logEvent = new LogEvents.InstanceStatusUpdate(
+                account,
+                taskHub,
+                instanceId,
+                executionId,
+                eventType,
+                episode,
+                latencyMs);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void FetchedInstanceStatus(
+            string account,
+            string taskHub,
+            string instanceId,
+            string executionId,
+            long latencyMs)
+        {
+            var logEvent = new LogEvents.FetchedInstanceStatus(
+                account,
+                taskHub,
+                instanceId,
+                executionId,
+                latencyMs);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void GeneralWarning(
+            string account,
+            string taskHub,
+            string details)
+        {
+            var logEvent = new LogEvents.GeneralWarning(
+                account,
+                taskHub,
+                details);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void SplitBrainDetected(
+            string account,
+            string taskHub,
+            string instanceId,
+            string executionId,
+            int newEventCount,
+            int totalEventCount,
+            string newEvents,
+            long latencyMs,
+            string eTag)
+        {
+            var logEvent = new LogEvents.SplitBrainDetected(
+                account,
+                taskHub,
+                instanceId,
+                executionId,
+                newEventCount,
+                totalEventCount,
+                newEvents,
+                latencyMs,
+                eTag);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void DiscardingWorkItem(
+            string account,
+            string taskHub,
+            string instanceId,
+            string executionId,
+            int newEventCount,
+            int totalEventCount,
+            string newEvents,
+            string details)
+        {
+            var logEvent = new LogEvents.DiscardingWorkItem(
+                account,
+                taskHub,
+                instanceId,
+                executionId,
+                newEventCount,
+                totalEventCount,
+                newEvents,
+                details);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void ProcessingMessage(
+            Guid relatedActivityId,
+            string account,
+            string taskHub,
+            string eventType,
+            int taskEventId,
+            string instanceId,
+            string executionId,
+            string messageId,
+            int age,
+            long sequenceNumber,
+            int episode,
+            bool isExtendedSession)
+        {
+            var logEvent = new LogEvents.ProcessingMessage(
+                relatedActivityId,
+                account,
+                taskHub,
+                eventType,
+                taskEventId,
+                instanceId,
+                executionId,
+                messageId,
+                age,
+                sequenceNumber,
+                episode,
+                isExtendedSession);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        internal void PurgeInstanceHistory(
+            string account,
+            string taskHub,
+            string instanceId,
+            string createdTimeFrom,
+            string createdTimeTo,
+            string runtimeStatus,
+            int requestCount,
+            long latencyMs)
+        {
+            var logEvent = new LogEvents.PurgeInstanceHistory(
+                account,
+                taskHub,
+                instanceId,
+                createdTimeFrom,
+                createdTimeTo,
+                runtimeStatus,
+                requestCount,
+                latencyMs);
+            this.WriteStructuredLog(logEvent);
+        }
+
+        void WriteStructuredLog(ILogEvent logEvent, Exception exception = null)
+        {
+            LoggingExtensions.LogDurableEvent(this.log, logEvent, exception);
+        }
+    }
+}

--- a/src/DurableTask.AzureStorage/Logging/LogHelper.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogHelper.cs
@@ -195,6 +195,8 @@ namespace DurableTask.AzureStorage.Logging
         internal void DuplicateMessageDetected(
             string account,
             string taskHub,
+            string eventType,
+            int taskEventId,
             string messageId,
             string instanceId,
             string executionId,
@@ -204,6 +206,8 @@ namespace DurableTask.AzureStorage.Logging
             var logEvent = new LogEvents.DuplicateMessageDetected(
                 account,
                 taskHub,
+                eventType,
+                taskEventId,
                 messageId,
                 instanceId,
                 executionId,
@@ -215,6 +219,8 @@ namespace DurableTask.AzureStorage.Logging
         internal void PoisonMessageDetected(
             string account,
             string taskHub,
+            string eventType,
+            int taskEventId,
             string messageId,
             string instanceId,
             string executionId,
@@ -224,6 +230,8 @@ namespace DurableTask.AzureStorage.Logging
             var logEvent = new LogEvents.PoisonMessageDetected(
                 account,
                 taskHub,
+                eventType,
+                taskEventId,
                 messageId,
                 instanceId,
                 executionId,

--- a/src/DurableTask.AzureStorage/Logging/LogHelper.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogHelper.cs
@@ -14,6 +14,7 @@
 namespace DurableTask.AzureStorage.Logging
 {
     using System;
+    using DurableTask.Core;
     using DurableTask.Core.Logging;
     using Microsoft.Extensions.Logging;
 
@@ -685,7 +686,7 @@ namespace DurableTask.AzureStorage.Logging
             string taskHub,
             string instanceId,
             string executionId,
-            string eventType,
+            OrchestrationStatus runtimeStatus,
             int episode,
             long latencyMs)
         {
@@ -694,7 +695,7 @@ namespace DurableTask.AzureStorage.Logging
                 taskHub,
                 instanceId,
                 executionId,
-                eventType,
+                runtimeStatus,
                 episode,
                 latencyMs);
             this.WriteStructuredLog(logEvent);

--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -22,7 +22,6 @@ namespace DurableTask.AzureStorage
     using System.Text;
     using System.Threading.Tasks;
     using DurableTask.AzureStorage.Monitoring;
-    using DurableTask.Core;
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Blob;
     using Microsoft.WindowsAzure.Storage.Queue;
@@ -36,9 +35,6 @@ namespace DurableTask.AzureStorage
     {
         const int MaxStorageQueuePayloadSizeInBytes = 60 * 1024; // 60KB
         const int DefaultBufferSize = 64 * 2014; // 64KB
-
-        const string LargeMessageBlobNameSeparator = "/";
-        const string blobExtension = ".json.gz";
 
         readonly string blobContainerName;
         readonly CloudBlobContainer cloudBlobContainer;

--- a/src/DurableTask.AzureStorage/Messaging/ActivitySession.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ActivitySession.cs
@@ -20,11 +20,11 @@ namespace DurableTask.AzureStorage.Messaging
         readonly int orchestrationEpisode;
 
         public ActivitySession(
+            AzureStorageOrchestrationServiceSettings settings,
             string storageAccountName,
-            string taskHubName,
             MessageData message,
             Guid traceActivityId)
-            : base(storageAccountName, taskHubName, message.TaskMessage.OrchestrationInstance, traceActivityId)
+            : base(settings, storageAccountName, message.TaskMessage.OrchestrationInstance, traceActivityId)
         {
             this.MessageData = message ?? throw new ArgumentNullException(nameof(message));
             this.orchestrationEpisode = message.Episode ?? -1;

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -19,6 +19,7 @@ namespace DurableTask.AzureStorage.Messaging
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using DurableTask.AzureStorage.Logging;
     using DurableTask.AzureStorage.Monitoring;
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Queue;
@@ -63,12 +64,11 @@ namespace DurableTask.AzureStorage.Messaging
                         if (!pendingOrchestratorMessageLimitReached)
                         {
                             pendingOrchestratorMessageLimitReached = true;
-                            AnalyticsEventSource.Log.PendingOrchestratorMessageLimitReached(
+                            this.settings.Logger.PendingOrchestratorMessageLimitReached(
                                 this.storageAccountName,
                                 this.settings.TaskHubName,
                                 this.Name,
-                                pendingOrchestratorMessages,
-                                Utils.ExtensionVersion);
+                                pendingOrchestratorMessages);
                         }
 
                         await Task.Delay(TimeSpan.FromSeconds(1));
@@ -84,7 +84,7 @@ namespace DurableTask.AzureStorage.Messaging
                             "GetMessages",
                             context.ClientRequestID,
                             this.storageAccountName,
-                            this.settings.TaskHubName,
+                            this.settings,
                             () =>
                             {
                                 return this.storageQueue.GetMessagesAsync(
@@ -102,11 +102,10 @@ namespace DurableTask.AzureStorage.Messaging
                             if (!isWaitingForMoreMessages)
                             {
                                 isWaitingForMoreMessages = true;
-                                AnalyticsEventSource.Log.WaitingForMoreMessages(
+                                this.settings.Logger.WaitingForMoreMessages(
                                     this.storageAccountName,
                                     this.settings.TaskHubName,
-                                    this.storageQueue.Name,
-                                    Utils.ExtensionVersion);
+                                    this.storageQueue.Name);
                             }
 
                             await this.backoffHelper.WaitAsync(linkedCts.Token);
@@ -129,15 +128,14 @@ namespace DurableTask.AzureStorage.Messaging
                             {
                                 // This message is already loaded in memory and is therefore a duplicate.
                                 // We will continue to process it because we need the updated pop receipt.
-                                AnalyticsEventSource.Log.DuplicateMessageDetected(
+                                this.settings.Logger.DuplicateMessageDetected(
                                     this.storageAccountName,
                                     this.settings.TaskHubName,
                                     queueMessage.Id,
                                     messageData.TaskMessage.OrchestrationInstance.InstanceId,
                                     messageData.TaskMessage.OrchestrationInstance.ExecutionId,
                                     this.Name,
-                                    queueMessage.DequeueCount,
-                                    Utils.ExtensionVersion);
+                                    queueMessage.DequeueCount);
                             }
 
                             batchMessages.Add(messageData);
@@ -150,9 +148,9 @@ namespace DurableTask.AzureStorage.Messaging
                         foreach (MessageData message in sortedMessages)
                         {
                             AzureStorageOrchestrationService.TraceMessageReceived(
+                                this.settings,
                                 message,
-                                this.storageAccountName,
-                                this.settings.TaskHubName);
+                                this.storageAccountName);
                         }
 
                         return sortedMessages;
@@ -161,7 +159,7 @@ namespace DurableTask.AzureStorage.Messaging
                     {
                         if (!linkedCts.IsCancellationRequested)
                         {
-                            AnalyticsEventSource.Log.MessageFailure(
+                            this.settings.Logger.MessageFailure(
                                 this.storageAccountName,
                                 this.settings.TaskHubName,
                                 string.Empty /* MessageId */,
@@ -170,8 +168,7 @@ namespace DurableTask.AzureStorage.Messaging
                                 this.storageQueue.Name,
                                 string.Empty /* EventType */,
                                 0 /* TaskEventId */,
-                                e.ToString(),
-                                Utils.ExtensionVersion);
+                                e.ToString());
 
                             await this.backoffHelper.WaitAsync(linkedCts.Token);
                         }

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -19,7 +19,6 @@ namespace DurableTask.AzureStorage.Messaging
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-    using DurableTask.AzureStorage.Logging;
     using DurableTask.AzureStorage.Monitoring;
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Queue;
@@ -131,6 +130,8 @@ namespace DurableTask.AzureStorage.Messaging
                                 this.settings.Logger.DuplicateMessageDetected(
                                     this.storageAccountName,
                                     this.settings.TaskHubName,
+                                    messageData.TaskMessage.Event.EventType.ToString(),
+                                    Utils.GetTaskEventId(messageData.TaskMessage.Event),
                                     queueMessage.Id,
                                     messageData.TaskMessage.OrchestrationInstance.InstanceId,
                                     messageData.TaskMessage.OrchestrationInstance.ExecutionId,

--- a/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
+++ b/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
@@ -28,8 +28,8 @@ namespace DurableTask.AzureStorage.Messaging
         readonly MessageCollection nextMessageBatch;
 
         public OrchestrationSession(
+            AzureStorageOrchestrationServiceSettings settings,
             string storageAccountName,
-            string taskHubName,
             OrchestrationInstance orchestrationInstance,
             ControlQueue controlQueue,
             List<MessageData> initialMessageBatch,
@@ -38,7 +38,7 @@ namespace DurableTask.AzureStorage.Messaging
             DateTime lastCheckpointTime,
             TimeSpan idleTimeout,
             Guid traceActivityId)
-            : base(storageAccountName, taskHubName, orchestrationInstance, traceActivityId)
+            : base(settings, storageAccountName, orchestrationInstance, traceActivityId)
         {
             this.idleTimeout = idleTimeout;
             this.ControlQueue = controlQueue ?? throw new ArgumentNullException(nameof(controlQueue));

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -209,6 +209,8 @@ namespace DurableTask.AzureStorage.Messaging
                 this.settings.Logger.PoisonMessageDetected(
                     this.storageAccountName,
                     this.settings.TaskHubName,
+                    taskMessage.Event.EventType.ToString(),
+                    Utils.GetTaskEventId(taskMessage.Event),
                     queueMessage.Id,
                     instance.InstanceId,
                     instance.ExecutionId,

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -109,7 +109,7 @@ namespace DurableTask.AzureStorage.Messaging
                 string rawContent = await this.messageManager.SerializeMessageDataAsync(data);
                 CloudQueueMessage queueMessage = new CloudQueueMessage(rawContent);
 
-                AnalyticsEventSource.Log.SendingMessage(
+                this.settings.Logger.SendingMessage(
                     outboundTraceActivityId,
                     this.storageAccountName,
                     this.settings.TaskHubName,
@@ -122,8 +122,7 @@ namespace DurableTask.AzureStorage.Messaging
                     taskMessage.OrchestrationInstance.InstanceId,
                     taskMessage.OrchestrationInstance.ExecutionId,
                     data.SequenceNumber,
-                    data.Episode.GetValueOrDefault(-1),
-                    Utils.ExtensionVersion);
+                    data.Episode.GetValueOrDefault(-1));
 
                 await this.storageQueue.AddMessageAsync(
                     queueMessage,
@@ -139,7 +138,7 @@ namespace DurableTask.AzureStorage.Messaging
             }
             catch (StorageException e)
             {
-                AnalyticsEventSource.Log.MessageFailure(
+                this.settings.Logger.MessageFailure(
                     this.storageAccountName,
                     this.settings.TaskHubName,
                     string.Empty /* MessageId */,
@@ -148,8 +147,7 @@ namespace DurableTask.AzureStorage.Messaging
                     this.storageQueue.Name,
                     taskMessage.Event.EventType.ToString(),
                     Utils.GetTaskEventId(taskMessage.Event),
-                    e.ToString(),
-                    Utils.ExtensionVersion);
+                    e.ToString());
                 throw;
             }
             finally
@@ -208,18 +206,17 @@ namespace DurableTask.AzureStorage.Messaging
                 maxSecondsToWait;
             if (numSecondsToWait == maxSecondsToWait)
             {
-                AnalyticsEventSource.Log.PoisonMessageDetected(
+                this.settings.Logger.PoisonMessageDetected(
                     this.storageAccountName,
                     this.settings.TaskHubName,
                     queueMessage.Id,
                     instance.InstanceId,
                     instance.ExecutionId,
                     this.storageQueue.Name,
-                    queueMessage.DequeueCount,
-                    Utils.ExtensionVersion);
+                    queueMessage.DequeueCount);
             }
 
-            AnalyticsEventSource.Log.AbandoningMessage(
+            this.settings.Logger.AbandoningMessage(
                 this.storageAccountName,
                 this.settings.TaskHubName,
                 taskMessage.Event.EventType.ToString(),
@@ -229,8 +226,7 @@ namespace DurableTask.AzureStorage.Messaging
                 instance.ExecutionId,
                 this.storageQueue.Name,
                 message.SequenceNumber,
-                numSecondsToWait,
-                Utils.ExtensionVersion);
+                numSecondsToWait);
 
             try
             {
@@ -262,7 +258,7 @@ namespace DurableTask.AzureStorage.Messaging
             TaskMessage taskMessage = message.TaskMessage;
             OrchestrationInstance instance = taskMessage.OrchestrationInstance;
 
-            AnalyticsEventSource.Log.RenewingMessage(
+            this.settings.Logger.RenewingMessage(
                 this.storageAccountName,
                 this.settings.TaskHubName,
                 instance.InstanceId,
@@ -271,8 +267,7 @@ namespace DurableTask.AzureStorage.Messaging
                 message.TaskMessage.Event.EventType.ToString(),
                 Utils.GetTaskEventId(message.TaskMessage.Event),
                 queueMessage.Id,
-                (int)this.MessageVisibilityTimeout.TotalSeconds,
-                Utils.ExtensionVersion);
+                (int)this.MessageVisibilityTimeout.TotalSeconds);
 
             try
             {
@@ -301,7 +296,7 @@ namespace DurableTask.AzureStorage.Messaging
             CloudQueueMessage queueMessage = message.OriginalQueueMessage;
             TaskMessage taskMessage = message.TaskMessage;
 
-            AnalyticsEventSource.Log.DeletingMessage(
+            this.settings.Logger.DeletingMessage(
                 this.storageAccountName,
                 this.settings.TaskHubName,
                 taskMessage.Event.EventType.ToString(),
@@ -310,8 +305,7 @@ namespace DurableTask.AzureStorage.Messaging
                 session.Instance.InstanceId,
                 session.Instance.ExecutionId,
                 this.storageQueue.Name,
-                message.SequenceNumber,
-                Utils.ExtensionVersion);
+                message.SequenceNumber);
 
             var haveRetried = false;
             while (true)
@@ -353,7 +347,7 @@ namespace DurableTask.AzureStorage.Messaging
             if (IsMessageGoneException(e))
             {
                 // Message may have been processed and deleted already.
-                AnalyticsEventSource.Log.MessageGone(
+                this.settings.Logger.MessageGone(
                     this.storageAccountName,
                     this.settings.TaskHubName,
                     message.OriginalQueueMessage.Id,
@@ -362,12 +356,11 @@ namespace DurableTask.AzureStorage.Messaging
                     this.storageQueue.Name,
                     message.TaskMessage.Event.EventType.ToString(),
                     Utils.GetTaskEventId(message.TaskMessage.Event),
-                    details,
-                    Utils.ExtensionVersion);
+                    details);
             }
             else
             {
-                AnalyticsEventSource.Log.MessageFailure(
+                this.settings.Logger.MessageFailure(
                     this.storageAccountName,
                     this.settings.TaskHubName,
                     message.OriginalQueueMessage.Id,
@@ -376,8 +369,7 @@ namespace DurableTask.AzureStorage.Messaging
                     this.storageQueue.Name,
                     message.TaskMessage.Event.EventType.ToString(),
                     Utils.GetTaskEventId(message.TaskMessage.Event),
-                    e.ToString(),
-                    Utils.ExtensionVersion);
+                    e.ToString());
 
                 // Rethrow the original exception, preserving the callstack.
                 ExceptionDispatchInfo.Capture(e).Throw();
@@ -390,18 +382,17 @@ namespace DurableTask.AzureStorage.Messaging
             {
                 if (await this.storageQueue.CreateIfNotExistsAsync(this.QueueRequestOptions, null))
                 {
-                    AnalyticsEventSource.Log.PartitionManagerInfo(
+                    this.settings.Logger.PartitionManagerInfo(
                         this.storageAccountName,
                         this.settings.TaskHubName,
                         this.settings.WorkerId,
                         this.storageQueue.Name,
-                        $"Created {this.GetType().Name} named {this.Name}.",
-                        Utils.ExtensionVersion);
+                        $"Created {this.GetType().Name} named {this.Name}.");
                 }
             }
             catch (Exception e)
             {
-                AnalyticsEventSource.Log.MessageFailure(
+                this.settings.Logger.MessageFailure(
                     this.storageAccountName,
                     this.settings.TaskHubName,
                     string.Empty /* MessageId */,
@@ -410,8 +401,7 @@ namespace DurableTask.AzureStorage.Messaging
                     this.storageQueue.Name,
                     string.Empty /* EventType */,
                     0 /* TaskEventId */,
-                    e.ToString(),
-                    Utils.ExtensionVersion);
+                    e.ToString());
                 throw;
             }
             finally
@@ -426,18 +416,17 @@ namespace DurableTask.AzureStorage.Messaging
             {
                 if (await this.storageQueue.DeleteIfExistsAsync(this.QueueRequestOptions, null))
                 {
-                    AnalyticsEventSource.Log.PartitionManagerInfo(
+                    this.settings.Logger.PartitionManagerInfo(
                         this.storageAccountName,
                         this.settings.TaskHubName,
                         this.settings.WorkerId,
                         this.storageQueue.Name,
-                        $"Deleted {this.GetType().Name} named {this.Name}.",
-                        Utils.ExtensionVersion);
+                        $"Deleted {this.GetType().Name} named {this.Name}.");
                 }
             }
             catch (Exception e)
             {
-                AnalyticsEventSource.Log.MessageFailure(
+                this.settings.Logger.MessageFailure(
                     this.storageAccountName,
                     this.settings.TaskHubName,
                     string.Empty /* MessageId */,
@@ -446,8 +435,7 @@ namespace DurableTask.AzureStorage.Messaging
                     this.storageQueue.Name,
                     string.Empty /* EventType */,
                     0 /* TaskEventId */,
-                    e.ToString(),
-                    Utils.ExtensionVersion);
+                    e.ToString());
                 throw;
             }
             finally

--- a/src/DurableTask.AzureStorage/Messaging/WorkItemQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/WorkItemQueue.cs
@@ -42,7 +42,7 @@ namespace DurableTask.AzureStorage.Messaging
                 try
                 {
                     OperationContext context = new OperationContext { ClientRequestID = Guid.NewGuid().ToString() };
-                    CloudQueueMessage queueMessage = await TimeoutHandler.ExecuteWithTimeout("GetMessage", context.ClientRequestID, storageAccountName, settings.TaskHubName, () =>
+                    CloudQueueMessage queueMessage = await TimeoutHandler.ExecuteWithTimeout("GetMessage", context.ClientRequestID, storageAccountName, settings, () =>
                     {
                         return this.storageQueue.GetMessageAsync(
                             this.settings.WorkItemQueueVisibilityTimeout,
@@ -72,7 +72,7 @@ namespace DurableTask.AzureStorage.Messaging
                 {
                     if (!cancellationToken.IsCancellationRequested)
                     {
-                        AnalyticsEventSource.Log.MessageFailure(
+                        this.settings.Logger.MessageFailure(
                             this.storageAccountName,
                             this.settings.TaskHubName,
                             string.Empty /* MessageId */,
@@ -81,8 +81,7 @@ namespace DurableTask.AzureStorage.Messaging
                             this.storageQueue.Name,
                             string.Empty /* EventType */,
                             0 /* TaskEventId */,
-                            e.ToString(),
-                            Utils.ExtensionVersion);
+                            e.ToString());
 
                         await this.backoffHelper.WaitAsync(cancellationToken);
                     }

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -62,13 +62,12 @@ namespace DurableTask.AzureStorage
             }
             else
             {
-                AnalyticsEventSource.Log.PartitionManagerWarning(
+                this.settings.Logger.PartitionManagerWarning(
                     this.storageAccountName,
                     this.settings.TaskHubName,
                     this.settings.WorkerId,
                     partitionId,
-                    $"Attempted to add a control queue {controlQueue.Name} multiple times!",
-                    Utils.ExtensionVersion);
+                    $"Attempted to add a control queue {controlQueue.Name} multiple times!");
             }
         }
 
@@ -80,25 +79,23 @@ namespace DurableTask.AzureStorage
             }
             else
             {
-                AnalyticsEventSource.Log.PartitionManagerWarning(
+                this.settings.Logger.PartitionManagerWarning(
                     this.storageAccountName,
                     this.settings.TaskHubName,
                     this.settings.WorkerId,
                     partitionId,
-                    $"Attempted to remove control queue {controlQueue.Name}, which wasn't being watched!",
-                    Utils.ExtensionVersion);
+                    $"Attempted to remove control queue {controlQueue.Name}, which wasn't being watched!");
             }
         }
 
         async void DequeueLoop(string partitionId, ControlQueue controlQueue, CancellationToken cancellationToken)
         {
-            AnalyticsEventSource.Log.PartitionManagerInfo(
+            this.settings.Logger.PartitionManagerInfo(
                 this.storageAccountName,
                 this.settings.TaskHubName,
                 this.settings.WorkerId,
                 partitionId,
-                $"Started listening for messages on queue {controlQueue.Name}.",
-                Utils.ExtensionVersion);
+                $"Started listening for messages on queue {controlQueue.Name}.");
 
             try
             {
@@ -106,7 +103,7 @@ namespace DurableTask.AzureStorage
                 {
                     // Every dequeue operation has a common trace ID so that batches of dequeued messages can be correlated together.
                     // Both the dequeue traces and the processing traces will share the same "related" trace activity ID.
-                    Guid traceActivityId = AzureStorageOrchestrationService.StartNewLogicalTraceScope();
+                    Guid traceActivityId = AzureStorageOrchestrationService.StartNewLogicalTraceScope(useExisting: false);
 
                     // This will block until either new messages arrive or the queue is released.
                     IReadOnlyList<MessageData> messages = await controlQueue.GetMessagesAsync(cancellationToken);
@@ -119,13 +116,12 @@ namespace DurableTask.AzureStorage
             }
             finally
             {
-                AnalyticsEventSource.Log.PartitionManagerInfo(
+                this.settings.Logger.PartitionManagerInfo(
                     this.storageAccountName,
                     this.settings.TaskHubName,
                     this.settings.WorkerId,
                     partitionId,
-                    $"Stopped listening for messages on queue {controlQueue.Name}.",
-                    Utils.ExtensionVersion);
+                    $"Stopped listening for messages on queue {controlQueue.Name}.");
             }
         }
 
@@ -271,13 +267,12 @@ namespace DurableTask.AzureStorage
                 }
                 catch (Exception e)
                 {
-                    AnalyticsEventSource.Log.OrchestrationProcessingFailure(
+                    this.settings.Logger.OrchestrationProcessingFailure(
                         this.storageAccountName,
                         this.settings.TaskHubName,
                         batch.OrchestrationInstanceId,
                         batch.OrchestrationExecutionId,
-                        e.ToString(),
-                        Utils.ExtensionVersion);
+                        e.ToString());
 
                     // Sleep briefly to avoid a tight failure loop.
                     await Task.Delay(TimeSpan.FromSeconds(5));
@@ -312,11 +307,11 @@ namespace DurableTask.AzureStorage
                                 ExecutionId = nextBatch.OrchestrationExecutionId,
                             };
 
-                        Guid traceActivityId = AzureStorageOrchestrationService.StartNewLogicalTraceScope();
+                        Guid traceActivityId = AzureStorageOrchestrationService.StartNewLogicalTraceScope(useExisting: true);
 
                         OrchestrationSession session = new OrchestrationSession(
+                            this.settings,
                             this.storageAccountName,
-                            this.settings.TaskHubName,
                             instance,
                             nextBatch.ControlQueue,
                             nextBatch.Messages,
@@ -395,11 +390,10 @@ namespace DurableTask.AzureStorage
                 }
                 else
                 {
-                    AnalyticsEventSource.Log.AssertFailure(
+                    this.settings.Logger.AssertFailure(
                         this.storageAccountName,
                         this.settings.TaskHubName,
-                        $"{nameof(TryReleaseSession)}: Session for instance {instanceId} was not found!",
-                        Utils.ExtensionVersion);
+                        $"{nameof(TryReleaseSession)}: Session for instance {instanceId} was not found!");
                     return false;
                 }
             }

--- a/src/DurableTask.AzureStorage/Partitioning/BlobLeaseManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/BlobLeaseManager.cs
@@ -156,10 +156,10 @@ namespace DurableTask.AzureStorage.Partitioning
             }
             catch (StorageException se)
             {
+                // eat any storage exception related to conflict
+                // this means the blob already exist
                 if (se.RequestInformation.HttpStatusCode != 409)
                 {
-                    // eat any storage exception related to conflict
-                    // this means the blob already exist
                     this.settings.Logger.PartitionManagerInfo(
                         this.storageAccountName,
                         this.taskHubName,

--- a/src/DurableTask.AzureStorage/Partitioning/BlobLeaseManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/BlobLeaseManager.cs
@@ -156,21 +156,24 @@ namespace DurableTask.AzureStorage.Partitioning
             }
             catch (StorageException se)
             {
-                // eat any storage exception related to conflict
-                // this means the blob already exist
-                this.settings.Logger.PartitionManagerInfo(
-                    this.storageAccountName,
-                    this.taskHubName,
-                    this.workerName,
-                    partitionId,
-                    string.Format(
-                        CultureInfo.InvariantCulture,
-                        "CreateLeaseIfNotExistAsync - leaseContainerName: {0}, consumerGroupName: {1}, partitionId: {2}, blobPrefix: {3}, exception: {4}.",
-                        this.leaseContainerName,
-                        this.consumerGroupName,
+                if (se.RequestInformation.HttpStatusCode != 409)
+                {
+                    // eat any storage exception related to conflict
+                    // this means the blob already exist
+                    this.settings.Logger.PartitionManagerInfo(
+                        this.storageAccountName,
+                        this.taskHubName,
+                        this.workerName,
                         partitionId,
-                        this.blobPrefix ?? string.Empty,
-                        se.Message));
+                        string.Format(
+                            CultureInfo.InvariantCulture,
+                            "CreateLeaseIfNotExistAsync - leaseContainerName: {0}, consumerGroupName: {1}, partitionId: {2}, blobPrefix: {3}, exception: {4}",
+                            this.leaseContainerName,
+                            this.consumerGroupName,
+                            partitionId,
+                            this.blobPrefix ?? string.Empty,
+                            se.Message));
+                }
             }
             finally
             {

--- a/src/DurableTask.AzureStorage/TimeoutHandler.cs
+++ b/src/DurableTask.AzureStorage/TimeoutHandler.cs
@@ -11,20 +11,25 @@
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
 
-using System;
-using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace DurableTask.AzureStorage
 {
+    using System;
+    using System.Diagnostics;
+    using System.Threading;
+    using System.Threading.Tasks;
+
     // Class that acts as a timeout handler to wrap Azure Storage calls, mitigating a deadlock that occurs with Azure Storage SDK 9.3.3.
     // The TimeoutHandler class is based off of the similar Azure Functions fix seen here: https://github.com/Azure/azure-webjobs-sdk/pull/2291
     internal static class TimeoutHandler
     {
         private static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(2);
 
-        public static async Task<T> ExecuteWithTimeout<T>(string operationName, string clientRequestId, string account, string taskHub, Func<Task<T>> operation)
+        public static async Task<T> ExecuteWithTimeout<T>(
+            string operationName,
+            string clientRequestId,
+            string account,
+            AzureStorageOrchestrationServiceSettings settings,
+            Func<Task<T>> operation)
         {
             if (Debugger.IsAttached)
             {
@@ -41,8 +46,9 @@ namespace DurableTask.AzureStorage
 
                 if (Equals(timeoutTask, completedTask))
                 {
-                    var message = $"The operation '{operationName}' with id '{clientRequestId}' did not complete in '{DefaultTimeout}'. Terminating the process to mitigate potential deadlock.";
-                    AnalyticsEventSource.Log.GeneralError(account ?? "", taskHub ?? "", message, Utils.ExtensionVersion);
+                    string taskHubName = settings.TaskHubName;
+                    string message = $"The operation '{operationName}' with id '{clientRequestId}' did not complete in '{DefaultTimeout}'. Terminating the process to mitigate potential deadlock.";
+                    settings.Logger.GeneralError(account ?? "", taskHubName ?? "", message);
 
                     // Delay to ensure the ETW event gets written
                     await Task.Delay(TimeSpan.FromSeconds(3));

--- a/src/DurableTask.AzureStorage/Utils.cs
+++ b/src/DurableTask.AzureStorage/Utils.cs
@@ -28,6 +28,9 @@ namespace DurableTask.AzureStorage
 
         public static readonly string ExtensionVersion = FileVersionInfo.GetVersionInfo(typeof(AzureStorageOrchestrationService).Assembly.Location).FileVersion;
 
+        // DurableTask.Core has a public static variable that contains the app name
+        public static readonly string AppName = DurableTask.Core.Common.Utils.AppName;
+
         public static async Task ParallelForEachAsync<TSource>(
             this IEnumerable<TSource> enumerable,
             Func<TSource, Task> action)

--- a/src/DurableTask.Core/Common/Utils.cs
+++ b/src/DurableTask.Core/Common/Utils.cs
@@ -52,9 +52,12 @@ namespace DurableTask.Core.Common
         /// </summary>
         /// <remarks>
         /// The default value comes from the WEBSITE_SITE_NAME environment variable, which is defined
-        /// in Azure App Service.
+        /// in Azure App Service. Other environments can use DTFX_APP_NAME to set this value.
         /// </remarks>
-        public static string AppName { get; set; } = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME") ?? string.Empty;
+        public static string AppName { get; set; } = 
+            Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME") ??
+            Environment.GetEnvironmentVariable("DTFX_APP_NAME") ??
+            string.Empty;
 
         /// <summary>
         /// NoOp utility method

--- a/src/DurableTask.Core/Common/Utils.cs
+++ b/src/DurableTask.Core/Common/Utils.cs
@@ -19,13 +19,13 @@ namespace DurableTask.Core.Common
     using System.IO.Compression;
     using System.Runtime.ExceptionServices;
     using System.Text;
-    using System.Threading.Tasks;
-    using Newtonsoft.Json;
-    using DurableTask.Core.Exceptions;
-    using DurableTask.Core.Serializing;
-    using Tracing;
     using System.Threading;
+    using System.Threading.Tasks;
+    using DurableTask.Core.Exceptions;
     using DurableTask.Core.History;
+    using DurableTask.Core.Serializing;
+    using DurableTask.Core.Tracing;
+    using Newtonsoft.Json;
 
     /// <summary>
     /// Utility Methods
@@ -41,6 +41,20 @@ namespace DurableTask.Core.Common
             DateTime.MaxValue.Subtract(TimeSpan.FromDays(1)).ToUniversalTime();
 
         static readonly byte[] GzipHeader = { 0x1f, 0x8b };
+
+        /// <summary>
+        /// Gets the version of the DurableTask.Core nuget package, which by convension is the same as the assembly file version.
+        /// </summary>
+        internal static readonly string PackageVersion = FileVersionInfo.GetVersionInfo(typeof(TaskOrchestration).Assembly.Location).FileVersion;
+
+        /// <summary>
+        /// Gets or sets the name of the app, for use when writing structured event source traces.
+        /// </summary>
+        /// <remarks>
+        /// The default value comes from the WEBSITE_SITE_NAME environment variable, which is defined
+        /// in Azure App Service.
+        /// </remarks>
+        public static string AppName { get; set; } = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME") ?? string.Empty;
 
         /// <summary>
         /// NoOp utility method

--- a/src/DurableTask.Core/Common/Utils.cs
+++ b/src/DurableTask.Core/Common/Utils.cs
@@ -451,7 +451,13 @@ namespace DurableTask.Core.Common
             return historyEvent.EventId;
         }
 
-        static bool TryGetTaskScheduledId(HistoryEvent historyEvent, out int taskScheduledId)
+        /// <summary>
+        /// Gets the task event ID for the specified <see cref="HistoryEvent"/> if one exists.
+        /// </summary>
+        /// <param name="historyEvent">The history which may or may not contain a task event ID.</param>
+        /// <param name="taskScheduledId">The task event ID or <c>-1</c> if none exists.</param>
+        /// <returns>Returns <c>true</c> if a task event ID was found; <c>false</c> otherwise.</returns>
+        public static bool TryGetTaskScheduledId(HistoryEvent historyEvent, out int taskScheduledId)
         {
             switch (historyEvent.EventType)
             {

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -2,18 +2,21 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Microsoft.Azure.DurableTask.Core</PackageId>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="ImpromptuInterface" Version="6.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="ImpromptuInterface" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 

--- a/src/DurableTask.Core/Logging/EventIds.cs
+++ b/src/DurableTask.Core/Logging/EventIds.cs
@@ -1,0 +1,60 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core.Logging
+{
+    // WARNING: Changing the *name* OR the *value* of any of these constants is a breaking change!!
+    static class EventIds
+    {
+        public const int TaskHubWorkerStarting = 10;
+        public const int TaskHubWorkerStarted = 11;
+        public const int TaskHubWorkerStopping = 12;
+        public const int TaskHubWorkerStopped = 13;
+
+        public const int DispatcherStarting = 20;
+        public const int DispatcherStopped = 21;
+        public const int DispatchersStopping = 22;
+        public const int FetchingWorkItem = 23;
+        public const int FetchedWorkItem = 24;
+        public const int FetchWorkItemFailure = 25;
+        public const int FetchingThrottled = 26;
+        public const int ProcessWorkItemStarting = 27;
+        public const int ProcessWorkItemCompleted = 28;
+        public const int ProcessWorkItemFailed = 29;
+
+        public const int SchedulingOrchestration = 40;
+        public const int RaisingEvent = 41;
+        public const int TerminatingInstance = 42;
+        public const int WaitingForInstance = 43;
+        public const int FetchingInstanceState = 44;
+        public const int FetchingInstanceHistory = 45;
+        public const int SchedulingActivity = 46;
+        public const int CreatingTimer = 47;
+        public const int SendingEvent = 48;
+        public const int OrchestrationCompleted = 49;
+        public const int ProcessingOrchestrationMessage = 50;
+        public const int OrchestrationExecuting = 51;
+        public const int OrchestrationExecuted = 52;
+        public const int OrchestrationAborted = 53;
+        public const int DiscardingMessage = 54;
+
+        public const int TaskActivityStarting = 60;
+        public const int TaskActivityCompleted = 61;
+        public const int TaskActivityFailure = 62;
+        public const int TaskActivityAborted = 63;
+        public const int TaskActivityDispatcherError = 64;
+        public const int RenewActivityMessageStarting = 65;
+        public const int RenewActivityMessageCompleted = 66;
+        public const int RenewActivityMessageFailed = 67;
+    }
+}

--- a/src/DurableTask.Core/Logging/EventIds.cs
+++ b/src/DurableTask.Core/Logging/EventIds.cs
@@ -24,8 +24,8 @@ namespace DurableTask.Core.Logging
         public const int DispatcherStarting = 20;
         public const int DispatcherStopped = 21;
         public const int DispatchersStopping = 22;
-        public const int FetchingWorkItem = 23;
-        public const int FetchedWorkItem = 24;
+        public const int FetchWorkItemStarting = 23;
+        public const int FetchWorkItemCompleted = 24;
         public const int FetchWorkItemFailure = 25;
         public const int FetchingThrottled = 26;
         public const int ProcessWorkItemStarting = 27;

--- a/src/DurableTask.Core/Logging/IEventSourceEvent.cs
+++ b/src/DurableTask.Core/Logging/IEventSourceEvent.cs
@@ -1,0 +1,26 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core.Logging
+{
+    /// <summary>
+    /// Interface for all log messages that are written to the an event source tracer.
+    /// </summary>
+    public interface IEventSourceEvent
+    {
+        /// <summary>
+        /// Writes the event to the event source log.
+        /// </summary>
+        void WriteEventSource();
+    }
+}

--- a/src/DurableTask.Core/Logging/ILogEvent.cs
+++ b/src/DurableTask.Core/Logging/ILogEvent.cs
@@ -35,6 +35,6 @@ namespace DurableTask.Core.Logging
         /// Gets the message to write to the <see cref="ILogger"/> infrastructure.
         /// This method will not be called if the corresponding event is filtered out.
         /// </summary>
-        string GetLogMessage();
+        string FormattedMessage { get; }
     }
 }

--- a/src/DurableTask.Core/Logging/ILogEvent.cs
+++ b/src/DurableTask.Core/Logging/ILogEvent.cs
@@ -1,0 +1,40 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core.Logging
+{
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    /// Basic interface that defines the basic requirements for all DurableTask
+    /// log messages for <see cref="ILogger"/> compatibility.
+    /// </summary>
+    public interface ILogEvent
+    {
+        /// <summary>
+        /// The ID of the log event. This must match one of the values in <see cref="EventIds"/>.
+        /// </summary>
+        EventId EventId { get; }
+
+        /// <summary>
+        /// The level of the log event.
+        /// </summary>
+        LogLevel Level { get; }
+
+        /// <summary>
+        /// Gets the message to write to the <see cref="ILogger"/> infrastructure.
+        /// This method will not be called if the corresponding event is filtered out.
+        /// </summary>
+        string GetLogMessage();
+    }
+}

--- a/src/DurableTask.Core/Logging/LogEvents.cs
+++ b/src/DurableTask.Core/Logging/LogEvents.cs
@@ -20,6 +20,13 @@ namespace DurableTask.Core.Logging
     using DurableTask.Core.History;
     using Microsoft.Extensions.Logging;
 
+    /// <summary>
+    /// This class defines all log events supported by DurableTask.Core.
+    /// </summary>
+    /// <remarks>
+    /// Each inner-class represents a single log event that derives from <see cref="StructuredLogEvent"/> and
+    /// optionally implements <see cref="IEventSourceEvent"/>.
+    /// </remarks>
     static class LogEvents
     {
         internal class TaskHubWorkerStarting : StructuredLogEvent, IEventSourceEvent

--- a/src/DurableTask.Core/Logging/LogEvents.cs
+++ b/src/DurableTask.Core/Logging/LogEvents.cs
@@ -40,7 +40,7 @@ namespace DurableTask.Core.Logging
             protected override string CreateLogMessage() => "Durable task hub worker is starting";
 
             void IEventSourceEvent.WriteEventSource() => 
-                StructuredEventSource.Log.TaskHubWorkerStarting();
+                StructuredEventSource.Log.TaskHubWorkerStarting(Utils.AppName, Utils.PackageVersion);
         }
 
         internal class TaskHubWorkerStarted : StructuredLogEvent, IEventSourceEvent
@@ -63,7 +63,7 @@ namespace DurableTask.Core.Logging
                 $"Durable task hub worker started successfully after {this.LatencyMs}ms";
 
             void IEventSourceEvent.WriteEventSource() =>
-                StructuredEventSource.Log.TaskHubWorkerStarted(this.LatencyMs);
+                StructuredEventSource.Log.TaskHubWorkerStarted(this.LatencyMs, Utils.AppName, Utils.PackageVersion);
         }
 
         internal class TaskHubWorkerStopping : StructuredLogEvent, IEventSourceEvent
@@ -86,7 +86,7 @@ namespace DurableTask.Core.Logging
                 $"Durable task hub worker is stopping (isForced = {this.IsForced})";
 
             void IEventSourceEvent.WriteEventSource() =>
-                StructuredEventSource.Log.TaskHubWorkerStopping(this.IsForced);
+                StructuredEventSource.Log.TaskHubWorkerStopping(this.IsForced, Utils.AppName, Utils.PackageVersion);
         }
 
         internal class TaskHubWorkerStopped : StructuredLogEvent, IEventSourceEvent
@@ -109,7 +109,7 @@ namespace DurableTask.Core.Logging
                 $"Durable task hub worker stopped successfully after {this.LatencyMs}ms";
 
             void IEventSourceEvent.WriteEventSource() =>
-                StructuredEventSource.Log.TaskHubWorkerStopped(this.LatencyMs);
+                StructuredEventSource.Log.TaskHubWorkerStopped(this.LatencyMs, Utils.AppName, Utils.PackageVersion);
         }
 
         internal class DispatcherStarting : StructuredLogEvent, IEventSourceEvent
@@ -131,7 +131,7 @@ namespace DurableTask.Core.Logging
             protected override string CreateLogMessage() => $"{this.Dispatcher}: Starting dispatch loop";
 
             void IEventSourceEvent.WriteEventSource() =>
-                StructuredEventSource.Log.DispatcherStarting(this.Dispatcher);
+                StructuredEventSource.Log.DispatcherStarting(this.Dispatcher, Utils.AppName, Utils.PackageVersion);
         }
 
         internal class DispatcherStopped : StructuredLogEvent, IEventSourceEvent
@@ -153,7 +153,7 @@ namespace DurableTask.Core.Logging
             protected override string CreateLogMessage() => $"{this.Dispatcher}: Stopped dispatch loop";
 
             void IEventSourceEvent.WriteEventSource() =>
-                StructuredEventSource.Log.DispatcherStopped(this.Dispatcher);
+                StructuredEventSource.Log.DispatcherStopped(this.Dispatcher, Utils.AppName, Utils.PackageVersion);
         }
 
         internal class DispatchersStopping : StructuredLogEvent, IEventSourceEvent
@@ -186,7 +186,12 @@ namespace DurableTask.Core.Logging
                 $"Remaining work item fetchers: {this.ActiveFetcherCount}";
 
             void IEventSourceEvent.WriteEventSource() =>
-                StructuredEventSource.Log.DispatchersStopping(this.Dispatcher, this.WorkItemCount, this.ActiveFetcherCount);
+                StructuredEventSource.Log.DispatchersStopping(
+                    this.Dispatcher,
+                    this.WorkItemCount,
+                    this.ActiveFetcherCount,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         internal class FetchWorkItemStarting : StructuredLogEvent, IEventSourceEvent
@@ -230,7 +235,9 @@ namespace DurableTask.Core.Logging
                     this.Dispatcher,
                     this.TimeoutSeconds,
                     this.WorkItemCount,
-                    this.MaxWorkItemCount);
+                    this.MaxWorkItemCount,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         internal class FetchWorkItemCompleted : StructuredLogEvent, IEventSourceEvent
@@ -280,7 +287,9 @@ namespace DurableTask.Core.Logging
                     this.WorkItemId,
                     this.LatencyMs,
                     this.WorkItemCount,
-                    this.MaxWorkItemCount);
+                    this.MaxWorkItemCount,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         internal class FetchWorkItemFailure : StructuredLogEvent, IEventSourceEvent
@@ -307,7 +316,11 @@ namespace DurableTask.Core.Logging
                 $"{this.Dispatcher}: Failed to fetch a work-item: {this.Details}";
 
             void IEventSourceEvent.WriteEventSource() =>
-                StructuredEventSource.Log.FetchWorkItemFailure(this.Dispatcher, this.Details);
+                StructuredEventSource.Log.FetchWorkItemFailure(
+                    this.Dispatcher,
+                    this.Details,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         internal class FetchingThrottled : StructuredLogEvent, IEventSourceEvent
@@ -345,7 +358,9 @@ namespace DurableTask.Core.Logging
                 StructuredEventSource.Log.FetchingThrottled(
                     this.Dispatcher,
                     this.WorkItemCount,
-                    this.MaxWorkItemCount);
+                    this.MaxWorkItemCount,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         internal class ProcessWorkItemStarting : StructuredLogEvent, IEventSourceEvent
@@ -372,7 +387,11 @@ namespace DurableTask.Core.Logging
                 $"{this.Dispatcher}: Processing work-item '{this.WorkItemId}'";
 
             void IEventSourceEvent.WriteEventSource() =>
-                StructuredEventSource.Log.ProcessWorkItemStarting(this.Dispatcher, this.WorkItemId);
+                StructuredEventSource.Log.ProcessWorkItemStarting(
+                    this.Dispatcher,
+                    this.WorkItemId,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         internal class ProcessWorkItemCompleted : StructuredLogEvent, IEventSourceEvent
@@ -399,7 +418,11 @@ namespace DurableTask.Core.Logging
                 $"{this.Dispatcher}: Finished processing work-item '{this.WorkItemId}'";
 
             void IEventSourceEvent.WriteEventSource() =>
-                StructuredEventSource.Log.ProcessWorkItemCompleted(this.Dispatcher, this.WorkItemId);
+                StructuredEventSource.Log.ProcessWorkItemCompleted(
+                    this.Dispatcher,
+                    this.WorkItemId,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         internal class ProcessWorkItemFailed : StructuredLogEvent, IEventSourceEvent
@@ -434,7 +457,12 @@ namespace DurableTask.Core.Logging
                 $"{this.Dispatcher}: Unhandled exception with work item '{this.WorkItemId}': {this.Details}";
 
             void IEventSourceEvent.WriteEventSource() =>
-                StructuredEventSource.Log.ProcessWorkItemFailed(this.Dispatcher, this.WorkItemId, this.Details);
+                StructuredEventSource.Log.ProcessWorkItemFailed(
+                    this.Dispatcher,
+                    this.WorkItemId,
+                    this.Details,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         internal class SchedulingOrchestration : StructuredLogEvent, IEventSourceEvent
@@ -497,7 +525,9 @@ namespace DurableTask.Core.Logging
                     this.TargetExecutionId,
                     this.Name,
                     this.TaskEventId,
-                    this.SizeInBytes);
+                    this.SizeInBytes,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         internal class RaisingEvent : StructuredLogEvent, IEventSourceEvent
@@ -564,7 +594,9 @@ namespace DurableTask.Core.Logging
                     this.TargetInstanceId,
                     this.Name,
                     this.TaskEventId,
-                    this.SizeInBytes);
+                    this.SizeInBytes,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         internal class TerminatingInstance : StructuredLogEvent, IEventSourceEvent
@@ -598,7 +630,9 @@ namespace DurableTask.Core.Logging
                 StructuredEventSource.Log.TerminatingInstance(
                     this.InstanceId,
                     this.ExecutionId,
-                    this.Details);
+                    this.Details,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         internal class WaitingForInstance : StructuredLogEvent, IEventSourceEvent
@@ -632,7 +666,9 @@ namespace DurableTask.Core.Logging
                 StructuredEventSource.Log.WaitingForInstance(
                     this.InstanceId,
                     this.ExecutionId,
-                    this.TimeoutSeconds);
+                    this.TimeoutSeconds,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         internal class FetchingInstanceState : StructuredLogEvent, IEventSourceEvent
@@ -661,7 +697,9 @@ namespace DurableTask.Core.Logging
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.FetchingInstanceState(
                     this.InstanceId,
-                    this.ExecutionId);
+                    this.ExecutionId,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         /// <summary>
@@ -693,7 +731,9 @@ namespace DurableTask.Core.Logging
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.FetchingInstanceHistory(
                     this.InstanceId,
-                    this.ExecutionId);
+                    this.ExecutionId,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         /// <summary>
@@ -735,7 +775,9 @@ namespace DurableTask.Core.Logging
                     this.InstanceId,
                     this.ExecutionId,
                     this.EventType,
-                    this.TaskEventId);
+                    this.TaskEventId,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         /// <summary>
@@ -772,7 +814,9 @@ namespace DurableTask.Core.Logging
                 StructuredEventSource.Log.OrchestrationExecuting(
                     this.InstanceId,
                     this.ExecutionId,
-                    this.Name);
+                    this.Name,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         /// <summary>
@@ -814,7 +858,9 @@ namespace DurableTask.Core.Logging
                     this.InstanceId,
                     this.ExecutionId,
                     this.Name,
-                    this.ActionCount);
+                    this.ActionCount,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         /// <summary>
@@ -861,7 +907,9 @@ namespace DurableTask.Core.Logging
                     this.ExecutionId,
                     this.Name,
                     this.TaskEventId,
-                    this.SizeInBytes);
+                    this.SizeInBytes,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         /// <summary>
@@ -912,7 +960,9 @@ namespace DurableTask.Core.Logging
                     this.ExecutionId,
                     this.FireAt,
                     this.TaskEventId,
-                    this.IsInternal);
+                    this.IsInternal,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         /// <summary>
@@ -962,7 +1012,9 @@ namespace DurableTask.Core.Logging
                     this.ExecutionId,
                     this.RuntimeStatus,
                     this.Details,
-                    this.SizeInBytes);
+                    this.SizeInBytes,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         /// <summary>
@@ -999,7 +1051,9 @@ namespace DurableTask.Core.Logging
                 StructuredEventSource.Log.OrchestrationAborted(
                     this.InstanceId,
                     this.ExecutionId,
-                    this.Details);
+                    this.Details,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         /// <summary>
@@ -1046,7 +1100,9 @@ namespace DurableTask.Core.Logging
                     this.ExecutionId,
                     this.EventType,
                     this.TaskEventId,
-                    this.Details);
+                    this.Details,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         /// <summary>
@@ -1088,7 +1144,9 @@ namespace DurableTask.Core.Logging
                     this.InstanceId,
                     this.ExecutionId,
                     this.Name,
-                    this.TaskEventId);
+                    this.TaskEventId,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         /// <summary>
@@ -1138,7 +1196,9 @@ namespace DurableTask.Core.Logging
                     this.ExecutionId,
                     this.Name,
                     this.TaskEventId,
-                    this.SizeInBytes);
+                    this.SizeInBytes,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         internal class TaskActivityFailure : StructuredLogEvent, IEventSourceEvent
@@ -1186,7 +1246,9 @@ namespace DurableTask.Core.Logging
                     this.ExecutionId,
                     this.Name,
                     this.TaskEventId,
-                    this.Details);
+                    this.Details,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         internal class TaskActivityAborted : StructuredLogEvent, IEventSourceEvent
@@ -1230,7 +1292,9 @@ namespace DurableTask.Core.Logging
                     this.ExecutionId,
                     this.Name,
                     this.TaskEventId,
-                    this.Details);
+                    this.Details,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         internal class TaskActivityDispatcherError : StructuredLogEvent, IEventSourceEvent
@@ -1264,7 +1328,9 @@ namespace DurableTask.Core.Logging
                 StructuredEventSource.Log.TaskActivityDispatcherError(
                     this.InstanceId,
                     this.ExecutionId,
-                    this.Details);
+                    this.Details,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         internal class RenewActivityMessageStarting : StructuredLogEvent, IEventSourceEvent
@@ -1304,7 +1370,9 @@ namespace DurableTask.Core.Logging
                     this.InstanceId,
                     this.ExecutionId,
                     this.Name,
-                    this.TaskEventId);
+                    this.TaskEventId,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         internal class RenewActivityMessageCompleted : StructuredLogEvent, IEventSourceEvent
@@ -1351,7 +1419,9 @@ namespace DurableTask.Core.Logging
                     this.ExecutionId,
                     this.Name,
                     this.TaskEventId,
-                    this.NextRenewal);
+                    this.NextRenewal,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
 
         internal class RenewActivityMessageFailed : StructuredLogEvent, IEventSourceEvent
@@ -1397,7 +1467,9 @@ namespace DurableTask.Core.Logging
                     this.ExecutionId,
                     this.Name,
                     this.TaskEventId,
-                    this.Details);
+                    this.Details,
+                    Utils.AppName,
+                    Utils.PackageVersion);
         }
     }
 }

--- a/src/DurableTask.Core/Logging/LogEvents.cs
+++ b/src/DurableTask.Core/Logging/LogEvents.cs
@@ -37,7 +37,7 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() => "Durable task hub worker is starting";
+            protected override string CreateLogMessage() => "Durable task hub worker is starting";
 
             void IEventSourceEvent.WriteEventSource() => 
                 StructuredEventSource.Log.TaskHubWorkerStarting();
@@ -59,7 +59,8 @@ namespace DurableTask.Core.Logging
             [StructuredLogField]
             public long LatencyMs { get; }
 
-            public override string GetLogMessage() => $"Durable task hub worker started successfully after {this.LatencyMs}ms";
+            protected override string CreateLogMessage() => 
+                $"Durable task hub worker started successfully after {this.LatencyMs}ms";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.TaskHubWorkerStarted(this.LatencyMs);
@@ -81,7 +82,8 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() => $"Durable task hub worker is stopping (isForced = {this.IsForced})";
+            protected override string CreateLogMessage() =>
+                $"Durable task hub worker is stopping (isForced = {this.IsForced})";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.TaskHubWorkerStopping(this.IsForced);
@@ -103,7 +105,7 @@ namespace DurableTask.Core.Logging
             [StructuredLogField]
             public long LatencyMs { get; }
 
-            public override string GetLogMessage() => 
+            protected override string CreateLogMessage() => 
                 $"Durable task hub worker stopped successfully after {this.LatencyMs}ms";
 
             void IEventSourceEvent.WriteEventSource() =>
@@ -126,7 +128,7 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Debug;
 
-            public override string GetLogMessage() => $"Starting {this.Dispatcher}";
+            protected override string CreateLogMessage() => $"{this.Dispatcher}: Starting dispatch loop";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.DispatcherStarting(this.Dispatcher);
@@ -148,7 +150,7 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Debug;
 
-            public override string GetLogMessage() => $"{this.Dispatcher} stopped";
+            protected override string CreateLogMessage() => $"{this.Dispatcher}: Stopped dispatch loop";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.DispatcherStopped(this.Dispatcher);
@@ -179,9 +181,9 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Debug;
 
-            public override string GetLogMessage() =>
-                $"{this.Dispatcher} dispatchers are draining. Remaining work items: {this.WorkItemCount}. " +
-                $"Remaining work item fetchers: {this.ActiveFetcherCount}.";
+            protected override string CreateLogMessage() =>
+                $"{this.Dispatcher}: Dispatchers are draining. Remaining work items: {this.WorkItemCount}. " +
+                $"Remaining work item fetchers: {this.ActiveFetcherCount}";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.DispatchersStopping(this.Dispatcher, this.WorkItemCount, this.ActiveFetcherCount);
@@ -219,7 +221,7 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Debug;
 
-            public override string GetLogMessage() =>
+            protected override string CreateLogMessage() =>
                 $"{this.Dispatcher}: Fetching next work item. Current active work-item count: {this.WorkItemCount}. " +
                 $"Maximum active work-item count: {this.MaxWorkItemCount}. Timeout: {this.TimeoutSeconds}s";
 
@@ -268,9 +270,9 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Debug;
 
-            public override string GetLogMessage() =>
+            protected override string CreateLogMessage() =>
                 $"{this.Dispatcher}: Fetched next work item '{this.WorkItemId}' after {this.LatencyMs}ms. " +
-                $"Current active work-item count: {this.WorkItemCount}. Maximum active work-item count: {this.MaxWorkItemCount}.";
+                $"Current active work-item count: {this.WorkItemCount}. Maximum active work-item count: {this.MaxWorkItemCount}";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.FetchWorkItemCompleted(
@@ -301,7 +303,8 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Error;
 
-            public override string GetLogMessage() => $"{this.Dispatcher} failed to fetch a work-item: {this.Details}";
+            protected override string CreateLogMessage() =>
+                $"{this.Dispatcher}: Failed to fetch a work-item: {this.Details}";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.FetchWorkItemFailure(this.Dispatcher, this.Details);
@@ -334,7 +337,7 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() =>
+            protected override string CreateLogMessage() =>
                 $"{this.Dispatcher}: Delaying work item fetching because the current active work-item count ({this.WorkItemCount}) " +
                 $"exceeds the configured maximum active work-item count ({this.MaxWorkItemCount})";
 
@@ -365,7 +368,8 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Debug;
 
-            public override string GetLogMessage() => $"{this.Dispatcher}: Processing work-item '{this.WorkItemId}'";
+            protected override string CreateLogMessage() =>
+                $"{this.Dispatcher}: Processing work-item '{this.WorkItemId}'";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.ProcessWorkItemStarting(this.Dispatcher, this.WorkItemId);
@@ -391,7 +395,8 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Debug;
 
-            public override string GetLogMessage() => $"{this.Dispatcher}: Finished processing work-item '{this.WorkItemId}'";
+            protected override string CreateLogMessage() =>
+                $"{this.Dispatcher}: Finished processing work-item '{this.WorkItemId}'";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.ProcessWorkItemCompleted(this.Dispatcher, this.WorkItemId);
@@ -425,8 +430,8 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Error;
 
-            public override string GetLogMessage() =>
-                $"Unhandled exception with work item '{this.WorkItemId}' in {this.Dispatcher}: {this.Details}";
+            protected override string CreateLogMessage() =>
+                $"{this.Dispatcher}: Unhandled exception with work item '{this.WorkItemId}': {this.Details}";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.ProcessWorkItemFailed(this.Dispatcher, this.WorkItemId, this.Details);
@@ -472,9 +477,17 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() =>
-                $"Scheduling orchestration '{this.Name}' with ID: '{this.InstanceId}'. " +
-                $"Input size (in bytes): {this.SizeInBytes}";
+            protected override string CreateLogMessage()
+            {
+                string message = $"Scheduling orchestration '{this.Name}' with instance ID = '{this.TargetInstanceId}' and {this.SizeInBytes} bytes of input";
+                if (!string.IsNullOrEmpty(this.InstanceId))
+                {
+                    // This is the case where a parent orchestration is scheduling a child-orchestration
+                    message = this.InstanceId + ": " + message;
+                }
+
+                return message;
+            }
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.SchedulingOrchestration(
@@ -533,8 +546,16 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() =>
-                $"Raising event '{this.Name}' with {this.SizeInBytes} bytes to '{this.InstanceId}'";
+            protected override string CreateLogMessage()
+            {
+                string message = $"Raising '{this.Name}' event with {this.SizeInBytes} bytes to '{this.TargetInstanceId}'";
+                if (!string.IsNullOrEmpty(this.InstanceId))
+                {
+                    message = this.InstanceId + ": " + message;
+                }
+
+                return message;
+            }
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.RaisingEvent(
@@ -570,7 +591,7 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() =>
+            protected override string CreateLogMessage() =>
                 $"Terminating instance '{this.InstanceId}': {this.Details}";
 
             void IEventSourceEvent.WriteEventSource() =>
@@ -604,7 +625,7 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() =>
+            protected override string CreateLogMessage() =>
                 $"Waiting up to {this.TimeoutSeconds} seconds for instance '{this.InstanceId}' to complete, fail, or be terminated";
 
             void IEventSourceEvent.WriteEventSource() =>
@@ -634,8 +655,8 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() =>
-                $"Fetching state for instance: {this.InstanceId}";
+            protected override string CreateLogMessage() =>
+                $"Fetching tracking state for instance '{this.InstanceId}'";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.FetchingInstanceState(
@@ -643,6 +664,9 @@ namespace DurableTask.Core.Logging
                     this.ExecutionId);
         }
 
+        /// <summary>
+        /// Log event representing a task hub client querying for orchestration instance history.
+        /// </summary>
         internal class FetchingInstanceHistory : StructuredLogEvent, IEventSourceEvent
         {
             public FetchingInstanceHistory(OrchestrationInstance instance)
@@ -663,8 +687,8 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() =>
-                $"Fetching history for instance: {this.InstanceId}";
+            protected override string CreateLogMessage() =>
+                $"Fetching history for instance '{this.InstanceId}'";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.FetchingInstanceHistory(
@@ -672,6 +696,9 @@ namespace DurableTask.Core.Logging
                     this.ExecutionId);
         }
 
+        /// <summary>
+        /// Log event representing a task hub worker processing a new message from a fetched work item.
+        /// </summary>
         internal class ProcessingOrchestrationMessage : StructuredLogEvent, IEventSourceEvent
         {
             public ProcessingOrchestrationMessage(TaskOrchestrationWorkItem workItem, TaskMessage message)
@@ -700,8 +727,8 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Debug;
 
-            public override string GetLogMessage() =>
-                $"Fetching history for instance: {this.InstanceId}";
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Preparing to process a {GetEventDescription(this.EventType, this.TaskEventId)} message";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.ProcessingOrchestrationMessage(
@@ -711,6 +738,9 @@ namespace DurableTask.Core.Logging
                     this.TaskEventId);
         }
 
+        /// <summary>
+        /// Log event representing a task hub worker beginning an orchestration instance execution.
+        /// </summary>
         internal class OrchestrationExecuting : StructuredLogEvent, IEventSourceEvent
         {
             public OrchestrationExecuting(OrchestrationInstance instance, string name)
@@ -735,8 +765,8 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() =>
-                $"Executing orchestration '{this.Name}' with ID '{this.InstanceId}'";
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Executing '{this.Name}' orchestration logic";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.OrchestrationExecuting(
@@ -745,6 +775,9 @@ namespace DurableTask.Core.Logging
                     this.Name);
         }
 
+        /// <summary>
+        /// Log event representing a task hub worker completed an orchestration instance execution.
+        /// </summary>
         internal class OrchestrationExecuted : StructuredLogEvent, IEventSourceEvent
         {
             public OrchestrationExecuted(OrchestrationInstance instance, string name, int actionCount)
@@ -773,8 +806,8 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() =>
-                $"Execution of orchestration '{this.Name}' with ID '{this.InstanceId}' resulted in {this.ActionCount} new action(s).";
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Orchestration '{this.Name}' awaited and scheduled {this.ActionCount} durable operation(s).";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.OrchestrationExecuted(
@@ -784,6 +817,9 @@ namespace DurableTask.Core.Logging
                     this.ActionCount);
         }
 
+        /// <summary>
+        /// Log event representing an orchestration instance scheduling an activity as part of its execution.
+        /// </summary>
         internal class SchedulingActivity : StructuredLogEvent, IEventSourceEvent
         {
             public SchedulingActivity(OrchestrationInstance instance, TaskScheduledEvent taskScheduledEvent)
@@ -816,9 +852,8 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() =>
-                $"Scheduling activity '{this.Name}' with task event ID {this.TaskEventId}. " +
-                $"Input size (in bytes): {this.SizeInBytes}";
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Scheduling activity {GetEventDescription(this.Name, this.TaskEventId)} with {this.SizeInBytes} bytes of input";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.SchedulingActivity(
@@ -829,6 +864,10 @@ namespace DurableTask.Core.Logging
                     this.SizeInBytes);
         }
 
+        /// <summary>
+        /// Log event representing an orchestration instance scheduling an activity as part of its execution.
+        /// This could be an explicit timer created by the orchestration or an implicit one created by the dispatcher.
+        /// </summary>
         internal class CreatingTimer : StructuredLogEvent, IEventSourceEvent
         {
             public CreatingTimer(
@@ -864,8 +903,8 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() =>
-                $"Scheduling timer with ID = {this.TaskEventId} to fire at {this.FireAt:o}";
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Scheduling {GetEventDescription(EventType.TimerFired.ToString(), this.TaskEventId)} to fire at {this.FireAt:o}";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.CreatingTimer(
@@ -876,6 +915,10 @@ namespace DurableTask.Core.Logging
                     this.IsInternal);
         }
 
+        /// <summary>
+        /// Log event representing an orchestration instance ran to completion.
+        /// This could be a success or a failure.
+        /// </summary>
         internal class OrchestrationCompleted : StructuredLogEvent, IEventSourceEvent
         {
             public OrchestrationCompleted(
@@ -910,8 +953,8 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() =>
-                $"{this.InstanceId}: Orchestration completed. Status: {this.RuntimeStatus}. Details: {this.Details}";
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Orchestration completed with a '{this.RuntimeStatus}' status and {this.SizeInBytes} bytes of output. Details: {this.Details}";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.OrchestrationCompleted(
@@ -922,6 +965,9 @@ namespace DurableTask.Core.Logging
                     this.SizeInBytes);
         }
 
+        /// <summary>
+        /// Log event representing an orchestration aborted event, which can happen if the host is shutting down.
+        /// </summary>
         internal class OrchestrationAborted : StructuredLogEvent, IEventSourceEvent
         {
             public OrchestrationAborted(OrchestrationInstance instance, string reason)
@@ -946,7 +992,7 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Warning;
 
-            public override string GetLogMessage() =>
+            protected override string CreateLogMessage() =>
                 $"{this.InstanceId}: Orchestration execution was aborted: {this.Details}";
 
             void IEventSourceEvent.WriteEventSource() =>
@@ -956,6 +1002,9 @@ namespace DurableTask.Core.Logging
                     this.Details);
         }
 
+        /// <summary>
+        /// Log event representing the discarding of an orchestration message that cannot be processed.
+        /// </summary>
         internal class DiscardingMessage : StructuredLogEvent, IEventSourceEvent
         {
             public DiscardingMessage(TaskOrchestrationWorkItem workItem, TaskMessage message, string reason)
@@ -988,8 +1037,8 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Warning;
 
-            public override string GetLogMessage() =>
-                $"{this.InstanceId}: Discarding {this.EventType} message with ID = {this.TaskEventId}: {this.Details}";
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Discarding {GetEventDescription(this.EventType, this.TaskEventId)}: {this.Details}";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.DiscardingMessage(
@@ -1000,6 +1049,9 @@ namespace DurableTask.Core.Logging
                     this.Details);
         }
 
+        /// <summary>
+        /// Log event indicating that an activity execution is starting.
+        /// </summary>
         internal class TaskActivityStarting : StructuredLogEvent, IEventSourceEvent
         {
             public TaskActivityStarting(OrchestrationInstance instance, TaskScheduledEvent taskEvent)
@@ -1028,8 +1080,8 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() =>
-                $"{this.InstanceId}: Starting task activity {this.Name} with ID = {this.TaskEventId}";
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Starting task activity {GetEventDescription(this.Name, this.TaskEventId)}";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.TaskActivityStarting(
@@ -1039,6 +1091,9 @@ namespace DurableTask.Core.Logging
                     this.TaskEventId);
         }
 
+        /// <summary>
+        /// Log event indicating that an activity execution has completed successfully.
+        /// </summary>
         internal class TaskActivityCompleted : StructuredLogEvent, IEventSourceEvent
         {
             public TaskActivityCompleted(
@@ -1074,8 +1129,8 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() =>
-                $"{this.InstanceId}: Task activity {this.Name} with ID = {this.TaskEventId} completed successfully";
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Task activity {GetEventDescription(this.Name, this.TaskEventId)} completed successfully";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.TaskActivityCompleted(
@@ -1120,10 +1175,10 @@ namespace DurableTask.Core.Logging
                 EventIds.TaskActivityFailure,
                 nameof(EventIds.TaskActivityFailure));
 
-            public override LogLevel Level => LogLevel.Warning;
+            public override LogLevel Level => LogLevel.Information;
 
-            public override string GetLogMessage() =>
-                $"{this.InstanceId}: Task activity {this.Name} with ID = {this.TaskEventId} failed: {this.Details}";
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Task activity {GetEventDescription(this.Name, this.TaskEventId)} failed: {this.Details}";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.TaskActivityFailure(
@@ -1166,8 +1221,8 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Warning;
 
-            public override string GetLogMessage() =>
-                $"{this.InstanceId}: Task activity {this.Name} with ID = {this.TaskEventId} was aborted: {this.Details}";
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Task activity {GetEventDescription(this.Name, this.TaskEventId)} was aborted: {this.Details}";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.TaskActivityAborted(
@@ -1203,7 +1258,7 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Error;
 
-            public override string GetLogMessage() => this.Details;
+            protected override string CreateLogMessage() => this.Details;
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.TaskActivityDispatcherError(
@@ -1241,8 +1296,8 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Debug;
 
-            public override string GetLogMessage() =>
-                $"{this.InstanceId}: Renewing message for task activity {this.Name} (ID = {this.TaskEventId})";
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Renewing message for task activity {GetEventDescription(this.Name, this.TaskEventId)}";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.RenewActivityMessageStarting(
@@ -1286,8 +1341,8 @@ namespace DurableTask.Core.Logging
 
             public override LogLevel Level => LogLevel.Debug;
 
-            public override string GetLogMessage() =>
-                $"{this.InstanceId}: Renewed message for task activity {this.Name} (ID = {this.TaskEventId}) successfully. " +
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Renewed message for task activity {GetEventDescription(this.Name, this.TaskEventId)} successfully. " +
                 $"Next renewal time is {this.NextRenewal:o}";
 
             void IEventSourceEvent.WriteEventSource() =>
@@ -1331,10 +1386,10 @@ namespace DurableTask.Core.Logging
                 EventIds.RenewActivityMessageFailed,
                 nameof(EventIds.RenewActivityMessageFailed));
 
-            public override LogLevel Level => LogLevel.Error;
+            public override LogLevel Level => LogLevel.Warning;
 
-            public override string GetLogMessage() =>
-                $"{this.InstanceId}: Failed to renew message for task activity {this.Name} (ID = {this.TaskEventId}): {this.Details}";
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Failed to renew message for task activity {GetEventDescription(this.Name, this.TaskEventId)}: {this.Details}";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.RenewActivityMessageFailed(

--- a/src/DurableTask.Core/Logging/LogEvents.cs
+++ b/src/DurableTask.Core/Logging/LogEvents.cs
@@ -180,9 +180,9 @@ namespace DurableTask.Core.Logging
                 StructuredEventSource.Log.DispatchersStopping(this.Dispatcher, this.WorkItemCount, this.ActiveFetcherCount);
         }
 
-        internal class FetchingWorkItem : StructuredLogEvent, IEventSourceEvent
+        internal class FetchWorkItemStarting : StructuredLogEvent, IEventSourceEvent
         {
-            public FetchingWorkItem(
+            public FetchWorkItemStarting(
                 WorkItemDispatcherContext context,
                 TimeSpan timeout,
                 int concurrentWorkItemCount,
@@ -207,8 +207,8 @@ namespace DurableTask.Core.Logging
             public int MaxWorkItemCount { get; }
 
             public override EventId EventId => new EventId(
-                EventIds.FetchingWorkItem,
-                nameof(EventIds.FetchingWorkItem));
+                EventIds.FetchWorkItemStarting,
+                nameof(EventIds.FetchWorkItemStarting));
 
             public override LogLevel Level => LogLevel.Debug;
 
@@ -217,16 +217,16 @@ namespace DurableTask.Core.Logging
                 $"Maximum active work-item count: {this.MaxWorkItemCount}. Timeout: {this.TimeoutSeconds}s";
 
             void IEventSourceEvent.WriteEventSource() =>
-                StructuredEventSource.Log.FetchingWorkItem(
+                StructuredEventSource.Log.FetchWorkItemStarting(
                     this.Dispatcher,
                     this.TimeoutSeconds,
                     this.WorkItemCount,
                     this.MaxWorkItemCount);
         }
 
-        internal class FetchedWorkItem : StructuredLogEvent, IEventSourceEvent
+        internal class FetchWorkItemCompleted : StructuredLogEvent, IEventSourceEvent
         {
-            public FetchedWorkItem(
+            public FetchWorkItemCompleted(
                 WorkItemDispatcherContext context,
                 string workItemId,
                 TimeSpan latency,
@@ -256,8 +256,8 @@ namespace DurableTask.Core.Logging
             public int MaxWorkItemCount { get; }
 
             public override EventId EventId => new EventId(
-                EventIds.FetchedWorkItem,
-                nameof(EventIds.FetchedWorkItem));
+                EventIds.FetchWorkItemCompleted,
+                nameof(EventIds.FetchWorkItemCompleted));
 
             public override LogLevel Level => LogLevel.Debug;
 
@@ -266,7 +266,7 @@ namespace DurableTask.Core.Logging
                 $"Current active work-item count: {this.WorkItemCount}. Maximum active work-item count: {this.MaxWorkItemCount}.";
 
             void IEventSourceEvent.WriteEventSource() =>
-                StructuredEventSource.Log.FetchedWorkItem(
+                StructuredEventSource.Log.FetchWorkItemCompleted(
                     this.Dispatcher,
                     this.WorkItemId,
                     this.LatencyMs,
@@ -877,7 +877,7 @@ namespace DurableTask.Core.Logging
             {
                 this.InstanceId = runtimeState.OrchestrationInstance.InstanceId;
                 this.ExecutionId = runtimeState.OrchestrationInstance.ExecutionId;
-                this.Status = action.OrchestrationStatus.ToString();
+                this.RuntimeStatus = action.OrchestrationStatus.ToString();
                 this.Details = action.Details;
                 this.SizeInBytes = Encoding.UTF8.GetByteCount(action.Result ?? string.Empty);
             }
@@ -889,7 +889,7 @@ namespace DurableTask.Core.Logging
             public string ExecutionId { get; }
 
             [StructuredLogField]
-            public string Status { get; }
+            public string RuntimeStatus { get; }
 
             [StructuredLogField]
             public string Details { get; }
@@ -904,13 +904,13 @@ namespace DurableTask.Core.Logging
             public override LogLevel Level => LogLevel.Information;
 
             public override string GetLogMessage() =>
-                $"{this.InstanceId}: Orchestration completed. Status: {this.Status}. Details: {this.Details}";
+                $"{this.InstanceId}: Orchestration completed. Status: {this.RuntimeStatus}. Details: {this.Details}";
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.OrchestrationCompleted(
                     this.InstanceId,
                     this.ExecutionId,
-                    this.Status,
+                    this.RuntimeStatus,
                     this.Details,
                     this.SizeInBytes);
         }

--- a/src/DurableTask.Core/Logging/LogEvents.cs
+++ b/src/DurableTask.Core/Logging/LogEvents.cs
@@ -1,0 +1,1341 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core.Logging
+{
+    using System;
+    using System.Text;
+    using DurableTask.Core.Command;
+    using DurableTask.Core.Common;
+    using DurableTask.Core.History;
+    using Microsoft.Extensions.Logging;
+
+    static class LogEvents
+    {
+        internal class TaskHubWorkerStarting : StructuredLogEvent, IEventSourceEvent
+        {
+            public override EventId EventId => new EventId(
+                EventIds.TaskHubWorkerStarted,
+                nameof(EventIds.TaskHubWorkerStarted));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => "Durable task hub worker is starting";
+
+            void IEventSourceEvent.WriteEventSource() => 
+                StructuredEventSource.Log.TaskHubWorkerStarting();
+        }
+
+        internal class TaskHubWorkerStarted : StructuredLogEvent, IEventSourceEvent
+        {
+            public TaskHubWorkerStarted(TimeSpan latency)
+            {
+                this.LatencyMs = (long)latency.TotalMilliseconds;
+            }
+
+            public override EventId EventId => new EventId(
+                EventIds.TaskHubWorkerStarted,
+                nameof(EventIds.TaskHubWorkerStarted));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            [StructuredLogField]
+            public long LatencyMs { get; }
+
+            public override string GetLogMessage() => $"Durable task hub worker started successfully after {this.LatencyMs}ms";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.TaskHubWorkerStarted(this.LatencyMs);
+        }
+
+        internal class TaskHubWorkerStopping : StructuredLogEvent, IEventSourceEvent
+        {
+            public TaskHubWorkerStopping(bool isForced)
+            {
+                this.IsForced = isForced;
+            }
+
+            [StructuredLogField]
+            public bool IsForced { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.TaskHubWorkerStopping,
+                nameof(EventIds.TaskHubWorkerStopping));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() => $"Durable task hub worker is stopping (isForced = {this.IsForced})";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.TaskHubWorkerStopping(this.IsForced);
+        }
+
+        internal class TaskHubWorkerStopped : StructuredLogEvent, IEventSourceEvent
+        {
+            public TaskHubWorkerStopped(TimeSpan latency)
+            {
+                this.LatencyMs = (long)latency.TotalMilliseconds;
+            }
+
+            public override EventId EventId => new EventId(
+                EventIds.TaskHubWorkerStopped,
+                nameof(EventIds.TaskHubWorkerStopped));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            [StructuredLogField]
+            public long LatencyMs { get; }
+
+            public override string GetLogMessage() => 
+                $"Durable task hub worker stopped successfully after {this.LatencyMs}ms";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.TaskHubWorkerStopped(this.LatencyMs);
+        }
+
+        internal class DispatcherStarting : StructuredLogEvent, IEventSourceEvent
+        {
+            public DispatcherStarting(WorkItemDispatcherContext context)
+            {
+                this.Dispatcher = context.GetDisplayName();
+            }
+
+            [StructuredLogField]
+            public string Dispatcher { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.DispatcherStarting,
+                nameof(EventIds.DispatcherStarting));
+
+            public override LogLevel Level => LogLevel.Debug;
+
+            public override string GetLogMessage() => $"Starting {this.Dispatcher}";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.DispatcherStarting(this.Dispatcher);
+        }
+
+        internal class DispatcherStopped : StructuredLogEvent, IEventSourceEvent
+        {
+            public DispatcherStopped(WorkItemDispatcherContext context)
+            {
+                this.Dispatcher = context.GetDisplayName();
+            }
+
+            [StructuredLogField]
+            public string Dispatcher { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.DispatcherStopped,
+                nameof(EventIds.DispatcherStopped));
+
+            public override LogLevel Level => LogLevel.Debug;
+
+            public override string GetLogMessage() => $"{this.Dispatcher} stopped";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.DispatcherStopped(this.Dispatcher);
+        }
+
+        internal class DispatchersStopping : StructuredLogEvent, IEventSourceEvent
+        {
+            public DispatchersStopping(string name, string id, int concurrentWorkItemCount, int activeFetchers)
+            {
+                // Use a fake dispatcher name with the same basic pattern
+                this.Dispatcher = new WorkItemDispatcherContext(name, id, "*").GetDisplayName();
+                this.WorkItemCount = concurrentWorkItemCount;
+                this.ActiveFetcherCount = activeFetchers;
+            }
+
+            [StructuredLogField]
+            public string Dispatcher { get; }
+
+            [StructuredLogField]
+            public int WorkItemCount { get; }
+
+            [StructuredLogField]
+            public int ActiveFetcherCount { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.DispatchersStopping,
+                nameof(EventIds.DispatchersStopping));
+
+            public override LogLevel Level => LogLevel.Debug;
+
+            public override string GetLogMessage() =>
+                $"{this.Dispatcher} dispatchers are draining. Remaining work items: {this.WorkItemCount}. " +
+                $"Remaining work item fetchers: {this.ActiveFetcherCount}.";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.DispatchersStopping(this.Dispatcher, this.WorkItemCount, this.ActiveFetcherCount);
+        }
+
+        internal class FetchingWorkItem : StructuredLogEvent, IEventSourceEvent
+        {
+            public FetchingWorkItem(
+                WorkItemDispatcherContext context,
+                TimeSpan timeout,
+                int concurrentWorkItemCount,
+                int maxConcurrentWorkItems)
+            {
+                this.Dispatcher = context.GetDisplayName();
+                this.TimeoutSeconds = (int)timeout.TotalSeconds;
+                this.WorkItemCount = concurrentWorkItemCount;
+                this.MaxWorkItemCount = maxConcurrentWorkItems;
+            }
+
+            [StructuredLogField]
+            public string Dispatcher { get; }
+
+            [StructuredLogField]
+            public int TimeoutSeconds { get; }
+
+            [StructuredLogField]
+            public int WorkItemCount { get; }
+
+            [StructuredLogField]
+            public int MaxWorkItemCount { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.FetchingWorkItem,
+                nameof(EventIds.FetchingWorkItem));
+
+            public override LogLevel Level => LogLevel.Debug;
+
+            public override string GetLogMessage() =>
+                $"{this.Dispatcher}: Fetching next work item. Current active work-item count: {this.WorkItemCount}. " +
+                $"Maximum active work-item count: {this.MaxWorkItemCount}. Timeout: {this.TimeoutSeconds}s";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.FetchingWorkItem(
+                    this.Dispatcher,
+                    this.TimeoutSeconds,
+                    this.WorkItemCount,
+                    this.MaxWorkItemCount);
+        }
+
+        internal class FetchedWorkItem : StructuredLogEvent, IEventSourceEvent
+        {
+            public FetchedWorkItem(
+                WorkItemDispatcherContext context,
+                string workItemId,
+                TimeSpan latency,
+                int concurrentWorkItemCount,
+                int maxConcurrentWorkItems)
+            {
+                this.Dispatcher = context.GetDisplayName();
+                this.WorkItemId = workItemId;
+                this.LatencyMs = (long)latency.TotalMilliseconds;
+                this.WorkItemCount = concurrentWorkItemCount;
+                this.MaxWorkItemCount = maxConcurrentWorkItems;
+            }
+
+            [StructuredLogField]
+            public string Dispatcher { get; }
+
+            [StructuredLogField]
+            public string WorkItemId { get; }
+
+            [StructuredLogField]
+            public long LatencyMs { get; }
+
+            [StructuredLogField]
+            public int WorkItemCount { get; }
+
+            [StructuredLogField]
+            public int MaxWorkItemCount { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.FetchedWorkItem,
+                nameof(EventIds.FetchedWorkItem));
+
+            public override LogLevel Level => LogLevel.Debug;
+
+            public override string GetLogMessage() =>
+                $"{this.Dispatcher}: Fetched next work item '{this.WorkItemId}' after {this.LatencyMs}ms. " +
+                $"Current active work-item count: {this.WorkItemCount}. Maximum active work-item count: {this.MaxWorkItemCount}.";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.FetchedWorkItem(
+                    this.Dispatcher,
+                    this.WorkItemId,
+                    this.LatencyMs,
+                    this.WorkItemCount,
+                    this.MaxWorkItemCount);
+        }
+
+        internal class FetchWorkItemFailure : StructuredLogEvent, IEventSourceEvent
+        {
+            public FetchWorkItemFailure(WorkItemDispatcherContext context, Exception exception)
+            {
+                this.Dispatcher = context.GetDisplayName();
+                this.Details = exception?.ToString() ?? string.Empty;
+            }
+
+            [StructuredLogField]
+            public string Dispatcher { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.FetchWorkItemFailure,
+                nameof(EventIds.FetchWorkItemFailure));
+
+            public override LogLevel Level => LogLevel.Error;
+
+            public override string GetLogMessage() => $"{this.Dispatcher} failed to fetch a work-item: {this.Details}";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.FetchWorkItemFailure(this.Dispatcher, this.Details);
+        }
+
+        internal class FetchingThrottled : StructuredLogEvent, IEventSourceEvent
+        {
+            public FetchingThrottled(
+                WorkItemDispatcherContext context,
+                int concurrentWorkItemCount,
+                int maxConcurrentWorkItems)
+            {
+                this.Dispatcher = context.GetDisplayName();
+                this.WorkItemCount = concurrentWorkItemCount;
+                this.MaxWorkItemCount = maxConcurrentWorkItems;
+            }
+
+            [StructuredLogField]
+            public string Dispatcher { get; }
+
+            [StructuredLogField]
+            public int WorkItemCount { get; }
+
+            [StructuredLogField]
+            public int MaxWorkItemCount { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.FetchingThrottled,
+                nameof(EventIds.FetchingThrottled));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() =>
+                $"{this.Dispatcher}: Delaying work item fetching because the current active work-item count ({this.WorkItemCount}) " +
+                $"exceeds the configured maximum active work-item count ({this.MaxWorkItemCount})";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.FetchingThrottled(
+                    this.Dispatcher,
+                    this.WorkItemCount,
+                    this.MaxWorkItemCount);
+        }
+
+        internal class ProcessWorkItemStarting : StructuredLogEvent, IEventSourceEvent
+        {
+            public ProcessWorkItemStarting(WorkItemDispatcherContext context, string workItemId)
+            {
+                this.Dispatcher = context.GetDisplayName();
+                this.WorkItemId = workItemId;
+            }
+
+            [StructuredLogField]
+            public string Dispatcher { get; }
+
+            [StructuredLogField]
+            public string WorkItemId { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.ProcessWorkItemStarting,
+                nameof(EventIds.ProcessWorkItemStarting));
+
+            public override LogLevel Level => LogLevel.Debug;
+
+            public override string GetLogMessage() => $"{this.Dispatcher}: Processing work-item '{this.WorkItemId}'";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.ProcessWorkItemStarting(this.Dispatcher, this.WorkItemId);
+        }
+
+        internal class ProcessWorkItemCompleted : StructuredLogEvent, IEventSourceEvent
+        {
+            public ProcessWorkItemCompleted(WorkItemDispatcherContext context, string workItemId)
+            {
+                this.Dispatcher = context.GetDisplayName();
+                this.WorkItemId = workItemId;
+            }
+
+            [StructuredLogField]
+            public string Dispatcher { get; }
+
+            [StructuredLogField]
+            public string WorkItemId { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.ProcessWorkItemCompleted,
+                nameof(EventIds.ProcessWorkItemCompleted));
+
+            public override LogLevel Level => LogLevel.Debug;
+
+            public override string GetLogMessage() => $"{this.Dispatcher}: Finished processing work-item '{this.WorkItemId}'";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.ProcessWorkItemCompleted(this.Dispatcher, this.WorkItemId);
+        }
+
+        internal class ProcessWorkItemFailed : StructuredLogEvent, IEventSourceEvent
+        {
+            public ProcessWorkItemFailed(WorkItemDispatcherContext context, string workItemId, string additionalInfo, Exception exception)
+            {
+                this.Dispatcher = context.GetDisplayName();
+                this.WorkItemId = workItemId;
+                this.Details = string.Concat(
+                    exception.ToString(),
+                    Environment.NewLine,
+                    Environment.NewLine,
+                    additionalInfo);
+            }
+
+            public override EventId EventId => new EventId(
+                EventIds.ProcessWorkItemFailed,
+                nameof(EventIds.ProcessWorkItemFailed));
+
+            [StructuredLogField]
+            public string Dispatcher { get; }
+
+            [StructuredLogField]
+            public string WorkItemId { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override LogLevel Level => LogLevel.Error;
+
+            public override string GetLogMessage() =>
+                $"Unhandled exception with work item '{this.WorkItemId}' in {this.Dispatcher}: {this.Details}";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.ProcessWorkItemFailed(this.Dispatcher, this.WorkItemId, this.Details);
+        }
+
+        internal class SchedulingOrchestration : StructuredLogEvent, IEventSourceEvent
+        {
+            public SchedulingOrchestration(ExecutionStartedEvent startedEvent)
+            {
+                this.Name = startedEvent.Name;
+                this.TaskEventId = startedEvent.ParentInstance?.TaskScheduleId ?? startedEvent.EventId;
+                this.InstanceId = startedEvent.ParentInstance?.OrchestrationInstance.InstanceId ?? string.Empty;
+                this.ExecutionId = startedEvent.ParentInstance?.OrchestrationInstance.ExecutionId ?? string.Empty;
+                this.TargetInstanceId = startedEvent.OrchestrationInstance.InstanceId;
+                this.TargetExecutionId = startedEvent.OrchestrationInstance.ExecutionId ?? string.Empty;
+                this.SizeInBytes = Encoding.UTF8.GetByteCount(startedEvent.Input ?? string.Empty);
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string TargetInstanceId { get; }
+
+            [StructuredLogField]
+            public string TargetExecutionId { get; }
+
+            [StructuredLogField]
+            public string Name { get; }
+
+            [StructuredLogField]
+            public int TaskEventId { get; }
+
+            [StructuredLogField]
+            public int SizeInBytes { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.SchedulingOrchestration,
+                nameof(EventIds.SchedulingOrchestration));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() =>
+                $"Scheduling orchestration '{this.Name}' with ID: '{this.InstanceId}'. " +
+                $"Input size (in bytes): {this.SizeInBytes}";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.SchedulingOrchestration(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.TargetInstanceId,
+                    this.TargetExecutionId,
+                    this.Name,
+                    this.TaskEventId,
+                    this.SizeInBytes);
+        }
+
+        internal class RaisingEvent : StructuredLogEvent, IEventSourceEvent
+        {
+            public RaisingEvent(OrchestrationInstance target, EventRaisedEvent raisedEvent)
+            {
+                this.Name = raisedEvent.Name;
+                this.TaskEventId = raisedEvent.EventId;
+                this.InstanceId = string.Empty;
+                this.ExecutionId = string.Empty;
+                this.TargetInstanceId = target.InstanceId;
+                this.SizeInBytes = raisedEvent.Input != null ? Encoding.UTF8.GetByteCount(raisedEvent.Input) : 0;
+            }
+
+            public RaisingEvent(OrchestrationInstance source, EventSentEvent sentEvent)
+            {
+                this.Name = sentEvent.Name;
+                this.TaskEventId = sentEvent.EventId;
+                this.InstanceId = source.InstanceId;
+                this.ExecutionId = source.ExecutionId;
+                this.TargetInstanceId = sentEvent.InstanceId;
+                this.SizeInBytes = sentEvent.Input != null ? Encoding.UTF8.GetByteCount(sentEvent.Input) : 0;
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string TargetInstanceId { get; }
+
+            [StructuredLogField]
+            public string Name { get; }
+
+            [StructuredLogField]
+            public int TaskEventId { get; }
+
+            [StructuredLogField]
+            public int SizeInBytes { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.RaisingEvent,
+                nameof(EventIds.RaisingEvent));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() =>
+                $"Raising event '{this.Name}' with {this.SizeInBytes} bytes to '{this.InstanceId}'";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.RaisingEvent(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.TargetInstanceId,
+                    this.Name,
+                    this.TaskEventId,
+                    this.SizeInBytes);
+        }
+
+        internal class TerminatingInstance : StructuredLogEvent, IEventSourceEvent
+        {
+            public TerminatingInstance(OrchestrationInstance instance, string reason)
+            {
+                this.InstanceId = instance.InstanceId;
+                this.ExecutionId = instance.ExecutionId;
+                this.Details = reason;
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.TerminatingInstance,
+                nameof(EventIds.TerminatingInstance));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() =>
+                $"Terminating instance '{this.InstanceId}': {this.Details}";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.TerminatingInstance(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.Details);
+        }
+
+        internal class WaitingForInstance : StructuredLogEvent, IEventSourceEvent
+        {
+            public WaitingForInstance(OrchestrationInstance instance, TimeSpan timeout)
+            {
+                this.InstanceId = instance.InstanceId;
+                this.ExecutionId = instance.ExecutionId ?? string.Empty;
+                this.TimeoutSeconds = (int)timeout.TotalSeconds;
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public int TimeoutSeconds { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.WaitingForInstance,
+                nameof(EventIds.WaitingForInstance));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() =>
+                $"Waiting up to {this.TimeoutSeconds} seconds for instance '{this.InstanceId}' to complete, fail, or be terminated";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.WaitingForInstance(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.TimeoutSeconds);
+        }
+
+        internal class FetchingInstanceState : StructuredLogEvent, IEventSourceEvent
+        {
+            public FetchingInstanceState(string instanceId, string executionId = null)
+            {
+                this.InstanceId = instanceId;
+                this.ExecutionId = executionId ?? string.Empty;
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.FetchingInstanceState,
+                nameof(EventIds.FetchingInstanceState));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() =>
+                $"Fetching state for instance: {this.InstanceId}";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.FetchingInstanceState(
+                    this.InstanceId,
+                    this.ExecutionId);
+        }
+
+        internal class FetchingInstanceHistory : StructuredLogEvent, IEventSourceEvent
+        {
+            public FetchingInstanceHistory(OrchestrationInstance instance)
+            {
+                this.InstanceId = instance.InstanceId;
+                this.ExecutionId = instance.ExecutionId ?? string.Empty;
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.FetchingInstanceHistory,
+                nameof(EventIds.FetchingInstanceHistory));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() =>
+                $"Fetching history for instance: {this.InstanceId}";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.FetchingInstanceHistory(
+                    this.InstanceId,
+                    this.ExecutionId);
+        }
+
+        internal class ProcessingOrchestrationMessage : StructuredLogEvent, IEventSourceEvent
+        {
+            public ProcessingOrchestrationMessage(TaskOrchestrationWorkItem workItem, TaskMessage message)
+            {
+                this.InstanceId = workItem.InstanceId;
+                this.ExecutionId = message.OrchestrationInstance.ExecutionId ?? string.Empty;
+                this.EventType = message.Event.EventType.ToString();
+                this.TaskEventId = Utils.GetTaskEventId(message.Event);
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string EventType { get; }
+
+            [StructuredLogField]
+            public int TaskEventId { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.ProcessingOrchestrationMessage,
+                nameof(EventIds.ProcessingOrchestrationMessage));
+
+            public override LogLevel Level => LogLevel.Debug;
+
+            public override string GetLogMessage() =>
+                $"Fetching history for instance: {this.InstanceId}";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.ProcessingOrchestrationMessage(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.EventType,
+                    this.TaskEventId);
+        }
+
+        internal class OrchestrationExecuting : StructuredLogEvent, IEventSourceEvent
+        {
+            public OrchestrationExecuting(OrchestrationInstance instance, string name)
+            {
+                this.InstanceId = instance.InstanceId;
+                this.ExecutionId = instance.ExecutionId ?? string.Empty;
+                this.Name = name;
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string Name { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.OrchestrationExecuting,
+                nameof(EventIds.OrchestrationExecuting));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() =>
+                $"Executing orchestration '{this.Name}' with ID '{this.InstanceId}'";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.OrchestrationExecuting(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.Name);
+        }
+
+        internal class OrchestrationExecuted : StructuredLogEvent, IEventSourceEvent
+        {
+            public OrchestrationExecuted(OrchestrationInstance instance, string name, int actionCount)
+            {
+                this.InstanceId = instance.InstanceId;
+                this.ExecutionId = instance.ExecutionId ?? string.Empty;
+                this.Name = name;
+                this.ActionCount = actionCount;
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string Name { get; }
+            
+            [StructuredLogField]
+            public int ActionCount { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.OrchestrationExecuted,
+                nameof(EventIds.OrchestrationExecuted));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() =>
+                $"Execution of orchestration '{this.Name}' with ID '{this.InstanceId}' resulted in {this.ActionCount} new action(s).";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.OrchestrationExecuted(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.Name,
+                    this.ActionCount);
+        }
+
+        internal class SchedulingActivity : StructuredLogEvent, IEventSourceEvent
+        {
+            public SchedulingActivity(OrchestrationInstance instance, TaskScheduledEvent taskScheduledEvent)
+            {
+                this.Name = taskScheduledEvent.Name;
+                this.TaskEventId = taskScheduledEvent.EventId;
+                this.InstanceId = instance.InstanceId;
+                this.ExecutionId = instance.ExecutionId;
+                this.SizeInBytes = Encoding.UTF8.GetByteCount(taskScheduledEvent.Input ?? string.Empty);
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string Name { get; }
+
+            [StructuredLogField]
+            public int TaskEventId { get; }
+
+            [StructuredLogField]
+            public int SizeInBytes { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.SchedulingActivity,
+                nameof(EventIds.SchedulingActivity));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() =>
+                $"Scheduling activity '{this.Name}' with task event ID {this.TaskEventId}. " +
+                $"Input size (in bytes): {this.SizeInBytes}";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.SchedulingActivity(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.Name,
+                    this.TaskEventId,
+                    this.SizeInBytes);
+        }
+
+        internal class CreatingTimer : StructuredLogEvent, IEventSourceEvent
+        {
+            public CreatingTimer(
+                OrchestrationInstance instance,
+                TimerCreatedEvent timerEvent,
+                bool isInternal)
+            {
+                this.InstanceId = instance.InstanceId;
+                this.ExecutionId = instance.ExecutionId;
+                this.FireAt = timerEvent.FireAt;
+                this.TaskEventId = timerEvent.EventId;
+                this.IsInternal = isInternal;
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public DateTime FireAt { get; }
+
+            [StructuredLogField]
+            public int TaskEventId { get; }
+
+            [StructuredLogField]
+            public bool IsInternal { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.CreatingTimer,
+                nameof(EventIds.CreatingTimer));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() =>
+                $"Scheduling timer with ID = {this.TaskEventId} to fire at {this.FireAt:o}";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.CreatingTimer(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.FireAt,
+                    this.TaskEventId,
+                    this.IsInternal);
+        }
+
+        internal class OrchestrationCompleted : StructuredLogEvent, IEventSourceEvent
+        {
+            public OrchestrationCompleted(
+                OrchestrationRuntimeState runtimeState,
+                OrchestrationCompleteOrchestratorAction action)
+            {
+                this.InstanceId = runtimeState.OrchestrationInstance.InstanceId;
+                this.ExecutionId = runtimeState.OrchestrationInstance.ExecutionId;
+                this.Status = action.OrchestrationStatus.ToString();
+                this.Details = action.Details;
+                this.SizeInBytes = Encoding.UTF8.GetByteCount(action.Result ?? string.Empty);
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string Status { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            [StructuredLogField]
+            public int SizeInBytes { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.OrchestrationCompleted,
+                nameof(EventIds.OrchestrationCompleted));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() =>
+                $"{this.InstanceId}: Orchestration completed. Status: {this.Status}. Details: {this.Details}";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.OrchestrationCompleted(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.Status,
+                    this.Details,
+                    this.SizeInBytes);
+        }
+
+        internal class OrchestrationAborted : StructuredLogEvent, IEventSourceEvent
+        {
+            public OrchestrationAborted(OrchestrationInstance instance, string reason)
+            {
+                this.InstanceId = instance.InstanceId;
+                this.ExecutionId = instance.ExecutionId;
+                this.Details = reason;
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.OrchestrationAborted,
+                nameof(EventIds.OrchestrationAborted));
+
+            public override LogLevel Level => LogLevel.Warning;
+
+            public override string GetLogMessage() =>
+                $"{this.InstanceId}: Orchestration execution was aborted: {this.Details}";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.OrchestrationAborted(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.Details);
+        }
+
+        internal class DiscardingMessage : StructuredLogEvent, IEventSourceEvent
+        {
+            public DiscardingMessage(TaskOrchestrationWorkItem workItem, TaskMessage message, string reason)
+            {
+                this.InstanceId = message.OrchestrationInstance?.InstanceId ?? workItem.InstanceId;
+                this.ExecutionId = message.OrchestrationInstance?.ExecutionId;
+                this.EventType = message.Event.EventType.ToString();
+                this.TaskEventId = Utils.GetTaskEventId(message.Event);
+                this.Details = reason;
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string EventType { get; }
+
+            [StructuredLogField]
+            public int TaskEventId { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.DiscardingMessage,
+                nameof(EventIds.DiscardingMessage));
+
+            public override LogLevel Level => LogLevel.Warning;
+
+            public override string GetLogMessage() =>
+                $"{this.InstanceId}: Discarding {this.EventType} message with ID = {this.TaskEventId}: {this.Details}";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.DiscardingMessage(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.EventType,
+                    this.TaskEventId,
+                    this.Details);
+        }
+
+        internal class TaskActivityStarting : StructuredLogEvent, IEventSourceEvent
+        {
+            public TaskActivityStarting(OrchestrationInstance instance, TaskScheduledEvent taskEvent)
+            {
+                this.InstanceId = instance.InstanceId;
+                this.ExecutionId = instance.ExecutionId;
+                this.Name = taskEvent.Name;
+                this.TaskEventId = taskEvent.EventId;
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string Name { get; }
+
+            [StructuredLogField]
+            public int TaskEventId { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.TaskActivityStarting,
+                nameof(EventIds.TaskActivityStarting));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() =>
+                $"{this.InstanceId}: Starting task activity {this.Name} with ID = {this.TaskEventId}";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.TaskActivityStarting(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.Name,
+                    this.TaskEventId);
+        }
+
+        internal class TaskActivityCompleted : StructuredLogEvent, IEventSourceEvent
+        {
+            public TaskActivityCompleted(
+                OrchestrationInstance instance,
+                string name,
+                TaskCompletedEvent taskEvent)
+            {
+                this.InstanceId = instance.InstanceId;
+                this.ExecutionId = instance.ExecutionId;
+                this.Name = name;
+                this.TaskEventId = taskEvent.TaskScheduledId;
+                this.SizeInBytes = Encoding.UTF8.GetByteCount(taskEvent.Result ?? string.Empty);
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string Name { get; }
+
+            [StructuredLogField]
+            public int TaskEventId { get; }
+
+            [StructuredLogField]
+            public int SizeInBytes { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.TaskActivityCompleted,
+                nameof(EventIds.TaskActivityCompleted));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            public override string GetLogMessage() =>
+                $"{this.InstanceId}: Task activity {this.Name} with ID = {this.TaskEventId} completed successfully";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.TaskActivityCompleted(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.Name,
+                    this.TaskEventId,
+                    this.SizeInBytes);
+        }
+
+        internal class TaskActivityFailure : StructuredLogEvent, IEventSourceEvent
+        {
+            public TaskActivityFailure(
+                OrchestrationInstance instance,
+                string name,
+                TaskFailedEvent taskEvent,
+                Exception exception)
+            {
+                this.InstanceId = instance.InstanceId;
+                this.ExecutionId = instance.ExecutionId;
+                this.Name = name;
+                this.TaskEventId = taskEvent.EventId;
+                this.Details = exception.ToString();
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string Name { get; }
+
+            [StructuredLogField]
+            public int TaskEventId { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.TaskActivityFailure,
+                nameof(EventIds.TaskActivityFailure));
+
+            public override LogLevel Level => LogLevel.Warning;
+
+            public override string GetLogMessage() =>
+                $"{this.InstanceId}: Task activity {this.Name} with ID = {this.TaskEventId} failed: {this.Details}";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.TaskActivityFailure(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.Name,
+                    this.TaskEventId,
+                    this.Details);
+        }
+
+        internal class TaskActivityAborted : StructuredLogEvent, IEventSourceEvent
+        {
+            public TaskActivityAborted(OrchestrationInstance instance, TaskScheduledEvent taskEvent, string details)
+            {
+                this.InstanceId = instance.InstanceId;
+                this.ExecutionId = instance.ExecutionId;
+                this.Name = taskEvent.Name;
+                this.TaskEventId = taskEvent.EventId;
+                this.Details = details;
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string Name { get; }
+
+            [StructuredLogField]
+            public int TaskEventId { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.TaskActivityAborted,
+                nameof(EventIds.TaskActivityAborted));
+
+            public override LogLevel Level => LogLevel.Warning;
+
+            public override string GetLogMessage() =>
+                $"{this.InstanceId}: Task activity {this.Name} with ID = {this.TaskEventId} was aborted: {this.Details}";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.TaskActivityAborted(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.Name,
+                    this.TaskEventId,
+                    this.Details);
+        }
+
+        internal class TaskActivityDispatcherError : StructuredLogEvent, IEventSourceEvent
+        {
+            public TaskActivityDispatcherError(TaskActivityWorkItem workItem, string details)
+            {
+                // There's no guarantee that we received valid work item data
+                this.InstanceId = workItem.TaskMessage?.OrchestrationInstance?.InstanceId;
+                this.ExecutionId = workItem.TaskMessage?.OrchestrationInstance?.ExecutionId;
+                this.Details = details;
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.TaskActivityDispatcherError,
+                nameof(EventIds.TaskActivityDispatcherError));
+
+            public override LogLevel Level => LogLevel.Error;
+
+            public override string GetLogMessage() => this.Details;
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.TaskActivityDispatcherError(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.Details);
+        }
+
+        internal class RenewActivityMessageStarting : StructuredLogEvent, IEventSourceEvent
+        {
+            public RenewActivityMessageStarting(TaskActivityWorkItem workItem)
+            {
+                this.InstanceId = workItem.TaskMessage.OrchestrationInstance.InstanceId;
+                this.ExecutionId = workItem.TaskMessage.OrchestrationInstance.ExecutionId;
+                var taskEvent = (TaskScheduledEvent)workItem.TaskMessage.Event;
+                this.Name = taskEvent.Name;
+                this.TaskEventId = taskEvent.EventId;
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string Name { get; }
+
+            [StructuredLogField]
+            public int TaskEventId { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.RenewActivityMessageStarting,
+                nameof(EventIds.RenewActivityMessageStarting));
+
+            public override LogLevel Level => LogLevel.Debug;
+
+            public override string GetLogMessage() =>
+                $"{this.InstanceId}: Renewing message for task activity {this.Name} (ID = {this.TaskEventId})";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.RenewActivityMessageStarting(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.Name,
+                    this.TaskEventId);
+        }
+
+        internal class RenewActivityMessageCompleted : StructuredLogEvent, IEventSourceEvent
+        {
+            public RenewActivityMessageCompleted(TaskActivityWorkItem workItem, DateTime renewAt)
+            {
+                this.InstanceId = workItem.TaskMessage.OrchestrationInstance.InstanceId;
+                this.ExecutionId = workItem.TaskMessage.OrchestrationInstance.ExecutionId;
+
+                var taskEvent = (TaskScheduledEvent)workItem.TaskMessage.Event;
+                this.Name = taskEvent.Name;
+                this.TaskEventId = taskEvent.EventId;
+                this.NextRenewal = renewAt;
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string Name { get; }
+
+            [StructuredLogField]
+            public int TaskEventId { get; }
+
+            [StructuredLogField]
+            public DateTime NextRenewal { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.RenewActivityMessageCompleted,
+                nameof(EventIds.RenewActivityMessageCompleted));
+
+            public override LogLevel Level => LogLevel.Debug;
+
+            public override string GetLogMessage() =>
+                $"{this.InstanceId}: Renewed message for task activity {this.Name} (ID = {this.TaskEventId}) successfully. " +
+                $"Next renewal time is {this.NextRenewal:o}";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.RenewActivityMessageCompleted(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.Name,
+                    this.TaskEventId,
+                    this.NextRenewal);
+        }
+
+        internal class RenewActivityMessageFailed : StructuredLogEvent, IEventSourceEvent
+        {
+            public RenewActivityMessageFailed(TaskActivityWorkItem workItem, Exception exception)
+            {
+                this.InstanceId = workItem.TaskMessage.OrchestrationInstance.InstanceId;
+                this.ExecutionId = workItem.TaskMessage.OrchestrationInstance.ExecutionId;
+
+                var taskEvent = (TaskScheduledEvent)workItem.TaskMessage.Event;
+                this.Name = taskEvent.Name;
+                this.TaskEventId = taskEvent.EventId;
+                this.Details = exception.ToString();
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string Name { get; }
+
+            [StructuredLogField]
+            public int TaskEventId { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.RenewActivityMessageFailed,
+                nameof(EventIds.RenewActivityMessageFailed));
+
+            public override LogLevel Level => LogLevel.Error;
+
+            public override string GetLogMessage() =>
+                $"{this.InstanceId}: Failed to renew message for task activity {this.Name} (ID = {this.TaskEventId}): {this.Details}";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.RenewActivityMessageFailed(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.Name,
+                    this.TaskEventId,
+                    this.Details);
+        }
+    }
+}

--- a/src/DurableTask.Core/Logging/LogHelper.cs
+++ b/src/DurableTask.Core/Logging/LogHelper.cs
@@ -128,7 +128,7 @@ namespace DurableTask.Core.Logging
         /// <param name="timeout">The fetch timeout.</param>
         /// <param name="concurrentWorkItemCount">The current number of concurrent work items.</param>
         /// <param name="maxConcurrentWorkItems">The maximum number of concurrent work items.</param>
-        internal void FetchingWorkItem(
+        internal void FetchWorkItemStarting(
             WorkItemDispatcherContext context,
             TimeSpan timeout,
             int concurrentWorkItemCount,
@@ -137,7 +137,7 @@ namespace DurableTask.Core.Logging
             if (this.IsStructuredLoggingEnabled)
             {
                 this.WriteStructuredLog(
-                    new LogEvents.FetchingWorkItem(
+                    new LogEvents.FetchWorkItemStarting(
                         context,
                         timeout,
                         concurrentWorkItemCount,
@@ -154,7 +154,7 @@ namespace DurableTask.Core.Logging
         /// <param name="latency">The latency of the fetch operation.</param>
         /// <param name="concurrentWorkItemCount">The current number of concurrent work items.</param>
         /// <param name="maxConcurrentWorkItems">The maximum number of concurrent work items.</param>
-        internal void FetchedWorkItem(
+        internal void FetchWorkItemCompleted(
             WorkItemDispatcherContext context,
             string workItemId,
             TimeSpan latency,
@@ -164,7 +164,7 @@ namespace DurableTask.Core.Logging
             if (this.IsStructuredLoggingEnabled)
             {
                 this.WriteStructuredLog(
-                    new LogEvents.FetchedWorkItem(
+                    new LogEvents.FetchWorkItemCompleted(
                         context,
                         workItemId,
                         latency,

--- a/src/DurableTask.Core/Logging/LogHelper.cs
+++ b/src/DurableTask.Core/Logging/LogHelper.cs
@@ -1,0 +1,621 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core.Logging
+{
+    using System;
+    using System.Collections.Generic;
+    using DurableTask.Core.Command;
+    using DurableTask.Core.History;
+    using Microsoft.Extensions.Logging;
+
+    class LogHelper
+    {
+        readonly ILogger log;
+
+        public LogHelper(ILogger log)
+        {
+            // null is okay
+            this.log = log;
+        }
+
+        bool IsStructuredLoggingEnabled => this.log != null;
+
+        #region TaskHubWorker
+        /// <summary>
+        /// Logs that a <see cref="TaskHubWorker"/> is starting.
+        /// </summary>
+        internal void TaskHubWorkerStarting()
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.TaskHubWorkerStarting());
+            }
+        }
+
+        /// <summary>
+        /// Logs that a <see cref="TaskHubWorker"/> started successfully.
+        /// </summary>
+        /// <param name="latency">The amount of time it took to start the <see cref="TaskHubWorker"/>.</param>
+        internal void TaskHubWorkerStarted(TimeSpan latency)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.TaskHubWorkerStarted(latency));
+            }
+        }
+
+        /// <summary>
+        /// Logs that a <see cref="TaskHubWorker"/> is stopping.
+        /// </summary>
+        internal void TaskHubWorkerStopping(bool isForced)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.TaskHubWorkerStopping(isForced));
+            }
+        }
+
+        /// <summary>
+        /// Logs that a <see cref="TaskHubWorker"/> stopped successfully.
+        /// </summary>
+        /// <param name="latency">The amount of time it took to stop the <see cref="TaskHubWorker"/>.</param>
+        internal void TaskHubWorkerStopped(TimeSpan latency)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.TaskHubWorkerStopped(latency));
+            }
+        }
+        #endregion
+
+        #region WorkItemDispatcher traces
+
+        /// <summary>
+        /// Indicates that the work item dispatcher is starting.
+        /// </summary>
+        /// <param name="context">The context of the starting dispatcher.</param>
+        internal void DispatcherStarting(WorkItemDispatcherContext context)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.DispatcherStarting(context));
+            }
+        }
+
+
+        /// <summary>
+        /// Logs that a work item dispatcher has stopped running.
+        /// </summary>
+        /// <param name="context">The context of the starting dispatcher.</param>
+        internal void DispatcherStopped(WorkItemDispatcherContext context)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.DispatcherStopped(context));
+            }
+        }
+
+        /// <summary>
+        /// Logs that the work item dispatcher is watching for individual dispatch loops to finish stopping.
+        /// </summary>
+        /// <param name="name">The name of the dispatcher - e.g. "TaskOrchestrationDispatcher"</param>
+        /// <param name="id">The unique ID of the dispatcher.</param>
+        /// <param name="concurrentWorkItemCount">The number of active work items.</param>
+        /// <param name="activeFetchers">The number of active fetchers.</param>
+        internal void DispatchersStopping(string name, string id, int concurrentWorkItemCount, int activeFetchers)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.DispatchersStopping(name, id, concurrentWorkItemCount, activeFetchers));
+            }
+        }
+
+        /// <summary>
+        /// Logs that we're starting to fetch a new work item.
+        /// </summary>
+        /// <param name="context">The dispatcher context.</param>
+        /// <param name="timeout">The fetch timeout.</param>
+        /// <param name="concurrentWorkItemCount">The current number of concurrent work items.</param>
+        /// <param name="maxConcurrentWorkItems">The maximum number of concurrent work items.</param>
+        internal void FetchingWorkItem(
+            WorkItemDispatcherContext context,
+            TimeSpan timeout,
+            int concurrentWorkItemCount,
+            int maxConcurrentWorkItems)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(
+                    new LogEvents.FetchingWorkItem(
+                        context,
+                        timeout,
+                        concurrentWorkItemCount,
+                        maxConcurrentWorkItems));
+            }
+        }
+
+        /// <summary>
+        /// Logs that a work-item was fetched successfully.
+        /// This event does not have enough context to understand the details of the work item.
+        /// </summary>
+        /// <param name="context">The dispatcher context.</param>
+        /// <param name="workItemId">The ID of the fetched work item.</param>
+        /// <param name="latency">The latency of the fetch operation.</param>
+        /// <param name="concurrentWorkItemCount">The current number of concurrent work items.</param>
+        /// <param name="maxConcurrentWorkItems">The maximum number of concurrent work items.</param>
+        internal void FetchedWorkItem(
+            WorkItemDispatcherContext context,
+            string workItemId,
+            TimeSpan latency,
+            int concurrentWorkItemCount,
+            int maxConcurrentWorkItems)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(
+                    new LogEvents.FetchedWorkItem(
+                        context,
+                        workItemId,
+                        latency,
+                        concurrentWorkItemCount,
+                        maxConcurrentWorkItems));
+            }
+        }
+
+        /// <summary>
+        /// Logs that a work-item fetched failed with an unhandled exception.
+        /// </summary>
+        /// <param name="context">The dispatcher context.</param>
+        /// <param name="exception">The exception associted with the failure.</param>
+        internal void FetchWorkItemFailure(WorkItemDispatcherContext context, Exception exception)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(
+                    new LogEvents.FetchWorkItemFailure(context, exception),
+                    exception);
+            }
+        }
+
+        /// <summary>
+        /// Logs that work-item fetching has been throttled due to concurrency constraints.
+        /// </summary>
+        /// <param name="context">The dispatcher context.</param>
+        /// <param name="concurrentWorkItemCount">The current number of concurrent work items.</param>
+        /// <param name="maxConcurrentWorkItems">The maximum number of concurrent work items.</param>
+        internal void FetchingThrottled(
+            WorkItemDispatcherContext context,
+            int concurrentWorkItemCount,
+            int maxConcurrentWorkItems)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(
+                    new LogEvents.FetchingThrottled(
+                        context,
+                        concurrentWorkItemCount,
+                        maxConcurrentWorkItems));
+            }
+        }
+
+        /// <summary>
+        /// Logs that a work item is about to be processed.
+        /// This event does not have enough context to understand the details of the work item.
+        /// </summary>
+        /// <param name="context">The dispatcher context.</param>
+        /// <param name="workItemId">The ID of the work item.</param>
+        internal void ProcessWorkItemStarting(WorkItemDispatcherContext context, string workItemId)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(
+                    new LogEvents.ProcessWorkItemStarting(context, workItemId));
+            }
+        }
+
+        /// <summary>
+        /// Logs that a work item was processed successfully.
+        /// This event does not have enough context to understand the details of the work item.
+        /// </summary>
+        /// <param name="context">The dispatcher context.</param>
+        /// <param name="workItemId">The ID of the work item.</param>
+        internal void ProcessWorkItemCompleted(WorkItemDispatcherContext context, string workItemId)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(
+                    new LogEvents.ProcessWorkItemCompleted(context, workItemId));
+            }
+        }
+
+        /// <summary>
+        /// Logs that a work item was processed successfully.
+        /// This event does not have enough context to understand the details of the work item.
+        /// </summary>
+        /// <param name="context">The dispatcher context.</param>
+        /// <param name="workItemId">The ID of the work item.</param>
+        /// <param name="additionalInfo">Additional information associated with the failure.</param>
+        /// <param name="exception">The exception associated with the failure.</param>
+        internal void ProcessWorkItemFailed(
+            WorkItemDispatcherContext context,
+            string workItemId,
+            string additionalInfo,
+            Exception exception)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(
+                    new LogEvents.ProcessWorkItemFailed(context, workItemId, additionalInfo, exception),
+                    exception);
+            }
+        }
+        #endregion
+
+        #region TaskHubClient traces
+
+        /// <summary>
+        /// Logs that a new orchestration instance has been scheduled.
+        /// </summary>
+        /// <param name="startedEvent">The start event for the new orchestration.</param>
+        internal void SchedulingOrchestration(ExecutionStartedEvent startedEvent)
+        {
+            // Note that this log event is also used when orchestrations send events
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.SchedulingOrchestration(startedEvent));
+            }
+        }
+
+        /// <summary>
+        /// Logs that an event is being raised to an orchestration.
+        /// </summary>
+        /// <param name="target">The target orchestration instance.</param>
+        /// <param name="raisedEvent">The event-raised event.</param>
+        internal void RaisingEvent(OrchestrationInstance target, EventRaisedEvent raisedEvent)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.RaisingEvent(target, raisedEvent));
+            }
+        }
+
+        /// <summary>
+        /// Logs that an event is being raised by an orchestration.
+        /// </summary>
+        /// <param name="source">The sending orchestration instance.</param>
+        /// <param name="raisedEvent">The event-sent event.</param>
+        internal void RaisingEvent(OrchestrationInstance source, EventSentEvent raisedEvent)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.RaisingEvent(source, raisedEvent));
+            }
+        }
+
+        /// <summary>
+        /// Logs that an instance is being scheduled to be terminated.
+        /// </summary>
+        /// <param name="instance">The instance to be terminated.</param>
+        /// <param name="reason">The user-specified reason for the termination.</param>
+        internal void TerminatingInstance(OrchestrationInstance instance, string reason)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.TerminatingInstance(instance, reason));
+            }
+        }
+
+        /// <summary>
+        /// Logs that the client is waiting for an instance to reach a terminal state.
+        /// </summary>
+        /// <param name="instance">The instance being awaited.</param>
+        /// <param name="timeout">The maximum timeout the client will wait.</param>
+        internal void WaitingForInstance(OrchestrationInstance instance, TimeSpan timeout)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.WaitingForInstance(instance, timeout));
+            }
+        }
+
+        /// <summary>
+        /// Logs that the client is attempting to fetch the state of an orchestration instance.
+        /// </summary>
+        /// <param name="instanceId">The ID of the instance.</param>
+        /// <param name="executionId">The execution ID of the instance, if applicable.</param>
+        internal void FetchingInstanceState(string instanceId, string executionId = null)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.FetchingInstanceState(instanceId, executionId));
+            }
+        }
+
+        /// <summary>
+        /// Logs that the client is attempting to fetch the history of an orchestration instance.
+        /// </summary>
+        /// <param name="instance">The instance to fetch the history of.</param>
+        internal void FetchingInstanceHistory(OrchestrationInstance instance)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.FetchingInstanceHistory(instance));
+            }
+        }
+
+        #endregion
+
+        #region Orchestration dispatcher
+
+        /// <summary>
+        /// Logs that an orchestration work item message is being processed.
+        /// </summary>
+        /// <param name="workItem">The orchestration work item.</param>
+        /// <param name="message">The message being processed.</param>
+        internal void ProcessingOrchestrationMessage(TaskOrchestrationWorkItem workItem, TaskMessage message)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.ProcessingOrchestrationMessage(workItem, message));
+            }
+        }
+
+        /// <summary>
+        /// Logs that an orchestration is about to start executing.
+        /// </summary>
+        /// <param name="instance">The orchestration instance that is about to start.</param>
+        /// <param name="name">The name of the orchestration.</param>
+        internal void OrchestrationExecuting(OrchestrationInstance instance, string name)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.OrchestrationExecuting(instance, name));
+            }
+        }
+
+        /// <summary>
+        /// Logs that an orchestration successfully executed an episode.
+        /// </summary>
+        /// <param name="instance">The orchestration instance that was executed.</param>
+        /// <param name="name">The name of the orchestration.</param>
+        /// <param name="actions">The actions taken by the orchestration</param>
+        internal void OrchestrationExecuted(
+            OrchestrationInstance instance,
+            string name,
+            IReadOnlyList<OrchestratorAction> actions)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.OrchestrationExecuted(instance, name, actions.Count));
+            }
+        }
+
+        /// <summary>
+        /// Logs that an orchestration is scheduling a task activity for execution.
+        /// </summary>
+        /// <param name="instance">The orchestration instance scheduling the task activity.</param>
+        /// <param name="scheduledEvent">The task scheduled event.</param>
+        internal void SchedulingActivity(OrchestrationInstance instance, TaskScheduledEvent scheduledEvent)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.SchedulingActivity(instance, scheduledEvent));
+            }
+        }
+
+        /// <summary>
+        /// Logs that an orchestration is creating a durable timer.
+        /// </summary>
+        /// <param name="instance">The orchestration instance scheduling the task activity.</param>
+        /// <param name="timerEvent">The timer creation event.</param>
+        /// <param name="isInternal"><c>true</c> if the timer was created internally by the framework; <c>false</c> if it was created by user code.</param>
+        internal void CreatingTimer(OrchestrationInstance instance, TimerCreatedEvent timerEvent, bool isInternal)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.CreatingTimer(instance, timerEvent, isInternal));
+            }
+        }
+
+        /// <summary>
+        /// Logs that an orchestration is sending an event to another orchestration instance.
+        /// </summary>
+        /// <param name="source">The orchestration instance sending the event.</param>
+        /// <param name="eventSentEvent">The event being sent.</param>
+        internal void SendingEvent(OrchestrationInstance source, EventSentEvent eventSentEvent)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                // We re-use the existing RaisingEvent log event for this
+                this.WriteStructuredLog(new LogEvents.RaisingEvent(source, eventSentEvent));
+            }
+        }
+
+        /// <summary>
+        /// Logs that an orchestration instance has completed.
+        /// </summary>
+        /// <param name="runtimeState">The final runtime state of the completed orchestration.</param>
+        /// <param name="action">The orchestration instance's completion actions.</param>
+        internal void OrchestrationCompleted(
+            OrchestrationRuntimeState runtimeState,
+            OrchestrationCompleteOrchestratorAction action)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.OrchestrationCompleted(runtimeState, action));
+            }
+        }
+
+        /// <summary>
+        /// Logs that an orchestration execution was aborted.
+        /// </summary>
+        /// <param name="instance">The orchestration instance that aborted execution.</param>
+        /// <param name="reason">The reason for aborting the orchestration execution.</param>
+        internal void OrchestrationAborted(OrchestrationInstance instance, string reason)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.OrchestrationAborted(instance, reason));
+            }
+        }
+
+        /// <summary>
+        /// Helper method for logging the dropping of all messages associated with the specified work item.
+        /// </summary>
+        /// <param name="workItem">The work item being dropped.</param>
+        /// <param name="reason">The reason for dropping this work item.</param>
+        internal void DroppingOrchestrationWorkItem(TaskOrchestrationWorkItem workItem, string reason)
+        {
+            foreach (TaskMessage message in workItem.NewMessages)
+            {
+                this.DroppingOrchestrationMessage(workItem, message, reason);
+            }
+        }
+
+        /// <summary>
+        /// Logs that a work item message is being dropped and includes a reason.
+        /// </summary>
+        /// <param name="workItem">The work item that this message belonged to.</param>
+        /// <param name="message">The message being dropped.</param>
+        /// <param name="reason">The reason for dropping the message.</param>
+        internal void DroppingOrchestrationMessage(TaskOrchestrationWorkItem workItem, TaskMessage message, string reason)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.DiscardingMessage(workItem, message, reason));
+            }
+        }
+        #endregion
+
+        #region Activity dispatcher
+        /// <summary>
+        /// Logs that a task activity is about to begin execution.
+        /// </summary>
+        /// <param name="instance">The orchestration instance that scheduled this task activity.</param>
+        /// <param name="taskEvent">The history event associated with this activity execution.</param>
+        internal void TaskActivityStarting(OrchestrationInstance instance, TaskScheduledEvent taskEvent)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.TaskActivityStarting(instance, taskEvent));
+            }
+        }
+
+        /// <summary>
+        /// Logs that a task activity completed successfully.
+        /// </summary>
+        /// <param name="instance">The orchestration instance that scheduled this task activity.</param>
+        /// <param name="name">The name of the task activity.</param>
+        /// <param name="taskEvent">The history event associated with this activity completion.</param>
+        internal void TaskActivityCompleted(OrchestrationInstance instance, string name, TaskCompletedEvent taskEvent)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.TaskActivityCompleted(instance, name, taskEvent));
+            }
+        }
+
+        /// <summary>
+        /// Logs that an activity failed with an unhandled exception.
+        /// </summary>
+        /// <param name="instance">The orchestration instance that scheduled this task activity.</param>
+        /// <param name="name">The name of the task activity.</param>
+        /// <param name="failedEvent">The history event associated with this activity failure.</param>
+        /// <param name="exception">The unhandled exception.</param>
+        internal void TaskActivityFailure(
+            OrchestrationInstance instance,
+            string name,
+            TaskFailedEvent failedEvent,
+            Exception exception)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(
+                    new LogEvents.TaskActivityFailure(instance, name, failedEvent, exception),
+                    exception);
+            }
+        }
+
+        /// <summary>
+        /// Logs a warning indicating that the activity execution was aborted.
+        /// </summary>
+        /// <param name="instance">The orchestration instance that scheduled this task activity.</param>
+        /// <param name="taskEvent">The history event associated with this activity execution.</param>
+        /// <param name="details">More information about why the execution was aborted.</param>
+        internal void TaskActivityAborted(OrchestrationInstance instance, TaskScheduledEvent taskEvent, string details)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.TaskActivityAborted(instance, taskEvent, details));
+            }
+        }
+
+        /// <summary>
+        /// Logs that an error occurred when attempting to dispatch an activity work item.
+        /// </summary>
+        /// <param name="workItem">The work item that caused the failure.</param>
+        /// <param name="details">The details of the failure.</param>
+        internal void TaskActivityDispatcherError(TaskActivityWorkItem workItem, string details)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.TaskActivityDispatcherError(workItem, details));
+            }
+        }
+
+        /// <summary>
+        /// Logs that an activity message renewal operation is starting.
+        /// </summary>
+        /// <param name="workItem">The work item associated with the message to be renewed.</param>
+        internal void RenewActivityMessageStarting(TaskActivityWorkItem workItem)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.RenewActivityMessageStarting(workItem));
+            }
+        }
+
+        /// <summary>
+        /// Logs that an activity message renewal operation succeeded.
+        /// </summary>
+        /// <param name="workItem">The work item associated with the renewed message.</param>
+        /// <param name="renewAt">The next scheduled renewal message time.</param>
+        internal void RenewActivityMessageCompleted(TaskActivityWorkItem workItem, DateTime renewAt)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.RenewActivityMessageCompleted(workItem, renewAt));
+            }
+        }
+
+        /// <summary>
+        /// Logs that an activity message renewal operation failed.
+        /// </summary>
+        /// <param name="workItem">The work item associated with the message to be renewed.</param>
+        /// <param name="exception">The renew failure exception.</param>
+        internal void RenewActivityMessageFailed(TaskActivityWorkItem workItem, Exception exception)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.RenewActivityMessageFailed(workItem, exception), exception);
+            }
+        }
+        #endregion
+
+        void WriteStructuredLog(ILogEvent logEvent, Exception exception = null)
+        {
+            this.log?.LogDurableEvent(logEvent, exception);
+        }
+    }
+}

--- a/src/DurableTask.Core/Logging/LoggingExtensions.cs
+++ b/src/DurableTask.Core/Logging/LoggingExtensions.cs
@@ -39,7 +39,7 @@ namespace DurableTask.Core.Logging
                 logEvent.EventId,
                 logEvent,
                 exception,
-                formatter: (s, e) => s.GetLogMessage());
+                formatter: (s, e) => s.FormattedMessage);
 
             if (logEvent is IEventSourceEvent eventSourceEvent)
             {

--- a/src/DurableTask.Core/Logging/LoggingExtensions.cs
+++ b/src/DurableTask.Core/Logging/LoggingExtensions.cs
@@ -29,17 +29,12 @@ namespace DurableTask.Core.Logging
         /// <param name="exception">Optional exception parameter for logging.</param>
         public static void LogDurableEvent(this ILogger logger, ILogEvent logEvent, Exception exception = null)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
             if (logEvent == null)
             {
                 throw new ArgumentNullException(nameof(logEvent));
             }
 
-            logger.Log(
+            logger?.Log(
                 logEvent.Level,
                 logEvent.EventId,
                 logEvent,
@@ -48,19 +43,7 @@ namespace DurableTask.Core.Logging
 
             if (logEvent is IEventSourceEvent eventSourceEvent)
             {
-                // TODO: Uncomment this code when distributed tracing is integrated
-                ////// If there is an Activity.Current, use it for the EventSource activity ID
-                ////if (Activity.Current != null)
-                ////{
-                ////    Guid activityId = new Guid(Activity.Current.TraceId.ToString());
-                ////    StructuredEventSource.SetLogicalTraceActivityId(activityId);
-                ////}
-                ////else
-                ////{
-                    // Otherwise, use our own built-in activity ID tracking
-                    StructuredEventSource.EnsureLogicalTraceActivityId();
-                ////}
-
+                StructuredEventSource.EnsureLogicalTraceActivityId();
                 eventSourceEvent.WriteEventSource();
             }
         }

--- a/src/DurableTask.Core/Logging/LoggingExtensions.cs
+++ b/src/DurableTask.Core/Logging/LoggingExtensions.cs
@@ -1,0 +1,55 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core.Logging
+{
+    using System;
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    /// Extension methods for the <see cref="ILoggerFactory"/> class.
+    /// </summary>
+    public static class LoggingExtensions
+    {
+        /// <summary>
+        /// Writes an <see cref="ILogEvent"/> to the provider <see cref="ILogger"/> and 
+        /// </summary>
+        /// <param name="logger">The logger to write to.</param>
+        /// <param name="logEvent">The event to be logged.</param>
+        /// <param name="exception">Optional exception parameter for logging.</param>
+        public static void LogDurableEvent(this ILogger logger, ILogEvent logEvent, Exception exception = null)
+        {
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            if (logEvent == null)
+            {
+                throw new ArgumentNullException(nameof(logEvent));
+            }
+
+            logger.Log(
+                logEvent.Level,
+                logEvent.EventId,
+                logEvent,
+                exception,
+                formatter: (s, e) => s.GetLogMessage());
+
+            if (logEvent is IEventSourceEvent eventSourceEvent)
+            {
+                eventSourceEvent.WriteEventSource();
+            }
+        }
+    }
+}

--- a/src/DurableTask.Core/Logging/LoggingExtensions.cs
+++ b/src/DurableTask.Core/Logging/LoggingExtensions.cs
@@ -48,6 +48,19 @@ namespace DurableTask.Core.Logging
 
             if (logEvent is IEventSourceEvent eventSourceEvent)
             {
+                // TODO: Uncomment this code when distributed tracing is integrated
+                ////// If there is an Activity.Current, use it for the EventSource activity ID
+                ////if (Activity.Current != null)
+                ////{
+                ////    Guid activityId = new Guid(Activity.Current.TraceId.ToString());
+                ////    StructuredEventSource.SetLogicalTraceActivityId(activityId);
+                ////}
+                ////else
+                ////{
+                    // Otherwise, use our own built-in activity ID tracking
+                    StructuredEventSource.EnsureLogicalTraceActivityId();
+                ////}
+
                 eventSourceEvent.WriteEventSource();
             }
         }

--- a/src/DurableTask.Core/Logging/README.md
+++ b/src/DurableTask.Core/Logging/README.md
@@ -1,0 +1,58 @@
+# DurableTask.Core Logging
+
+DurableTask.Core supports two forms of logging:
+
+1. [Event Source](https://docs.microsoft.com/dotnet/api/system.diagnostics.tracing.eventsource)
+1. [ILogger](https://docs.microsoft.com/aspnet/core/fundamentals/logging)
+
+**Event Source** is the high-performance logger for .NET and is used by platforms like Azure Functions and Azure App Service to automatically collect telemetry that is available to Customer Support. **ILogger** is primarily intended to allow users to collect logs for their own use (although users can also use Event Source directly, if desired). Collecting Event Source logs is outside the scope of this document, however.
+
+## ILogger configuration
+
+Starting in DurableTask.Core v2.4.0, `TaskHubWorker` and `TaskHubClient` have constructor overloads that accept an [ILoggerFactory](https://docs.microsoft.com/dotnet/api/microsoft.extensions.logging.iloggerfactory). The `ILoggerFactory` can be used to collect logs and have them written to the console, a file, [Azure Application Insights](https://docs.microsoft.com/azure/azure-monitor/app/ilogger), or any custom location that you choose.
+
+```csharp
+// configure logging
+var loggerFactory = LoggerFactory.Create(
+    builder =>
+    {
+        builder.AddConsole();
+        builder.AddFile("Logs/{Date}.txt", minimumLevel: LogLevel.Trace);
+        builder.AddApplicationInsights(instrumentationKey);
+    });
+var worker = new TaskHubWorker(orchestrationService, loggerFactory);
+```
+
+## Event Source configuration
+
+Event Source logging is always enabled and does not have any _explicit_ configuration. However, there are currently two flavors of event source logging, _structured_ and _unstructured_. By default, Event Source logs are _unstructured_.
+
+Starting in **DurableTask.Core v2.4.0**, a more modern _structured_ Event Source logging is available. To enable the structured Event Source logging, a non-null `loggerFactory` must be configured. Even using [NullLoggerFactory.Instance](https://docs.microsoft.com/dotnet/api/microsoft.extensions.logging.abstractions.nullloggerfactory.instance) can be used to enabled structured event source logging.
+
+The difference between the legacy and structured event source providers is the provider GUID values, as shown in the following table.
+
+| Event Source Type | Provider Name | Provider GUID |
+|-|-|-|
+| Structured (recommended) | [DurableTask-Core](src/DurableTask.Core/Logging/StructuredEventSource.cs) | 413F7E86-75A9-5E9C-35DD-51DB8427E7E7 |
+| Unstructured (legacy) | [DurableTask-Core](src/DurableTask.Core/Tracing/DefaultEventSource.cs) | 7DA4779A-152E-44A2-A6F2-F80D991A5BEE |
+
+Note that some transaction store providers, like **DurableTask.AzureStorage** also support Event Source logging.
+
+| Event Source Type | Provider Name | Provider GUID |
+|-|-|-|
+| Structured | [DurableTask-AzureStorage](src/DurableTask.AzureStorage/AnalyticsEventSource.cs) | 4C4AD4A2-F396-5E18-01B6-618C12A10433 |
+| Structured | [DurableTask-SqlServer](https://github.com/cgillum/durabletask-sqlserver/blob/main/src/DurableTask.SqlServer/Logging/DefaultEventSource.cs) | 4BA38912-E64F-5FD2-170D-68AC65B1E58D |
+
+## Structured logging
+
+There are a large number of log events emitted by DurableTask.Core. The full list, including their event IDs, verbosity, and schemas can be found in [LogEvents.cs](src/DurableTask.Core/Logging/LogEvents.cs).
+
+Each log event is represented as a class that derives from [StructuredLogEvent](src/DurableTask.Core/Logging/StructuredLogEvent.cs). Each data field of the event is declared as a property with the [StructuredLogField](src/DurableTask.Core/Logging/StructuredLogFieldAttribute.cs) attribute. If a log event supports being written to Event Source, then it also implements the [IEventSourceEvent](src/DurableTask.Core/Logging/IEventSourceEvent.cs) interface.
+
+Note that these classes are public. It is recommended that all Durable Task transaction store implementations leverage these classes to implement their own logging. This will enable those providers to participate in [end-to-end tracing](#end-to-end-tracing).
+
+## Activity tracing
+
+DurableTask.Core and the transaction store providers mentioned previously support activity tracing when writing the Event Source. This is critically important for filtering and correlating logs that are related to each other, especially when lots of operations are executing concurrently, and especially when the logs are being generated from multiple trace sources. For example, a new `ActivityId` GUID value is created every time a dispatcher attempts to fetch a new message. This trace activity value is associated with all traces within the same logical thread of execution, even across transaction store providers.
+
+Depending on the transaction store provider (like DurableTask.AzureStorage) related activity IDs are also logged to help correlate sent messages with received messages, allowing you to easily trace the entire lifetime of an orchestration instance.

--- a/src/DurableTask.Core/Logging/README.md
+++ b/src/DurableTask.Core/Logging/README.md
@@ -25,16 +25,16 @@ var worker = new TaskHubWorker(orchestrationService, loggerFactory);
 
 ## Event Source configuration
 
-Event Source logging is always enabled and does not have any _explicit_ configuration. However, there are currently two flavors of event source logging, _structured_ and _unstructured_. By default, Event Source logs are _unstructured_.
+Event Source logging is always enabled and does not have any _explicit_ configuration. However, there are currently two flavors of event source logging, _structured_ and _unstructured_. By default, Event Source logs are _unstructured_. This means that every log uses a common schema such that the important information is included in a text message.
 
-Starting in **DurableTask.Core v2.4.0**, a more modern _structured_ Event Source logging is available. To enable the structured Event Source logging, a non-null `loggerFactory` must be configured. Even using [NullLoggerFactory.Instance](https://docs.microsoft.com/dotnet/api/microsoft.extensions.logging.abstractions.nullloggerfactory.instance) can be used to enabled structured event source logging.
+Starting in **DurableTask.Core v2.4.0**, a more modern _structured_ Event Source logging is available. Rather than logging text messages, each log event has its own unique schema, making it easier to query for very specific information when logs are stored in places like Kusto. To enable the structured Event Source logging, a non-null `loggerFactory` must be configured. Even using [NullLoggerFactory.Instance](https://docs.microsoft.com/dotnet/api/microsoft.extensions.logging.abstractions.nullloggerfactory.instance) can be used to enabled structured event source logging.
 
-The difference between the legacy and structured event source providers is the provider GUID values, as shown in the following table.
+Both the legacy and structured event source providers have a provider name of `DurableTask-Core`. However, they have different provider GUID values, as shown in the following table.
 
 | Event Source Type | Provider Name | Provider GUID |
 |-|-|-|
-| Structured (recommended) | [DurableTask-Core](src/DurableTask.Core/Logging/StructuredEventSource.cs) | 413F7E86-75A9-5E9C-35DD-51DB8427E7E7 |
-| Unstructured (legacy) | [DurableTask-Core](src/DurableTask.Core/Tracing/DefaultEventSource.cs) | 7DA4779A-152E-44A2-A6F2-F80D991A5BEE |
+| Structured (recommended) | [DurableTask-Core](StructuredEventSource.cs) | 413F7E86-75A9-5E9C-35DD-51DB8427E7E7 |
+| Unstructured (legacy) | [DurableTask-Core](../Tracing/DefaultEventSource.cs) | 7DA4779A-152E-44A2-A6F2-F80D991A5BEE |
 
 Note that some transaction store providers, like **DurableTask.AzureStorage** also support Event Source logging.
 
@@ -45,9 +45,9 @@ Note that some transaction store providers, like **DurableTask.AzureStorage** al
 
 ## Structured logging
 
-There are a large number of log events emitted by DurableTask.Core. The full list, including their event IDs, verbosity, and schemas can be found in [LogEvents.cs](src/DurableTask.Core/Logging/LogEvents.cs).
+There are a large number of log events emitted by DurableTask.Core. The full list, including their event IDs, verbosity, and schemas can be found in [LogEvents.cs](LogEvents.cs).
 
-Each log event is represented as a class that derives from [StructuredLogEvent](src/DurableTask.Core/Logging/StructuredLogEvent.cs). Each data field of the event is declared as a property with the [StructuredLogField](src/DurableTask.Core/Logging/StructuredLogFieldAttribute.cs) attribute. If a log event supports being written to Event Source, then it also implements the [IEventSourceEvent](src/DurableTask.Core/Logging/IEventSourceEvent.cs) interface.
+Each log event is represented as a class that derives from [StructuredLogEvent](StructuredLogEvent.cs). Each data field of the event is declared as a property with the [StructuredLogField](StructuredLogFieldAttribute.cs) attribute. If a log event supports being written to Event Source, then it also implements the [IEventSourceEvent](IEventSourceEvent.cs) interface.
 
 Note that these classes are public. It is recommended that all Durable Task transaction store implementations leverage these classes to implement their own logging. This will enable those providers to participate in [end-to-end tracing](#end-to-end-tracing).
 

--- a/src/DurableTask.Core/Logging/StructuredEventSource.cs
+++ b/src/DurableTask.Core/Logging/StructuredEventSource.cs
@@ -51,37 +51,55 @@ namespace DurableTask.Core.Logging
         [Event(EventIds.TaskHubWorkerStarting, Level = EventLevel.Informational, Version = 1)]
         public void TaskHubWorkerStarting(string AppName, string ExtensionVersion)
         {
-            this.WriteEvent(EventIds.TaskHubWorkerStarting, AppName, ExtensionVersion);
+            if (this.IsEnabled(EventLevel.Informational))
+            {
+                this.WriteEvent(EventIds.TaskHubWorkerStarting, AppName, ExtensionVersion);
+            }
         }
 
         [Event(EventIds.TaskHubWorkerStarted, Level = EventLevel.Informational, Version = 1)]
         public void TaskHubWorkerStarted(long LatencyMs, string AppName, string ExtensionVersion)
         {
-            this.WriteEvent(EventIds.TaskHubWorkerStarted, LatencyMs, AppName, ExtensionVersion);
+            if (this.IsEnabled(EventLevel.Informational))
+            {
+                this.WriteEvent(EventIds.TaskHubWorkerStarted, LatencyMs, AppName, ExtensionVersion);
+            }
         }
 
         [Event(EventIds.TaskHubWorkerStopping, Level = EventLevel.Informational, Version = 1)]
         public void TaskHubWorkerStopping(bool IsForced, string AppName, string ExtensionVersion)
         {
-            this.WriteEvent(EventIds.TaskHubWorkerStopping, IsForced, AppName, ExtensionVersion);
+            if (this.IsEnabled(EventLevel.Informational))
+            {
+                this.WriteEvent(EventIds.TaskHubWorkerStopping, IsForced, AppName, ExtensionVersion);
+            }
         }
 
         [Event(EventIds.TaskHubWorkerStopped, Level = EventLevel.Informational, Version = 1)]
         public void TaskHubWorkerStopped(long LatencyMs, string AppName, string ExtensionVersion)
         {
-            this.WriteEvent(EventIds.TaskHubWorkerStopped, LatencyMs, AppName, ExtensionVersion);
+            if (this.IsEnabled(EventLevel.Informational))
+            {
+                this.WriteEvent(EventIds.TaskHubWorkerStopped, LatencyMs, AppName, ExtensionVersion);
+            }
         }
 
         [Event(EventIds.DispatcherStarting, Level = EventLevel.Verbose, Version = 1)]
         public void DispatcherStarting(string Dispatcher, string AppName, string ExtensionVersion)
         {
-            this.WriteEvent(EventIds.DispatcherStarting, Dispatcher, AppName, ExtensionVersion);
+            if (this.IsEnabled(EventLevel.Verbose))
+            {
+                this.WriteEvent(EventIds.DispatcherStarting, Dispatcher, AppName, ExtensionVersion);
+            }
         }
 
         [Event(EventIds.DispatcherStopped, Level = EventLevel.Verbose, Version = 1)]
         public void DispatcherStopped(string Dispatcher, string AppName, string ExtensionVersion)
         {
-            this.WriteEvent(EventIds.DispatcherStopped, Dispatcher, AppName, ExtensionVersion);
+            if (this.IsEnabled(EventLevel.Verbose))
+            {
+                this.WriteEvent(EventIds.DispatcherStopped, Dispatcher, AppName, ExtensionVersion);
+            }
         }
 
         [Event(EventIds.DispatchersStopping, Level = EventLevel.Verbose, Version = 1)]
@@ -92,13 +110,16 @@ namespace DurableTask.Core.Logging
             string AppName,
             string ExtensionVersion)
         {
-            this.WriteEvent(
-                EventIds.DispatchersStopping,
-                Dispatcher,
-                WorkItemCount,
-                ActiveFetcherCount,
-                AppName,
-                ExtensionVersion);
+            if (this.IsEnabled(EventLevel.Verbose))
+            {
+                this.WriteEvent(
+                    EventIds.DispatchersStopping,
+                    Dispatcher,
+                    WorkItemCount,
+                    ActiveFetcherCount,
+                    AppName,
+                    ExtensionVersion);
+            }
         }
 
         [Event(EventIds.FetchWorkItemStarting, Level = EventLevel.Verbose, Version = 1)]
@@ -158,12 +179,15 @@ namespace DurableTask.Core.Logging
         [Event(EventIds.FetchWorkItemFailure, Level = EventLevel.Error, Version = 1)]
         internal void FetchWorkItemFailure(string Dispatcher, string Details, string AppName, string ExtensionVersion)
         {
-            this.WriteEvent(
-                EventIds.FetchWorkItemFailure,
-                Dispatcher,
-                Details,
-                AppName,
-                ExtensionVersion);
+            if (this.IsEnabled(EventLevel.Error))
+            {
+                this.WriteEvent(
+                    EventIds.FetchWorkItemFailure,
+                    Dispatcher,
+                    Details,
+                    AppName,
+                    ExtensionVersion);
+            }
         }
 
         [Event(EventIds.FetchingThrottled, Level = EventLevel.Informational, Version = 1)]
@@ -174,13 +198,16 @@ namespace DurableTask.Core.Logging
             string AppName,
             string ExtensionVersion)
         {
-            this.WriteEvent(
-                EventIds.FetchingThrottled,
-                Dispatcher,
-                WorkItemCount,
-                MaxWorkItemCount,
-                AppName,
-                ExtensionVersion);
+            if (this.IsEnabled(EventLevel.Informational))
+            {
+                this.WriteEvent(
+                    EventIds.FetchingThrottled,
+                    Dispatcher,
+                    WorkItemCount,
+                    MaxWorkItemCount,
+                    AppName,
+                    ExtensionVersion);
+            }
         }
 
         [Event(EventIds.ProcessWorkItemStarting, Level = EventLevel.Verbose, Version = 1)]
@@ -190,12 +217,15 @@ namespace DurableTask.Core.Logging
             string AppName,
             string ExtensionVersion)
         {
-            this.WriteEvent(
-                EventIds.ProcessWorkItemStarting,
-                Dispatcher,
-                WorkItemId,
-                AppName,
-                ExtensionVersion);
+            if (this.IsEnabled(EventLevel.Verbose))
+            {
+                this.WriteEvent(
+                    EventIds.ProcessWorkItemStarting,
+                    Dispatcher,
+                    WorkItemId,
+                    AppName,
+                    ExtensionVersion);
+            }
         }
 
         [Event(EventIds.ProcessWorkItemCompleted, Level = EventLevel.Verbose, Version = 1)]
@@ -205,12 +235,15 @@ namespace DurableTask.Core.Logging
             string AppName,
             string ExtensionVersion)
         {
-            this.WriteEvent(
-                EventIds.ProcessWorkItemCompleted,
-                Dispatcher,
-                WorkItemId,
-                AppName,
-                ExtensionVersion);
+            if (this.IsEnabled(EventLevel.Verbose))
+            {
+                this.WriteEvent(
+                    EventIds.ProcessWorkItemCompleted,
+                    Dispatcher,
+                    WorkItemId,
+                    AppName,
+                    ExtensionVersion);
+            }
         }
 
         [Event(EventIds.ProcessWorkItemFailed, Level = EventLevel.Error, Version = 1)]
@@ -221,13 +254,16 @@ namespace DurableTask.Core.Logging
             string AppName,
             string ExtensionVersion)
         {
-            this.WriteEvent(
-                EventIds.ProcessWorkItemFailed,
-                Dispatcher,
-                WorkItemId,
-                Details,
-                AppName,
-                ExtensionVersion);
+            if (this.IsEnabled(EventLevel.Error))
+            {
+                this.WriteEvent(
+                    EventIds.ProcessWorkItemFailed,
+                    Dispatcher,
+                    WorkItemId,
+                    Details,
+                    AppName,
+                    ExtensionVersion);
+            }
         }
 
         [Event(EventIds.SchedulingOrchestration, Level = EventLevel.Informational, Version = 1)]
@@ -294,13 +330,16 @@ namespace DurableTask.Core.Logging
             string AppName,
             string ExtensionVersion)
         {
-            this.WriteEvent(
-                EventIds.TerminatingInstance,
-                InstanceId,
-                ExecutionId ?? string.Empty,
-                Details ?? string.Empty,
-                AppName,
-                ExtensionVersion);
+            if (this.IsEnabled(EventLevel.Informational))
+            {
+                this.WriteEvent(
+                    EventIds.TerminatingInstance,
+                    InstanceId,
+                    ExecutionId ?? string.Empty,
+                    Details ?? string.Empty,
+                    AppName,
+                    ExtensionVersion);
+            }
         }
 
         [Event(EventIds.WaitingForInstance, Level = EventLevel.Informational, Version = 1)]
@@ -311,13 +350,16 @@ namespace DurableTask.Core.Logging
             string AppName,
             string ExtensionVersion)
         {
-            this.WriteEvent(
-                EventIds.WaitingForInstance,
-                InstanceId,
-                ExecutionId ?? string.Empty,
-                TimeoutSeconds,
-                AppName,
-                ExtensionVersion);
+            if (this.IsEnabled(EventLevel.Informational))
+            {
+                this.WriteEvent(
+                    EventIds.WaitingForInstance,
+                    InstanceId,
+                    ExecutionId ?? string.Empty,
+                    TimeoutSeconds,
+                    AppName,
+                    ExtensionVersion);
+            }
         }
 
         [Event(EventIds.FetchingInstanceState, Level = EventLevel.Informational, Version = 1)]
@@ -327,12 +369,15 @@ namespace DurableTask.Core.Logging
             string AppName,
             string ExtensionVersion)
         {
-            this.WriteEvent(
-                EventIds.FetchingInstanceState,
-                InstanceId,
-                ExecutionId ?? string.Empty,
-                AppName,
-                ExtensionVersion);
+            if (this.IsEnabled(EventLevel.Informational))
+            {
+                this.WriteEvent(
+                    EventIds.FetchingInstanceState,
+                    InstanceId,
+                    ExecutionId ?? string.Empty,
+                    AppName,
+                    ExtensionVersion);
+            }
         }
 
         [Event(EventIds.FetchingInstanceHistory, Level = EventLevel.Informational, Version = 1)]
@@ -342,12 +387,15 @@ namespace DurableTask.Core.Logging
             string AppName,
             string ExtensionVersion)
         {
-            this.WriteEvent(
-                EventIds.FetchingInstanceHistory,
-                InstanceId,
-                ExecutionId ?? string.Empty,
-                AppName,
-                ExtensionVersion);
+            if (this.IsEnabled(EventLevel.Informational))
+            {
+                this.WriteEvent(
+                    EventIds.FetchingInstanceHistory,
+                    InstanceId,
+                    ExecutionId ?? string.Empty,
+                    AppName,
+                    ExtensionVersion);
+            }
         }
 
         [Event(EventIds.ProcessingOrchestrationMessage, Level = EventLevel.Verbose, Version = 1)]

--- a/src/DurableTask.Core/Logging/StructuredEventSource.cs
+++ b/src/DurableTask.Core/Logging/StructuredEventSource.cs
@@ -49,45 +49,56 @@ namespace DurableTask.Core.Logging
         bool IsEnabled(EventLevel level) => this.IsEnabled(level, EventKeywords.None);
 
         [Event(EventIds.TaskHubWorkerStarting, Level = EventLevel.Informational, Version = 1)]
-        public void TaskHubWorkerStarting()
+        public void TaskHubWorkerStarting(string AppName, string ExtensionVersion)
         {
-            this.WriteEvent(EventIds.TaskHubWorkerStarting);
+            this.WriteEvent(EventIds.TaskHubWorkerStarting, AppName, ExtensionVersion);
         }
 
         [Event(EventIds.TaskHubWorkerStarted, Level = EventLevel.Informational, Version = 1)]
-        public void TaskHubWorkerStarted(long LatencyMs)
+        public void TaskHubWorkerStarted(long LatencyMs, string AppName, string ExtensionVersion)
         {
-            this.WriteEvent(EventIds.TaskHubWorkerStarted, LatencyMs);
+            this.WriteEvent(EventIds.TaskHubWorkerStarted, LatencyMs, AppName, ExtensionVersion);
         }
 
         [Event(EventIds.TaskHubWorkerStopping, Level = EventLevel.Informational, Version = 1)]
-        public void TaskHubWorkerStopping(bool IsForced)
+        public void TaskHubWorkerStopping(bool IsForced, string AppName, string ExtensionVersion)
         {
-            this.WriteEvent(EventIds.TaskHubWorkerStopping, IsForced);
+            this.WriteEvent(EventIds.TaskHubWorkerStopping, IsForced, AppName, ExtensionVersion);
         }
 
         [Event(EventIds.TaskHubWorkerStopped, Level = EventLevel.Informational, Version = 1)]
-        public void TaskHubWorkerStopped(long LatencyMs)
+        public void TaskHubWorkerStopped(long LatencyMs, string AppName, string ExtensionVersion)
         {
-            this.WriteEvent(EventIds.TaskHubWorkerStopped, LatencyMs);
+            this.WriteEvent(EventIds.TaskHubWorkerStopped, LatencyMs, AppName, ExtensionVersion);
         }
 
         [Event(EventIds.DispatcherStarting, Level = EventLevel.Verbose, Version = 1)]
-        public void DispatcherStarting(string Dispatcher)
+        public void DispatcherStarting(string Dispatcher, string AppName, string ExtensionVersion)
         {
-            this.WriteEvent(EventIds.DispatcherStarting, Dispatcher);
+            this.WriteEvent(EventIds.DispatcherStarting, Dispatcher, AppName, ExtensionVersion);
         }
 
         [Event(EventIds.DispatcherStopped, Level = EventLevel.Verbose, Version = 1)]
-        public void DispatcherStopped(string Dispatcher)
+        public void DispatcherStopped(string Dispatcher, string AppName, string ExtensionVersion)
         {
-            this.WriteEvent(EventIds.DispatcherStopped, Dispatcher);
+            this.WriteEvent(EventIds.DispatcherStopped, Dispatcher, AppName, ExtensionVersion);
         }
 
         [Event(EventIds.DispatchersStopping, Level = EventLevel.Verbose, Version = 1)]
-        public void DispatchersStopping(string Dispatcher, int WorkItemCount, int ActiveFetcherCount)
+        public void DispatchersStopping(
+            string Dispatcher,
+            int WorkItemCount,
+            int ActiveFetcherCount,
+            string AppName,
+            string ExtensionVersion)
         {
-            this.WriteEvent(EventIds.DispatchersStopping, Dispatcher, WorkItemCount, ActiveFetcherCount);
+            this.WriteEvent(
+                EventIds.DispatchersStopping,
+                Dispatcher,
+                WorkItemCount,
+                ActiveFetcherCount,
+                AppName,
+                ExtensionVersion);
         }
 
         [Event(EventIds.FetchWorkItemStarting, Level = EventLevel.Verbose, Version = 1)]
@@ -95,7 +106,9 @@ namespace DurableTask.Core.Logging
             string Dispatcher,
             int TimeoutSeconds,
             int WorkItemCount,
-            int MaxWorkItemCount)
+            int MaxWorkItemCount,
+            string AppName,
+            string ExtensionVersion)
         {
             if (this.IsEnabled())
             {
@@ -111,7 +124,9 @@ namespace DurableTask.Core.Logging
                     Dispatcher,
                     TimeoutSeconds,
                     WorkItemCount,
-                    MaxWorkItemCount);
+                    MaxWorkItemCount,
+                    AppName,
+                    ExtensionVersion);
             }
         }
 
@@ -121,7 +136,9 @@ namespace DurableTask.Core.Logging
             string WorkItemId,
             long LatencyMs,
             int WorkItemCount,
-            int MaxWorkItemCount)
+            int MaxWorkItemCount,
+            string AppName,
+            string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Verbose))
             {
@@ -132,38 +149,85 @@ namespace DurableTask.Core.Logging
                     WorkItemId,
                     LatencyMs,
                     WorkItemCount,
-                    MaxWorkItemCount);
+                    MaxWorkItemCount,
+                    AppName,
+                    ExtensionVersion);
             }
         }
 
         [Event(EventIds.FetchWorkItemFailure, Level = EventLevel.Error, Version = 1)]
-        internal void FetchWorkItemFailure(string Dispatcher, string Details)
+        internal void FetchWorkItemFailure(string Dispatcher, string Details, string AppName, string ExtensionVersion)
         {
-            this.WriteEvent(EventIds.FetchWorkItemFailure, Dispatcher, Details);
+            this.WriteEvent(
+                EventIds.FetchWorkItemFailure,
+                Dispatcher,
+                Details,
+                AppName,
+                ExtensionVersion);
         }
 
         [Event(EventIds.FetchingThrottled, Level = EventLevel.Informational, Version = 1)]
-        internal void FetchingThrottled(string Dispatcher, int WorkItemCount, int MaxWorkItemCount)
+        internal void FetchingThrottled(
+            string Dispatcher,
+            int WorkItemCount,
+            int MaxWorkItemCount,
+            string AppName,
+            string ExtensionVersion)
         {
-            this.WriteEvent(EventIds.FetchingThrottled, Dispatcher, WorkItemCount, MaxWorkItemCount);
+            this.WriteEvent(
+                EventIds.FetchingThrottled,
+                Dispatcher,
+                WorkItemCount,
+                MaxWorkItemCount,
+                AppName,
+                ExtensionVersion);
         }
 
         [Event(EventIds.ProcessWorkItemStarting, Level = EventLevel.Verbose, Version = 1)]
-        internal void ProcessWorkItemStarting(string Dispatcher, string WorkItemId)
+        internal void ProcessWorkItemStarting(
+            string Dispatcher,
+            string WorkItemId,
+            string AppName,
+            string ExtensionVersion)
         {
-            this.WriteEvent(EventIds.ProcessWorkItemStarting, Dispatcher, WorkItemId);
+            this.WriteEvent(
+                EventIds.ProcessWorkItemStarting,
+                Dispatcher,
+                WorkItemId,
+                AppName,
+                ExtensionVersion);
         }
 
         [Event(EventIds.ProcessWorkItemCompleted, Level = EventLevel.Verbose, Version = 1)]
-        internal void ProcessWorkItemCompleted(string Dispatcher, string WorkItemId)
+        internal void ProcessWorkItemCompleted(
+            string Dispatcher,
+            string WorkItemId,
+            string AppName,
+            string ExtensionVersion)
         {
-            this.WriteEvent(EventIds.ProcessWorkItemCompleted, Dispatcher, WorkItemId);
+            this.WriteEvent(
+                EventIds.ProcessWorkItemCompleted,
+                Dispatcher,
+                WorkItemId,
+                AppName,
+                ExtensionVersion);
         }
 
         [Event(EventIds.ProcessWorkItemFailed, Level = EventLevel.Error, Version = 1)]
-        public void ProcessWorkItemFailed(string Dispatcher, string WorkItemId, string Details)
+        public void ProcessWorkItemFailed(
+            string Dispatcher,
+            string WorkItemId,
+            string Details,
+            string AppName,
+            string ExtensionVersion)
         {
-            this.WriteEvent(EventIds.ProcessWorkItemFailed, Dispatcher, WorkItemId, Details);
+            this.WriteEvent(
+                EventIds.ProcessWorkItemFailed,
+                Dispatcher,
+                WorkItemId,
+                Details,
+                AppName,
+                ExtensionVersion);
         }
 
         [Event(EventIds.SchedulingOrchestration, Level = EventLevel.Informational, Version = 1)]
@@ -174,7 +238,9 @@ namespace DurableTask.Core.Logging
             string TargetExecutionId,
             string Name,
             int TaskEventId,
-            int SizeInBytes)
+            int SizeInBytes,
+            string AppName,
+            string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Informational))
             {
@@ -187,7 +253,9 @@ namespace DurableTask.Core.Logging
                     TargetExecutionId,
                     Name,
                     TaskEventId,
-                    SizeInBytes);
+                    SizeInBytes,
+                    AppName,
+                    ExtensionVersion);
             }
         }
 
@@ -198,7 +266,9 @@ namespace DurableTask.Core.Logging
             string TargetInstanceId,
             string Name,
             int TaskEventId,
-            int SizeInBytes)
+            int SizeInBytes,
+            string AppName,
+            string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Informational))
             {
@@ -210,49 +280,74 @@ namespace DurableTask.Core.Logging
                     TargetInstanceId,
                     Name,
                     TaskEventId,
-                    SizeInBytes);
+                    SizeInBytes,
+                    AppName,
+                    ExtensionVersion);
             }
         }
 
         [Event(EventIds.TerminatingInstance, Level = EventLevel.Informational, Version = 1)]
-        internal void TerminatingInstance(string InstanceId, string ExecutionId, string Details)
+        internal void TerminatingInstance(
+            string InstanceId,
+            string ExecutionId,
+            string Details,
+            string AppName,
+            string ExtensionVersion)
         {
             this.WriteEvent(
                 EventIds.TerminatingInstance,
                 InstanceId,
                 ExecutionId ?? string.Empty,
-                Details ?? string.Empty);
+                Details ?? string.Empty,
+                AppName,
+                ExtensionVersion);
         }
 
         [Event(EventIds.WaitingForInstance, Level = EventLevel.Informational, Version = 1)]
         internal void WaitingForInstance(
             string InstanceId,
             string ExecutionId,
-            int TimeoutSeconds)
+            int TimeoutSeconds,
+            string AppName,
+            string ExtensionVersion)
         {
             this.WriteEvent(
                 EventIds.WaitingForInstance,
                 InstanceId,
                 ExecutionId ?? string.Empty,
-                TimeoutSeconds);
+                TimeoutSeconds,
+                AppName,
+                ExtensionVersion);
         }
 
         [Event(EventIds.FetchingInstanceState, Level = EventLevel.Informational, Version = 1)]
-        internal void FetchingInstanceState(string InstanceId, string ExecutionId)
+        internal void FetchingInstanceState(
+            string InstanceId,
+            string ExecutionId,
+            string AppName,
+            string ExtensionVersion)
         {
             this.WriteEvent(
                 EventIds.FetchingInstanceState,
                 InstanceId,
-                ExecutionId ?? string.Empty);
+                ExecutionId ?? string.Empty,
+                AppName,
+                ExtensionVersion);
         }
 
         [Event(EventIds.FetchingInstanceHistory, Level = EventLevel.Informational, Version = 1)]
-        internal void FetchingInstanceHistory(string InstanceId, string ExecutionId)
+        internal void FetchingInstanceHistory(
+            string InstanceId,
+            string ExecutionId,
+            string AppName,
+            string ExtensionVersion)
         {
             this.WriteEvent(
                 EventIds.FetchingInstanceHistory,
                 InstanceId,
-                ExecutionId ?? string.Empty);
+                ExecutionId ?? string.Empty,
+                AppName,
+                ExtensionVersion);
         }
 
         [Event(EventIds.ProcessingOrchestrationMessage, Level = EventLevel.Verbose, Version = 1)]
@@ -260,7 +355,9 @@ namespace DurableTask.Core.Logging
             string InstanceId,
             string ExecutionId,
             string EventType,
-            int TaskEventId)
+            int TaskEventId,
+            string AppName,
+            string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Verbose))
             {
@@ -270,7 +367,9 @@ namespace DurableTask.Core.Logging
                     InstanceId,
                     ExecutionId ?? string.Empty,
                     EventType,
-                    TaskEventId);
+                    TaskEventId,
+                    AppName,
+                    ExtensionVersion);
             }
         }
 
@@ -278,13 +377,20 @@ namespace DurableTask.Core.Logging
         internal void OrchestrationExecuting(
             string InstanceId,
             string ExecutionId,
-            string Name)
+            string Name,
+            string AppName,
+            string ExtensionVersion)
         {
-            this.WriteEvent(
-                EventIds.OrchestrationExecuting,
-                InstanceId,
-                ExecutionId,
-                Name);
+            if (this.IsEnabled(EventLevel.Informational))
+            {
+                this.WriteEvent(
+                    EventIds.OrchestrationExecuting,
+                    InstanceId,
+                    ExecutionId,
+                    Name,
+                    AppName,
+                    ExtensionVersion);
+            }
         }
 
         [Event(EventIds.OrchestrationExecuted, Level = EventLevel.Informational, Version = 1)]
@@ -292,7 +398,9 @@ namespace DurableTask.Core.Logging
             string InstanceId,
             string ExecutionId,
             string Name,
-            int ActionCount)
+            int ActionCount,
+            string AppName,
+            string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Informational))
             {
@@ -302,7 +410,9 @@ namespace DurableTask.Core.Logging
                     InstanceId,
                     ExecutionId,
                     Name,
-                    ActionCount);
+                    ActionCount,
+                    AppName,
+                    ExtensionVersion);
             }
         }
 
@@ -312,7 +422,9 @@ namespace DurableTask.Core.Logging
             string ExecutionId,
             string Name,
             int TaskEventId,
-            int SizeInBytes)
+            int SizeInBytes,
+            string AppName,
+            string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Informational))
             {
@@ -323,7 +435,9 @@ namespace DurableTask.Core.Logging
                     ExecutionId,
                     Name,
                     TaskEventId,
-                    SizeInBytes);
+                    SizeInBytes,
+                    AppName,
+                    ExtensionVersion);
             }
         }
 
@@ -333,7 +447,9 @@ namespace DurableTask.Core.Logging
             string ExecutionId,
             DateTime FireAt,
             int TaskEventId,
-            bool IsInternal)
+            bool IsInternal,
+            string AppName,
+            string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Informational))
             {
@@ -344,7 +460,9 @@ namespace DurableTask.Core.Logging
                     ExecutionId,
                     FireAt,
                     TaskEventId,
-                    IsInternal);
+                    IsInternal,
+                    AppName,
+                    ExtensionVersion);
             }
         }
 
@@ -354,7 +472,9 @@ namespace DurableTask.Core.Logging
             string ExecutionId,
             string RuntimeStatus,
             string Details,
-            int SizeInBytes)
+            int SizeInBytes,
+            string AppName,
+            string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Informational))
             {
@@ -365,7 +485,9 @@ namespace DurableTask.Core.Logging
                     ExecutionId,
                     RuntimeStatus,
                     Details,
-                    SizeInBytes);
+                    SizeInBytes,
+                    AppName,
+                    ExtensionVersion);
             }
         }
 
@@ -373,7 +495,9 @@ namespace DurableTask.Core.Logging
         internal void OrchestrationAborted(
             string InstanceId,
             string ExecutionId,
-            string Details)
+            string Details,
+            string AppName,
+            string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Warning))
             {
@@ -381,7 +505,9 @@ namespace DurableTask.Core.Logging
                     EventIds.OrchestrationAborted,
                     InstanceId,
                     ExecutionId,
-                    Details);
+                    Details,
+                    AppName,
+                    ExtensionVersion);
             }
         }
 
@@ -391,7 +517,9 @@ namespace DurableTask.Core.Logging
             string ExecutionId,
             string EventType,
             int TaskEventId,
-            string Details)
+            string Details,
+            string AppName,
+            string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Warning))
             {
@@ -402,7 +530,9 @@ namespace DurableTask.Core.Logging
                     ExecutionId ?? string.Empty,
                     EventType,
                     TaskEventId,
-                    Details);
+                    Details,
+                    AppName,
+                    ExtensionVersion);
             }
         }
 
@@ -411,7 +541,9 @@ namespace DurableTask.Core.Logging
             string InstanceId,
             string ExecutionId,
             string Name,
-            int TaskEventId)
+            int TaskEventId,
+            string AppName,
+            string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Informational))
             {
@@ -421,7 +553,9 @@ namespace DurableTask.Core.Logging
                     InstanceId,
                     ExecutionId,
                     Name,
-                    TaskEventId);
+                    TaskEventId,
+                    AppName,
+                    ExtensionVersion);
             }
         }
 
@@ -431,7 +565,9 @@ namespace DurableTask.Core.Logging
             string ExecutionId,
             string Name,
             int TaskEventId,
-            int SizeInBytes)
+            int SizeInBytes,
+            string AppName,
+            string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Informational))
             {
@@ -442,7 +578,9 @@ namespace DurableTask.Core.Logging
                     ExecutionId,
                     Name,
                     TaskEventId,
-                    SizeInBytes);
+                    SizeInBytes,
+                    AppName,
+                    ExtensionVersion);
             }
         }
 
@@ -452,7 +590,9 @@ namespace DurableTask.Core.Logging
             string ExecutionId,
             string Name,
             int TaskEventId,
-            string Details)
+            string Details,
+            string AppName,
+            string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Warning))
             {
@@ -463,7 +603,9 @@ namespace DurableTask.Core.Logging
                     ExecutionId,
                     Name,
                     TaskEventId,
-                    Details);
+                    Details,
+                    AppName,
+                    ExtensionVersion);
             }
         }
 
@@ -473,7 +615,9 @@ namespace DurableTask.Core.Logging
             string ExecutionId,
             string Name,
             int TaskEventId,
-            string Details)
+            string Details,
+            string AppName,
+            string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Warning))
             {
@@ -484,7 +628,9 @@ namespace DurableTask.Core.Logging
                     ExecutionId,
                     Name,
                     TaskEventId,
-                    Details);
+                    Details,
+                    AppName,
+                    ExtensionVersion);
             }
         }
 
@@ -492,7 +638,9 @@ namespace DurableTask.Core.Logging
         internal void TaskActivityDispatcherError(
             string InstanceId,
             string ExecutionId,
-            string Details)
+            string Details,
+            string AppName,
+            string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Error))
             {
@@ -500,7 +648,9 @@ namespace DurableTask.Core.Logging
                     EventIds.TaskActivityDispatcherError,
                     InstanceId,
                     ExecutionId,
-                    Details);
+                    Details,
+                    AppName,
+                    ExtensionVersion);
             }
         }
 
@@ -509,7 +659,9 @@ namespace DurableTask.Core.Logging
             string InstanceId,
             string ExecutionId,
             string Name,
-            int TaskEventId)
+            int TaskEventId,
+            string AppName,
+            string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Verbose))
             {
@@ -519,7 +671,9 @@ namespace DurableTask.Core.Logging
                     InstanceId,
                     ExecutionId,
                     Name,
-                    TaskEventId);
+                    TaskEventId,
+                    AppName,
+                    ExtensionVersion);
             }
         }
 
@@ -529,7 +683,9 @@ namespace DurableTask.Core.Logging
             string ExecutionId,
             string Name,
             int TaskEventId,
-            DateTime NextRenewal)
+            DateTime NextRenewal,
+            string AppName,
+            string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Verbose))
             {
@@ -540,7 +696,9 @@ namespace DurableTask.Core.Logging
                     ExecutionId,
                     Name,
                     TaskEventId,
-                    NextRenewal);
+                    NextRenewal,
+                    AppName,
+                    ExtensionVersion);
             }
         }
 
@@ -550,7 +708,9 @@ namespace DurableTask.Core.Logging
             string ExecutionId,
             string Name,
             int TaskEventId,
-            string Details)
+            string Details,
+            string AppName,
+            string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Error))
             {
@@ -560,7 +720,9 @@ namespace DurableTask.Core.Logging
                     ExecutionId,
                     Name,
                     TaskEventId,
-                    Details);
+                    Details,
+                    AppName,
+                    ExtensionVersion);
             }
         }
     }

--- a/src/DurableTask.Core/Logging/StructuredEventSource.cs
+++ b/src/DurableTask.Core/Logging/StructuredEventSource.cs
@@ -18,6 +18,9 @@ namespace DurableTask.Core.Logging
     using System.Threading;
 
     // NOTE: This is intended to eventually replace the other DurableTask-Core provider
+    /// <summary>
+    /// Event source logger for DurableTask.Core that uses structured events rather than log messages.
+    /// </summary>
     [EventSource(Name = "DurableTask-Core")]
     class StructuredEventSource : EventSource
     {

--- a/src/DurableTask.Core/Logging/StructuredEventSource.cs
+++ b/src/DurableTask.Core/Logging/StructuredEventSource.cs
@@ -87,8 +87,8 @@ namespace DurableTask.Core.Logging
             this.WriteEvent(EventIds.DispatchersStopping, Dispatcher, WorkItemCount, ActiveFetcherCount);
         }
 
-        [Event(EventIds.FetchingWorkItem, Level = EventLevel.Verbose, Version = 1)]
-        internal void FetchingWorkItem(
+        [Event(EventIds.FetchWorkItemStarting, Level = EventLevel.Verbose, Version = 1)]
+        internal void FetchWorkItemStarting(
             string Dispatcher,
             int TimeoutSeconds,
             int WorkItemCount,
@@ -104,7 +104,7 @@ namespace DurableTask.Core.Logging
             {
                 // CONSIDER: Use WriteEventCore for better performance
                 this.WriteEvent(
-                    EventIds.FetchingWorkItem,
+                    EventIds.FetchWorkItemStarting,
                     Dispatcher,
                     TimeoutSeconds,
                     WorkItemCount,
@@ -112,8 +112,8 @@ namespace DurableTask.Core.Logging
             }
         }
 
-        [Event(EventIds.FetchedWorkItem, Level = EventLevel.Verbose, Version = 1)]
-        internal void FetchedWorkItem(
+        [Event(EventIds.FetchWorkItemCompleted, Level = EventLevel.Verbose, Version = 1)]
+        internal void FetchWorkItemCompleted(
             string Dispatcher,
             string WorkItemId,
             long LatencyMs,
@@ -124,7 +124,7 @@ namespace DurableTask.Core.Logging
             {
                 // CONSIDER: Use WriteEventCore for better performance
                 this.WriteEvent(
-                    EventIds.FetchedWorkItem,
+                    EventIds.FetchWorkItemCompleted,
                     Dispatcher,
                     WorkItemId,
                     LatencyMs,
@@ -349,7 +349,7 @@ namespace DurableTask.Core.Logging
         internal void OrchestrationCompleted(
             string InstanceId,
             string ExecutionId,
-            string Status,
+            string RuntimeStatus,
             string Details,
             int SizeInBytes)
         {
@@ -360,7 +360,7 @@ namespace DurableTask.Core.Logging
                     EventIds.OrchestrationCompleted,
                     InstanceId,
                     ExecutionId,
-                    Status,
+                    RuntimeStatus,
                     Details,
                     SizeInBytes);
             }

--- a/src/DurableTask.Core/Logging/StructuredEventSource.cs
+++ b/src/DurableTask.Core/Logging/StructuredEventSource.cs
@@ -34,7 +34,7 @@ namespace DurableTask.Core.Logging
         }
 
         [NonEvent]
-        static void EnsureLogicalTraceActivityId()
+        internal static void EnsureLogicalTraceActivityId()
         {
             Guid currentActivityId = ActivityIdState.Value;
             if (currentActivityId != CurrentThreadActivityId)
@@ -48,49 +48,42 @@ namespace DurableTask.Core.Logging
         [Event(EventIds.TaskHubWorkerStarting, Level = EventLevel.Informational, Version = 1)]
         public void TaskHubWorkerStarting()
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(EventIds.TaskHubWorkerStarting);
         }
 
         [Event(EventIds.TaskHubWorkerStarted, Level = EventLevel.Informational, Version = 1)]
         public void TaskHubWorkerStarted(long LatencyMs)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(EventIds.TaskHubWorkerStarted, LatencyMs);
         }
 
         [Event(EventIds.TaskHubWorkerStopping, Level = EventLevel.Informational, Version = 1)]
         public void TaskHubWorkerStopping(bool IsForced)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(EventIds.TaskHubWorkerStopping, IsForced);
         }
 
         [Event(EventIds.TaskHubWorkerStopped, Level = EventLevel.Informational, Version = 1)]
         public void TaskHubWorkerStopped(long LatencyMs)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(EventIds.TaskHubWorkerStopped, LatencyMs);
         }
 
         [Event(EventIds.DispatcherStarting, Level = EventLevel.Verbose, Version = 1)]
         public void DispatcherStarting(string Dispatcher)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(EventIds.DispatcherStarting, Dispatcher);
         }
 
         [Event(EventIds.DispatcherStopped, Level = EventLevel.Verbose, Version = 1)]
         public void DispatcherStopped(string Dispatcher)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(EventIds.DispatcherStopped, Dispatcher);
         }
 
         [Event(EventIds.DispatchersStopping, Level = EventLevel.Verbose, Version = 1)]
         public void DispatchersStopping(string Dispatcher, int WorkItemCount, int ActiveFetcherCount)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(EventIds.DispatchersStopping, Dispatcher, WorkItemCount, ActiveFetcherCount);
         }
 
@@ -101,8 +94,9 @@ namespace DurableTask.Core.Logging
             int WorkItemCount,
             int MaxWorkItemCount)
         {
-            if (this.IsEnabled() && ActivityIdState.Value == Guid.Empty)
+            if (this.IsEnabled())
             {
+                // Fetching a work item is always the start of a new operation
                 SetLogicalTraceActivityId(Guid.NewGuid());
             }
 
@@ -128,7 +122,6 @@ namespace DurableTask.Core.Logging
         {
             if (this.IsEnabled(EventLevel.Verbose))
             {
-                EnsureLogicalTraceActivityId();
                 // CONSIDER: Use WriteEventCore for better performance
                 this.WriteEvent(
                     EventIds.FetchedWorkItem,
@@ -143,35 +136,30 @@ namespace DurableTask.Core.Logging
         [Event(EventIds.FetchWorkItemFailure, Level = EventLevel.Error, Version = 1)]
         internal void FetchWorkItemFailure(string Dispatcher, string Details)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(EventIds.FetchWorkItemFailure, Dispatcher, Details);
         }
 
         [Event(EventIds.FetchingThrottled, Level = EventLevel.Informational, Version = 1)]
         internal void FetchingThrottled(string Dispatcher, int WorkItemCount, int MaxWorkItemCount)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(EventIds.FetchingThrottled, Dispatcher, WorkItemCount, MaxWorkItemCount);
         }
 
         [Event(EventIds.ProcessWorkItemStarting, Level = EventLevel.Verbose, Version = 1)]
         internal void ProcessWorkItemStarting(string Dispatcher, string WorkItemId)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(EventIds.ProcessWorkItemStarting, Dispatcher, WorkItemId);
         }
 
         [Event(EventIds.ProcessWorkItemCompleted, Level = EventLevel.Verbose, Version = 1)]
         internal void ProcessWorkItemCompleted(string Dispatcher, string WorkItemId)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(EventIds.ProcessWorkItemCompleted, Dispatcher, WorkItemId);
         }
 
         [Event(EventIds.ProcessWorkItemFailed, Level = EventLevel.Error, Version = 1)]
         public void ProcessWorkItemFailed(string Dispatcher, string WorkItemId, string Details)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(EventIds.ProcessWorkItemFailed, Dispatcher, WorkItemId, Details);
         }
 
@@ -187,7 +175,6 @@ namespace DurableTask.Core.Logging
         {
             if (this.IsEnabled(EventLevel.Informational))
             {
-                EnsureLogicalTraceActivityId();
                 // TODO: Use WriteEventCore for better performance
                 this.WriteEvent(
                     EventIds.SchedulingOrchestration,
@@ -212,7 +199,6 @@ namespace DurableTask.Core.Logging
         {
             if (this.IsEnabled(EventLevel.Informational))
             {
-                EnsureLogicalTraceActivityId();
                 // TODO: Use WriteEventCore for better performance
                 this.WriteEvent(
                     EventIds.RaisingEvent,
@@ -228,7 +214,6 @@ namespace DurableTask.Core.Logging
         [Event(EventIds.TerminatingInstance, Level = EventLevel.Informational, Version = 1)]
         internal void TerminatingInstance(string InstanceId, string ExecutionId, string Details)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 EventIds.TerminatingInstance,
                 InstanceId,
@@ -242,7 +227,6 @@ namespace DurableTask.Core.Logging
             string ExecutionId,
             int TimeoutSeconds)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 EventIds.WaitingForInstance,
                 InstanceId,
@@ -253,7 +237,6 @@ namespace DurableTask.Core.Logging
         [Event(EventIds.FetchingInstanceState, Level = EventLevel.Informational, Version = 1)]
         internal void FetchingInstanceState(string InstanceId, string ExecutionId)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 EventIds.FetchingInstanceState,
                 InstanceId,
@@ -263,7 +246,6 @@ namespace DurableTask.Core.Logging
         [Event(EventIds.FetchingInstanceHistory, Level = EventLevel.Informational, Version = 1)]
         internal void FetchingInstanceHistory(string InstanceId, string ExecutionId)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 EventIds.FetchingInstanceHistory,
                 InstanceId,
@@ -279,7 +261,6 @@ namespace DurableTask.Core.Logging
         {
             if (this.IsEnabled(EventLevel.Verbose))
             {
-                EnsureLogicalTraceActivityId();
                 // TODO: Use WriteEventCore for better performance
                 this.WriteEvent(
                     EventIds.ProcessingOrchestrationMessage,
@@ -296,7 +277,6 @@ namespace DurableTask.Core.Logging
             string ExecutionId,
             string Name)
         {
-            EnsureLogicalTraceActivityId();
             this.WriteEvent(
                 EventIds.OrchestrationExecuting,
                 InstanceId,
@@ -313,7 +293,6 @@ namespace DurableTask.Core.Logging
         {
             if (this.IsEnabled(EventLevel.Informational))
             {
-                EnsureLogicalTraceActivityId();
                 // TODO: Use WriteEventCore for better performance
                 this.WriteEvent(
                     EventIds.OrchestrationExecuted,
@@ -334,7 +313,6 @@ namespace DurableTask.Core.Logging
         {
             if (this.IsEnabled(EventLevel.Informational))
             {
-                EnsureLogicalTraceActivityId();
                 // TODO: Use WriteEventCore for better performance
                 this.WriteEvent(
                     EventIds.SchedulingActivity,
@@ -356,7 +334,6 @@ namespace DurableTask.Core.Logging
         {
             if (this.IsEnabled(EventLevel.Informational))
             {
-                EnsureLogicalTraceActivityId();
                 // TODO: Use WriteEventCore for better performance
                 this.WriteEvent(
                     EventIds.CreatingTimer,
@@ -378,7 +355,6 @@ namespace DurableTask.Core.Logging
         {
             if (this.IsEnabled(EventLevel.Informational))
             {
-                EnsureLogicalTraceActivityId();
                 // TODO: Use WriteEventCore for better performance
                 this.WriteEvent(
                     EventIds.OrchestrationCompleted,
@@ -398,7 +374,6 @@ namespace DurableTask.Core.Logging
         {
             if (this.IsEnabled(EventLevel.Warning))
             {
-                EnsureLogicalTraceActivityId();
                 this.WriteEvent(
                     EventIds.OrchestrationAborted,
                     InstanceId,
@@ -417,7 +392,6 @@ namespace DurableTask.Core.Logging
         {
             if (this.IsEnabled(EventLevel.Warning))
             {
-                EnsureLogicalTraceActivityId();
                 // TODO: Use WriteEventCore for better performance
                 this.WriteEvent(
                     EventIds.DiscardingMessage,
@@ -438,7 +412,6 @@ namespace DurableTask.Core.Logging
         {
             if (this.IsEnabled(EventLevel.Informational))
             {
-                EnsureLogicalTraceActivityId();
                 // TODO: Use WriteEventCore for better performance
                 this.WriteEvent(
                     EventIds.TaskActivityStarting,
@@ -459,7 +432,6 @@ namespace DurableTask.Core.Logging
         {
             if (this.IsEnabled(EventLevel.Informational))
             {
-                EnsureLogicalTraceActivityId();
                 // TODO: Use WriteEventCore for better performance
                 this.WriteEvent(
                     EventIds.TaskActivityCompleted,
@@ -481,7 +453,6 @@ namespace DurableTask.Core.Logging
         {
             if (this.IsEnabled(EventLevel.Warning))
             {
-                EnsureLogicalTraceActivityId();
                 // TODO: Use WriteEventCore for better performance
                 this.WriteEvent(
                     EventIds.TaskActivityFailure,
@@ -503,7 +474,6 @@ namespace DurableTask.Core.Logging
         {
             if (this.IsEnabled(EventLevel.Warning))
             {
-                EnsureLogicalTraceActivityId();
                 // TODO: Use WriteEventCore for better performance
                 this.WriteEvent(
                     EventIds.TaskActivityAborted,
@@ -523,7 +493,6 @@ namespace DurableTask.Core.Logging
         {
             if (this.IsEnabled(EventLevel.Error))
             {
-                EnsureLogicalTraceActivityId();
                 this.WriteEvent(
                     EventIds.TaskActivityDispatcherError,
                     InstanceId,
@@ -541,7 +510,6 @@ namespace DurableTask.Core.Logging
         {
             if (this.IsEnabled(EventLevel.Verbose))
             {
-                EnsureLogicalTraceActivityId();
                 // TODO: Use WriteEventCore for better performance
                 this.WriteEvent(
                     EventIds.RenewActivityMessageStarting,
@@ -562,7 +530,6 @@ namespace DurableTask.Core.Logging
         {
             if (this.IsEnabled(EventLevel.Verbose))
             {
-                EnsureLogicalTraceActivityId();
                 // TODO: Use WriteEventCore for better performance
                 this.WriteEvent(
                     EventIds.RenewActivityMessageCompleted,
@@ -584,7 +551,6 @@ namespace DurableTask.Core.Logging
         {
             if (this.IsEnabled(EventLevel.Error))
             {
-                EnsureLogicalTraceActivityId();
                 this.WriteEvent(
                     EventIds.RenewActivityMessageFailed,
                     InstanceId,

--- a/src/DurableTask.Core/Logging/StructuredEventSource.cs
+++ b/src/DurableTask.Core/Logging/StructuredEventSource.cs
@@ -1,0 +1,598 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core.Logging
+{
+    using System;
+    using System.Diagnostics.Tracing;
+    using System.Threading;
+
+    // NOTE: This is intended to eventually replace the other DurableTask-Core provider
+    [EventSource(Name = "DurableTask-Core")]
+    class StructuredEventSource : EventSource
+    {
+        public static readonly StructuredEventSource Log = new StructuredEventSource();
+
+        static readonly AsyncLocal<Guid> ActivityIdState = new AsyncLocal<Guid>();
+
+        [NonEvent]
+        public static void SetLogicalTraceActivityId(Guid activityId)
+        {
+            // We use AsyncLocal to preserve activity IDs across async/await boundaries.
+            ActivityIdState.Value = activityId;
+            SetCurrentThreadActivityId(activityId);
+        }
+
+        [NonEvent]
+        static void EnsureLogicalTraceActivityId()
+        {
+            Guid currentActivityId = ActivityIdState.Value;
+            if (currentActivityId != CurrentThreadActivityId)
+            {
+                SetCurrentThreadActivityId(currentActivityId);
+            }
+        }
+
+        bool IsEnabled(EventLevel level) => this.IsEnabled(level, EventKeywords.None);
+
+        [Event(EventIds.TaskHubWorkerStarting, Level = EventLevel.Informational, Version = 1)]
+        public void TaskHubWorkerStarting()
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(EventIds.TaskHubWorkerStarting);
+        }
+
+        [Event(EventIds.TaskHubWorkerStarted, Level = EventLevel.Informational, Version = 1)]
+        public void TaskHubWorkerStarted(long LatencyMs)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(EventIds.TaskHubWorkerStarted, LatencyMs);
+        }
+
+        [Event(EventIds.TaskHubWorkerStopping, Level = EventLevel.Informational, Version = 1)]
+        public void TaskHubWorkerStopping(bool IsForced)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(EventIds.TaskHubWorkerStopping, IsForced);
+        }
+
+        [Event(EventIds.TaskHubWorkerStopped, Level = EventLevel.Informational, Version = 1)]
+        public void TaskHubWorkerStopped(long LatencyMs)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(EventIds.TaskHubWorkerStopped, LatencyMs);
+        }
+
+        [Event(EventIds.DispatcherStarting, Level = EventLevel.Verbose, Version = 1)]
+        public void DispatcherStarting(string Dispatcher)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(EventIds.DispatcherStarting, Dispatcher);
+        }
+
+        [Event(EventIds.DispatcherStopped, Level = EventLevel.Verbose, Version = 1)]
+        public void DispatcherStopped(string Dispatcher)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(EventIds.DispatcherStopped, Dispatcher);
+        }
+
+        [Event(EventIds.DispatchersStopping, Level = EventLevel.Verbose, Version = 1)]
+        public void DispatchersStopping(string Dispatcher, int WorkItemCount, int ActiveFetcherCount)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(EventIds.DispatchersStopping, Dispatcher, WorkItemCount, ActiveFetcherCount);
+        }
+
+        [Event(EventIds.FetchingWorkItem, Level = EventLevel.Verbose, Version = 1)]
+        internal void FetchingWorkItem(
+            string Dispatcher,
+            int TimeoutSeconds,
+            int WorkItemCount,
+            int MaxWorkItemCount)
+        {
+            if (this.IsEnabled() && ActivityIdState.Value == Guid.Empty)
+            {
+                SetLogicalTraceActivityId(Guid.NewGuid());
+            }
+
+            if (this.IsEnabled(EventLevel.Verbose))
+            {
+                // CONSIDER: Use WriteEventCore for better performance
+                this.WriteEvent(
+                    EventIds.FetchingWorkItem,
+                    Dispatcher,
+                    TimeoutSeconds,
+                    WorkItemCount,
+                    MaxWorkItemCount);
+            }
+        }
+
+        [Event(EventIds.FetchedWorkItem, Level = EventLevel.Verbose, Version = 1)]
+        internal void FetchedWorkItem(
+            string Dispatcher,
+            string WorkItemId,
+            long LatencyMs,
+            int WorkItemCount,
+            int MaxWorkItemCount)
+        {
+            if (this.IsEnabled(EventLevel.Verbose))
+            {
+                EnsureLogicalTraceActivityId();
+                // CONSIDER: Use WriteEventCore for better performance
+                this.WriteEvent(
+                    EventIds.FetchedWorkItem,
+                    Dispatcher,
+                    WorkItemId,
+                    LatencyMs,
+                    WorkItemCount,
+                    MaxWorkItemCount);
+            }
+        }
+
+        [Event(EventIds.FetchWorkItemFailure, Level = EventLevel.Error, Version = 1)]
+        internal void FetchWorkItemFailure(string Dispatcher, string Details)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(EventIds.FetchWorkItemFailure, Dispatcher, Details);
+        }
+
+        [Event(EventIds.FetchingThrottled, Level = EventLevel.Informational, Version = 1)]
+        internal void FetchingThrottled(string Dispatcher, int WorkItemCount, int MaxWorkItemCount)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(EventIds.FetchingThrottled, Dispatcher, WorkItemCount, MaxWorkItemCount);
+        }
+
+        [Event(EventIds.ProcessWorkItemStarting, Level = EventLevel.Verbose, Version = 1)]
+        internal void ProcessWorkItemStarting(string Dispatcher, string WorkItemId)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(EventIds.ProcessWorkItemStarting, Dispatcher, WorkItemId);
+        }
+
+        [Event(EventIds.ProcessWorkItemCompleted, Level = EventLevel.Verbose, Version = 1)]
+        internal void ProcessWorkItemCompleted(string Dispatcher, string WorkItemId)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(EventIds.ProcessWorkItemCompleted, Dispatcher, WorkItemId);
+        }
+
+        [Event(EventIds.ProcessWorkItemFailed, Level = EventLevel.Error, Version = 1)]
+        public void ProcessWorkItemFailed(string Dispatcher, string WorkItemId, string Details)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(EventIds.ProcessWorkItemFailed, Dispatcher, WorkItemId, Details);
+        }
+
+        [Event(EventIds.SchedulingOrchestration, Level = EventLevel.Informational, Version = 1)]
+        internal void SchedulingOrchestration(
+            string InstanceId,
+            string ExecutionId,
+            string TargetInstanceId,
+            string TargetExecutionId,
+            string Name,
+            int TaskEventId,
+            int SizeInBytes)
+        {
+            if (this.IsEnabled(EventLevel.Informational))
+            {
+                EnsureLogicalTraceActivityId();
+                // TODO: Use WriteEventCore for better performance
+                this.WriteEvent(
+                    EventIds.SchedulingOrchestration,
+                    InstanceId,
+                    ExecutionId,
+                    TargetInstanceId,
+                    TargetExecutionId,
+                    Name,
+                    TaskEventId,
+                    SizeInBytes);
+            }
+        }
+
+        [Event(EventIds.RaisingEvent, Level = EventLevel.Informational, Version = 1)]
+        internal void RaisingEvent(
+            string InstanceId,
+            string ExecutionId,
+            string TargetInstanceId,
+            string Name,
+            int TaskEventId,
+            int SizeInBytes)
+        {
+            if (this.IsEnabled(EventLevel.Informational))
+            {
+                EnsureLogicalTraceActivityId();
+                // TODO: Use WriteEventCore for better performance
+                this.WriteEvent(
+                    EventIds.RaisingEvent,
+                    InstanceId ?? string.Empty,
+                    ExecutionId ?? string.Empty,
+                    TargetInstanceId,
+                    Name,
+                    TaskEventId,
+                    SizeInBytes);
+            }
+        }
+
+        [Event(EventIds.TerminatingInstance, Level = EventLevel.Informational, Version = 1)]
+        internal void TerminatingInstance(string InstanceId, string ExecutionId, string Details)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(
+                EventIds.TerminatingInstance,
+                InstanceId,
+                ExecutionId ?? string.Empty,
+                Details ?? string.Empty);
+        }
+
+        [Event(EventIds.WaitingForInstance, Level = EventLevel.Informational, Version = 1)]
+        internal void WaitingForInstance(
+            string InstanceId,
+            string ExecutionId,
+            int TimeoutSeconds)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(
+                EventIds.WaitingForInstance,
+                InstanceId,
+                ExecutionId ?? string.Empty,
+                TimeoutSeconds);
+        }
+
+        [Event(EventIds.FetchingInstanceState, Level = EventLevel.Informational, Version = 1)]
+        internal void FetchingInstanceState(string InstanceId, string ExecutionId)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(
+                EventIds.FetchingInstanceState,
+                InstanceId,
+                ExecutionId ?? string.Empty);
+        }
+
+        [Event(EventIds.FetchingInstanceHistory, Level = EventLevel.Informational, Version = 1)]
+        internal void FetchingInstanceHistory(string InstanceId, string ExecutionId)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(
+                EventIds.FetchingInstanceHistory,
+                InstanceId,
+                ExecutionId ?? string.Empty);
+        }
+
+        [Event(EventIds.ProcessingOrchestrationMessage, Level = EventLevel.Verbose, Version = 1)]
+        internal void ProcessingOrchestrationMessage(
+            string InstanceId,
+            string ExecutionId,
+            string EventType,
+            int TaskEventId)
+        {
+            if (this.IsEnabled(EventLevel.Verbose))
+            {
+                EnsureLogicalTraceActivityId();
+                // TODO: Use WriteEventCore for better performance
+                this.WriteEvent(
+                    EventIds.ProcessingOrchestrationMessage,
+                    InstanceId,
+                    ExecutionId ?? string.Empty,
+                    EventType,
+                    TaskEventId);
+            }
+        }
+
+        [Event(EventIds.OrchestrationExecuting, Level = EventLevel.Informational, Version = 1)]
+        internal void OrchestrationExecuting(
+            string InstanceId,
+            string ExecutionId,
+            string Name)
+        {
+            EnsureLogicalTraceActivityId();
+            this.WriteEvent(
+                EventIds.OrchestrationExecuting,
+                InstanceId,
+                ExecutionId,
+                Name);
+        }
+
+        [Event(EventIds.OrchestrationExecuted, Level = EventLevel.Informational, Version = 1)]
+        internal void OrchestrationExecuted(
+            string InstanceId,
+            string ExecutionId,
+            string Name,
+            int ActionCount)
+        {
+            if (this.IsEnabled(EventLevel.Informational))
+            {
+                EnsureLogicalTraceActivityId();
+                // TODO: Use WriteEventCore for better performance
+                this.WriteEvent(
+                    EventIds.OrchestrationExecuted,
+                    InstanceId,
+                    ExecutionId,
+                    Name,
+                    ActionCount);
+            }
+        }
+
+        [Event(EventIds.SchedulingActivity, Level = EventLevel.Informational, Version = 1)]
+        internal void SchedulingActivity(
+            string InstanceId,
+            string ExecutionId,
+            string Name,
+            int TaskEventId,
+            int SizeInBytes)
+        {
+            if (this.IsEnabled(EventLevel.Informational))
+            {
+                EnsureLogicalTraceActivityId();
+                // TODO: Use WriteEventCore for better performance
+                this.WriteEvent(
+                    EventIds.SchedulingActivity,
+                    InstanceId,
+                    ExecutionId,
+                    Name,
+                    TaskEventId,
+                    SizeInBytes);
+            }
+        }
+
+        [Event(EventIds.CreatingTimer, Level = EventLevel.Informational, Version = 1)]
+        internal void CreatingTimer(
+            string InstanceId,
+            string ExecutionId,
+            DateTime FireAt,
+            int TaskEventId,
+            bool IsInternal)
+        {
+            if (this.IsEnabled(EventLevel.Informational))
+            {
+                EnsureLogicalTraceActivityId();
+                // TODO: Use WriteEventCore for better performance
+                this.WriteEvent(
+                    EventIds.CreatingTimer,
+                    InstanceId,
+                    ExecutionId,
+                    FireAt,
+                    TaskEventId,
+                    IsInternal);
+            }
+        }
+
+        [Event(EventIds.OrchestrationCompleted, Level = EventLevel.Informational, Version = 1)]
+        internal void OrchestrationCompleted(
+            string InstanceId,
+            string ExecutionId,
+            string Status,
+            string Details,
+            int SizeInBytes)
+        {
+            if (this.IsEnabled(EventLevel.Informational))
+            {
+                EnsureLogicalTraceActivityId();
+                // TODO: Use WriteEventCore for better performance
+                this.WriteEvent(
+                    EventIds.OrchestrationCompleted,
+                    InstanceId,
+                    ExecutionId,
+                    Status,
+                    Details,
+                    SizeInBytes);
+            }
+        }
+
+        [Event(EventIds.OrchestrationAborted, Level = EventLevel.Warning, Version = 1)]
+        internal void OrchestrationAborted(
+            string InstanceId,
+            string ExecutionId,
+            string Details)
+        {
+            if (this.IsEnabled(EventLevel.Warning))
+            {
+                EnsureLogicalTraceActivityId();
+                this.WriteEvent(
+                    EventIds.OrchestrationAborted,
+                    InstanceId,
+                    ExecutionId,
+                    Details);
+            }
+        }
+
+        [Event(EventIds.DiscardingMessage, Level = EventLevel.Warning, Version = 1)]
+        internal void DiscardingMessage(
+            string InstanceId,
+            string ExecutionId,
+            string EventType,
+            int TaskEventId,
+            string Details)
+        {
+            if (this.IsEnabled(EventLevel.Warning))
+            {
+                EnsureLogicalTraceActivityId();
+                // TODO: Use WriteEventCore for better performance
+                this.WriteEvent(
+                    EventIds.DiscardingMessage,
+                    InstanceId,
+                    ExecutionId ?? string.Empty,
+                    EventType,
+                    TaskEventId,
+                    Details);
+            }
+        }
+
+        [Event(EventIds.TaskActivityStarting, Level = EventLevel.Informational, Version = 1)]
+        internal void TaskActivityStarting(
+            string InstanceId,
+            string ExecutionId,
+            string Name,
+            int TaskEventId)
+        {
+            if (this.IsEnabled(EventLevel.Informational))
+            {
+                EnsureLogicalTraceActivityId();
+                // TODO: Use WriteEventCore for better performance
+                this.WriteEvent(
+                    EventIds.TaskActivityStarting,
+                    InstanceId,
+                    ExecutionId,
+                    Name,
+                    TaskEventId);
+            }
+        }
+
+        [Event(EventIds.TaskActivityCompleted, Level = EventLevel.Informational, Version = 1)]
+        internal void TaskActivityCompleted(
+            string InstanceId,
+            string ExecutionId,
+            string Name,
+            int TaskEventId,
+            int SizeInBytes)
+        {
+            if (this.IsEnabled(EventLevel.Informational))
+            {
+                EnsureLogicalTraceActivityId();
+                // TODO: Use WriteEventCore for better performance
+                this.WriteEvent(
+                    EventIds.TaskActivityCompleted,
+                    InstanceId,
+                    ExecutionId,
+                    Name,
+                    TaskEventId,
+                    SizeInBytes);
+            }
+        }
+
+        [Event(EventIds.TaskActivityFailure, Level = EventLevel.Warning, Version = 1)]
+        internal void TaskActivityFailure(
+            string InstanceId,
+            string ExecutionId,
+            string Name,
+            int TaskEventId,
+            string Details)
+        {
+            if (this.IsEnabled(EventLevel.Warning))
+            {
+                EnsureLogicalTraceActivityId();
+                // TODO: Use WriteEventCore for better performance
+                this.WriteEvent(
+                    EventIds.TaskActivityFailure,
+                    InstanceId,
+                    ExecutionId,
+                    Name,
+                    TaskEventId,
+                    Details);
+            }
+        }
+
+        [Event(EventIds.TaskActivityAborted, Level = EventLevel.Warning, Version = 1)]
+        internal void TaskActivityAborted(
+            string InstanceId,
+            string ExecutionId,
+            string Name,
+            int TaskEventId,
+            string Details)
+        {
+            if (this.IsEnabled(EventLevel.Warning))
+            {
+                EnsureLogicalTraceActivityId();
+                // TODO: Use WriteEventCore for better performance
+                this.WriteEvent(
+                    EventIds.TaskActivityAborted,
+                    InstanceId,
+                    ExecutionId,
+                    Name,
+                    TaskEventId,
+                    Details);
+            }
+        }
+
+        [Event(EventIds.TaskActivityDispatcherError, Level = EventLevel.Error, Version = 1)]
+        internal void TaskActivityDispatcherError(
+            string InstanceId,
+            string ExecutionId,
+            string Details)
+        {
+            if (this.IsEnabled(EventLevel.Error))
+            {
+                EnsureLogicalTraceActivityId();
+                this.WriteEvent(
+                    EventIds.TaskActivityDispatcherError,
+                    InstanceId,
+                    ExecutionId,
+                    Details);
+            }
+        }
+
+        [Event(EventIds.RenewActivityMessageStarting, Level = EventLevel.Verbose, Version = 1)]
+        internal void RenewActivityMessageStarting(
+            string InstanceId,
+            string ExecutionId,
+            string Name,
+            int TaskEventId)
+        {
+            if (this.IsEnabled(EventLevel.Verbose))
+            {
+                EnsureLogicalTraceActivityId();
+                // TODO: Use WriteEventCore for better performance
+                this.WriteEvent(
+                    EventIds.RenewActivityMessageStarting,
+                    InstanceId,
+                    ExecutionId,
+                    Name,
+                    TaskEventId);
+            }
+        }
+
+        [Event(EventIds.RenewActivityMessageCompleted, Level = EventLevel.Verbose, Version = 1)]
+        internal void RenewActivityMessageCompleted(
+            string InstanceId,
+            string ExecutionId,
+            string Name,
+            int TaskEventId,
+            DateTime NextRenewal)
+        {
+            if (this.IsEnabled(EventLevel.Verbose))
+            {
+                EnsureLogicalTraceActivityId();
+                // TODO: Use WriteEventCore for better performance
+                this.WriteEvent(
+                    EventIds.RenewActivityMessageCompleted,
+                    InstanceId,
+                    ExecutionId,
+                    Name,
+                    TaskEventId,
+                    NextRenewal);
+            }
+        }
+
+        [Event(EventIds.RenewActivityMessageFailed, Level = EventLevel.Error, Version = 1)]
+        internal void RenewActivityMessageFailed(
+            string InstanceId,
+            string ExecutionId,
+            string Name,
+            int TaskEventId,
+            string Details)
+        {
+            if (this.IsEnabled(EventLevel.Error))
+            {
+                EnsureLogicalTraceActivityId();
+                this.WriteEvent(
+                    EventIds.RenewActivityMessageFailed,
+                    InstanceId,
+                    ExecutionId,
+                    Name,
+                    TaskEventId,
+                    Details);
+            }
+        }
+    }
+}

--- a/src/DurableTask.Core/Logging/StructuredLogEvent.cs
+++ b/src/DurableTask.Core/Logging/StructuredLogEvent.cs
@@ -28,6 +28,8 @@ namespace DurableTask.Core.Logging
     /// </summary>
     public abstract class StructuredLogEvent : ILogEvent, IReadOnlyDictionary<string, object>
     {
+        // We reflect over all the properties just once and reuse the cached property set for subsequent log
+        // statements to minimize the overhead of using reflection.
         static readonly ConcurrentDictionary<Type, ConcurrentDictionary<string, PropertyInfo>> SharedPropertiesCache =
             new ConcurrentDictionary<Type, ConcurrentDictionary<string, PropertyInfo>>();
 
@@ -97,6 +99,24 @@ namespace DurableTask.Core.Logging
 
                 return properties;
             });
+        }
+
+        /// <summary>
+        /// Gets a log-friendly description of a history event.
+        /// </summary>
+        /// <param name="eventType">The type of history event in string-form.</param>
+        /// <param name="taskEventId">The task event ID.</param>
+        /// <returns>Returns <paramref name="eventType"/> and appends <paramref name="taskEventId"/> in parenthesis if it is a non-negative number - e.g. "TaskActivityScheduled(1)".</returns>
+        protected static string GetHistoryEventDescription(string eventType, int taskEventId)
+        {
+            if (taskEventId >= 0)
+            {
+                return eventType + "(" + taskEventId + ")";
+            }
+            else
+            {
+                return eventType;
+            }
         }
     }
 }

--- a/src/DurableTask.Core/Logging/StructuredLogEvent.cs
+++ b/src/DurableTask.Core/Logging/StructuredLogEvent.cs
@@ -1,0 +1,102 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core.Logging
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    /// Abstract base class for all structured log events. This base class implements
+    /// <see cref="IReadOnlyDictionary{String, Object}"/>using reflection to make it easy
+    /// to support structured log events for providers like Application Insights.
+    /// </summary>
+    public abstract class StructuredLogEvent : ILogEvent, IReadOnlyDictionary<string, object>
+    {
+        static readonly ConcurrentDictionary<Type, ConcurrentDictionary<string, PropertyInfo>> SharedPropertiesCache =
+            new ConcurrentDictionary<Type, ConcurrentDictionary<string, PropertyInfo>>();
+
+        ConcurrentDictionary<string, PropertyInfo> Properties => GetProperties(this.GetType());
+
+        /// <inheritdoc />
+        public abstract EventId EventId { get; }
+
+        /// <inheritdoc />
+        public abstract LogLevel Level { get; }
+
+        /// <inheritdoc />
+        public abstract string GetLogMessage();
+
+        IEnumerable<string> IReadOnlyDictionary<string, object>.Keys => this.Properties.Keys;
+
+        IEnumerable<object> IReadOnlyDictionary<string, object>.Values => this.Properties.Values.Select(p => p.GetValue(this));
+
+        int IReadOnlyCollection<KeyValuePair<string, object>>.Count => this.Properties.Count;
+
+        object IReadOnlyDictionary<string, object>.this[string key] => this.Properties[key].GetValue(this);
+
+        bool IReadOnlyDictionary<string, object>.ContainsKey(string key) => this.Properties.ContainsKey(key);
+
+        bool IReadOnlyDictionary<string, object>.TryGetValue(string key, out object value)
+        {
+            if (this.Properties.TryGetValue(key, out PropertyInfo getter))
+            {
+                value = getter.GetValue(this);
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        IEnumerator<KeyValuePair<string, object>> IEnumerable<KeyValuePair<string, object>>.GetEnumerator()
+        {
+            return this.Properties.Select(pair => new KeyValuePair<string, object>(pair.Key, pair.Value.GetValue(this))).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable<KeyValuePair<string, object>>)this).GetEnumerator();
+        }
+
+        static ConcurrentDictionary<string, PropertyInfo> GetProperties(Type type)
+        {
+            return SharedPropertiesCache.GetOrAdd(type, t =>
+            {
+                var properties = new ConcurrentDictionary<string, PropertyInfo>();
+
+                foreach (PropertyInfo property in t.GetProperties())
+                {
+                    StructuredLogFieldAttribute fieldAttribute = property.GetCustomAttribute<StructuredLogFieldAttribute>();
+                    if (fieldAttribute != null)
+                    {
+                        if (!property.CanRead)
+                        {
+                            throw new InvalidOperationException($"Properties with {nameof(StructuredLogFieldAttribute)} must have a getter.");
+                        }
+
+                        string propertyName = fieldAttribute.Name ?? property.Name;
+                        properties.TryAdd(propertyName, property);
+                    }
+                }
+
+                return properties;
+            });
+        }
+    }
+}

--- a/src/DurableTask.Core/Logging/StructuredLogFieldAttribute.cs
+++ b/src/DurableTask.Core/Logging/StructuredLogFieldAttribute.cs
@@ -1,0 +1,38 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core.Logging
+{
+    using System;
+
+    /// <summary>
+    /// Attribute used to indicate that a <see cref="ILogEvent"/> field should be serialized to the structured log provider.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class StructuredLogFieldAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StructuredLogFieldAttribute"/> class.
+        /// </summary>
+        /// <param name="name">The name of the log entry field. If not specified, the name of the property is used.</param>
+        public StructuredLogFieldAttribute(string name = null)
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
+        /// Gets the name of the log entry field. If not specified, the name of the property is used.
+        /// </summary>
+        public string Name { get; }
+    }
+}

--- a/src/DurableTask.Core/OrchestrationInstance.cs
+++ b/src/DurableTask.Core/OrchestrationInstance.cs
@@ -22,12 +22,6 @@ namespace DurableTask.Core
     [DataContract]
     public class OrchestrationInstance : IExtensibleDataObject
     {
-        internal readonly static OrchestrationInstance Empty = new OrchestrationInstance
-        {
-            InstanceId = string.Empty,
-            ExecutionId = string.Empty,
-        };
-
         /// <summary>
         /// The instance id, assigned as unique to the orchestration
         /// </summary>

--- a/src/DurableTask.Core/OrchestrationInstance.cs
+++ b/src/DurableTask.Core/OrchestrationInstance.cs
@@ -22,6 +22,12 @@ namespace DurableTask.Core
     [DataContract]
     public class OrchestrationInstance : IExtensibleDataObject
     {
+        internal readonly static OrchestrationInstance Empty = new OrchestrationInstance
+        {
+            InstanceId = string.Empty,
+            ExecutionId = string.Empty,
+        };
+
         /// <summary>
         /// The instance id, assigned as unique to the orchestration
         /// </summary>
@@ -52,7 +58,7 @@ namespace DurableTask.Core
         [SuppressMessage("ReSharper", "NonReadonlyMemberInGetHashCode")]
         public override int GetHashCode()
         {
-            return (InstanceId ?? string.Empty).GetHashCode() ^ (ExecutionId ?? string.Empty).GetHashCode();
+            return (this.InstanceId ?? string.Empty).GetHashCode() ^ (this.ExecutionId ?? string.Empty).GetHashCode();
         }
 
         /// <summary>
@@ -63,7 +69,7 @@ namespace DurableTask.Core
         /// </returns>
         public override string ToString()
         {
-            return $"[InstanceId: {InstanceId}, ExecutionId: {ExecutionId}]";
+            return $"[InstanceId: {this.InstanceId}, ExecutionId: {this.ExecutionId}]";
         }
 
         /// <summary>

--- a/src/DurableTask.Core/TaskActivityDispatcher.cs
+++ b/src/DurableTask.Core/TaskActivityDispatcher.cs
@@ -20,6 +20,7 @@ namespace DurableTask.Core
     using DurableTask.Core.Common;
     using DurableTask.Core.Exceptions;
     using DurableTask.Core.History;
+    using DurableTask.Core.Logging;
     using DurableTask.Core.Middleware;
     using DurableTask.Core.Tracing;
 
@@ -32,27 +33,31 @@ namespace DurableTask.Core
         readonly WorkItemDispatcher<TaskActivityWorkItem> dispatcher;
         readonly IOrchestrationService orchestrationService;
         readonly DispatchMiddlewarePipeline dispatchPipeline;
+        readonly LogHelper logHelper;
 
         internal TaskActivityDispatcher(
             IOrchestrationService orchestrationService,
             INameVersionObjectManager<TaskActivity> objectManager,
-            DispatchMiddlewarePipeline dispatchPipeline)
+            DispatchMiddlewarePipeline dispatchPipeline,
+            LogHelper logHelper)
         {
             this.orchestrationService = orchestrationService ?? throw new ArgumentNullException(nameof(orchestrationService));
             this.objectManager = objectManager ?? throw new ArgumentNullException(nameof(objectManager));
             this.dispatchPipeline = dispatchPipeline ?? throw new ArgumentNullException(nameof(dispatchPipeline));
+            this.logHelper = logHelper;
 
             this.dispatcher = new WorkItemDispatcher<TaskActivityWorkItem>(
                 "TaskActivityDispatcher",
                 item => item.Id,
-                OnFetchWorkItemAsync,
-                OnProcessWorkItemAsync)
+                this.OnFetchWorkItemAsync,
+                this.OnProcessWorkItemAsync)
             {
                 AbortWorkItem = orchestrationService.AbandonTaskActivityWorkItemAsync,
                 GetDelayInSecondsAfterOnFetchException = orchestrationService.GetDelayInSecondsAfterOnFetchException,
                 GetDelayInSecondsAfterOnProcessException = orchestrationService.GetDelayInSecondsAfterOnProcessException,
                 DispatcherCount = orchestrationService.TaskActivityDispatcherCount,
-                MaxConcurrentWorkItems = orchestrationService.MaxConcurrentTaskActivityWorkItems
+                MaxConcurrentWorkItems = orchestrationService.MaxConcurrentTaskActivityWorkItems,
+                LogHelper = logHelper,
             };
         }
 
@@ -95,6 +100,9 @@ namespace DurableTask.Core
             {
                 if (string.IsNullOrWhiteSpace(orchestrationInstance?.InstanceId))
                 {
+                    this.logHelper.TaskActivityDispatcherError(
+                        workItem,
+                        $"The activity worker received a message that does not have any OrchestrationInstance information.");
                     throw TraceHelper.TraceException(
                         TraceEventType.Error,
                         "TaskActivityDispatcher-MissingOrchestrationInstance",
@@ -103,6 +111,9 @@ namespace DurableTask.Core
 
                 if (taskMessage.Event.EventType != EventType.TaskScheduled)
                 {
+                    this.logHelper.TaskActivityDispatcherError(
+                        workItem, 
+                        $"The activity worker received an event of type '{taskMessage.Event.EventType}' but only '{EventType.TaskScheduled}' is supported.");
                     throw TraceHelper.TraceException(
                         TraceEventType.Critical,
                         "TaskActivityDispatcher-UnsupportedEventType",
@@ -112,13 +123,16 @@ namespace DurableTask.Core
 
                 // call and get return message
                 scheduledEvent = (TaskScheduledEvent)taskMessage.Event;
+                this.logHelper.TaskActivityStarting(orchestrationInstance, scheduledEvent);
                 TaskActivity taskActivity = this.objectManager.GetObject(scheduledEvent.Name, scheduledEvent.Version);
                 if (taskActivity == null)
                 {
                     throw new TypeMissingException($"TaskActivity {scheduledEvent.Name} version {scheduledEvent.Version} was not found");
                 }
 
-                renewTask = Task.Factory.StartNew(() => RenewUntil(workItem, renewCancellationTokenSource.Token), renewCancellationTokenSource.Token);
+                renewTask = Task.Factory.StartNew(
+                    () => this.RenewUntil(workItem, renewCancellationTokenSource.Token),
+                    renewCancellationTokenSource.Token);
 
                 // TODO : pass workflow instance data
                 var context = new TaskContext(taskMessage.OrchestrationInstance);
@@ -139,16 +153,23 @@ namespace DurableTask.Core
                     catch (TaskFailureException e)
                     {
                         TraceHelper.TraceExceptionInstance(TraceEventType.Error, "TaskActivityDispatcher-ProcessTaskFailure", taskMessage.OrchestrationInstance, e);
-                        string details = IncludeDetails ? e.Details : null;
+                        string details = this.IncludeDetails ? e.Details : null;
                         eventToRespond = new TaskFailedEvent(-1, scheduledEvent.EventId, e.Message, details);
+                        this.logHelper.TaskActivityFailure(orchestrationInstance, scheduledEvent.Name, (TaskFailedEvent)eventToRespond, e);
                     }
                     catch (Exception e) when (!Utils.IsFatal(e) && !Utils.IsExecutionAborting(e))
                     {
                         TraceHelper.TraceExceptionInstance(TraceEventType.Error, "TaskActivityDispatcher-ProcessException", taskMessage.OrchestrationInstance, e);
-                        string details = IncludeDetails
+                        string details = this.IncludeDetails
                             ? $"Unhandled exception while executing task: {e}\n\t{e.StackTrace}"
                             : null;
                         eventToRespond = new TaskFailedEvent(-1, scheduledEvent.EventId, e.Message, details);
+                        this.logHelper.TaskActivityFailure(orchestrationInstance, scheduledEvent.Name, (TaskFailedEvent)eventToRespond, e);
+                    }
+
+                    if (eventToRespond is TaskCompletedEvent completedEvent)
+                    {
+                        this.logHelper.TaskActivityCompleted(orchestrationInstance, scheduledEvent.Name, completedEvent);
                     }
                 });
 
@@ -163,8 +184,8 @@ namespace DurableTask.Core
             catch (SessionAbortedException e)
             {
                 // The activity aborted its execution
-                string activityName = scheduledEvent?.Name ?? "(unknown)";
-                TraceHelper.TraceInstance(TraceEventType.Warning, "TaskActivityDispatcher-ExecutionAborted", orchestrationInstance, "{0}: {1}", activityName, e.Message);
+                this.logHelper.TaskActivityAborted(orchestrationInstance, scheduledEvent, e.Message);
+                TraceHelper.TraceInstance(TraceEventType.Warning, "TaskActivityDispatcher-ExecutionAborted", orchestrationInstance, "{0}: {1}", scheduledEvent.Name, e.Message);
                 await this.orchestrationService.AbandonTaskActivityWorkItemAsync(workItem);
             }
             finally
@@ -199,7 +220,7 @@ namespace DurableTask.Core
                 // what the message.LockedUntilUtc says. if the sku is negative then in the worst case we will be
                 // renewing every 5 secs
                 //
-                renewAt = AdjustRenewAt(renewAt);
+                renewAt = this.AdjustRenewAt(renewAt);
 
                 while (!cancellationToken.IsCancellationRequested)
                 {
@@ -212,15 +233,18 @@ namespace DurableTask.Core
 
                     try
                     {
+                        this.logHelper.RenewActivityMessageStarting(workItem);
                         TraceHelper.Trace(TraceEventType.Information, "TaskActivityDispatcher-RenewLock", "Renewing lock for work item id {0}", workItem.Id);
                         workItem = await this.orchestrationService.RenewTaskActivityWorkItemLockAsync(workItem);
                         renewAt = workItem.LockedUntilUtc.Subtract(TimeSpan.FromSeconds(30));
-                        renewAt = AdjustRenewAt(renewAt);
+                        renewAt = this.AdjustRenewAt(renewAt);
+                        this.logHelper.RenewActivityMessageCompleted(workItem, renewAt);
                         TraceHelper.Trace(TraceEventType.Information, "TaskActivityDispatcher-RenewLockAt", "Next renew for work item id '{0}' at '{1}'", workItem.Id, renewAt);
                     }
                     catch (Exception exception) when (!Utils.IsFatal(exception))
                     {
                         // might have been completed
+                        this.logHelper.RenewActivityMessageFailed(workItem, exception);
                         TraceHelper.TraceException(TraceEventType.Warning, "TaskActivityDispatcher-RenewLockFailure", exception, "Failed to renew lock for work item {0}", workItem.Id);
                         break;
                     }

--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -19,7 +19,9 @@ namespace DurableTask.Core
     using System.Threading;
     using System.Threading.Tasks;
     using DurableTask.Core.History;
+    using DurableTask.Core.Logging;
     using DurableTask.Core.Serializing;
+    using Microsoft.Extensions.Logging;
 
     /// <summary>
     ///     Client used to manage and query orchestration instances
@@ -27,6 +29,7 @@ namespace DurableTask.Core
     public sealed class TaskHubClient
     {
         readonly DataConverter defaultConverter;
+        readonly LogHelper logHelper;
 
         /// <summary>
         /// The orchestration service client for this task hub client
@@ -38,9 +41,8 @@ namespace DurableTask.Core
         /// </summary>
         /// <param name="serviceClient">Object implementing the <see cref="IOrchestrationServiceClient"/> interface </param>
         public TaskHubClient(IOrchestrationServiceClient serviceClient)
+            : this(serviceClient, new JsonDataConverter())
         {
-            ServiceClient = serviceClient ?? throw new ArgumentNullException(nameof(serviceClient));
-            this.defaultConverter = new JsonDataConverter();
         }
 
         /// <summary>
@@ -49,9 +51,21 @@ namespace DurableTask.Core
         /// <param name="serviceClient">Object implementing the <see cref="IOrchestrationServiceClient"/> interface </param>
         /// <param name="dataConverter">The <see cref="JsonDataConverter"/> to use for message serialization.</param>
         public TaskHubClient(IOrchestrationServiceClient serviceClient, JsonDataConverter dataConverter)
+            : this(serviceClient, dataConverter, null)
         {
-            ServiceClient = serviceClient ?? throw new ArgumentNullException(nameof(serviceClient));
-            this.defaultConverter = dataConverter ?? throw new ArgumentNullException(nameof(dataConverter));
+        }
+
+        /// <summary>
+        ///     Create a new TaskHubClient with the given OrchestrationServiceClient, JsonDataConverter, and ILoggerFactory.
+        /// </summary>
+        /// <param name="serviceClient">Object implementing the <see cref="IOrchestrationServiceClient"/> interface </param>
+        /// <param name="dataConverter">The <see cref="DataConverter"/> to use for message serialization.</param>
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging.</param>
+        public TaskHubClient(IOrchestrationServiceClient serviceClient, DataConverter dataConverter = null, ILoggerFactory loggerFactory = null)
+        {
+            this.ServiceClient = serviceClient ?? throw new ArgumentNullException(nameof(serviceClient));
+            this.defaultConverter = dataConverter ?? new JsonDataConverter();
+            this.logHelper = new LogHelper(loggerFactory?.CreateLogger("DurableTask.Core"));
         }
 
         /// <summary>
@@ -62,7 +76,7 @@ namespace DurableTask.Core
         /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
         public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(Type orchestrationType, object input)
         {
-            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
+            return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 NameVersionHelper.GetDefaultName(orchestrationType),
                 NameVersionHelper.GetDefaultVersion(orchestrationType),
                 null,
@@ -85,7 +99,7 @@ namespace DurableTask.Core
             string instanceId,
             object input)
         {
-            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
+            return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 NameVersionHelper.GetDefaultName(orchestrationType),
                 NameVersionHelper.GetDefaultVersion(orchestrationType),
                 instanceId,
@@ -108,10 +122,9 @@ namespace DurableTask.Core
             Type orchestrationType,
             string instanceId,
             object input,
-            OrchestrationStatus[] dedupeStatuses
-            )
+            OrchestrationStatus[] dedupeStatuses)
         {
-            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
+            return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 NameVersionHelper.GetDefaultName(orchestrationType),
                 NameVersionHelper.GetDefaultVersion(orchestrationType),
                 instanceId,
@@ -131,7 +144,15 @@ namespace DurableTask.Core
         /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
         public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(string name, string version, object input)
         {
-            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(name, version, null, input, null, null, null, null);
+            return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
+                name,
+                version,
+                null,
+                input,
+                null,
+                null,
+                null,
+                null);
         }
 
         /// <summary>
@@ -144,7 +165,15 @@ namespace DurableTask.Core
         /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
         public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(string name, string version, string instanceId, object input)
         {
-            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(name, version, instanceId, input, null, null, null, null);
+            return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
+                name,
+                version,
+                instanceId,
+                input,
+                null,
+                null,
+                null,
+                null);
         }
 
         /// <summary>
@@ -163,7 +192,15 @@ namespace DurableTask.Core
             object input,
             IDictionary<string, string> tags)
         {
-            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(name, version, instanceId, input, tags, null, null, null);
+            return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
+                name,
+                version,
+                instanceId,
+                input,
+                tags,
+                null,
+                null,
+                null);
         }
 
         /// <summary>
@@ -184,7 +221,15 @@ namespace DurableTask.Core
             IDictionary<string, string> tags,
             OrchestrationStatus[] dedupeStatuses)
         {
-            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(name, version, instanceId, input, tags, dedupeStatuses, null, null);
+            return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
+                name,
+                version,
+                instanceId,
+                input,
+                tags,
+                dedupeStatuses,
+                null,
+                null);
         }
 
         /// <summary>
@@ -202,7 +247,7 @@ namespace DurableTask.Core
             string eventName,
             object eventData)
         {
-            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
+            return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 NameVersionHelper.GetDefaultName(orchestrationType),
                 NameVersionHelper.GetDefaultVersion(orchestrationType),
                 null,
@@ -230,7 +275,7 @@ namespace DurableTask.Core
             string eventName,
             object eventData)
         {
-            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
+            return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 NameVersionHelper.GetDefaultName(orchestrationType),
                 NameVersionHelper.GetDefaultVersion(orchestrationType),
                 instanceId,
@@ -260,7 +305,7 @@ namespace DurableTask.Core
             string eventName,
             object eventData)
         {
-            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
+            return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 NameVersionHelper.GetDefaultName(orchestrationType),
                 NameVersionHelper.GetDefaultVersion(orchestrationType),
                 instanceId,
@@ -285,7 +330,7 @@ namespace DurableTask.Core
             string eventName,
             object eventData)
         {
-            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
+            return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 orchestrationName,
                 orchestrationVersion,
                 null,
@@ -311,7 +356,7 @@ namespace DurableTask.Core
             string eventName,
             object eventData)
         {
-            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
+            return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 orchestrationName,
                 orchestrationVersion,
                 null, orchestrationInput,
@@ -340,7 +385,7 @@ namespace DurableTask.Core
             string eventName,
             object eventData)
         {
-            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
+            return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 orchestrationName,
                 orchestrationVersion,
                 instanceId,
@@ -370,7 +415,7 @@ namespace DurableTask.Core
             string eventName,
             object eventData)
         {
-            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
+            return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 orchestrationName,
                 orchestrationVersion,
                 instanceId,
@@ -404,7 +449,7 @@ namespace DurableTask.Core
             string eventName,
             object eventData)
         {
-            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
+            return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 orchestrationName,
                 orchestrationVersion,
                 instanceId,
@@ -431,7 +476,7 @@ namespace DurableTask.Core
             string eventName,
             object eventData)
         {
-            return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
+            return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 orchestrationName,
                 orchestrationVersion,
                 instanceId,
@@ -470,19 +515,17 @@ namespace DurableTask.Core
                 OrchestrationInstance = orchestrationInstance
             };
 
-            var taskMessages = new List<TaskMessage>
+            var startMessage = new TaskMessage
             {
-                new TaskMessage
-                {
-                    OrchestrationInstance = orchestrationInstance,
-                    Event = startedEvent
-                }
+                OrchestrationInstance = orchestrationInstance,
+                Event = startedEvent
             };
 
+            TaskMessage eventMessage = null;
             if (eventData != null)
             {
                 string serializedEventData = this.defaultConverter.Serialize(eventData);
-                taskMessages.Add(new TaskMessage
+                eventMessage = new TaskMessage
                 {
                     OrchestrationInstance = new OrchestrationInstance
                     {
@@ -495,12 +538,20 @@ namespace DurableTask.Core
                         ExecutionId = null
                     },
                     Event = new EventRaisedEvent(-1, serializedEventData) { Name = eventName }
-                });
+                };
             }
 
+            this.logHelper.SchedulingOrchestration(startedEvent);
+
             // Raised events and create orchestration calls use different methods so get handled separately
-            await Task.WhenAll(taskMessages.Where(t => !(t.Event is EventRaisedEvent)).Select(sEvent => ServiceClient.CreateTaskOrchestrationAsync(sEvent, dedupeStatuses)));
-            await ServiceClient.SendTaskOrchestrationMessageBatchAsync(taskMessages.Where(t => (t.Event is EventRaisedEvent)).ToArray());
+            await this.ServiceClient.CreateTaskOrchestrationAsync(startMessage, dedupeStatuses);
+
+            if (eventMessage != null)
+            {
+                this.logHelper.RaisingEvent(orchestrationInstance, (EventRaisedEvent)eventMessage.Event);
+                await this.ServiceClient.SendTaskOrchestrationMessageAsync(eventMessage);
+            }
+
             return orchestrationInstance;
         }
 
@@ -525,7 +576,8 @@ namespace DurableTask.Core
                 Event = new EventRaisedEvent(-1, serializedInput) { Name = eventName }
             };
 
-            await ServiceClient.SendTaskOrchestrationMessageAsync(taskMessage);
+            this.logHelper.RaisingEvent(orchestrationInstance, (EventRaisedEvent)taskMessage.Event);
+            await this.ServiceClient.SendTaskOrchestrationMessageAsync(taskMessage);
         }
 
         /// <summary>
@@ -534,7 +586,7 @@ namespace DurableTask.Core
         /// <param name="orchestrationInstance">Instance to terminate</param>
         public Task TerminateInstanceAsync(OrchestrationInstance orchestrationInstance)
         {
-            return TerminateInstanceAsync(orchestrationInstance, string.Empty);
+            return this.TerminateInstanceAsync(orchestrationInstance, string.Empty);
         }
 
         /// <summary>
@@ -549,7 +601,8 @@ namespace DurableTask.Core
                 throw new ArgumentException("orchestrationInstance");
             }
 
-            await ServiceClient.ForceTerminateTaskOrchestrationAsync(orchestrationInstance.InstanceId, reason);
+            this.logHelper.TerminatingInstance(orchestrationInstance, reason);
+            await this.ServiceClient.ForceTerminateTaskOrchestrationAsync(orchestrationInstance.InstanceId, reason);
         }
 
         /// <summary>
@@ -566,7 +619,8 @@ namespace DurableTask.Core
                 throw new ArgumentException(nameof(orchestrationInstance));
             }
 
-            return ServiceClient.WaitForOrchestrationAsync(
+            this.logHelper.WaitingForInstance(orchestrationInstance, timeout);
+            return this.ServiceClient.WaitForOrchestrationAsync(
                 orchestrationInstance.InstanceId,
                 orchestrationInstance.ExecutionId,
                 timeout,
@@ -589,7 +643,8 @@ namespace DurableTask.Core
                 throw new ArgumentException(nameof(orchestrationInstance));
             }
 
-            return ServiceClient.WaitForOrchestrationAsync(
+            this.logHelper.WaitingForInstance(orchestrationInstance, timeout);
+            return this.ServiceClient.WaitForOrchestrationAsync(
                 orchestrationInstance.InstanceId,
                 orchestrationInstance.ExecutionId,
                 timeout,
@@ -607,7 +662,7 @@ namespace DurableTask.Core
         /// <exception cref="InvalidOperationException">Thrown if instance store not configured</exception>
         public async Task<OrchestrationState> GetOrchestrationStateAsync(string instanceId)
         {
-            IList<OrchestrationState> state = await GetOrchestrationStateAsync(instanceId, false);
+            IList<OrchestrationState> state = await this.GetOrchestrationStateAsync(instanceId, false);
             return state?.FirstOrDefault();
         }
 
@@ -627,7 +682,8 @@ namespace DurableTask.Core
         /// <exception cref="InvalidOperationException">Thrown if instance store not configured</exception>
         public Task<IList<OrchestrationState>> GetOrchestrationStateAsync(string instanceId, bool allExecutions)
         {
-            return ServiceClient.GetOrchestrationStateAsync(instanceId, allExecutions);
+            this.logHelper.FetchingInstanceState(instanceId);
+            return this.ServiceClient.GetOrchestrationStateAsync(instanceId, allExecutions);
         }
 
         /// <summary>
@@ -639,7 +695,7 @@ namespace DurableTask.Core
         /// <exception cref="InvalidOperationException">Thrown if instance store not configured</exception>
         public Task<OrchestrationState> GetOrchestrationStateAsync(OrchestrationInstance instance)
         {
-            return GetOrchestrationStateAsync(instance.InstanceId, instance.ExecutionId);
+            return this.GetOrchestrationStateAsync(instance.InstanceId, instance.ExecutionId);
         }
 
         /// <summary>
@@ -652,7 +708,8 @@ namespace DurableTask.Core
         /// <exception cref="InvalidOperationException">Thrown if instance store not configured</exception>
         public Task<OrchestrationState> GetOrchestrationStateAsync(string instanceId, string executionId)
         {
-            return ServiceClient.GetOrchestrationStateAsync(instanceId, executionId);
+            this.logHelper.FetchingInstanceState(instanceId, executionId);
+            return this.ServiceClient.GetOrchestrationStateAsync(instanceId, executionId);
         }
 
         // Orchestration History
@@ -672,7 +729,8 @@ namespace DurableTask.Core
                 throw new ArgumentException("instance, instanceId and/or ExecutionId cannot be null or empty", nameof(instance));
             }
 
-            return ServiceClient.GetOrchestrationHistoryAsync(instance.InstanceId, instance.ExecutionId);
+            this.logHelper.FetchingInstanceHistory(instance);
+            return this.ServiceClient.GetOrchestrationHistoryAsync(instance.InstanceId, instance.ExecutionId);
         }
 
         /// <summary>
@@ -682,10 +740,11 @@ namespace DurableTask.Core
         /// <param name="timeRangeFilterType">What to compare the threshold date time against</param>
         /// <returns></returns>
         /// <exception cref="InvalidOperationException">Thrown if instance store not configured</exception>
-        public Task PurgeOrchestrationInstanceHistoryAsync(DateTime thresholdDateTimeUtc,
+        public Task PurgeOrchestrationInstanceHistoryAsync(
+            DateTime thresholdDateTimeUtc,
             OrchestrationStateTimeRangeFilterType timeRangeFilterType)
         {
-            return ServiceClient.PurgeOrchestrationHistoryAsync(thresholdDateTimeUtc, timeRangeFilterType);
+            return this.ServiceClient.PurgeOrchestrationHistoryAsync(thresholdDateTimeUtc, timeRangeFilterType);
         }
     }
 }

--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -79,12 +79,12 @@ namespace DurableTask.Core
             return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 NameVersionHelper.GetDefaultName(orchestrationType),
                 NameVersionHelper.GetDefaultVersion(orchestrationType),
-                null,
-                input,
-                null,
-                null,
-                null,
-                null);
+                orchestrationInstanceId: null,
+                orchestrationInput: input,
+                orchestrationTags: null,
+                dedupeStatuses: null,
+                eventName: null,
+                eventData: null);
         }
 
         /// <summary>
@@ -104,10 +104,10 @@ namespace DurableTask.Core
                 NameVersionHelper.GetDefaultVersion(orchestrationType),
                 instanceId,
                 input,
-                null,
-                null,
-                null,
-                null);
+                orchestrationTags: null,
+                dedupeStatuses: null,
+                eventName: null,
+                eventData: null);
         }
 
         /// <summary>
@@ -129,10 +129,10 @@ namespace DurableTask.Core
                 NameVersionHelper.GetDefaultVersion(orchestrationType),
                 instanceId,
                 input,
-                null,
+                orchestrationTags: null,
                 dedupeStatuses,
-                null,
-                null);
+                eventName: null,
+                eventData: null);
         }
 
         /// <summary>
@@ -147,12 +147,12 @@ namespace DurableTask.Core
             return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 name,
                 version,
-                null,
+                orchestrationInstanceId: null,
                 input,
-                null,
-                null,
-                null,
-                null);
+                orchestrationTags: null,
+                dedupeStatuses: null,
+                eventName: null,
+                eventData: null);
         }
 
         /// <summary>
@@ -170,10 +170,10 @@ namespace DurableTask.Core
                 version,
                 instanceId,
                 input,
-                null,
-                null,
-                null,
-                null);
+                orchestrationTags: null,
+                dedupeStatuses: null,
+                eventName: null,
+                eventData: null);
         }
 
         /// <summary>
@@ -198,9 +198,9 @@ namespace DurableTask.Core
                 instanceId,
                 input,
                 tags,
-                null,
-                null,
-                null);
+                dedupeStatuses: null,
+                eventName: null,
+                eventData: null);
         }
 
         /// <summary>
@@ -228,8 +228,8 @@ namespace DurableTask.Core
                 input,
                 tags,
                 dedupeStatuses,
-                null,
-                null);
+                eventName: null,
+                eventData: null);
         }
 
         /// <summary>
@@ -250,10 +250,10 @@ namespace DurableTask.Core
             return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 NameVersionHelper.GetDefaultName(orchestrationType),
                 NameVersionHelper.GetDefaultVersion(orchestrationType),
-                null,
+                orchestrationInstanceId: null,
                 orchestrationInput,
-                null,
-                null,
+                orchestrationTags: null,
+                dedupeStatuses: null,
                 eventName,
                 eventData);
         }
@@ -280,8 +280,8 @@ namespace DurableTask.Core
                 NameVersionHelper.GetDefaultVersion(orchestrationType),
                 instanceId,
                 orchestrationInput,
-                null,
-                null,
+                orchestrationTags: null,
+                dedupeStatuses: null,
                 eventName,
                 eventData);
         }
@@ -310,7 +310,7 @@ namespace DurableTask.Core
                 NameVersionHelper.GetDefaultVersion(orchestrationType),
                 instanceId,
                 orchestrationInput,
-                null,
+                orchestrationTags: null,
                 dedupeStatuses,
                 eventName,
                 eventData);
@@ -333,10 +333,12 @@ namespace DurableTask.Core
             return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 orchestrationName,
                 orchestrationVersion,
-                null,
-                null,
-                null,
-                null, eventName, eventData);
+                orchestrationInstanceId: null,
+                orchestrationInput: null,
+                orchestrationTags: null,
+                dedupeStatuses: null,
+                eventName,
+                eventData);
         }
 
         /// <summary>
@@ -359,9 +361,10 @@ namespace DurableTask.Core
             return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 orchestrationName,
                 orchestrationVersion,
-                null, orchestrationInput,
-                null,
-                null,
+                orchestrationInstanceId: null,
+                orchestrationInput,
+                orchestrationTags: null,
+                dedupeStatuses: null,
                 eventName,
                 eventData);
         }
@@ -389,7 +392,9 @@ namespace DurableTask.Core
                 orchestrationName,
                 orchestrationVersion,
                 instanceId,
-                orchestrationInput, null, null,
+                orchestrationInput,
+                orchestrationTags: null,
+                dedupeStatuses: null,
                 eventName,
                 eventData);
         }
@@ -421,7 +426,7 @@ namespace DurableTask.Core
                 instanceId,
                 orchestrationInput,
                 orchestrationTags,
-                null,
+                dedupeStatuses: null,
                 eventName,
                 eventData);
         }
@@ -480,9 +485,11 @@ namespace DurableTask.Core
                 orchestrationName,
                 orchestrationVersion,
                 instanceId,
-                null,
-                null,
-                null, eventName, eventData);
+                orchestrationInput: null,
+                orchestrationTags: null,
+                dedupeStatuses: null,
+                eventName,
+                eventData);
         }
 
         async Task<OrchestrationInstance> InternalCreateOrchestrationInstanceWithRaisedEventAsync(

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -23,6 +23,7 @@ namespace DurableTask.Core
     using DurableTask.Core.Common;
     using DurableTask.Core.Exceptions;
     using DurableTask.Core.History;
+    using DurableTask.Core.Logging;
     using DurableTask.Core.Middleware;
     using DurableTask.Core.Serializing;
     using DurableTask.Core.Tracing;
@@ -39,29 +40,33 @@ namespace DurableTask.Core
         readonly IOrchestrationService orchestrationService;
         readonly WorkItemDispatcher<TaskOrchestrationWorkItem> dispatcher;
         readonly DispatchMiddlewarePipeline dispatchPipeline;
+        readonly LogHelper logHelper;
         readonly NonBlockingCountdownLock concurrentSessionLock;
 
         internal TaskOrchestrationDispatcher(
             IOrchestrationService orchestrationService,
             INameVersionObjectManager<TaskOrchestration> objectManager,
-            DispatchMiddlewarePipeline dispatchPipeline)
+            DispatchMiddlewarePipeline dispatchPipeline,
+            LogHelper logHelper)
         {
             this.objectManager = objectManager ?? throw new ArgumentNullException(nameof(objectManager));
             this.orchestrationService = orchestrationService ?? throw new ArgumentNullException(nameof(orchestrationService));
             this.dispatchPipeline = dispatchPipeline ?? throw new ArgumentNullException(nameof(dispatchPipeline));
+            this.logHelper = logHelper;
 
             this.dispatcher = new WorkItemDispatcher<TaskOrchestrationWorkItem>(
                 "TaskOrchestrationDispatcher",
                 item => item == null ? string.Empty : item.InstanceId,
-                OnFetchWorkItemAsync,
-                OnProcessWorkItemSessionAsync)
+                this.OnFetchWorkItemAsync,
+                this.OnProcessWorkItemSessionAsync)
             {
                 GetDelayInSecondsAfterOnFetchException = orchestrationService.GetDelayInSecondsAfterOnFetchException,
                 GetDelayInSecondsAfterOnProcessException = orchestrationService.GetDelayInSecondsAfterOnProcessException,
                 SafeReleaseWorkItem = orchestrationService.ReleaseTaskOrchestrationWorkItemAsync,
                 AbortWorkItem = orchestrationService.AbandonTaskOrchestrationWorkItemAsync,
                 DispatcherCount = orchestrationService.TaskOrchestrationDispatcherCount,
-                MaxConcurrentWorkItems = orchestrationService.MaxConcurrentTaskOrchestrationWorkItems
+                MaxConcurrentWorkItems = orchestrationService.MaxConcurrentTaskOrchestrationWorkItems,
+                LogHelper = logHelper,
             };
 
             // To avoid starvation, we only allow half of all concurrently execution orchestrations to
@@ -115,7 +120,7 @@ namespace DurableTask.Core
                 if (workItem.Session == null)
                 {
                     // Legacy behavior
-                    await OnProcessWorkItemAsync(workItem);
+                    await this.OnProcessWorkItemAsync(workItem);
                     return;
                 }
 
@@ -128,7 +133,7 @@ namespace DurableTask.Core
                         // If the provider provided work items, execute them.
                         if (workItem.NewMessages?.Count > 0)
                         {
-                            bool isCompletedOrInterrupted = await OnProcessWorkItemAsync(workItem);
+                            bool isCompletedOrInterrupted = await this.OnProcessWorkItemAsync(workItem);
                             if (isCompletedOrInterrupted)
                             {
                                 break;
@@ -182,6 +187,7 @@ namespace DurableTask.Core
             {
                 // Either the orchestration or the orchestration service explicitly abandoned the session.
                 OrchestrationInstance instance = workItem.OrchestrationRuntimeState?.OrchestrationInstance ?? new OrchestrationInstance { InstanceId = workItem.InstanceId };
+                this.logHelper.OrchestrationAborted(instance, e.Message);
                 TraceHelper.TraceInstance(TraceEventType.Warning, "TaskOrchestrationDispatcher-ExecutionAborted", instance, "{0}", e.Message);
                 await this.orchestrationService.AbandonTaskOrchestrationWorkItemAsync(workItem);
             }
@@ -213,9 +219,10 @@ namespace DurableTask.Core
 
             OrchestrationState instanceState = null;
 
-            if (!ReconcileMessagesWithState(workItem))
+            if (!this.ReconcileMessagesWithState(workItem))
             {
                 // TODO : mark an orchestration as faulted if there is data corruption
+                this.logHelper?.DroppingOrchestrationWorkItem(workItem, "Received result for a deleted orchestration");
                 TraceHelper.TraceSession(
                     TraceEventType.Error,
                     "TaskOrchestrationDispatcher-DeletedOrchestration",
@@ -230,6 +237,7 @@ namespace DurableTask.Core
                     continuedAsNew = false;
                     continuedAsNewMessage = null;
 
+                    this.logHelper?.OrchestrationExecuting(runtimeState.OrchestrationInstance, runtimeState.Name);
                     TraceHelper.TraceInstance(
                         TraceEventType.Verbose,
                         "TaskOrchestrationDispatcher-ExecuteUserOrchestration-Begin",
@@ -239,15 +247,19 @@ namespace DurableTask.Core
 
                     if (workItem.Cursor == null)
                     {
-                        workItem.Cursor = await ExecuteOrchestrationAsync(runtimeState);
+                        workItem.Cursor = await this.ExecuteOrchestrationAsync(runtimeState);
                     }
                     else
                     {
-                        await ResumeOrchestrationAsync(workItem.Cursor);
+                        await this.ResumeOrchestrationAsync(workItem.Cursor);
                     }
 
                     IReadOnlyList<OrchestratorAction> decisions = workItem.Cursor.LatestDecisions.ToList();
 
+                    this.logHelper?.OrchestrationExecuted(
+                        runtimeState.OrchestrationInstance,
+                        runtimeState.Name,
+                        decisions);
                     TraceHelper.TraceInstance(
                         TraceEventType.Information,
                         "TaskOrchestrationDispatcher-ExecuteUserOrchestration-End",
@@ -267,29 +279,37 @@ namespace DurableTask.Core
                         switch (decision.OrchestratorActionType)
                         {
                             case OrchestratorActionType.ScheduleOrchestrator:
-                                messagesToSend.Add(
-                                    ProcessScheduleTaskDecision((ScheduleTaskOrchestratorAction)decision, runtimeState,
-                                        IncludeParameters));
+                                var scheduleTaskAction = (ScheduleTaskOrchestratorAction)decision;
+                                var message = this.ProcessScheduleTaskDecision(
+                                    scheduleTaskAction,
+                                    runtimeState,
+                                    this.IncludeParameters);
+                                messagesToSend.Add(message);
                                 break;
                             case OrchestratorActionType.CreateTimer:
                                 var timerOrchestratorAction = (CreateTimerOrchestratorAction)decision;
-                                timerMessages.Add(ProcessCreateTimerDecision(timerOrchestratorAction, runtimeState));
+                                timerMessages.Add(this.ProcessCreateTimerDecision(
+                                    timerOrchestratorAction,
+                                    runtimeState,
+                                    isInternal: false));
                                 break;
                             case OrchestratorActionType.CreateSubOrchestration:
                                 var createSubOrchestrationAction = (CreateSubOrchestrationAction)decision;
                                 orchestratorMessages.Add(
-                                    ProcessCreateSubOrchestrationInstanceDecision(createSubOrchestrationAction,
-                                        runtimeState, IncludeParameters));
+                                    this.ProcessCreateSubOrchestrationInstanceDecision(
+                                        createSubOrchestrationAction,
+                                        runtimeState,
+                                        this.IncludeParameters));
                                 break;
                             case OrchestratorActionType.SendEvent:
                                 var sendEventAction = (SendEventOrchestratorAction)decision;
                                 orchestratorMessages.Add(
-                                   ProcessSendEventDecision(sendEventAction, runtimeState));
+                                    this.ProcessSendEventDecision(sendEventAction, runtimeState));
                                 break;
                             case OrchestratorActionType.OrchestrationComplete:
                                 OrchestrationCompleteOrchestratorAction completeDecision = (OrchestrationCompleteOrchestratorAction)decision;
                                 TaskMessage workflowInstanceCompletedMessage =
-                                    ProcessWorkflowCompletedTaskDecision(completeDecision, runtimeState, IncludeDetails, out continuedAsNew);
+                                    this.ProcessWorkflowCompletedTaskDecision(completeDecision, runtimeState, this.IncludeDetails, out continuedAsNew);
                                 if (workflowInstanceCompletedMessage != null)
                                 {
                                     // Send complete message to parent workflow or to itself to start a new execution
@@ -318,7 +338,7 @@ namespace DurableTask.Core
                                     TraceEventType.Error,
                                     "TaskOrchestrationDispatcher-UnsupportedDecisionType",
                                     runtimeState.OrchestrationInstance,
-                                    new NotSupportedException("decision type not supported"));
+                                    new NotSupportedException($"Decision type '{decision.OrchestratorActionType}' not supported"));
                         }
 
                         // Underlying orchestration service provider may have a limit of messages per call, to avoid the situation
@@ -350,7 +370,10 @@ namespace DurableTask.Core
                                 FireAt = DateTime.UtcNow
                             };
 
-                            timerMessages.Add(ProcessCreateTimerDecision(dummyTimer, runtimeState));
+                            timerMessages.Add(this.ProcessCreateTimerDecision(
+                                dummyTimer,
+                                runtimeState,
+                                isInternal: true));
                             isInterrupted = true;
                             break;
                         }
@@ -407,12 +430,12 @@ namespace DurableTask.Core
                                 new TaskOrchestrationExecutor(
                                     runtimeState,
                                     newOrchestration,
-                                    orchestrationService.EventBehaviourForContinueAsNew),
+                                    this.orchestrationService.EventBehaviourForContinueAsNew),
                                 latestDecisions: null);
 
                             if (workItem.LockedUntilUtc < DateTime.UtcNow.AddMinutes(1))
                             {
-                                await orchestrationService.RenewTaskOrchestrationWorkItemLockAsync(workItem);
+                                await this.orchestrationService.RenewTaskOrchestrationWorkItemLockAsync(workItem);
                             }
                         }
 
@@ -456,7 +479,7 @@ namespace DurableTask.Core
             dispatchContext.SetProperty(taskOrchestration);
             dispatchContext.SetProperty(runtimeState);
 
-            var executor = new TaskOrchestrationExecutor(runtimeState, taskOrchestration, orchestrationService.EventBehaviourForContinueAsNew);
+            var executor = new TaskOrchestrationExecutor(runtimeState, taskOrchestration, this.orchestrationService.EventBehaviourForContinueAsNew);
 
             IEnumerable<OrchestratorAction> decisions = Enumerable.Empty<OrchestratorAction>();
             await this.dispatchPipeline.RunAsync(dispatchContext, _ =>
@@ -483,7 +506,7 @@ namespace DurableTask.Core
             });
         }
 
-        static bool ReconcileMessagesWithState(TaskOrchestrationWorkItem workItem)
+        bool ReconcileMessagesWithState(TaskOrchestrationWorkItem workItem)
         {
             foreach (TaskMessage message in workItem.NewMessages)
             {
@@ -504,6 +527,7 @@ namespace DurableTask.Core
                     return false;
                 }
 
+                this.logHelper.ProcessingOrchestrationMessage(workItem, message);
                 TraceHelper.TraceInstance(
                     TraceEventType.Information,
                     "TaskOrchestrationDispatcher-ProcessEvent",
@@ -517,6 +541,7 @@ namespace DurableTask.Core
                     if (workItem.OrchestrationRuntimeState.Events.Count > 1)
                     {
                         // this was caused due to a dupe execution started event, swallow this one
+                        this.logHelper.DroppingOrchestrationMessage(workItem, message, "Duplicate start event");
                         TraceHelper.TraceInstance(
                             TraceEventType.Warning,
                             "TaskOrchestrationDispatcher-DuplicateStartEvent",
@@ -533,6 +558,10 @@ namespace DurableTask.Core
                              workItem.OrchestrationRuntimeState.OrchestrationInstance.ExecutionId))
                 {
                     // eat up any events for previous executions
+                    this.logHelper.DroppingOrchestrationMessage(
+                        workItem,
+                        message,
+                        $"ExecutionId of event ({orchestrationInstance.ExecutionId}) does not match current executionId");
                     TraceHelper.TraceInstance(
                         TraceEventType.Warning,
                         "TaskOrchestrationDispatcher-ExecutionIdMismatch",
@@ -549,7 +578,7 @@ namespace DurableTask.Core
             return true;
         }
 
-        static TaskMessage ProcessWorkflowCompletedTaskDecision(
+        TaskMessage ProcessWorkflowCompletedTaskDecision(
             OrchestrationCompleteOrchestratorAction completeOrchestratorAction,
             OrchestrationRuntimeState runtimeState,
             bool includeDetails,
@@ -571,6 +600,7 @@ namespace DurableTask.Core
 
             runtimeState.AddEvent(executionCompletedEvent);
 
+            this.logHelper?.OrchestrationCompleted(runtimeState, completeOrchestratorAction);
             TraceHelper.TraceInstance(
                 runtimeState.OrchestrationStatus == OrchestrationStatus.Failed ? TraceEventType.Warning : TraceEventType.Information,
                 "TaskOrchestrationDispatcher-InstanceCompleted",
@@ -643,7 +673,7 @@ namespace DurableTask.Core
             return null;
         }
 
-        static TaskMessage ProcessScheduleTaskDecision(
+        TaskMessage ProcessScheduleTaskDecision(
             ScheduleTaskOrchestratorAction scheduleTaskOrchestratorAction,
             OrchestrationRuntimeState runtimeState,
             bool includeParameters)
@@ -669,20 +699,27 @@ namespace DurableTask.Core
                 };
             }
 
+            this.logHelper.SchedulingActivity(
+                runtimeState.OrchestrationInstance,
+                scheduledEvent);
+
             runtimeState.AddEvent(scheduledEvent);
             return taskMessage;
         }
 
-        static TaskMessage ProcessCreateTimerDecision(
+        TaskMessage ProcessCreateTimerDecision(
             CreateTimerOrchestratorAction createTimerOrchestratorAction,
-            OrchestrationRuntimeState runtimeState)
+            OrchestrationRuntimeState runtimeState,
+            bool isInternal)
         {
             var taskMessage = new TaskMessage();
 
-            runtimeState.AddEvent(new TimerCreatedEvent(createTimerOrchestratorAction.Id)
+            var timerCreatedEvent = new TimerCreatedEvent(createTimerOrchestratorAction.Id)
             {
                 FireAt = createTimerOrchestratorAction.FireAt
-            });
+            };
+
+            runtimeState.AddEvent(timerCreatedEvent);
 
             taskMessage.Event = new TimerFiredEvent(-1)
             {
@@ -690,12 +727,17 @@ namespace DurableTask.Core
                 FireAt = createTimerOrchestratorAction.FireAt
             };
 
+            this.logHelper.CreatingTimer(
+                runtimeState.OrchestrationInstance,
+                timerCreatedEvent,
+                isInternal);
+
             taskMessage.OrchestrationInstance = runtimeState.OrchestrationInstance;
 
             return taskMessage;
         }
 
-        static TaskMessage ProcessCreateSubOrchestrationInstanceDecision(
+        TaskMessage ProcessCreateSubOrchestrationInstanceDecision(
             CreateSubOrchestrationAction createSubOrchestrationAction,
             OrchestrationRuntimeState runtimeState,
             bool includeParameters)
@@ -734,13 +776,15 @@ namespace DurableTask.Core
                 Version = createSubOrchestrationAction.Version
             };
 
+            this.logHelper.SchedulingOrchestration(startedEvent);
+
             taskMessage.OrchestrationInstance = startedEvent.OrchestrationInstance;
             taskMessage.Event = startedEvent;
 
             return taskMessage;
         }
 
-        static TaskMessage ProcessSendEventDecision(
+        TaskMessage ProcessSendEventDecision(
             SendEventOrchestratorAction sendEventAction,
             OrchestrationRuntimeState runtimeState)
         {
@@ -753,6 +797,8 @@ namespace DurableTask.Core
             
             runtimeState.AddEvent(historyEvent);
 
+            this.logHelper.RaisingEvent(runtimeState.OrchestrationInstance, historyEvent);
+
             return new TaskMessage
             {
                 OrchestrationInstance = sendEventAction.Instance,
@@ -762,7 +808,6 @@ namespace DurableTask.Core
                 }
             };
         }
-
  
         class NonBlockingCountdownLock
         {
@@ -776,7 +821,10 @@ namespace DurableTask.Core
                 }
 
                 this.available = available;
+                this.Capacity = available;
             }
+
+            public int Capacity { get; }
 
             public bool Acquire()
             {

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -52,7 +52,7 @@ namespace DurableTask.Core
             this.objectManager = objectManager ?? throw new ArgumentNullException(nameof(objectManager));
             this.orchestrationService = orchestrationService ?? throw new ArgumentNullException(nameof(orchestrationService));
             this.dispatchPipeline = dispatchPipeline ?? throw new ArgumentNullException(nameof(dispatchPipeline));
-            this.logHelper = logHelper;
+            this.logHelper = logHelper ?? throw new ArgumentNullException(nameof(logHelper));
 
             this.dispatcher = new WorkItemDispatcher<TaskOrchestrationWorkItem>(
                 "TaskOrchestrationDispatcher",
@@ -222,7 +222,7 @@ namespace DurableTask.Core
             if (!this.ReconcileMessagesWithState(workItem))
             {
                 // TODO : mark an orchestration as faulted if there is data corruption
-                this.logHelper?.DroppingOrchestrationWorkItem(workItem, "Received result for a deleted orchestration");
+                this.logHelper.DroppingOrchestrationWorkItem(workItem, "Received result for a deleted orchestration");
                 TraceHelper.TraceSession(
                     TraceEventType.Error,
                     "TaskOrchestrationDispatcher-DeletedOrchestration",
@@ -237,7 +237,7 @@ namespace DurableTask.Core
                     continuedAsNew = false;
                     continuedAsNewMessage = null;
 
-                    this.logHelper?.OrchestrationExecuting(runtimeState.OrchestrationInstance, runtimeState.Name);
+                    this.logHelper.OrchestrationExecuting(runtimeState.OrchestrationInstance, runtimeState.Name);
                     TraceHelper.TraceInstance(
                         TraceEventType.Verbose,
                         "TaskOrchestrationDispatcher-ExecuteUserOrchestration-Begin",
@@ -256,7 +256,7 @@ namespace DurableTask.Core
 
                     IReadOnlyList<OrchestratorAction> decisions = workItem.Cursor.LatestDecisions.ToList();
 
-                    this.logHelper?.OrchestrationExecuted(
+                    this.logHelper.OrchestrationExecuted(
                         runtimeState.OrchestrationInstance,
                         runtimeState.Name,
                         decisions);
@@ -600,7 +600,7 @@ namespace DurableTask.Core
 
             runtimeState.AddEvent(executionCompletedEvent);
 
-            this.logHelper?.OrchestrationCompleted(runtimeState, completeOrchestratorAction);
+            this.logHelper.OrchestrationCompleted(runtimeState, completeOrchestratorAction);
             TraceHelper.TraceInstance(
                 runtimeState.OrchestrationStatus == OrchestrationStatus.Failed ? TraceEventType.Warning : TraceEventType.Information,
                 "TaskOrchestrationDispatcher-InstanceCompleted",

--- a/src/DurableTask.Core/TaskOrchestrationExecutor.cs
+++ b/src/DurableTask.Core/TaskOrchestrationExecutor.cs
@@ -48,13 +48,13 @@ namespace DurableTask.Core
 
         public IEnumerable<OrchestratorAction> Execute()
         {
-            return ExecuteCore(this.orchestrationRuntimeState.Events);
+            return this.ExecuteCore(this.orchestrationRuntimeState.Events);
         }
 
         public IEnumerable<OrchestratorAction> ExecuteNewEvents()
         {
             this.context.ClearPendingActions();
-            return ExecuteCore(this.orchestrationRuntimeState.NewEvents);
+            return this.ExecuteCore(this.orchestrationRuntimeState.NewEvents);
         }
 
         IEnumerable<OrchestratorAction> ExecuteCore(IEnumerable<HistoryEvent> eventHistory)
@@ -79,7 +79,7 @@ namespace DurableTask.Core
                         }
 
                         this.context.IsReplaying = historyEvent.IsPlayed;
-                        ProcessEvent(historyEvent);
+                        this.ProcessEvent(historyEvent);
                         historyEvent.IsPlayed = true;
                     }
 

--- a/src/DurableTask.Core/WorkItemDispatcher.cs
+++ b/src/DurableTask.Core/WorkItemDispatcher.cs
@@ -252,7 +252,7 @@ namespace DurableTask.Core
                 try
                 {
                     Interlocked.Increment(ref this.activeFetchers);
-                    this.LogHelper.FetchingWorkItem(context, DefaultReceiveTimeout, this.concurrentWorkItemCount, this.MaxConcurrentWorkItems);
+                    this.LogHelper.FetchWorkItemStarting(context, DefaultReceiveTimeout, this.concurrentWorkItemCount, this.MaxConcurrentWorkItems);
                     TraceHelper.Trace(
                         TraceEventType.Verbose, 
                         "WorkItemDispatcherDispatch-StartFetch",
@@ -264,7 +264,7 @@ namespace DurableTask.Core
                     if (!IsNull(workItem))
                     {
                         string workItemId = this.workItemIdentifier(workItem);
-                        this.LogHelper.FetchedWorkItem(
+                        this.LogHelper.FetchWorkItemCompleted(
                             context,
                             workItemId,
                             timer.Elapsed,

--- a/src/DurableTask.Core/WorkItemDispatcher.cs
+++ b/src/DurableTask.Core/WorkItemDispatcher.cs
@@ -19,6 +19,7 @@ namespace DurableTask.Core
     using System.Threading.Tasks;
     using DurableTask.Core.Common;
     using DurableTask.Core.Exceptions;
+    using DurableTask.Core.Logging;
     using DurableTask.Core.Tracing;
 
     /// <summary>
@@ -84,6 +85,9 @@ namespace DurableTask.Core
         /// </summary>
         public Func<Exception, int> GetDelayInSecondsAfterOnProcessException = (exception) => 0;
 
+        // The default log helper is a no-op
+        internal LogHelper LogHelper { get; set; } = new LogHelper(null);
+
         /// <summary>
         /// Creates a new Work Item Dispatcher with given name and identifier method
         /// </summary>
@@ -95,14 +99,13 @@ namespace DurableTask.Core
             string name, 
             Func<T, string> workItemIdentifier,
             Func<TimeSpan, CancellationToken, Task<T>> fetchWorkItem,
-            Func<T, Task> processWorkItem
-            )
+            Func<T, Task> processWorkItem)
         {
             this.name = name;
             this.id = Guid.NewGuid().ToString("N");
             this.workItemIdentifier = workItemIdentifier ?? throw new ArgumentNullException(nameof(workItemIdentifier));
-            FetchWorkItem = fetchWorkItem ?? throw new ArgumentNullException(nameof(fetchWorkItem));
-            ProcessWorkItem = processWorkItem ?? throw new ArgumentNullException(nameof(processWorkItem));
+            this.FetchWorkItem = fetchWorkItem ?? throw new ArgumentNullException(nameof(fetchWorkItem));
+            this.ProcessWorkItem = processWorkItem ?? throw new ArgumentNullException(nameof(processWorkItem));
         }
 
         /// <summary>
@@ -122,7 +125,7 @@ namespace DurableTask.Core
                     }
 
                     this.concurrencyLock?.Dispose();
-                    this.concurrencyLock = new SemaphoreSlim(MaxConcurrentWorkItems);
+                    this.concurrencyLock = new SemaphoreSlim(this.MaxConcurrentWorkItems);
 
                     this.shutdownCancellationTokenSource?.Dispose();
                     this.shutdownCancellationTokenSource = new CancellationTokenSource();
@@ -131,12 +134,15 @@ namespace DurableTask.Core
 
                     TraceHelper.Trace(TraceEventType.Information, "WorkItemDispatcherStart", $"WorkItemDispatcher('{this.name}') starting. Id {this.id}.");
 
-                    for (var i = 0; i < DispatcherCount; i++)
+                    for (var i = 0; i < this.DispatcherCount; i++)
                     {
                         string dispatcherId = i.ToString();
+                        var context = new WorkItemDispatcherContext(this.name, this.id, dispatcherId);
+                        this.LogHelper.DispatcherStarting(context);
+
                         // We just want this to Run we intentionally don't wait
                         #pragma warning disable 4014
-                        Task.Run(() => DispatchAsync(dispatcherId));
+                        Task.Run(() => this.DispatchAsync(context));
                         #pragma warning restore 4014
                     }
                 }
@@ -175,6 +181,7 @@ namespace DurableTask.Core
                     var retryCount = 7;
                     while (!this.AllWorkItemsCompleted() && retryCount-- >= 0)
                     {
+                        this.LogHelper.DispatchersStopping(this.name, this.id, this.concurrentWorkItemCount, this.activeFetchers);
                         TraceHelper.Trace(TraceEventType.Information, "WorkItemDispatcherStop-Waiting", $"WorkItemDispatcher('{this.name}') waiting to stop. Id {this.id}. WorkItemCount: {this.concurrentWorkItemCount}, ActiveFetchers: {this.activeFetchers}");
                         await Task.Delay(1000);
                     }
@@ -210,36 +217,65 @@ namespace DurableTask.Core
             return false;
         }
 
-        async Task DispatchAsync(string dispatcherId)
+        async Task DispatchAsync(WorkItemDispatcherContext context)
         {
-            var context = new WorkItemDispatcherContext(this.name, this.id, dispatcherId);
+            string dispatcherId = context.DispatcherId;
 
+            bool logThrottle = true;
             while (this.isStarted)
             {
                 if (!await this.concurrencyLock.WaitAsync(TimeSpan.FromSeconds(5)))
                 {
-                    TraceHelper.Trace(
-                        TraceEventType.Warning,
-                        "WorkItemDispatcherDispatch-MaxOperations",
-                        GetFormattedLog(dispatcherId, $"Max concurrent operations ({this.concurrentWorkItemCount}) are already in progress. Still waiting for next accept."));
+                    if (logThrottle)
+                    {
+                        // This can happen frequently under heavy load.
+                        // To avoid log spam, we log just once until we can proceed.
+                        this.LogHelper.FetchingThrottled(
+                            context,
+                            this.concurrentWorkItemCount,
+                            this.MaxConcurrentWorkItems);
+                        TraceHelper.Trace(
+                            TraceEventType.Warning,
+                            "WorkItemDispatcherDispatch-MaxOperations",
+                            this.GetFormattedLog(dispatcherId, $"Max concurrent operations ({this.concurrentWorkItemCount}) are already in progress. Still waiting for next accept."));
+                        
+                        logThrottle = false;
+                    }
+
                     continue;
                 }
+
+                logThrottle = true;
 
                 var delaySecs = 0;
                 T workItem = default(T);
                 try
                 {
                     Interlocked.Increment(ref this.activeFetchers);
+                    this.LogHelper.FetchingWorkItem(context, DefaultReceiveTimeout, this.concurrentWorkItemCount, this.MaxConcurrentWorkItems);
                     TraceHelper.Trace(
                         TraceEventType.Verbose, 
                         "WorkItemDispatcherDispatch-StartFetch",
-                        GetFormattedLog(dispatcherId, $"Starting fetch with timeout of {DefaultReceiveTimeout} ({this.concurrentWorkItemCount}/{MaxConcurrentWorkItems} max)"));
+                        this.GetFormattedLog(dispatcherId, $"Starting fetch with timeout of {DefaultReceiveTimeout} ({this.concurrentWorkItemCount}/{this.MaxConcurrentWorkItems} max)"));
+
                     Stopwatch timer = Stopwatch.StartNew();
-                    workItem = await FetchWorkItem(DefaultReceiveTimeout, this.shutdownCancellationTokenSource.Token);
+                    workItem = await this.FetchWorkItem(DefaultReceiveTimeout, this.shutdownCancellationTokenSource.Token);
+
+                    if (!IsNull(workItem))
+                    {
+                        string workItemId = this.workItemIdentifier(workItem);
+                        this.LogHelper.FetchedWorkItem(
+                            context,
+                            workItemId,
+                            timer.Elapsed,
+                            this.concurrentWorkItemCount,
+                            this.MaxConcurrentWorkItems);
+                    }
+
                     TraceHelper.Trace(
                         TraceEventType.Verbose, 
                         "WorkItemDispatcherDispatch-EndFetch",
-                        GetFormattedLog(dispatcherId, $"After fetch ({timer.ElapsedMilliseconds} ms) ({this.concurrentWorkItemCount}/{MaxConcurrentWorkItems} max)"));
+                        this.GetFormattedLog(dispatcherId, $"After fetch ({timer.ElapsedMilliseconds} ms) ({this.concurrentWorkItemCount}/{this.MaxConcurrentWorkItems} max)"));
                 }
                 catch (TimeoutException)
                 {
@@ -250,7 +286,7 @@ namespace DurableTask.Core
                     TraceHelper.Trace(
                         TraceEventType.Information,
                         "WorkItemDispatcherDispatch-TaskCanceledException",
-                        GetFormattedLog(dispatcherId, $"TaskCanceledException while fetching workItem, should be harmless: {exception.Message}"));
+                        this.GetFormattedLog(dispatcherId, $"TaskCanceledException while fetching workItem, should be harmless: {exception.Message}"));
                     delaySecs = this.GetDelayInSecondsAfterOnFetchException(exception);
                 }
                 catch (Exception exception)
@@ -260,16 +296,17 @@ namespace DurableTask.Core
                         TraceHelper.Trace(
                             TraceEventType.Information, 
                             "WorkItemDispatcherDispatch-HarmlessException",
-                            GetFormattedLog(dispatcherId, $"Harmless exception while fetching workItem after Stop(): {exception.Message}"));
+                            this.GetFormattedLog(dispatcherId, $"Harmless exception while fetching workItem after Stop(): {exception.Message}"));
                     }
                     else
                     {
+                        this.LogHelper.FetchWorkItemFailure(context, exception);
                         // TODO : dump full node context here
                         TraceHelper.TraceException(
                             TraceEventType.Warning, 
                             "WorkItemDispatcherDispatch-Exception", 
                             exception,
-                            GetFormattedLog(dispatcherId, $"Exception while fetching workItem: {exception.Message}"));
+                            this.GetFormattedLog(dispatcherId, $"Exception while fetching workItem: {exception.Message}"));
                         delaySecs = this.GetDelayInSecondsAfterOnFetchException(exception);
                     }
                 }
@@ -279,7 +316,7 @@ namespace DurableTask.Core
                 }
 
                 var scheduledWorkItem = false;
-                if (!(Equals(workItem, default(T))))
+                if (!IsNull(workItem))
                 {
                     if (!this.isStarted)
                     {
@@ -293,7 +330,7 @@ namespace DurableTask.Core
                         Interlocked.Increment(ref this.concurrentWorkItemCount);
                         // We just want this to Run we intentionally don't wait
                         #pragma warning disable 4014 
-                        Task.Run(() => ProcessWorkItemAsync(context, workItem));
+                        Task.Run(() => this.ProcessWorkItemAsync(context, workItem));
                         #pragma warning restore 4014
 
                         scheduledWorkItem = true;
@@ -311,7 +348,11 @@ namespace DurableTask.Core
                     this.concurrencyLock.Release();
                 }
             }
+
+            this.LogHelper.DispatcherStopped(context);
         }
+
+        static bool IsNull(T value) => Equals(value, default(T));
 
         async Task ProcessWorkItemAsync(WorkItemDispatcherContext context, object workItemObj)
         {
@@ -323,36 +364,43 @@ namespace DurableTask.Core
             {
                 workItemId = this.workItemIdentifier(workItem);
 
+                this.LogHelper.ProcessWorkItemStarting(context, workItemId);
                 TraceHelper.Trace(
                     TraceEventType.Information, 
                     "WorkItemDispatcherProcess-Begin",
-                    GetFormattedLog(context.DispatcherId, $"Starting to process workItem {workItemId}"));
+                    this.GetFormattedLog(context.DispatcherId, $"Starting to process workItem {workItemId}"));
 
-                await ProcessWorkItem(workItem);
+                await this.ProcessWorkItem(workItem);
 
-                AdjustDelayModifierOnSuccess();
+                this.AdjustDelayModifierOnSuccess();
 
+                this.LogHelper.ProcessWorkItemCompleted(context, workItemId);
                 TraceHelper.Trace(
                     TraceEventType.Information, 
                     "WorkItemDispatcherProcess-End",
-                    GetFormattedLog(context.DispatcherId, $"Finished processing workItem {workItemId}"));
+                    this.GetFormattedLog(context.DispatcherId, $"Finished processing workItem {workItemId}"));
 
                 abortWorkItem = false;
             }
             catch (TypeMissingException exception)
             {
+                this.LogHelper.ProcessWorkItemFailed(
+                    context,
+                    workItemId,
+                    $"Backing off for {BackOffIntervalOnInvalidOperationSecs} seconds",
+                    exception);
                 TraceHelper.TraceException(
                     TraceEventType.Error, 
                     "WorkItemDispatcherProcess-TypeMissingException", 
                     exception,
-                    GetFormattedLog(context.DispatcherId, $"Exception while processing workItem {workItemId}"));
+                    this.GetFormattedLog(context.DispatcherId, $"Exception while processing workItem {workItemId}"));
                 TraceHelper.Trace(
                     TraceEventType.Error, 
                     "WorkItemDispatcherProcess-TypeMissingBackingOff",
                     "Backing off after invalid operation by " + BackOffIntervalOnInvalidOperationSecs);
 
                 // every time we hit invalid operation exception we back off the dispatcher
-                AdjustDelayModifierOnFailure(BackOffIntervalOnInvalidOperationSecs);
+                this.AdjustDelayModifierOnFailure(BackOffIntervalOnInvalidOperationSecs);
             }
             catch (Exception exception) when (!Utils.IsFatal(exception))
             {
@@ -360,24 +408,29 @@ namespace DurableTask.Core
                     TraceEventType.Error, 
                     "WorkItemDispatcherProcess-Exception", 
                     exception,
-                    GetFormattedLog(context.DispatcherId, $"Exception while processing workItem {workItemId}"));
+                    this.GetFormattedLog(context.DispatcherId, $"Exception while processing workItem {workItemId}"));
 
                 int delayInSecs = this.GetDelayInSecondsAfterOnProcessException(exception);
                 if (delayInSecs > 0)
                 {
+                    this.LogHelper.ProcessWorkItemFailed(
+                        context,
+                        workItemId,
+                        $"Backing off for {delayInSecs} seconds until {CountDownToZeroDelay} successful operations",
+                        exception);
                     TraceHelper.Trace(
                         TraceEventType.Error, 
                         "WorkItemDispatcherProcess-BackingOff",
                         "Backing off after exception by at least " + delayInSecs + " until " + CountDownToZeroDelay +
                         " successful operations");
 
-                    AdjustDelayModifierOnFailure(delayInSecs);
+                    this.AdjustDelayModifierOnFailure(delayInSecs);
                 }
                 else
                 {
                     // if the derived dispatcher doesn't think this exception worthy of back-off then
                     // count it as a 'successful' operation
-                    AdjustDelayModifierOnSuccess();
+                    this.AdjustDelayModifierOnSuccess();
                 }
             }
             finally
@@ -388,12 +441,20 @@ namespace DurableTask.Core
 
             if (abortWorkItem && this.AbortWorkItem != null)
             {
-                await ExceptionTraceWrapperAsync(() => this.AbortWorkItem(workItem));
+                await this.ExceptionTraceWrapperAsync(
+                    context,
+                    workItemId,
+                    nameof(this.AbortWorkItem),
+                    () => this.AbortWorkItem(workItem));
             }
 
             if (this.SafeReleaseWorkItem != null)
             {
-                await ExceptionTraceWrapperAsync(() => this.SafeReleaseWorkItem(workItem));
+                await this.ExceptionTraceWrapperAsync(
+                    context,
+                    workItemId,
+                    nameof(this.SafeReleaseWorkItem),
+                    () => this.SafeReleaseWorkItem(workItem));
             }
         }
 
@@ -422,7 +483,11 @@ namespace DurableTask.Core
             }
         }
 
-        async Task ExceptionTraceWrapperAsync(Func<Task> asyncAction)
+        async Task ExceptionTraceWrapperAsync(
+            WorkItemDispatcherContext context,
+            string workItemId,
+            string operation,
+            Func<Task> asyncAction)
         {
             try
             {
@@ -431,6 +496,7 @@ namespace DurableTask.Core
             catch (Exception exception) when (!Utils.IsFatal(exception))
             {
                 // eat and move on 
+                this.LogHelper.ProcessWorkItemFailed(context, workItemId, operation, exception);
                 TraceHelper.TraceException(TraceEventType.Error, "WorkItemDispatcher-ExceptionTraceError", exception);
             }
         }
@@ -449,7 +515,7 @@ namespace DurableTask.Core
         /// <inheritdoc />
         public void Dispose()
         {
-            Dispose(true);
+            this.Dispose(true);
             GC.SuppressFinalize(this);
         }
 

--- a/src/DurableTask.Core/WorkItemDispatcherContext.cs
+++ b/src/DurableTask.Core/WorkItemDispatcherContext.cs
@@ -26,24 +26,29 @@ namespace DurableTask.Core
         /// <param name="dispatcherId">The context dispatcher id</param>
         public WorkItemDispatcherContext(string name, string id, string dispatcherId)
         {
-            Name = name;
-            Id = id;
-            DispatcherId = dispatcherId;
+            this.Name = name;
+            this.Id = id;
+            this.DispatcherId = dispatcherId;
         }
 
         /// <summary>
         /// Gets the name from the context
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// Gets the id from the context
         /// </summary>
-        public string Id { get; private set; }
+        public string Id { get; }
 
         /// <summary>
         /// Gets the dispatcher id from the context
         /// </summary>
-        public string DispatcherId { get; private set; }
+        public string DispatcherId { get; }
+
+        internal string GetDisplayName() => $"{this.Name}-{this.Id}-{this.DispatcherId}";
+
+        /// <inheritdoc />
+        public override string ToString() => this.GetDisplayName();
     }
 }

--- a/src/DurableTask.Emulator/DurableTask.Emulator.csproj
+++ b/src/DurableTask.Emulator/DurableTask.Emulator.csproj
@@ -2,11 +2,11 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <PackageId>Microsoft.Azure.DurableTask.Emulator</PackageId>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Newtonsoft.Json" version="7.0.1" />
   </ItemGroup>
   

--- a/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
+++ b/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
@@ -2,11 +2,11 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <PackageId>Microsoft.Azure.DurableTask.ServiceBus</PackageId>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="ImpromptuInterface" version="6.2.2" />
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" version="1.0.0" />
     <PackageReference Include="Microsoft.Data.Edm" version="5.6.4" />

--- a/src/DurableTask.SqlServer/DurableTask.SqlServer.csproj
+++ b/src/DurableTask.SqlServer/DurableTask.SqlServer.csproj
@@ -2,7 +2,7 @@
   
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <FileVersion>1.0.0</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>

--- a/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
+++ b/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" />
     <PackageReference Include="Moq" Version="4.10.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />

--- a/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
+++ b/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
   </PropertyGroup>
 
 
@@ -26,13 +26,17 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.6" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\DurableTask.Core\DurableTask.Core.csproj" />
     <ProjectReference Include="..\..\src\DurableTask.AzureStorage\DurableTask.AzureStorage.csproj" />
     <ProjectReference Include="..\DurableTask.Core.Tests\DurableTask.Core.Tests.csproj" />
     <ProjectReference Include="..\DurableTask.Test.Orchestrations\DurableTask.Test.Orchestrations.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <Reference Include="System.Configuration" />
   </ItemGroup>
 

--- a/test/DurableTask.AzureStorage.Tests/TestHelpers.cs
+++ b/test/DurableTask.AzureStorage.Tests/TestHelpers.cs
@@ -17,6 +17,7 @@ namespace DurableTask.AzureStorage.Tests
     using System.Configuration;
     using System.Diagnostics;
     using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
 
     static class TestHelpers
     {
@@ -34,6 +35,10 @@ namespace DurableTask.AzureStorage.Tests
                 ExtendedSessionsEnabled = enableExtendedSessions,
                 ExtendedSessionIdleTimeout = TimeSpan.FromSeconds(extendedSessionTimeoutInSeconds),
                 FetchLargeMessageDataEnabled = fetchLargeMessages,
+
+                // Setting up a logger factory to enable the new DurableTask.Core logs
+                // TODO: Add a logger provider so we can collect these logs in memory.
+                LoggerFactory = new LoggerFactory(),
             };
 
             return new TestOrchestrationHost(settings);

--- a/test/DurableTask.AzureStorage.Tests/TestOrchestrationHost.cs
+++ b/test/DurableTask.AzureStorage.Tests/TestOrchestrationHost.cs
@@ -37,8 +37,8 @@ namespace DurableTask.AzureStorage.Tests
 
             this.settings = settings;
 
-            this.worker = new TaskHubWorker(service);
-            this.client = new TaskHubClient(service);
+            this.worker = new TaskHubWorker(service, loggerFactory: settings.LoggerFactory);
+            this.client = new TaskHubClient(service, loggerFactory: settings.LoggerFactory);
             this.addedOrchestrationTypes = new HashSet<Type>();
             this.addedActivityTypes = new HashSet<Type>();
         }

--- a/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj
+++ b/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj
@@ -2,10 +2,10 @@
 
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp2.1;net451</TargetFrameworks>
+		<TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
 	</PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer" Version="2.0.1406.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />

--- a/test/DurableTask.Emulator.Tests/DurableTask.Emulator.Tests.csproj
+++ b/test/DurableTask.Emulator.Tests/DurableTask.Emulator.Tests.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/DurableTask.ServiceBus.Tests/DurableTask.ServiceBus.Tests.csproj
+++ b/test/DurableTask.ServiceBus.Tests/DurableTask.ServiceBus.Tests.csproj
@@ -2,10 +2,10 @@
 
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp2.1;net451</TargetFrameworks>
+		<TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
 	</PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="CommandLineParser" version="1.9.71" />
     <PackageReference Include="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" />
     <PackageReference Include="ImpromptuInterface" version="6.2.2" />
@@ -50,7 +50,7 @@
 		</None>
 	</ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <Reference Include="System.Configuration" />
   </ItemGroup>
 

--- a/test/DurableTask.Stress.Tests/DurableTask.Stress.Tests.csproj
+++ b/test/DurableTask.Stress.Tests/DurableTask.Stress.Tests.csproj
@@ -2,7 +2,7 @@
 
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
 	<PropertyGroup>
-	  <TargetFrameworks>netcoreapp2.1;net451</TargetFrameworks>
+	  <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
 	  <StartupObject>DurableTask.Stress.Tests.Program</StartupObject>
 	  <ApplicationIcon />
 	  <OutputType>Exe</OutputType>
@@ -27,7 +27,7 @@
 	  <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />  
 	</ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="CommandLineParser" version="1.9.71" />
     <PackageReference Include="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" />
     <PackageReference Include="EnterpriseLibrary.SemanticLogging.TextFile" version="2.0.1406.1" />
@@ -55,7 +55,7 @@
 	  </None>
 	</ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <Reference Include="System.Configuration" />
   </ItemGroup>
 

--- a/test/DurableTask.Test.Orchestrations/DurableTask.Test.Orchestrations.csproj
+++ b/test/DurableTask.Test.Orchestrations/DurableTask.Test.Orchestrations.csproj
@@ -2,14 +2,14 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Newtonsoft.Json" version="11.0.2" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Newtonsoft.Json" version="7.0.1" />
   </ItemGroup>
   

--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -5,7 +5,7 @@
     <DebugType Condition="'$(Configuration)'=='Release'">pdbonly</DebugType>
     <DebugSymbols>True</DebugSymbols>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-
+    <LangVersion>7.3</LangVersion>
     <!-- Code Analysis Settings -->
     <RunCodeAnalysis>True</RunCodeAnalysis>
     <RunCodeAnalysis Condition=" '$(Configuration)' == 'Debug' ">False</RunCodeAnalysis>

--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -43,9 +43,9 @@
   <!-- Nuget Package Settings -->
   <PropertyGroup>
     <PackageOutputPath>..\..\build_output\packages</PackageOutputPath>
-    <AssemblyVersion>2.3.0</AssemblyVersion>
-    <FileVersion>2.3.0</FileVersion>
-    <Version>2.3.0</Version>
+    <AssemblyVersion>2.4.0</AssemblyVersion>
+    <FileVersion>2.4.0</FileVersion>
+    <Version>2.4.0</Version>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
     <Product>Durable Task Framework</Product>


### PR DESCRIPTION
# Please Read!
This PR adds basic support for [.NET Core's ILogger infrastructure](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/) to **DurableTask.Core** and **DurableTask.AzureStorage**. The motivation for this work is primarily for the benefit of Durable Functions, but there are significant benefits for any consumer of DTFx. The stated goals are as follows:

1. Enable **DurableTask.Core** logs to be more easily surfaced in Antares Kusto clusters (internal to Azure App Service)
2. Enable correlating **DurableTask.Core** logs with **DurableTask.AzureStorage** traces using simple Kusto queries
3. Enable users to export **DurableTask.Core** and **DurableTask.AzureStorage** logs to Application Insights automatically when running in Azure Functions.
4. Enable users to capture logs in any way they choose by supporting `ILogger` extensibility (this is critical for supporting Durable Functions on Linux platforms).
5. Make it easy for future transaction store providers (like **DurableTask.SqlServer**) to leverage the same logging infrastructure.

Before reviewing the code, I highly recommend you review [this README.md file](https://github.com/Azure/durabletask/blob/c80e6b5d96d27543202dc9078d1a9edb4e5708a4/src/DurableTask.Core/Logging/README.md) that I added. This will help you understand the design.

### Change summary
* **Upgraded all projects from `net451` to `net461`**. This was necessary to support `ILogger` without conditional compilation. All projects should now be `netstandard2.0` compatible. This will require any upstream projects that target `net451` to upgrade if they want to keep using DTFx.
* **Added a NEW `DurableTask-Core` EventSource implementation**. The old one will still be there (for now) just in case we find issues with the new implementation. The new one was meant to be compatible with our `DurableTask-AzureStorage` event source provider to make it easier to query in Kusto.
* **Added optional `ILoggerFactory` configuration** to both `DurableTask.Core` and `DurableTask.AzureStorage`. For Azure Functions, we will add the Azure Functions `ILoggerFactory` to these DTFx classes so that Functions users can have direct access to these logs. We can also use this to do JSON logging on Linux platforms (that part is not in scope for this PR, however).
* **Added logs of new structured logging code to `DurableTask.Core`**. This project needed an overhaul of its logging to make it more structured and query-able. I've basically added a bunch of new log events to help us with production debugging.
* **Replaced EventSource tracing with new LogHelper abstraction** in `DurableTask.AzureStorage`. This was a very mechanical change and should not impact existing Event Source logs. However, it allows us to plug into `ILogger` and get all those benefits.

### Pending changes:
- [x] Add log messages for DurableTask.AzureStorage log events
- [x] Add "AppName" log event field to make it even easier to correlate traces with Azure Functions traces.
- [x] Debug why "EventName" is not showing up in Application Insights logs (see https://github.com/Azure/azure-webjobs-sdk/pull/2544)

### Manual testing:
- [x] Capture ETW events and ensure everything flows correctly across `DurableTask-Core` and `DurableTask-AzureStorage`
- [x] Capture logs from a Function app and make sure they appear in Application Insights (when configured to do so)