### PR TITLE
[ServiceFabricProvider]: Fix a race condition while adding or updating the lockedSessions dictionary and other changes

### DIFF
--- a/src/DurableTask.AzureServiceFabric/FabricOrchestrationService.cs
+++ b/src/DurableTask.AzureServiceFabric/FabricOrchestrationService.cs
@@ -117,7 +117,9 @@ namespace DurableTask.AzureServiceFabric
 
         public bool IsMaxMessageCountExceeded(int currentMessageCount, OrchestrationRuntimeState runtimeState)
         {
-            return true;
+            // TODO: To avoid accumualating too many messages, make a decision based on the activities in progress 
+            // This is needed in case of parall tasks mostly (like WhenAll)
+            return currentMessageCount > 1000;
         }
 
         public int GetDelayInSecondsAfterOnProcessException(Exception exception)

--- a/src/DurableTask.AzureServiceFabric/FabricOrchestrationService.cs
+++ b/src/DurableTask.AzureServiceFabric/FabricOrchestrationService.cs
@@ -117,9 +117,7 @@ namespace DurableTask.AzureServiceFabric
 
         public bool IsMaxMessageCountExceeded(int currentMessageCount, OrchestrationRuntimeState runtimeState)
         {
-            // TODO: To avoid accumualating too many messages, make a decision based on the activities in progress 
-            // This is needed in case of parall tasks mostly (like WhenAll)
-            return currentMessageCount > 1000;
+            return false;
         }
 
         public int GetDelayInSecondsAfterOnProcessException(Exception exception)

--- a/src/DurableTask.AzureServiceFabric/FabricOrchestrationServiceClient.cs
+++ b/src/DurableTask.AzureServiceFabric/FabricOrchestrationServiceClient.cs
@@ -47,6 +47,11 @@ namespace DurableTask.AzureServiceFabric
         #region IOrchestrationServiceClient
         public async Task CreateTaskOrchestrationAsync(TaskMessage creationMessage)
         {
+            if (creationMessage.Event is ExecutionStartedEvent executionStarted && executionStarted.ScheduledStartTime.HasValue)
+            {
+                throw new NotSupportedException("Service Fabric storage provider for Durable Tasks currently does not support scheduled starts");
+            }
+
             creationMessage.OrchestrationInstance.InstanceId.EnsureValidInstanceId();
             ExecutionStartedEvent startEvent = creationMessage.Event as ExecutionStartedEvent;
             if (startEvent == null)
@@ -92,13 +97,6 @@ namespace DurableTask.AzureServiceFabric
                 throw new NotSupportedException($"DedupeStatuses are not supported yet with service fabric provider");
             }
 
-            if (creationMessage.Event is ExecutionStartedEvent executionStarted && executionStarted.ScheduledStartTime.HasValue)
-            {
-                throw new NotSupportedException("Service Fabric storage provider for Durable Tasks currently does not support scheduled starts");
-            }
-
-            creationMessage.OrchestrationInstance.InstanceId.EnsureValidInstanceId();
-
             return CreateTaskOrchestrationAsync(creationMessage);
         }
 
@@ -127,13 +125,30 @@ namespace DurableTask.AzureServiceFabric
                 throw new ArgumentException($"No execution id found for given instanceId {instanceId}, can only terminate the latest execution of a given orchestration");
             }
 
-            var taskMessage = new TaskMessage
+            if (reason?.Trim().StartsWith("CleanupStore", StringComparison.OrdinalIgnoreCase) == true)
             {
-                OrchestrationInstance = new OrchestrationInstance { InstanceId = instanceId, ExecutionId = latestExecutionId },
-                Event = new ExecutionTerminatedEvent(-1, reason)
-            };
+                using (var txn = this.stateManager.CreateTransaction())
+                {
+                    // DropSession does 2 things (like mentioned in the comments above) - remove the row from sessions dictionary
+                    // and delete the session messages dictionary. The second step is in a background thread and not part of transaction.
+                    // However even if this transaction failed but we ended up deleting session messages dictionary, that's ok - at
+                    // that time, it should be an empty dictionary and we would have updated the runtime session state to full completed
+                    // state in the transaction from Complete method. So the subsequent attempt would be able to complete the session.
+                    var instance = new OrchestrationInstance { InstanceId = instanceId, ExecutionId = latestExecutionId };
+                    await this.orchestrationProvider.DropSession(txn, instance);
+                    await txn.CommitAsync();
+                }
+            }
+            else
+            {
+                var taskMessage = new TaskMessage
+                {
+                    OrchestrationInstance = new OrchestrationInstance { InstanceId = instanceId, ExecutionId = latestExecutionId },
+                    Event = new ExecutionTerminatedEvent(-1, reason)
+                };
 
-            await SendTaskOrchestrationMessageAsync(taskMessage);
+                await SendTaskOrchestrationMessageAsync(taskMessage);
+            }
         }
 
         public async Task<IList<OrchestrationState>> GetOrchestrationStateAsync(string instanceId, bool allExecutions)

--- a/src/DurableTask.AzureServiceFabric/Remote/DefaultStringPartitionHashing.cs
+++ b/src/DurableTask.AzureServiceFabric/Remote/DefaultStringPartitionHashing.cs
@@ -11,7 +11,7 @@
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
 
-namespace DurableTask.AzureServiceFabric.Service
+namespace DurableTask.AzureServiceFabric.Remote
 {
     using System;
     using System.Security.Cryptography;

--- a/src/DurableTask.AzureServiceFabric/Remote/FabricPartitionEndpointResolver.cs
+++ b/src/DurableTask.AzureServiceFabric/Remote/FabricPartitionEndpointResolver.cs
@@ -11,7 +11,7 @@
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
 
-namespace DurableTask.AzureServiceFabric.Service
+namespace DurableTask.AzureServiceFabric.Remote
 {
     using System;
     using System.Collections.Generic;

--- a/src/DurableTask.AzureServiceFabric/Remote/IPartitionHashing.cs
+++ b/src/DurableTask.AzureServiceFabric/Remote/IPartitionHashing.cs
@@ -11,7 +11,7 @@
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
 
-namespace DurableTask.AzureServiceFabric.Service
+namespace DurableTask.AzureServiceFabric.Remote
 {
     using System.Threading;
     using System.Threading.Tasks;

--- a/src/DurableTask.AzureServiceFabric/Remote/RemoteOrchestrationServiceClient.cs
+++ b/src/DurableTask.AzureServiceFabric/Remote/RemoteOrchestrationServiceClient.cs
@@ -36,7 +36,7 @@ namespace DurableTask.AzureServiceFabric.Remote
     public class RemoteOrchestrationServiceClient : IOrchestrationServiceClient, IDisposable
     {
         private readonly IPartitionEndpointResolver partitionProvider;
-        private readonly int maxPollDealyInSecs = 10;
+        private readonly int maxPollDelayInSecs = 10;
         private HttpClient httpClient;
 
         /// <summary>
@@ -227,7 +227,7 @@ namespace DurableTask.AzureServiceFabric.Remote
             instanceId.EnsureValidInstanceId();
             var maxTime = DateTime.Now.Add(timeout);
             OrchestrationState state = null;
-            double pollDelayInSecs = maxPollDealyInSecs;
+            double pollDelayInSecs = maxPollDelayInSecs;
             if (timeout.TotalSeconds < pollDelayInSecs)
             {
                 pollDelayInSecs = timeout.TotalSeconds;

--- a/src/DurableTask.AzureServiceFabric/Remote/RemoteOrchestrationServiceClient.cs
+++ b/src/DurableTask.AzureServiceFabric/Remote/RemoteOrchestrationServiceClient.cs
@@ -36,7 +36,7 @@ namespace DurableTask.AzureServiceFabric.Remote
     public class RemoteOrchestrationServiceClient : IOrchestrationServiceClient, IDisposable
     {
         private readonly IPartitionEndpointResolver partitionProvider;
-        private readonly TimeSpan pollDelay = TimeSpan.FromSeconds(10);
+        private readonly int maxPollDealyInSecs = 10;
         private HttpClient httpClient;
 
         /// <summary>
@@ -78,11 +78,9 @@ namespace DurableTask.AzureServiceFabric.Remote
         /// <param name="creationMessage">Orchestration creation message</param>
         /// <exception cref="OrchestrationAlreadyExistsException">Will throw an OrchestrationAlreadyExistsException exception If any orchestration with the same instance Id exists in the instance store.</exception>
         /// <returns></returns>
-        public async Task CreateTaskOrchestrationAsync(TaskMessage creationMessage)
+        public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage)
         {
-            creationMessage.OrchestrationInstance.InstanceId.EnsureValidInstanceId();
-            var uri = await ConstructEndpointUriAsync(creationMessage.OrchestrationInstance.InstanceId, GetOrchestrationFragment(), CancellationToken.None);
-            await this.PutJsonAsync(uri, new CreateTaskOrchestrationParameters() { TaskMessage = creationMessage });
+            return this.CreateTaskOrchestrationAsync(creationMessage, null);
         }
 
         /// <summary>
@@ -155,6 +153,11 @@ namespace DurableTask.AzureServiceFabric.Remote
         /// <returns>The OrchestrationState of the specified instanceId or null if not found</returns>
         public async Task<OrchestrationState> GetOrchestrationStateAsync(string instanceId, string executionId)
         {
+            if (string.IsNullOrWhiteSpace(executionId))
+            {
+                return (await this.GetOrchestrationStateAsync(instanceId, false)).FirstOrDefault();
+            }
+
             instanceId.EnsureValidInstanceId();
             var uri = await ConstructEndpointUriAsync(instanceId, GetOrchestrationFragment(instanceId), CancellationToken.None);
             var builder = new UriBuilder($"{uri}?executionId={executionId}");
@@ -224,16 +227,28 @@ namespace DurableTask.AzureServiceFabric.Remote
             instanceId.EnsureValidInstanceId();
             var maxTime = DateTime.Now.Add(timeout);
             OrchestrationState state = null;
-            while (!cancellationToken.IsCancellationRequested && DateTime.Now < maxTime)
+            double pollDelayInSecs = maxPollDealyInSecs;
+            if (timeout.TotalSeconds < pollDelayInSecs)
             {
+                pollDelayInSecs = timeout.TotalSeconds;
+            }
+
+            state = await this.GetOrchestrationStateAsync(instanceId, executionId);
+            if (state != null && state.OrchestrationStatus.IsTerminalState())
+            {
+                return state;
+            }
+
+            do
+            {
+                await Task.Delay(TimeSpan.FromSeconds(pollDelayInSecs), cancellationToken);
                 state = await this.GetOrchestrationStateAsync(instanceId, executionId);
                 if (state != null && state.OrchestrationStatus.IsTerminalState())
                 {
                     return state;
                 }
 
-                await Task.Delay(this.pollDelay);
-            }
+            } while (!cancellationToken.IsCancellationRequested && DateTime.Now < maxTime);
 
             // Either cancellation was requested or timedout, return the last known state.
             return state;
@@ -263,9 +278,11 @@ namespace DurableTask.AzureServiceFabric.Remote
             };
 
             HttpResponseMessage result = await this.HttpClient.PutAsync(uri, @object, mediaFormatter);
+
+            // TODO: Improve exception handling
             if (result.StatusCode == System.Net.HttpStatusCode.Conflict)
             {
-                throw new OrchestrationAlreadyExistsException("Orchestration already exists");
+                throw await result.Content?.ReadAsAsync<OrchestrationAlreadyExistsException>();
             }
 
             if (!result.IsSuccessStatusCode)

--- a/src/DurableTask.AzureServiceFabric/Service/ActivityLoggingMessageHandler.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/ActivityLoggingMessageHandler.cs
@@ -37,7 +37,7 @@ namespace DurableTask.AzureServiceFabric.Service
             catch (Exception exception)
             {
                 ServiceFabricProviderEventSource.Tracing.LogProxyServiceError(requestUri, requestMethod, exception);
-                response = request.CreateErrorResponse(HttpStatusCode.InternalServerError, exception.Message);
+                response = request.CreateResponse(HttpStatusCode.InternalServerError, exception);
             }
 
             return response;

--- a/src/DurableTask.AzureServiceFabric/Service/FabricOrchestrationServiceController.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/FabricOrchestrationServiceController.cs
@@ -11,17 +11,16 @@
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
 
-namespace DurableTask.AzureServiceFabric
+namespace DurableTask.AzureServiceFabric.Service
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using System.Web.Http;
     using System.Web.Http.Results;
-
+    using DurableTask.AzureServiceFabric.Models;
     using DurableTask.Core;
     using DurableTask.Core.Exceptions;
-    using DurableTask.AzureServiceFabric.Models;
-    using DurableTask.AzureServiceFabric.Tracing;
 
     /// <summary>
     /// A Web Api controller that provides TaskHubClient operations.
@@ -56,6 +55,7 @@ namespace DurableTask.AzureServiceFabric
             {
                 return BadRequest($"OrchestrationId from Uri {orchestrationId} doesn't match with the one from body {parameters.TaskMessage.OrchestrationInstance.InstanceId}");
             }
+
             try
             {
                 if (parameters.DedupeStatuses == null)
@@ -69,9 +69,13 @@ namespace DurableTask.AzureServiceFabric
 
                 return new OkResult(this);
             }
-            catch (OrchestrationAlreadyExistsException)
+            catch (OrchestrationAlreadyExistsException ex)
             {
-                return Conflict();
+                return Content<OrchestrationAlreadyExistsException>(System.Net.HttpStatusCode.BadRequest, ex);
+            }
+            catch (NotSupportedException ex)
+            {
+                return Content<NotSupportedException>(System.Net.HttpStatusCode.BadRequest, ex);
             }
         }
 

--- a/test/DurableTask.AzureServiceFabric.Integration.Tests/AssemblySetup.cs
+++ b/test/DurableTask.AzureServiceFabric.Integration.Tests/AssemblySetup.cs
@@ -44,17 +44,16 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests
         {
             get
             {
-                var sourceRoot = Environment.GetEnvironmentVariable("SourceRoot") ?? string.Empty;
-                var applicationPath = Path.Combine(sourceRoot.Trim(), "Test", "TestFabricApplication", "TestApplication");
+                var applicationPath = Path.Combine(Directory.GetCurrentDirectory(), @"..\..\..\..\TestFabricApplication\TestApplication");
 
                 if (!Directory.Exists(applicationPath))
                 {
-                    throw new Exception("Could not find test application path, define SourceRoot environment variable to the source path");
+                    throw new Exception($"Could not find test application path '{applicationPath}', define SourceRoot environment variable to the source path");
                 }
 
                 if (!Directory.Exists(Path.Combine(applicationPath, "pkg", "Debug")))
                 {
-                    throw new Exception("Could not find test application package, make sure the test application is built and package generated before running the tests");
+                    throw new Exception($"Could not find test application package in '{applicationPath}', make sure the test application is built and package generated before running the tests");
                 }
 
                 return applicationPath;

--- a/test/DurableTask.AzureServiceFabric.Integration.Tests/StressTests.cs
+++ b/test/DurableTask.AzureServiceFabric.Integration.Tests/StressTests.cs
@@ -99,7 +99,7 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests
                 Console.WriteLine($"Begin testing orchestration with {numberOfActivities} parallel activities");
                 var taskHubClient = Utilities.CreateTaskHubClient();
                 var instance = await taskHubClient.CreateOrchestrationInstanceAsync(typeof(ExecutionCountingOrchestration), numberOfActivities);
-                var state = await taskHubClient.WaitForOrchestrationAsync(instance, TimeSpan.FromMinutes(3));
+                var state = await taskHubClient.WaitForOrchestrationAsync(instance, TimeSpan.FromMinutes(2));
                 await taskHubClient.PurgeOrchestrationInstanceHistoryAsync(DateTime.Now, OrchestrationStateTimeRangeFilterType.OrchestrationCompletedTimeFilter);
                 Assert.IsNotNull(state);
                 Assert.AreEqual(OrchestrationStatus.Completed, state.OrchestrationStatus);
@@ -119,13 +119,21 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests
                 DelayUnit = TimeSpan.FromSeconds(1)
             };
 
-            await RunTestOrchestrationsHelper(100, testOrchestratorInput);
-            Console.WriteLine();
+            try
+            {
+                await RunTestOrchestrationsHelper(100, testOrchestratorInput);
+                Console.WriteLine();
 
-            testOrchestratorInput.UseTimeoutTask = true;
-            testOrchestratorInput.ExecutionTimeout = TimeSpan.FromMinutes(2);
+                testOrchestratorInput.UseTimeoutTask = true;
+                testOrchestratorInput.ExecutionTimeout = TimeSpan.FromMinutes(2);
 
-            await RunTestOrchestrationsHelper(100, testOrchestratorInput);
+                await RunTestOrchestrationsHelper(100, testOrchestratorInput);
+            }
+            catch(Exception ex)
+            {
+                Console.WriteLine($"Exception {ex.ToString()}");
+                throw;
+            }
         }
 
         [TestMethod]
@@ -208,7 +216,10 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests
                 waitTasks.Add(Task.Run(async () =>
                 {
                     var state = await taskHubClient.WaitForOrchestrationAsync(instance, TimeSpan.FromMinutes(2));
-                    results.Add(Tuple.Create(instance, state));
+                    lock (results)
+                    {
+                        results.Add(Tuple.Create(instance, state));
+                    }
                 }));
                 if (delayGeneratorFunction != null)
                 {
@@ -233,7 +244,7 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests
                 {
                     failedOrchestrations++;
                     var state = await taskHubClient.GetOrchestrationStateAsync(kvp.Item1);
-                    Console.WriteLine($"Unfinished orchestration {kvp.Item1}, state : {kvp.Item2?.OrchestrationStatus}");
+                    Console.WriteLine($"Unfinished orchestration {kvp.Item1}, state : {state?.OrchestrationStatus}");
                     continue;
                 }
 

--- a/test/DurableTask.AzureServiceFabric.Integration.Tests/StressTests.cs
+++ b/test/DurableTask.AzureServiceFabric.Integration.Tests/StressTests.cs
@@ -119,21 +119,13 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests
                 DelayUnit = TimeSpan.FromSeconds(1)
             };
 
-            try
-            {
-                await RunTestOrchestrationsHelper(100, testOrchestratorInput);
-                Console.WriteLine();
+            await RunTestOrchestrationsHelper(100, testOrchestratorInput);
+            Console.WriteLine();
 
-                testOrchestratorInput.UseTimeoutTask = true;
-                testOrchestratorInput.ExecutionTimeout = TimeSpan.FromMinutes(2);
+            testOrchestratorInput.UseTimeoutTask = true;
+            testOrchestratorInput.ExecutionTimeout = TimeSpan.FromMinutes(2);
 
-                await RunTestOrchestrationsHelper(100, testOrchestratorInput);
-            }
-            catch(Exception ex)
-            {
-                Console.WriteLine($"Exception {ex.ToString()}");
-                throw;
-            }
+            await RunTestOrchestrationsHelper(100, testOrchestratorInput);
         }
 
         [TestMethod]

--- a/test/DurableTask.AzureServiceFabric.Integration.Tests/Utilities.cs
+++ b/test/DurableTask.AzureServiceFabric.Integration.Tests/Utilities.cs
@@ -17,7 +17,6 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests
     using System.Diagnostics;
     using System.Net.Http;
     using System.Threading.Tasks;
-
     using DurableTask.Core;
     using DurableTask.AzureServiceFabric.Remote;
     using DurableTask.AzureServiceFabric.Service;

--- a/test/DurableTask.AzureServiceFabric.Integration.Tests/WaitForOrchestrationTests.cs
+++ b/test/DurableTask.AzureServiceFabric.Integration.Tests/WaitForOrchestrationTests.cs
@@ -131,7 +131,7 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests
             });
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(result.OrchestrationStatus, OrchestrationStatus.Running);
+            Assert.AreEqual(OrchestrationStatus.Running, result.OrchestrationStatus);
             Assert.IsTrue(time > waitTime);
             Console.WriteLine($"Full WaitTime : {waitTime}, Actual time taken for Wait : {time}, Expected Orchestration Running Time : {orchestrationTimeInSeconds} seconds");
 

--- a/test/DurableTask.Test.Orchestrations/Performance/ExecutionCountingActivity.cs
+++ b/test/DurableTask.Test.Orchestrations/Performance/ExecutionCountingActivity.cs
@@ -27,7 +27,7 @@ namespace DurableTask.Test.Orchestrations.Performance
 
         protected override async Task<int> ExecuteAsync(TaskContext context, int taskId)
         {
-            await Task.Delay(new Random().Next(50, 100));
+            await Task.Delay(new Random().Next(5, 10));
             Interlocked.Increment(ref Counter);
             return Counter;
         }

--- a/test/TestFabricApplication/TestApplication.Common/Orchestrations/RecurringOrchestrationInput.cs
+++ b/test/TestFabricApplication/TestApplication.Common/Orchestrations/RecurringOrchestrationInput.cs
@@ -17,7 +17,7 @@ namespace TestApplication.Common.Orchestrations
     {
         public string TargetOrchestrationType { get; set; }
 
-        public string TargetOrchestrationInput { get; set; }
+        public int TargetOrchestrationInput { get; set; }
 
         public string TargetOrchestrationInstanceId { get; set; }
     }

--- a/test/TestFabricApplication/TestApplication.Common/Orchestrations/RecurringTargetOrchestration.cs
+++ b/test/TestFabricApplication/TestApplication.Common/Orchestrations/RecurringTargetOrchestration.cs
@@ -19,9 +19,9 @@ namespace TestApplication.Common.Orchestrations
 
     using TestApplication.Common.OrchestrationTasks;
 
-    public class RecurringTargetOrchestration : TaskOrchestration<int, string>
+    public class RecurringTargetOrchestration : TaskOrchestration<int, int>
     {
-        public override async Task<int> RunTask(OrchestrationContext context, string input)
+        public override async Task<int> RunTask(OrchestrationContext context, int input)
         {
             var testTasks = context.CreateClient<ITestTasks>();
             int count = await testTasks.IncrementGenerationCount();

--- a/test/TestFabricApplication/TestApplication.StatefulService/TestOrchestrationsProvider.cs
+++ b/test/TestFabricApplication/TestApplication.StatefulService/TestOrchestrationsProvider.cs
@@ -32,8 +32,8 @@ namespace TestApplication.StatefulService
         public FabricOrchestrationProviderSettings GetFabricOrchestrationProviderSettings()
         {
             var settings = new FabricOrchestrationProviderSettings();
-            settings.TaskOrchestrationDispatcherSettings.DispatcherCount = 5;
-            settings.TaskActivityDispatcherSettings.DispatcherCount = 5;
+            settings.TaskOrchestrationDispatcherSettings.DispatcherCount = 10;
+            settings.TaskActivityDispatcherSettings.DispatcherCount = 10;
             return settings;
         }
 


### PR DESCRIPTION
1. Fixed the race condition in SF provider
2. Fixed IsMaxMessageCountExceeded to enable more parallel processing
3. Fixed RemoteTaskHubClient to handle exceptions properly
4. Fixed multiple flaky tests
5. Locate the Service Fabric test application using relative path 