### PR TITLE
Increment DurableTask.Core to v2.4.1

### DIFF
--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -45,9 +45,9 @@
   <!-- Nuget Package Settings -->
   <PropertyGroup>
     <PackageOutputPath>..\..\build_output\packages</PackageOutputPath>
-    <AssemblyVersion>2.4.0</AssemblyVersion>
-    <FileVersion>2.4.0</FileVersion>
-    <Version>2.4.0</Version>
+    <AssemblyVersion>2.4.1</AssemblyVersion>
+    <FileVersion>2.4.1</FileVersion>
+    <Version>2.4.1</Version>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
     <Product>Durable Task Framework</Product>


### PR DESCRIPTION
In preparation for the "official" August 2020 release, which will be used by Durable Functions.

We unexpectedly had to do an early release of DurableTask.Core v2.4.0 (for the GA of DurableTask.AzureServiceFabric) which did not have the full payload of changes we wanted, hence why we have to do another version bump.