### PR TITLE
update the access of ConvertToJArray to public

### DIFF
--- a/src/DurableTask.Core/Common/Utils.cs
+++ b/src/DurableTask.Core/Common/Utils.cs
@@ -81,7 +81,10 @@ namespace DurableTask.Core.Common
             return input;
         }
 
-        internal static JArray ConvertToJArray(string input)
+        /// <summary>
+        /// Convert the string input to JArray
+        /// </summary>
+        public static JArray ConvertToJArray(string input)
         {
             JArray jArray;
             using (var stringReader = new StringReader(input))


### PR DESCRIPTION
It would be helpful to change the access modifier to public. There are scenarios that the user needs to override the RunAsync method in TaskActivity or override ReflectionBasedTaskActivity class.