### PR TITLE
Update stale taskhub.json in DurableTask.AzureStorage

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -613,7 +613,8 @@ namespace DurableTask.AzureStorage
             BlobLeaseManager inactiveLeaseManager = GetBlobLeaseManager(settings, "inactive", account, null);
 
             TaskHubInfo hubInfo = await inactiveLeaseManager.GetOrCreateTaskHubInfoAsync(
-                GetTaskHubInfo(taskHub, defaultPartitionCount));
+                GetTaskHubInfo(taskHub, defaultPartitionCount),
+                checkIfStale: false);
 
             CloudQueueClient queueClient = account.CreateCloudQueueClient();
 

--- a/src/DurableTask.AzureStorage/Partitioning/ILeaseManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/ILeaseManager.cs
@@ -20,7 +20,7 @@ namespace DurableTask.AzureStorage.Partitioning
     {
         Task<bool> LeaseStoreExistsAsync();
 
-        Task<bool> CreateLeaseStoreIfNotExistsAsync(TaskHubInfo eventHubInfo);
+        Task<bool> CreateLeaseStoreIfNotExistsAsync(TaskHubInfo eventHubInfo, bool checkIfStale = true);
 
         Task<IEnumerable<T>> ListLeasesAsync();
 

--- a/src/DurableTask.AzureStorage/Partitioning/LegacyPartitionManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/LegacyPartitionManager.cs
@@ -71,7 +71,7 @@ namespace DurableTask.AzureStorage.Partitioning
         {    
             TaskHubInfo hubInfo = new TaskHubInfo(this.settings.TaskHubName, DateTime.UtcNow, this.settings.PartitionCount);
             this.stats.StorageRequests.Increment();
-            return this.leaseManager.CreateLeaseStoreIfNotExistsAsync(hubInfo);
+            return this.leaseManager.CreateLeaseStoreIfNotExistsAsync(hubInfo, checkIfStale: true);
         }
 
         Task IPartitionManager.DeleteLeases()

--- a/src/DurableTask.AzureStorage/Partitioning/SafePartitionManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/SafePartitionManager.cs
@@ -105,8 +105,10 @@ namespace DurableTask.AzureStorage.Partitioning
         {
             TaskHubInfo hubInfo = new TaskHubInfo(this.settings.TaskHubName, DateTime.UtcNow, this.settings.PartitionCount);
             return Task.WhenAll(
-                this.intentLeaseManager.CreateLeaseStoreIfNotExistsAsync(hubInfo),
-                this.ownershipLeaseManager.CreateLeaseStoreIfNotExistsAsync(hubInfo));
+                // Only need to check if the lease store (i.e. the taskhub.json) is stale for one of the two
+                // lease managers.
+                this.intentLeaseManager.CreateLeaseStoreIfNotExistsAsync(hubInfo, checkIfStale: true),
+                this.ownershipLeaseManager.CreateLeaseStoreIfNotExistsAsync(hubInfo, checkIfStale: false));
         }
 
         Task IPartitionManager.DeleteLeases()


### PR DESCRIPTION
The Azure Functions scaling infrastructure relies on the partitionCount
value in the taskhub.json. However, our logic to create this
taskhub.json only updated the blob if it did not exist. This means that
if the taskhub lease store was created with one value of partitionCount,
and the customer updated the partitionCount, the taskhub.json would not
be updated, and the scaling logic would continue to look only at the
original control queues.

This PR aims to update the taskhub.json partition count if it is out of
sync with the provided value in AzureStorageOrchestrationService, so
that customers don't need to update this value by hand to get correct
scaling behavior.