### PR TITLE
Reduce maximum queue message size from 60 KB to 45 KB

### DIFF
--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -34,7 +34,9 @@ namespace DurableTask.AzureStorage
     /// </summary>
     class MessageManager
     {
-        const int MaxStorageQueuePayloadSizeInBytes = 60 * 1024; // 60KB
+        // Use 45 KB, as the Storage SDK will base64 encode the message,
+        // increasing the size by a factor of 4/3.
+        const int MaxStorageQueuePayloadSizeInBytes = 45 * 1024; // 45KB
         const int DefaultBufferSize = 64 * 2014; // 64KB
 
         const string LargeMessageBlobNameSeparator = "/";

--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -94,7 +94,7 @@ namespace DurableTask.AzureStorage
         public async Task<string> SerializeMessageDataAsync(MessageData messageData)
         {
             string rawContent = JsonConvert.SerializeObject(messageData, this.taskMessageSerializerSettings);
-            messageData.TotalMessageSizeBytes = Encoding.Unicode.GetByteCount(rawContent);
+            messageData.TotalMessageSizeBytes = Encoding.UTF8.GetByteCount(rawContent);
             MessageFormatFlags messageFormat = this.GetMessageFormatFlags(messageData);
 
             if (messageFormat != MessageFormatFlags.InlineJson)
@@ -150,7 +150,7 @@ namespace DurableTask.AzureStorage
             }
 
             envelope.OriginalQueueMessage = queueMessage;
-            envelope.TotalMessageSizeBytes = Encoding.Unicode.GetByteCount(queueMessage.AsString);
+            envelope.TotalMessageSizeBytes = Encoding.UTF8.GetByteCount(queueMessage.AsString);
             envelope.QueueName = queueName;
             return envelope;
         }

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -117,7 +117,7 @@ namespace DurableTask.AzureStorage.Messaging
                     Utils.GetTaskEventId(taskMessage.Event),
                     sourceInstance.InstanceId,
                     sourceInstance.ExecutionId,
-                    Encoding.Unicode.GetByteCount(rawContent),
+                    Encoding.UTF8.GetByteCount(rawContent),
                     data.QueueName /* PartitionId */,
                     taskMessage.OrchestrationInstance.InstanceId,
                     taskMessage.OrchestrationInstance.ExecutionId,


### PR DESCRIPTION
This change accounts for the fact that the Azure Storage SDK encodes the
content of the queue message in base64 encoding, increasing the size by
~33%. We shrink our message size maximum accordingly.