### PR TITLE
Changed query used when starting orchestration to prevent 404s

### DIFF
--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -499,7 +499,7 @@ namespace DurableTask.AzureStorage.Tracking
 
             var queryCondition = new OrchestrationInstanceStatusQueryCondition
             {
-                InstanceIdPrefix = instanceId,
+                InstanceId = instanceId,
                 FetchInput = fetchInput,
             };
 
@@ -536,7 +536,7 @@ namespace DurableTask.AzureStorage.Tracking
             return ConvertFromAsync(orchestrationInstanceStatus, tableEntity.PartitionKey);
         }
 
-        private OrchestrationInstanceStatus ConvertFromAsync(IDictionary<string, EntityProperty> properties)
+        static OrchestrationInstanceStatus ConvertFromAsync(IDictionary<string, EntityProperty> properties)
         {
             var orchestrationInstanceStatus = new OrchestrationInstanceStatus();
 
@@ -549,7 +549,7 @@ namespace DurableTask.AzureStorage.Tracking
                     var value = pair.Value;
                     if (value != null)
                     {
-                        if (property.PropertyType == typeof(DateTime))
+                        if (property.PropertyType == typeof(DateTime) || property.PropertyType == typeof(DateTime?))
                         {
                             property.SetValue(orchestrationInstanceStatus, value.DateTime);
                         }

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -504,7 +504,7 @@ namespace DurableTask.AzureStorage.Tracking
             };
 
             var stopwatch = new Stopwatch();
-            var segment = await this.InstancesTable.ExecuteQuerySegmentedAsync(queryCondition.ToTableQuery<DynamicTableEntity>(), null);
+            TableQuerySegment<DynamicTableEntity> segment = await this.InstancesTable.ExecuteQuerySegmentedAsync(queryCondition.ToTableQuery<DynamicTableEntity>(), null);
             stopwatch.Stop();
             this.stats.StorageRequests.Increment();
 

--- a/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
+++ b/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
@@ -95,12 +95,12 @@ namespace DurableTask.AzureStorage.Tracking
         {
             var conditions = new List<string>();
 
-            if (this.CreatedTimeFrom != null && this.CreatedTimeFrom > DateTime.MinValue)
+            if (this.CreatedTimeFrom > DateTime.MinValue)
             {
                 conditions.Add(TableQuery.GenerateFilterConditionForDate("CreatedTime", QueryComparisons.GreaterThanOrEqual, new DateTimeOffset(this.CreatedTimeFrom)));
             }
 
-            if (this.CreatedTimeTo != null && this.CreatedTimeTo != default(DateTime) && this.CreatedTimeTo < DateTime.MaxValue)
+            if (this.CreatedTimeTo != default(DateTime) && this.CreatedTimeTo < DateTime.MaxValue)
             {
                 conditions.Add(TableQuery.GenerateFilterConditionForDate("CreatedTime", QueryComparisons.LessThanOrEqual, new DateTimeOffset(this.CreatedTimeTo)));
             }

--- a/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
+++ b/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
@@ -65,7 +65,7 @@ namespace DurableTask.AzureStorage.Tracking
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
         public TableQuery<T> ToTableQuery<T>()
-            where T : TableEntity, new()
+            where T : ITableEntity, new()
         {
             var query = new TableQuery<T>();
             if (!((this.RuntimeStatus == null || (!this.RuntimeStatus.Any())) && 

--- a/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
+++ b/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
@@ -55,6 +55,11 @@ namespace DurableTask.AzureStorage.Tracking
         public string InstanceIdPrefix { get; set; }
 
         /// <summary>
+        /// InstanceIdPrefix
+        /// </summary>
+        public string InstanceId { get; set; }
+
+        /// <summary>
         /// If true, the input will be returned with the results. The default value is true.
         /// </summary>
         public bool FetchInput { get; set; } = true;
@@ -72,7 +77,8 @@ namespace DurableTask.AzureStorage.Tracking
                 this.CreatedTimeFrom == default(DateTime) && 
                 this.CreatedTimeTo == default(DateTime) &&
                 this.TaskHubNames == null &&
-                this.InstanceIdPrefix == null))
+                this.InstanceIdPrefix == null &&
+                 this.InstanceId == null))
             {
                 if (!this.FetchInput)
                 {
@@ -132,6 +138,11 @@ namespace DurableTask.AzureStorage.Tracking
                     TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThanOrEqual, InstanceIdPrefix), 
                     TableOperators.And, 
                     TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.LessThan, greaterThanPrefix)));
+            }
+
+            if (!string.IsNullOrEmpty(this.InstanceId))
+            {
+                conditions.Add(TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, InstanceId));
             }
 
             return conditions.Count == 1 ? 

--- a/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
+++ b/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
@@ -55,7 +55,7 @@ namespace DurableTask.AzureStorage.Tracking
         public string InstanceIdPrefix { get; set; }
 
         /// <summary>
-        /// InstanceIdPrefix
+        /// InstanceId
         /// </summary>
         public string InstanceId { get; set; }
 

--- a/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
+++ b/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
@@ -89,12 +89,12 @@ namespace DurableTask.AzureStorage.Tracking
         {
             var conditions = new List<string>();
 
-            if (this.CreatedTimeFrom > DateTime.MinValue)
+            if (this.CreatedTimeFrom != null && this.CreatedTimeFrom > DateTime.MinValue)
             {
                 conditions.Add(TableQuery.GenerateFilterConditionForDate("CreatedTime", QueryComparisons.GreaterThanOrEqual, new DateTimeOffset(this.CreatedTimeFrom)));
             }
 
-            if (this.CreatedTimeTo != default(DateTime) && this.CreatedTimeTo < DateTime.MaxValue)
+            if (this.CreatedTimeTo != null && this.CreatedTimeTo != default(DateTime) && this.CreatedTimeTo < DateTime.MaxValue)
             {
                 conditions.Add(TableQuery.GenerateFilterConditionForDate("CreatedTime", QueryComparisons.LessThanOrEqual, new DateTimeOffset(this.CreatedTimeTo)));
             }


### PR DESCRIPTION
Changed query used when starting an orchestrator to search the instances table for an existing orchestrator instance to prevent undesirable 404s.

Changed the query from a row retrieval operation to a query for existing instance statuses on the specific instance Id. When existing statuses associated with the instance Id are returned, the original row retrieval operation will take place in order to get the ETag associated with the row.

This change will add one additional storage transaction to starting a new instance only when attempting to start an instance with an existing instance Id. This change will prevent undesirable 404s in customers' App Insights dependency table.

resolves https://github.com/Azure/azure-functions-durable-extension/issues/593