### PR TITLE
Make AppLease deletion safer

### DIFF
--- a/src/DurableTask.AzureStorage/Partitioning/AppLeaseManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/AppLeaseManager.cs
@@ -316,24 +316,12 @@ namespace DurableTask.AzureStorage.Partitioning
                 }
                 else
                 {
-                    // If we are not the lease owner, attempt a best effort to delete
-                    // the container, but it is very likely we will not succeed as someone
-                    // else may own the lease.
-                    try
-                    {
-                        await this.appLeaseContainer.DeleteIfExistsAsync();
-                    }
-                    catch (StorageException)
-                    {
-                    }
+                    await this.appLeaseContainer.DeleteIfExistsAsync();
                 }
             }
-            catch (StorageException ex)
+            catch (StorageException)
             { 
-                if (ex.RequestInformation.HttpStatusCode != 404)
-                {
-                    throw;
-                }
+                // If we cannot delete the existing app lease due to another app having a lease, just ignore it.
             }
             finally
             {

--- a/src/DurableTask.AzureStorage/Partitioning/AppLeaseManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/AppLeaseManager.cs
@@ -316,7 +316,16 @@ namespace DurableTask.AzureStorage.Partitioning
                 }
                 else
                 {
-                    await this.appLeaseContainer.DeleteIfExistsAsync();
+                    // If we are not the lease owner, attempt a best effort to delete
+                    // the container, but it is very likely we will not succeed as someone
+                    // else may own the lease.
+                    try
+                    {
+                        await this.appLeaseContainer.DeleteIfExistsAsync();
+                    }
+                    catch (StorageException)
+                    {
+                    }
                 }
             }
             catch (StorageException ex)

--- a/test/DurableTask.AzureStorage.Tests/TestOrchestrationClient.cs
+++ b/test/DurableTask.AzureStorage.Tests/TestOrchestrationClient.cs
@@ -186,11 +186,6 @@ namespace DurableTask.AzureStorage.Tests
                     timeout = debuggingTimeout;
                 }
             }
-            else
-            {
-                // Account for additional startup time after partition management PR.
-                requestedTimeout.Add(TimeSpan.FromSeconds(30));
-            }
 
             return timeout;
         }

--- a/test/DurableTask.AzureStorage.Tests/TestOrchestrationClient.cs
+++ b/test/DurableTask.AzureStorage.Tests/TestOrchestrationClient.cs
@@ -186,6 +186,11 @@ namespace DurableTask.AzureStorage.Tests
                     timeout = debuggingTimeout;
                 }
             }
+            else
+            {
+                // Account for additional startup time after partition management PR.
+                requestedTimeout.Add(TimeSpan.FromSeconds(30));
+            }
 
             return timeout;
         }


### PR DESCRIPTION
Some tests were failing due to trying to delete an app lease when
someone else owns the lease.