### PR TITLE
[ServiceFabricProvider]: Fix a race condition while adding or updating the lockedSessions dictionary

### DIFF
--- a/src/DurableTask.ServiceFabric/SessionsProvider.cs
+++ b/src/DurableTask.ServiceFabric/SessionsProvider.cs
@@ -301,7 +301,6 @@ namespace DurableTask.ServiceFabric
 
         void TryEnqueueSession(string instanceId)
         {
-
             LockState newState = this.lockedSessions.AddOrUpdate(instanceId, LockState.InFetchQueue, (key, oldValue) =>
             {
                 if (oldValue == LockState.Locked)


### PR DESCRIPTION
Orchestration Dispatcher is trying to Release the session (UnlockSession) while the Activity Dispatcher is trying to complete the activity (EnqueueSession). In the Service Fabric provider layer, we use a concurrent dictionary for session locks. EnqueueSession and UnlockSession actions tried to update the SessionLocks dictionary in non-atomic way which left the session in a state where it can't be made available for further processing.