### PR TITLE
Make partition management strategy default

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -201,7 +201,7 @@ namespace DurableTask.AzureStorage
         /// Use the legacy partition management strategy, which improves performance at the cost of being less resiliant
         /// to split brain.
         /// </summary>
-        public bool UseLegacyPartitionManagement { get; set; } = true;
+        public bool UseLegacyPartitionManagement { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the optional <see cref="ILoggerFactory"/> to use for diagnostic logging.

--- a/src/DurableTask.AzureStorage/Partitioning/LeaseCollectionBalancer.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/LeaseCollectionBalancer.cs
@@ -180,7 +180,6 @@ namespace DurableTask.AzureStorage.Partitioning
                 string.Empty /* partitionId */,
                 $"Starting background renewal of {this.leaseType} leases with interval: {this.options.RenewInterval}.");
 
-            Trace.TraceInformation($"{this.workerName}: Starting lease renewal {this.leaseType} thread");
             while (this.isStarted == 1 || !shutdownComplete)
             {
                 try
@@ -279,7 +278,6 @@ namespace DurableTask.AzureStorage.Partitioning
                 string.Empty /* partitionId */,
                 $"Starting to check for available {this.leaseType} leases with interval: {this.options.AcquireInterval}.");
 
-            Trace.TraceInformation($"{this.workerName}: Starting lease taking {this.leaseType} thread");
             while (this.isStarted == 1)
             {
                 try
@@ -335,7 +333,6 @@ namespace DurableTask.AzureStorage.Partitioning
             var expiredLeases = new List<T>();
 
             var allLeases = await this.leaseManager.ListLeasesAsync();
-            Trace.TraceInformation($"{this.workerName}: Taking leases {this.leaseType}");
             foreach (T lease in allLeases)
             {
                 if (!this.shouldAquireLeaseDelegate(lease.PartitionId))
@@ -493,7 +490,6 @@ namespace DurableTask.AzureStorage.Partitioning
                     this.workerName,
                     lease.PartitionId,
                     lease.Token);
-                Trace.TraceInformation($"{this.workerName}: Renewing lease {this.leaseType} {lease.PartitionId}");
                 renewed = await this.leaseManager.RenewAsync(lease);
             }
             catch (Exception ex)
@@ -541,7 +537,6 @@ namespace DurableTask.AzureStorage.Partitioning
             bool acquired = false;
             try
             {
-                Trace.TraceInformation($"{this.workerName}: Acquiring lease {this.leaseType} {lease.PartitionId}");
                 acquired = await this.leaseManager.AcquireAsync(lease, this.workerName);
             }
             catch (LeaseLostException)
@@ -571,7 +566,6 @@ namespace DurableTask.AzureStorage.Partitioning
             bool stolen = false;
             try
             {
-                Trace.TraceInformation($"{this.workerName}: Stealing lease {this.leaseType} {lease.PartitionId}");
                 stolen = await this.leaseManager.AcquireAsync(lease, this.workerName);
             }
             catch (LeaseLostException)
@@ -600,7 +594,6 @@ namespace DurableTask.AzureStorage.Partitioning
                 bool failedToInitialize = false;
                 try
                 {
-                    Trace.TraceInformation($"Adding lease {this.leaseType} {lease.PartitionId}");
                     await this.leaseObserverManager.NotifyShardAcquiredAsync(lease);
                 }
                 catch (Exception ex)
@@ -678,8 +671,6 @@ namespace DurableTask.AzureStorage.Partitioning
                     this.workerName,
                     lease.PartitionId,
                     lease.Token);
-
-                Trace.TraceInformation($"{this.workerName} releasing {this.leaseType} {lease.PartitionId}");
 
                 try
                 {

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -257,7 +257,7 @@ namespace DurableTask.AzureStorage.Tests
         [DataTestMethod]
         [DataRow(false)]
         [DataRow(true)]
-        public async Task ContinueAsNewThenTimer(bool enableExtendedSessions)
+         public async Task ContinueAsNewThenTimer(bool enableExtendedSessions)
         {
             using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(enableExtendedSessions))
             {

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -257,7 +257,7 @@ namespace DurableTask.AzureStorage.Tests
         [DataTestMethod]
         [DataRow(false)]
         [DataRow(true)]
-         public async Task ContinueAsNewThenTimer(bool enableExtendedSessions)
+        public async Task ContinueAsNewThenTimer(bool enableExtendedSessions)
         {
             using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(enableExtendedSessions))
             {


### PR DESCRIPTION
Adds a small fix to new partition management strategy, and makes it the default for DurableTask.AzureStorage.