### PR TITLE
Preserve null values when serializing to storage

### DIFF
--- a/src/DurableTask.Core/Serializing/JsonDataConverter.cs
+++ b/src/DurableTask.Core/Serializing/JsonDataConverter.cs
@@ -69,6 +69,12 @@ namespace DurableTask.Core.Serializing
         /// <returns>Object serialized to a string</returns>
         public override string Serialize(object value, bool formatted)
         {
+            if (value == null)
+            {
+                // This avoids serializing null into "null"
+                return null;
+            }
+
             var sb = new StringBuilder(0x100);
             var textWriter = new StringWriter(sb, CultureInfo.InvariantCulture);
             using (var writer = new JsonTextWriter(textWriter))

--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -45,9 +45,9 @@
   <!-- Nuget Package Settings -->
   <PropertyGroup>
     <PackageOutputPath>..\..\build_output\packages</PackageOutputPath>
-    <AssemblyVersion>2.4.1</AssemblyVersion>
-    <FileVersion>2.4.1</FileVersion>
-    <Version>2.4.1</Version>
+    <AssemblyVersion>2.4.2</AssemblyVersion>
+    <FileVersion>2.4.2</FileVersion>
+    <Version>2.4.2</Version>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
     <Product>Durable Task Framework</Product>


### PR DESCRIPTION
I noticed this issue when working on the DurableTask.SqlServer backend provider. I think it should be a non-breaking change that only impacts that value written to the backend storage provider. I don't think this impacts null handling in user code. in that sense, it is primarily a storage and potentially a slight performance optimization.

I also incremented the version number of DurableTask.Core in this PR.