### PR TITLE
Updated JsonConverter default JsonSerializerSetting to include DateParseHandling.None

### DIFF
--- a/src/DurableTask.Core/Serializing/JsonDataConverter.cs
+++ b/src/DurableTask.Core/Serializing/JsonDataConverter.cs
@@ -33,6 +33,7 @@ namespace DurableTask.Core.Serializing
             : this(new JsonSerializerSettings
             {
                 TypeNameHandling = TypeNameHandling.Objects,
+                DateParseHandling = DateParseHandling.None,
 #if NETSTANDARD2_0
                 SerializationBinder = new PackageUpgradeSerializationBinder()
 #else


### PR DESCRIPTION
This change prevents strings that look like dates from being serialized into DateTime objects.

related to https://github.com/Azure/azure-functions-durable-js/issues/208