### PR TITLE
Mitigate null custom status regression in DurableTask.AzureStorage

### DIFF
--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <FileVersion>1.8.2</FileVersion>
+    <FileVersion>1.8.3</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <Version>$(FileVersion)</Version>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -977,15 +977,13 @@ namespace DurableTask.AzureStorage.Tracking
 
             OrchestrationStatus runtimeStatus = OrchestrationStatus.Running;
 
-            // TODO: This is temporary workaround. We should prioritize https://github.com/Azure/durabletask/issues/477
-            // so that this is no longer necessary.
-            newRuntimeState.Status = newRuntimeState.Status ?? "null"; 
-
             var instanceEntity = new DynamicTableEntity(instanceId, string.Empty)
             {
                 Properties =
                 {
-                    ["CustomStatus"] = new EntityProperty(newRuntimeState.Status),
+                    // TODO: Translating null to "null" is a temporary workaround. We should prioritize 
+                    // https://github.com/Azure/durabletask/issues/477 so that this is no longer necessary.
+                    ["CustomStatus"] = new EntityProperty(newRuntimeState.Status ?? "null"),
                     ["ExecutionId"] = new EntityProperty(executionId),
                     ["LastUpdatedTime"] = new EntityProperty(newEvents.Last().Timestamp),
                 }

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -977,6 +977,10 @@ namespace DurableTask.AzureStorage.Tracking
 
             OrchestrationStatus runtimeStatus = OrchestrationStatus.Running;
 
+            // TODO: This is temporary workaround. We should prioritize https://github.com/Azure/durabletask/issues/477
+            // so that this is no longer necessary.
+            newRuntimeState.Status = newRuntimeState.Status ?? "null"; 
+
             var instanceEntity = new DynamicTableEntity(instanceId, string.Empty)
             {
                 Properties =

--- a/test/DurableTask.Test.Orchestrations/SimpleOrchestrations.cs
+++ b/test/DurableTask.Test.Orchestrations/SimpleOrchestrations.cs
@@ -287,6 +287,40 @@ namespace DurableTask.Test.Orchestrations
         }
     }
 
+    public sealed class ChangeStatusOrchestration : TaskOrchestration<string, string[]>
+    {
+        private bool hasSetCustomStatus = false;
+        private string customStatus = null;
+
+        private async Task SetCustomStatus(OrchestrationContext context, string status)
+        {
+            this.hasSetCustomStatus = true;
+            this.customStatus = status;
+            // Dummy timer to persist state.
+            await context.CreateTimer<int>(context.CurrentUtcDateTime, 0);
+        }
+
+        public override async Task<string> RunTask(OrchestrationContext context, string[] input)
+        {
+            foreach (var status in input)
+            {
+                await this.SetCustomStatus(context, status);
+            }
+
+            return string.Empty;
+        }
+
+        public override string OnGetStatus()
+        {
+            if (this.hasSetCustomStatus)
+            {
+                return this.customStatus;
+            }
+
+            return base.OnGetStatus();
+        }
+    }
+
     [KnownType(typeof(EventConversationOrchestration.Responder))]
     public sealed class EventConversationOrchestration : TaskOrchestration<string, bool>
     {


### PR DESCRIPTION
Implement a temporary mitigation for `null` custom status updates not
actually updating the state in Azure Table Storage due to the way that
merge operations happen.

A better long term mitigation is detailed at
https://github.com/Azure/durabletask/issues/477.