### PR TITLE
Reverting logging dependencies to 2.2.0

### DIFF
--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <!--Change the Storage SDK version with extreme caution, otherwise may break Durable Functions usage with Azure Storage Extension. -->
     <PackageReference Include="WindowsAzure.Storage" version="9.3.1" />

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="ImpromptuInterface" Version="7.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
@amdeel noticed that my previous logging PR broke compatibility with Azure Functions 2.0 host (I tested against 1.0 and 3.0, but not 2.0). This PR resolves the issue and should be compatible with all three supported versions of the Functions runtime.

The problem was with the `Microsoft.Extensions.Logging.Abastractions` dependency for `netstandard2.0`. The `3.x` builds of this package are not compatible with the Functions 2.0 host, which runs on .NET Core 2.2. Reducing the dependency to `2.2.0` (to match the version used by Functions/WebJobs) seems to have resolved the issue based on my local testing.