### PR TITLE
Enforce that ExecutionStarted is the first event in a WorkItem

### DIFF
--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -174,7 +174,6 @@ namespace DurableTask.Core
                 batch.RemoveAt(executionStartedIndex);
                 batch.Insert(targetPosition, executionStartedEvent);
             }
-
         }
 
         async Task OnProcessWorkItemSessionAsync(TaskOrchestrationWorkItem workItem)

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -167,7 +167,7 @@ namespace DurableTask.Core
 
             // If we found an ExecutionStartedEvent, we place it either
             // (A) in the beginning or
-            // (B)  after the "right-most" event with non-null executionID that came before it.
+            // (B) after the "right-most" event with non-null executionID that came before it.
             int executionStartedIndex = index;
             if ((executionStartedEvent != null) && (executionStartedIndex != targetPosition))
             {

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -128,7 +128,6 @@ namespace DurableTask.Core
 
             // We look for *the first* instance of an ExecutionStarted event in the batch, if any.
             int index;
-            bool foundEvent = false;
             TaskMessage execStartedEvent = null;
             Dictionary<string, int> earliestExecIdIndex = new Dictionary<string, int>();
             for(index = 0; index < batch.Count; index ++)
@@ -146,7 +145,6 @@ namespace DurableTask.Core
                 if (message.Event.EventType == EventType.ExecutionStarted)
                 {
                     execStartedEvent = message;
-                    foundEvent = true;
                     break;
                 }
             }
@@ -155,9 +153,9 @@ namespace DurableTask.Core
             // (A) in the beginning or
             // (B) at the earliest position found for an event with a matching executionID
             int execStartedIndex = index;
-            earliestExecIdIndex.TryGetValue(execStartedEvent.OrchestrationInstance.ExecutionId, out int newPosition);
-            if (foundEvent)
+            if (execStartedEvent != null)
             {
+                earliestExecIdIndex.TryGetValue(execStartedEvent.OrchestrationInstance.ExecutionId, out int newPosition);
                 batch.RemoveAt(execStartedIndex);
                 batch.Insert(newPosition, execStartedEvent);
             }

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -151,13 +151,17 @@ namespace DurableTask.Core
 
 
                 // Find the first ExecutionStarted event.
-                // ParentInstance needs to be null to avoid re-ordering
-                // ContinueAsNew events
-                if ((message.Event.EventType == EventType.ExecutionStarted) &&
-                    (message.Event is ExecutionStartedEvent eventData) &&
-                    (eventData.ParentInstance == null))
+                if (message.Event.EventType == EventType.ExecutionStarted)
                 {
-                    execStartedEvent = message;
+                    // ParentInstance needs to be null to avoid re-ordering
+                    // ContinueAsNew events
+                    if ((message.Event is ExecutionStartedEvent eventData) &&
+                        (eventData.ParentInstance == null))
+                    {
+                        execStartedEvent = message;
+                    }
+                    // We only consider the first ExecutionStarted event in the
+                    // list, so we always break.
                     break;
                 }
                 index++;

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -168,10 +168,10 @@ namespace DurableTask.Core
             // If we found an ExecutionStartedEvent, we place it either
             // (A) in the beginning or
             // (B)  after the "right-most" event with non-null executionID that came before it.
-            int execStartedIndex = index;
-            if ((executionStartedEvent != null) && (execStartedIndex != targetPosition))
+            int executionStartedIndex = index;
+            if ((executionStartedEvent != null) && (executionStartedIndex != targetPosition))
             {
-                batch.RemoveAt(execStartedIndex);
+                batch.RemoveAt(executionStartedIndex);
                 batch.Insert(targetPosition, executionStartedEvent);
             }
 

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -276,7 +276,7 @@ namespace DurableTask.Core
             OrchestrationState instanceState = null;
 
 
-            // Assumes Execution Started is the first event in the workItem batch
+            // Assumes that: if the batch contains a new "ExecutionStarted" event, it is the first message in the batch.
             if (!this.ReconcileMessagesWithState(workItem))
             {
                 // TODO : mark an orchestration as faulted if there is data corruption
@@ -583,7 +583,7 @@ namespace DurableTask.Core
 
         /// <summary>
         /// Determines whether the workItem should be discarded as per the orchestration's state.
-        /// It assumes that the workItem batch has an ExecutionStartedEvent as its first element.
+        /// Assumes that: if the batch contains a new "ExecutionStarted" event, it is the first message in the batch.
         /// </summary>
         /// <param name="workItem">A batch of work item messages.</param>
         /// <returns>True if workItem should be processed further. False otherwise.</returns>

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -151,7 +151,11 @@ namespace DurableTask.Core
 
 
                 // Find the first ExecutionStarted event.
-                if (message.Event.EventType == EventType.ExecutionStarted)
+                // ParentInstance needs to be null to avoid re-ordering
+                // ContinueAsNew events
+                if ((message.Event.EventType == EventType.ExecutionStarted) &&
+                    (message.Event is ExecutionStartedEvent eventData) &&
+                    (eventData.ParentInstance == null))
                 {
                     execStartedEvent = message;
                     break;
@@ -163,7 +167,7 @@ namespace DurableTask.Core
             // (A) in the beginning or
             // (B)  after the "right-most" event with non-null executionID that came before it.
             int execStartedIndex = index;
-            if (execStartedEvent != null)
+            if ((execStartedEvent != null) && (execStartedIndex != targetPosition))
             {
                 batch.RemoveAt(execStartedIndex);
                 batch.Insert(targetPosition, execStartedEvent);


### PR DESCRIPTION
Currently, there's a race condition where raising an event to a pending orchestrator can lead to a raiseEvent message being processed before an executionStarted one. This leads to the workItem batch being discarded and the orchestrator getting into a bad state.

This _draft_ PR adds a pre-processing step that re-orders the workItem messages when an ExecutionStarted event is not at the beginning of its `NewMessages` property. We do the re-ordering in-place, for performance.

If we believe the in-place re-ordering is a premature optimization, we can replace the re-ordering method with two lines: one calling the IList `insert` API, and the other calling the IList `delete` API.