### PR TITLE
Fix:  correlation test fail except for external event with extended session

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -810,7 +810,7 @@ namespace DurableTask.AzureStorage
                     {
                         var history = session.RuntimeState.Events;
 
-                        var traceContextString = history.Where(p => p.EventType == EventType.ExecutionStarted).Select(p => (ExecutionStartedEvent)p).FirstOrDefault().Correlation;
+                        string traceContextString = session.RuntimeState.ExecutionStartedEvent?.Correlation;
                         parentTraceContext = TraceContextBase.Restore(traceContextString);
                     }
                 }            

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -984,7 +984,7 @@ namespace DurableTask.AzureStorage.Tracking
                         CorrelationTraceClient.Propagate(() =>
                         {
                             historyEntity.Properties["Correlation"] = new EntityProperty(executionStartedEvent.Correlation);
-                            estimatedBytes += System.Text.ASCIIEncoding.ASCII.GetByteCount(executionStartedEvent.Correlation);
+                            estimatedBytes += Encoding.Unicode.GetByteCount(executionStartedEvent.Correlation);
                         });
 
                         this.SetInstancesTablePropertyFromHistoryProperty(

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -946,7 +946,7 @@ namespace DurableTask.AzureStorage.Tracking
                     ["LastUpdatedTime"] = new EntityProperty(newEvents.Last().Timestamp),
                 }
             };
-            
+           
             for (int i = 0; i < newEvents.Count; i++)
             {
                 bool isFinalEvent = i == newEvents.Count - 1;
@@ -980,6 +980,12 @@ namespace DurableTask.AzureStorage.Tracking
                         instanceEntity.Properties["Version"] = new EntityProperty(executionStartedEvent.Version);
                         instanceEntity.Properties["CreatedTime"] = new EntityProperty(executionStartedEvent.Timestamp);
                         instanceEntity.Properties["RuntimeStatus"] = new EntityProperty(OrchestrationStatus.Running.ToString());
+                        CorrelationTraceClient.Propagate(() =>
+                        {
+                            var traceContext = CorrelationTraceContext.Current;
+                            historyEntity.Properties["Correlation"] = new EntityProperty(traceContext.SerializableTraceContext);
+                        });
+
                         this.SetInstancesTablePropertyFromHistoryProperty(
                             historyEntity,
                             instanceEntity,

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -56,6 +56,7 @@ namespace DurableTask.AzureStorage.Tracking
             OutputProperty,
             "Reason",
             "Details",
+            "Correlation"
         };
 
         readonly string storageAccountName;
@@ -984,6 +985,7 @@ namespace DurableTask.AzureStorage.Tracking
                         {
                             var traceContext = CorrelationTraceContext.Current;
                             historyEntity.Properties["Correlation"] = new EntityProperty(traceContext.SerializableTraceContext);
+                            estimatedBytes += System.Text.ASCIIEncoding.ASCII.GetByteCount(traceContext.SerializableTraceContext);
                         });
 
                         this.SetInstancesTablePropertyFromHistoryProperty(

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -983,9 +983,8 @@ namespace DurableTask.AzureStorage.Tracking
                         instanceEntity.Properties["RuntimeStatus"] = new EntityProperty(OrchestrationStatus.Running.ToString());
                         CorrelationTraceClient.Propagate(() =>
                         {
-                            var traceContext = CorrelationTraceContext.Current;
-                            historyEntity.Properties["Correlation"] = new EntityProperty(traceContext.SerializableTraceContext);
-                            estimatedBytes += System.Text.ASCIIEncoding.ASCII.GetByteCount(traceContext.SerializableTraceContext);
+                            historyEntity.Properties["Correlation"] = new EntityProperty(executionStartedEvent.Correlation);
+                            estimatedBytes += System.Text.ASCIIEncoding.ASCII.GetByteCount(executionStartedEvent.Correlation);
                         });
 
                         this.SetInstancesTablePropertyFromHistoryProperty(

--- a/src/DurableTask.Core/CorrelationTraceClient.cs
+++ b/src/DurableTask.Core/CorrelationTraceClient.cs
@@ -16,6 +16,7 @@ namespace DurableTask.Core
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Threading.Tasks;
     using DurableTask.Core.Settings;
 
     /// <summary>
@@ -111,6 +112,23 @@ namespace DurableTask.Core
         public static void Propagate(Action action)
         {
             Execute(action);
+        }
+
+        /// <summary>
+        /// Execute Aysnc Function for propagete correlation information
+        /// It suppresses the execution when <see cref="CorrelationSettings"/>.DisablePropagation is true.
+        /// </summary>
+        /// <param name="func"></param>
+        /// <returns></returns>
+        public static Task PropagateAsync(Func<Task> func)
+        {
+            if (CorrelationSettings.Current.EnableDistributedTracing)
+            {
+                return func();
+            } else
+            {
+                return Task.CompletedTask;
+            }
         }
 
         static void Tracking(Action tracking)

--- a/src/DurableTask.Core/CorrelationTraceClient.cs
+++ b/src/DurableTask.Core/CorrelationTraceClient.cs
@@ -125,7 +125,8 @@ namespace DurableTask.Core
             if (CorrelationSettings.Current.EnableDistributedTracing)
             {
                 return func();
-            } else
+            } 
+            else
             {
                 return Task.CompletedTask;
             }

--- a/src/DurableTask.Core/History/ExecutionStartedEvent.cs
+++ b/src/DurableTask.Core/History/ExecutionStartedEvent.cs
@@ -79,5 +79,11 @@ namespace DurableTask.Core.History
         /// </summary>
         [DataMember]
         public IDictionary<string, string> Tags { get; set; }
+
+        /// <summary>
+        /// Gets or sets the serialized end-to-end correlation state.
+        /// </summary>
+        [DataMember]
+        public string Correlation { get; set; }
     }
 }

--- a/src/DurableTask.Core/History/HistoryEvent.cs
+++ b/src/DurableTask.Core/History/HistoryEvent.cs
@@ -89,10 +89,5 @@ namespace DurableTask.Core.History
         /// </summary>
         public ExtensionDataObject ExtensionData { get; set; }
 
-        /// <summary>
-        /// Gets the Correlation
-        /// </summary>
-        [DataMember]
-        public string Correlation { get; set; }
     }
 }

--- a/src/DurableTask.Core/History/HistoryEvent.cs
+++ b/src/DurableTask.Core/History/HistoryEvent.cs
@@ -88,5 +88,11 @@ namespace DurableTask.Core.History
         /// Implementation for <see cref="IExtensibleDataObject.ExtensionData"/>.
         /// </summary>
         public ExtensionDataObject ExtensionData { get; set; }
+
+        /// <summary>
+        /// Gets the Correlation
+        /// </summary>
+        [DataMember]
+        public string Correlation { get; set; }
     }
 }

--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -535,6 +535,8 @@ namespace DurableTask.Core
             };
 
             this.logHelper.SchedulingOrchestration(startedEvent);
+            
+            CorrelationTraceClient.Propagate(() => CreateAndTrackDependencyTelemetry(requestTraceContext));
 
             // Raised events and create orchestration calls use different methods so get handled separately
             await this.ServiceClient.CreateTaskOrchestrationAsync(startMessage, dedupeStatuses);
@@ -559,10 +561,10 @@ namespace DurableTask.Core
                     },
                     Event = eventRaisedEvent,
                 };
+
                 await this.ServiceClient.SendTaskOrchestrationMessageAsync(eventMessage);
             }
 
-            CorrelationTraceClient.Propagate(() => CreateAndTrackDependencyTelemetry(requestTraceContext));
 
             return orchestrationInstance;
         }

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -392,6 +392,13 @@ namespace DurableTask.Core
                         }
                     }
 
+                    // correlation
+                    CorrelationTraceClient.Propagate(() => {
+                        if (runtimeState.ExecutionStartedEvent != null)
+                            runtimeState.ExecutionStartedEvent.Correlation = CorrelationTraceContext.Current.SerializableTraceContext;
+                     });
+
+
                     // finish up processing of the work item
                     if (!continuedAsNew && runtimeState.Events.Last().EventType != EventType.OrchestratorCompleted)
                     {
@@ -415,6 +422,11 @@ namespace DurableTask.Core
                                 "TaskOrchestrationDispatcher-UpdatingStateForContinuation",
                                 workItem.InstanceId,
                                 "Updating state for continuation");
+
+                            // correlation
+                            CorrelationTraceClient.Propagate(() => {
+                               continueAsNewExecutionStarted.Correlation = CorrelationTraceContext.Current.SerializableTraceContext;
+                            });
 
                             runtimeState = new OrchestrationRuntimeState();
                             runtimeState.AddEvent(new OrchestratorStartedEvent(-1));

--- a/test/DurableTask.AzureStorage.Tests/TestOrchestrationClient.cs
+++ b/test/DurableTask.AzureStorage.Tests/TestOrchestrationClient.cs
@@ -121,6 +121,13 @@ namespace DurableTask.AzureStorage.Tests
             return this.client.RaiseEventAsync(instance, eventName, eventData);
         }
 
+        public Task RaiseEventAsync(string instanceId, string eventName, object eventData)
+        {
+            Trace.TraceInformation($"Raising event to instance {instanceId} with name = {eventName}.");
+            var instance = new OrchestrationInstance { InstanceId = instanceId };
+            return this.client.RaiseEventAsync(instance, eventName, eventData);
+        }
+
         public Task TerminateAsync(string reason)
         {
             Trace.TraceInformation($"Terminating instance {this.instanceId} with reason = {reason}.");


### PR DESCRIPTION
Hi @cgillum 

I found the root cause why the correlation test fails. 
`TaskHubClient` changes the behavior. `CorrelationTraceClient.Propagate(() => CreateAndTrackDependencyTelemetry(requestTraceContext));` Should be coming before a method that eventually call the `TaskHubQueue`.  

This is the old code.  
https://github.com/TsuyoshiUshio/durabletask/blob/correlation/final/src/DurableTask.Core/TaskHubClient.cs#L497-L501

## TODO 
Only the External Event with non-extended session will fail. I'm not fully understand the new behavior, however, it is getting very close. 

![image](https://user-images.githubusercontent.com/1390976/89498235-b750f080-d772-11ea-9c99-2b4daba17c85.png)
