### PR TITLE
Allow Netherite back-end to be implemented externally

### DIFF
--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -16,6 +16,8 @@
     <DebugSymbols>true</DebugSymbols> 
     <DebugType>embedded</DebugType> 
     <IncludeSymbols>false</IncludeSymbols> 
+    <!--NuGet licenseUrl and PackageIconUrl/iconUrl deprecation. -->
+    <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DurableTask.Core/Common/Entities.cs
+++ b/src/DurableTask.Core/Common/Entities.cs
@@ -1,0 +1,105 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+using DurableTask.Core.History;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DurableTask.Core.Common
+{
+    /// <summary>
+    /// Helpers for dealing with special naming conventions around auto-started orchestrations (entities)
+    /// </summary>
+    public static class Entities
+    {
+        /// <summary>
+        /// Determine if a given instance id is an entity (an auto-started orchestration)
+        /// </summary>
+        /// <param name="instanceId"></param>
+        /// <returns></returns>
+        public static bool IsEntityInstance(string instanceId)
+        {
+            return !string.IsNullOrEmpty(instanceId) && instanceId[0] == '@';
+        }
+
+        /// <summary>
+        /// Determine if a task message is an entity message with a time delay
+        /// </summary>
+        /// <param name="taskMessage">The task message</param>
+        /// <param name="due">The universal time at which this message should be delivered</param>
+        /// <returns>true if this is an entity message with a time delay</returns>
+        /// <remarks>
+        /// We assume that auto-started orchestrations (i.e. instance ids starting with '@') are
+        /// used exclusively by durable entities; so we can follow 
+        /// a custom naming convention to pass a time parameter.
+        /// </remarks>
+        public static bool IsDelayedEntityMessage(TaskMessage taskMessage, out DateTime due)
+        {
+            // Special functionality for entity messages with a delivery delay 
+            if (taskMessage.Event is EventRaisedEvent eventRaisedEvent
+                && IsEntityInstance(taskMessage.OrchestrationInstance.InstanceId))
+            {
+                string eventName = eventRaisedEvent.Name;
+                if (eventName != null && eventName.Length >= 3 && eventName[2] == '@'
+                    && DateTime.TryParse(eventName.Substring(3), out DateTime scheduledTime))
+                {
+                    due = scheduledTime.ToUniversalTime();
+                    return true;
+                }
+            }
+
+            due = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Tests whether an instance should automatically start if receiving messages and not already being started, and inserts
+        /// a corresponding ExecutionStartedEvent taskMessage.
+        /// </summary>
+        /// <param name="instanceId"></param>
+        /// <param name="newMessages"></param>
+        /// <returns></returns>
+        public static bool AutoStart(string instanceId, IList<TaskMessage> newMessages)
+        {
+            if (IsEntityInstance(instanceId)
+                 && newMessages[0].Event.EventType == EventType.EventRaised
+                 && newMessages[0].OrchestrationInstance.ExecutionId == null)
+            {
+                // automatically start this instance
+                var orchestrationInstance = new OrchestrationInstance
+                {
+                    InstanceId = instanceId,
+                    ExecutionId = Guid.NewGuid().ToString("N"),
+                };
+                var startedEvent = new ExecutionStartedEvent(-1, null)
+                {
+                    Name = instanceId,
+                    Version = "",
+                    OrchestrationInstance = orchestrationInstance
+                };
+                var taskMessage = new TaskMessage()
+                {
+                    OrchestrationInstance = orchestrationInstance,
+                    Event = startedEvent
+                };
+                newMessages.Insert(0, taskMessage);
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/DurableTask.Core/Common/Utils.cs
+++ b/src/DurableTask.Core/Common/Utils.cs
@@ -447,7 +447,8 @@ namespace DurableTask.Core.Common
                 Size = runtimeState.Size,
                 CompressedSize = runtimeState.CompressedSize,
                 Input = runtimeState.Input,
-                Output = runtimeState.Output
+                Output = runtimeState.Output,
+                ScheduledStartTime = runtimeState.ExecutionStartedEvent?.ScheduledStartTime,
             };
         }
 

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -6,6 +6,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Microsoft.Azure.DurableTask.Core</PackageId>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <!--NuGet licenseUrl and PackageIconUrl/iconUrl deprecation. -->
+    <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/src/DurableTask.Core/History/HistoryEvent.cs
+++ b/src/DurableTask.Core/History/HistoryEvent.cs
@@ -14,31 +14,41 @@
 namespace DurableTask.Core.History
 {
     using System;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Runtime.Serialization;
 
     /// <summary>
     /// Base class for history events
     /// </summary>
     [DataContract]
-    [KnownType(typeof(ExecutionStartedEvent))]
-    [KnownType(typeof(ExecutionCompletedEvent))]
-    [KnownType(typeof(ExecutionTerminatedEvent))]
-    [KnownType(typeof(TaskCompletedEvent))]
-    [KnownType(typeof(TaskFailedEvent))]
-    [KnownType(typeof(TaskScheduledEvent))]
-    [KnownType(typeof(SubOrchestrationInstanceCreatedEvent))]
-    [KnownType(typeof(SubOrchestrationInstanceCompletedEvent))]
-    [KnownType(typeof(SubOrchestrationInstanceFailedEvent))]
-    [KnownType(typeof(TimerCreatedEvent))]
-    [KnownType(typeof(TimerFiredEvent))]
-    [KnownType(typeof(OrchestratorStartedEvent))]
-    [KnownType(typeof(OrchestratorCompletedEvent))]
-    [KnownType(typeof(EventSentEvent))]
-    [KnownType(typeof(EventRaisedEvent))]
-    [KnownType(typeof(ContinueAsNewEvent))]
-    [KnownType(typeof(HistoryStateEvent))]
+    [KnownTypeAttribute("KnownTypes")]
     public abstract class HistoryEvent : IExtensibleDataObject
     {
+        /// <summary>
+        /// List of all event classes, for use by the DataContractSerializer
+        /// </summary>
+        /// <returns></returns>
+        public static IEnumerable<Type> KnownTypes()
+        {
+            yield return typeof(ExecutionStartedEvent);
+            yield return typeof(ExecutionCompletedEvent);
+            yield return typeof(ExecutionTerminatedEvent);
+            yield return typeof(TaskCompletedEvent);
+            yield return typeof(TaskFailedEvent);
+            yield return typeof(TaskScheduledEvent);
+            yield return typeof(SubOrchestrationInstanceCreatedEvent);
+            yield return typeof(SubOrchestrationInstanceCompletedEvent);
+            yield return typeof(SubOrchestrationInstanceFailedEvent);
+            yield return typeof(TimerCreatedEvent);
+            yield return typeof(TimerFiredEvent);
+            yield return typeof(OrchestratorStartedEvent);
+            yield return typeof(OrchestratorCompletedEvent);
+            yield return typeof(EventSentEvent);
+            yield return typeof(EventRaisedEvent);
+            yield return typeof(ContinueAsNewEvent);
+            yield return typeof(HistoryStateEvent);
+        }
 
         /// <summary>
         /// Creates a new history event

--- a/src/DurableTask.Core/OrchestrationRuntimeState.cs
+++ b/src/DurableTask.Core/OrchestrationRuntimeState.cs
@@ -43,7 +43,10 @@ namespace DurableTask.Core
         /// </summary>
         public long CompressedSize;
 
-        ExecutionCompletedEvent ExecutionCompletedEvent { get; set; }
+        /// <summary>
+        /// Gets the execution completed event
+        /// </summary>
+        public ExecutionCompletedEvent ExecutionCompletedEvent { get; set; }
 
         /// <summary>
         /// Size of the serialized state (uncompressed)

--- a/src/DurableTask.Core/OrchestrationState.cs
+++ b/src/DurableTask.Core/OrchestrationState.cs
@@ -114,6 +114,36 @@ namespace DurableTask.Core
         public DateTime? ScheduledStartTime { get; set; }
 
         /// <summary>
+        /// Clear input and/or output fields. Creates a shallow copy since
+        /// we do not want to modify the original copy.
+        /// </summary>
+        /// <returns></returns>
+        public OrchestrationState ClearFieldsImmutably(bool includeInput, bool includeOutput)
+        {
+            if (includeInput && includeOutput)
+            {
+                return this;
+            }
+            else
+            {
+                // since we keep the OrchestrationState immutable in the backend, we must make a copy
+                var copy = (OrchestrationState)this.MemberwiseClone();
+
+                if (!includeInput)
+                {
+                    copy.Input = null;
+                }
+
+                if (!includeOutput)
+                {
+                    copy.Output = null;
+                }
+
+                return copy;
+            }
+        }
+
+        /// <summary>
         /// Implementation for <see cref="IExtensibleDataObject.ExtensionData"/>.
         /// </summary>
         public ExtensionDataObject ExtensionData { get; set; }

--- a/src/DurableTask.Core/OrchestrationState.cs
+++ b/src/DurableTask.Core/OrchestrationState.cs
@@ -118,23 +118,24 @@ namespace DurableTask.Core
         /// we do not want to modify the original copy.
         /// </summary>
         /// <returns></returns>
-        public OrchestrationState ClearFieldsImmutably(bool includeInput, bool includeOutput)
+        public OrchestrationState ClearFieldsImmutably(bool clearInput, bool clearOutput)
         {
-            if (includeInput && includeOutput)
+            if (! (clearInput || clearOutput))
             {
                 return this;
             }
             else
             {
                 // since we keep the OrchestrationState immutable in the backend, we must make a copy
+                // before we can clear those fields
                 var copy = (OrchestrationState)this.MemberwiseClone();
 
-                if (!includeInput)
+                if (clearInput)
                 {
                     copy.Input = null;
                 }
 
-                if (!includeOutput)
+                if (clearOutput)
                 {
                     copy.Output = null;
                 }

--- a/src/DurableTask.Core/TaskActivityDispatcher.cs
+++ b/src/DurableTask.Core/TaskActivityDispatcher.cs
@@ -130,9 +130,12 @@ namespace DurableTask.Core
                     throw new TypeMissingException($"TaskActivity {scheduledEvent.Name} version {scheduledEvent.Version} was not found");
                 }
 
-                renewTask = Task.Factory.StartNew(
-                    () => this.RenewUntil(workItem, renewCancellationTokenSource.Token),
-                    renewCancellationTokenSource.Token);
+                if (workItem.LockedUntilUtc < DateTime.MaxValue)
+                {
+                    renewTask = Task.Factory.StartNew(
+                        () => this.RenewUntil(workItem, renewCancellationTokenSource.Token),
+                        renewCancellationTokenSource.Token);
+                }
 
                 // TODO : pass workflow instance data
                 var context = new TaskContext(taskMessage.OrchestrationInstance);

--- a/src/DurableTask.Emulator/DurableTask.Emulator.csproj
+++ b/src/DurableTask.Emulator/DurableTask.Emulator.csproj
@@ -4,6 +4,8 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <PackageId>Microsoft.Azure.DurableTask.Emulator</PackageId>
+    <!--NuGet licenseUrl and PackageIconUrl/iconUrl deprecation. -->
+    <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/src/DurableTask.Redis/DurableTask.Redis.csproj
+++ b/src/DurableTask.Redis/DurableTask.Redis.csproj
@@ -18,6 +18,8 @@
     <DebugType>embedded</DebugType>
     <IncludeSymbols>false</IncludeSymbols>
     <LangVersion>7.3</LangVersion>
+    <!--NuGet licenseUrl and PackageIconUrl/iconUrl deprecation. -->
+    <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This contains the new Netherite backend implementation, with the Faster storage provider and the EventHubs transport provider. In this first version autoscaling is not yet supported, but it does support manual scaling (it balances the partitions among all the started nodes).

Most of this PR adds new files and projects; There are two new projects, DurableTask.EventSourced and DurableTask.EventSourced.Tests.

There are also some small changes / fixes to existing files:
- suppress deprecation warnings when building NuGet packages
- move entity-related functionality from AzureStorage to DurableTask.Core.Common so it can be shared by the providers
- make the `ExecutionCompletedEvent` field of `OrchestrationRuntimeState` public
- add a method to `OrchestrationState` that allows cloning of the state
- pass workitem, instead of workitem cursor, to resume
- do not start a work item renewal task if work item does not expire
- move KnownTypes from attributes into method (so other places can access this list of types)
- fix missing instanceState update in TaskOrchestrationDispatcher (this is a bug)
- fix missing ScheduledStartTime in Utils.cs (this is a bug)
