### PR TITLE
sanitize the instance ids used as partition keys

### DIFF
--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -276,7 +276,7 @@ namespace DurableTask.AzureStorage
             return $"{instanceId}/message-{activityId}-{eventType}.json.gz";
         }
 
-        internal async Task DeleteLargeMessageBlobs(string instanceId, AzureStorageOrchestrationServiceStats stats)
+        internal async Task DeleteLargeMessageBlobs(string sanitizedInstanceId, AzureStorageOrchestrationServiceStats stats)
         {
             var blobForDeletionTaskList = new List<Task>();
             if (!await this.cloudBlobContainer.ExistsAsync())
@@ -284,7 +284,7 @@ namespace DurableTask.AzureStorage
                 return;
             }
 
-            CloudBlobDirectory instanceDirectory = this.cloudBlobContainer.GetDirectoryReference(instanceId);
+            CloudBlobDirectory instanceDirectory = this.cloudBlobContainer.GetDirectoryReference(sanitizedInstanceId);
             BlobContinuationToken blobContinuationToken = null;
             while (true)
             {

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -368,7 +368,6 @@ namespace DurableTask.AzureStorage.Tracking
             // 5. Returns "failedLeaves", a list of the deepest failed instances on each failed branch to revive with RewindEvent messages
             ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-            string soInstanceId = instanceId;
             bool hasFailedSubOrchestrations = false;
             const char Quote = '\'';
 
@@ -444,7 +443,7 @@ namespace DurableTask.AzureStorage.Tracking
 
                     var subOrchesratrationEntities = await QueryHistoryAsync(soFilterCondition.ToString(), instanceId, cancellationToken);
 
-                    soInstanceId = subOrchesratrationEntities[0].Properties["InstanceId"].StringValue;
+                    var soInstanceId = subOrchesratrationEntities[0].Properties["InstanceId"].StringValue;
 
                     // the SubORchestrationCreatedEvent is still healthy and will not be overwritten, just marked as rewound
                     subOrchesratrationEntities[0].Properties["Reason"] = new EntityProperty("Rewound: " + subOrchesratrationEntities[0].Properties["EventType"].StringValue);

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -243,7 +243,8 @@ namespace DurableTask.AzureStorage.Tracking
             const char Quote = '\'';
 
             // e.g. "PartitionKey eq 'c138dd969a1e4a699b0644c7d8279f81'"
-            filterCondition.Append(PartitionKeyProperty).Append(" eq ").Append(Quote).Append(instanceId).Append(Quote);
+            var sanitizedInstanceId = KeySanitation.EscapePartitionKey(instanceId);
+            filterCondition.Append(PartitionKeyProperty).Append(" eq ").Append(Quote).Append(sanitizedInstanceId).Append(Quote);
             if (!string.IsNullOrEmpty(expectedExecutionId))
             {
                 // Filter down to a specific generation.
@@ -373,7 +374,8 @@ namespace DurableTask.AzureStorage.Tracking
 
             var orchestratorStartedFilterCondition = new StringBuilder(200);
 
-            orchestratorStartedFilterCondition.Append(PartitionKeyProperty).Append(" eq ").Append(Quote).Append(instanceId).Append(Quote); // = TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, instanceId);
+            string sanitizedInstanceId = KeySanitation.EscapePartitionKey(instanceId);
+            orchestratorStartedFilterCondition.Append(PartitionKeyProperty).Append(" eq ").Append(Quote).Append(sanitizedInstanceId).Append(Quote); // = TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, instanceId);
             orchestratorStartedFilterCondition.Append(" and EventType eq ").Append(Quote).Append("OrchestratorStarted").Append(Quote);
 
             var orchestratorStartedEntities = await this.QueryHistoryAsync(orchestratorStartedFilterCondition.ToString(), instanceId, cancellationToken);
@@ -386,7 +388,7 @@ namespace DurableTask.AzureStorage.Tracking
 
             var rowsToUpdateFilterCondition = new StringBuilder(200);
 
-            rowsToUpdateFilterCondition.Append(PartitionKeyProperty).Append(" eq ").Append(Quote).Append(instanceId).Append(Quote);
+            rowsToUpdateFilterCondition.Append(PartitionKeyProperty).Append(" eq ").Append(Quote).Append(sanitizedInstanceId).Append(Quote);
             rowsToUpdateFilterCondition.Append(" and ExecutionId eq ").Append(Quote).Append(executionId).Append(Quote);
             rowsToUpdateFilterCondition.Append(" and (OrchestrationStatus eq ").Append(Quote).Append("Failed").Append(Quote);
             rowsToUpdateFilterCondition.Append(" or EventType eq ").Append(Quote).Append("TaskFailed").Append(Quote);
@@ -414,7 +416,7 @@ namespace DurableTask.AzureStorage.Tracking
 
                     var tsFilterCondition = new StringBuilder(200);
 
-                    tsFilterCondition.Append(PartitionKeyProperty).Append(" eq ").Append(Quote).Append(instanceId).Append(Quote);
+                    tsFilterCondition.Append(PartitionKeyProperty).Append(" eq ").Append(Quote).Append(sanitizedInstanceId).Append(Quote);
                     tsFilterCondition.Append(" and ExecutionId eq ").Append(Quote).Append(executionId).Append(Quote);
                     tsFilterCondition.Append(" and EventId eq ").Append(taskScheduledId);
                     tsFilterCondition.Append(" and EventType eq ").Append(Quote).Append(nameof(EventType.TaskScheduled)).Append(Quote);
@@ -435,7 +437,7 @@ namespace DurableTask.AzureStorage.Tracking
 
                     var soFilterCondition = new StringBuilder(200);
 
-                    soFilterCondition.Append(PartitionKeyProperty).Append(" eq ").Append(Quote).Append(instanceId).Append(Quote);
+                    soFilterCondition.Append(PartitionKeyProperty).Append(" eq ").Append(Quote).Append(sanitizedInstanceId).Append(Quote);
                     soFilterCondition.Append(" and ExecutionId eq ").Append(Quote).Append(executionId).Append(Quote);
                     soFilterCondition.Append(" and EventId eq ").Append(subOrchestrationId);
                     soFilterCondition.Append(" and EventType eq ").Append(Quote).Append(nameof(EventType.SubOrchestrationInstanceCreated)).Append(Quote);
@@ -533,8 +535,8 @@ namespace DurableTask.AzureStorage.Tracking
         {
             var properties = tableEntity.Properties;
             var orchestrationInstanceStatus = ConvertFromAsync(properties);
-
-            return ConvertFromAsync(orchestrationInstanceStatus, tableEntity.PartitionKey);
+            var instanceId = KeySanitation.UnescapePartitionKey(tableEntity.PartitionKey);
+            return ConvertFromAsync(orchestrationInstanceStatus, instanceId);
         }
 
         static OrchestrationInstanceStatus ConvertFromAsync(IDictionary<string, EntityProperty> properties)
@@ -643,7 +645,8 @@ namespace DurableTask.AzureStorage.Tracking
 
             query.Take(top);
             var segment = await this.InstancesTable.ExecuteQuerySegmentedAsync(query, token);
-            IEnumerable<OrchestrationState> result = await Task.WhenAll(segment.Select( status => this.ConvertFromAsync(status, status.PartitionKey)));
+            IEnumerable<OrchestrationState> result = await Task.WhenAll(
+                segment.Select(status => this.ConvertFromAsync(status, KeySanitation.UnescapePartitionKey(status.PartitionKey))));
             orchestrationStates.AddRange(result);
 
             this.stats.StorageRequests.Increment();
@@ -673,7 +676,7 @@ namespace DurableTask.AzureStorage.Tracking
 
                 int previousCount = orchestrationStates.Count;
                 IEnumerable<OrchestrationState> result = await Task.WhenAll(segment.Select(
-                    status => this.ConvertFromAsync(status, status.PartitionKey)));
+                    status => this.ConvertFromAsync(status, KeySanitation.UnescapePartitionKey(status.PartitionKey))));
                 orchestrationStates.AddRange(result);
 
                 this.stats.StorageRequests.Increment();
@@ -732,7 +735,7 @@ namespace DurableTask.AzureStorage.Tracking
             int storageRequests = 0;
             int rowsDeleted = 0;
             HistoryEntitiesResponseInfo historyEntitiesResponseInfo = await this.GetHistoryEntitiesResponseInfoAsync(
-                orchestrationInstanceStatus.PartitionKey,
+                KeySanitation.UnescapePartitionKey(orchestrationInstanceStatus.PartitionKey),
                 null,
                 new []
                 {
@@ -781,9 +784,11 @@ namespace DurableTask.AzureStorage.Tracking
         /// <inheritdoc />
         public override async Task<PurgeHistoryResult> PurgeInstanceHistoryAsync(string instanceId)
         {
+            string sanitizedInstanceId = KeySanitation.EscapePartitionKey(instanceId);
+
             TableQuery<OrchestrationInstanceStatus> query = new TableQuery<OrchestrationInstanceStatus>().Where(
                 TableQuery.CombineFilters(
-                    TableQuery.GenerateFilterCondition(PartitionKeyProperty, QueryComparisons.Equal, instanceId),
+                    TableQuery.GenerateFilterCondition(PartitionKeyProperty, QueryComparisons.Equal, sanitizedInstanceId),
                     TableOperators.And,
                     TableQuery.GenerateFilterCondition(RowKeyProperty, QueryComparisons.Equal, string.Empty)));
 
@@ -854,7 +859,8 @@ namespace DurableTask.AzureStorage.Tracking
             string eTag,
             string inputStatusOverride)
         {
-            DynamicTableEntity entity = new DynamicTableEntity(executionStartedEvent.OrchestrationInstance.InstanceId, "")
+            string sanitizedInstanceId = KeySanitation.EscapePartitionKey(executionStartedEvent.OrchestrationInstance.InstanceId);
+            DynamicTableEntity entity = new DynamicTableEntity(sanitizedInstanceId, "")
             {
                 ETag = eTag,
                 Properties =
@@ -920,7 +926,8 @@ namespace DurableTask.AzureStorage.Tracking
         /// <inheritdoc />
         public override async Task UpdateStatusForRewindAsync(string instanceId)
         {
-            DynamicTableEntity entity = new DynamicTableEntity(instanceId, "")
+            string sanitizedInstanceId = KeySanitation.EscapePartitionKey(instanceId);
+            DynamicTableEntity entity = new DynamicTableEntity(sanitizedInstanceId, "")
             {
                 ETag = "*",
                 Properties =
@@ -976,8 +983,9 @@ namespace DurableTask.AzureStorage.Tracking
             var historyEventBatch = new TableBatchOperation();
 
             OrchestrationStatus runtimeStatus = OrchestrationStatus.Running;
+            string sanitizedInstanceId = KeySanitation.EscapePartitionKey(instanceId);
 
-            var instanceEntity = new DynamicTableEntity(instanceId, string.Empty)
+            var instanceEntity = new DynamicTableEntity(sanitizedInstanceId, string.Empty)
             {
                 Properties =
                 {
@@ -995,7 +1003,7 @@ namespace DurableTask.AzureStorage.Tracking
 
                 HistoryEvent historyEvent = newEvents[i];
                 DynamicTableEntity historyEntity = this.tableEntityConverter.ConvertToTableEntity(historyEvent);
-                historyEntity.PartitionKey = instanceId;
+                historyEntity.PartitionKey = sanitizedInstanceId;
 
                 newEventListBuffer.Append(historyEvent.EventType.ToString()).Append(',');
 
@@ -1079,6 +1087,7 @@ namespace DurableTask.AzureStorage.Tracking
                 {
                     eTagValue = await this.UploadHistoryBatch(
                         instanceId,
+                        sanitizedInstanceId,
                         executionId,
                         historyEventBatch,
                         newEventListBuffer,
@@ -1100,6 +1109,7 @@ namespace DurableTask.AzureStorage.Tracking
             {
                 eTagValue = await this.UploadHistoryBatch(
                     instanceId,
+                    sanitizedInstanceId,
                     executionId,
                     historyEventBatch,
                     newEventListBuffer,
@@ -1239,7 +1249,7 @@ namespace DurableTask.AzureStorage.Tracking
 
         static string GetBlobName(DynamicTableEntity entity, string property)
         {
-            string instanceId = entity.PartitionKey;
+            string sanitizedInstanceId = entity.PartitionKey;
             string sequenceNumber = entity.RowKey;
 
             string eventType;
@@ -1258,13 +1268,14 @@ namespace DurableTask.AzureStorage.Tracking
                 throw new InvalidOperationException($"Could not compute the blob name for property {property}");
             }
 
-            string blobName = $"{instanceId}/history-{sequenceNumber}-{eventType}-{property}.json.gz";
+            string blobName = $"{sanitizedInstanceId}/history-{sequenceNumber}-{eventType}-{property}.json.gz";
 
             return blobName;
         }
 
         async Task<string> UploadHistoryBatch(
             string instanceId,
+            string sanitizedInstanceId,
             string executionId,
             TableBatchOperation historyEventBatch,
             StringBuilder historyEventNamesBuffer,
@@ -1275,7 +1286,7 @@ namespace DurableTask.AzureStorage.Tracking
             bool isFinalBatch)
         {
             // Adding / updating sentinel entity
-            DynamicTableEntity sentinelEntity = new DynamicTableEntity(instanceId, SentinelRowKey)
+            DynamicTableEntity sentinelEntity = new DynamicTableEntity(sanitizedInstanceId, SentinelRowKey)
             {
                 Properties =
                 {

--- a/src/DurableTask.AzureStorage/Tracking/KeySanitation.cs
+++ b/src/DurableTask.AzureStorage/Tracking/KeySanitation.cs
@@ -42,12 +42,30 @@ namespace DurableTask.AzureStorage.Tracking
             {
                 switch (c)
                 {
-                    case escapeChar: b.Append(escapeChar); b.Append(escapeChar); break;
+                    case escapeChar:
+                        b.Append(escapeChar); 
+                        b.Append(escapeChar);
+                        break;
 
-                    case '/': b.Append(escapeChar); b.Append('0'); break;
-                    case '\\': b.Append(escapeChar); b.Append('1'); break;
-                    case '#': b.Append(escapeChar); b.Append('2'); break;
-                    case '?': b.Append(escapeChar); b.Append('3'); break;
+                    case '/':
+                        b.Append(escapeChar);
+                        b.Append('0');
+                        break;
+
+                    case '\\': 
+                        b.Append(escapeChar);
+                        b.Append('1'); 
+                        break;
+
+                    case '#': 
+                        b.Append(escapeChar); 
+                        b.Append('2'); 
+                        break;
+
+                    case '?': 
+                        b.Append(escapeChar); 
+                        b.Append('3');
+                        break;
 
                     default:
                         {
@@ -99,10 +117,21 @@ namespace DurableTask.AzureStorage.Tracking
                     {
                         case escapeChar: b.Append(escapeChar); break;
 
-                        case '0': b.Append('/'); break;
-                        case '1': b.Append('\\'); break;
-                        case '2': b.Append('#'); break;
-                        case '3': b.Append('?'); break;
+                        case '0':
+                            b.Append('/');
+                            break;
+
+                        case '1': 
+                            b.Append('\\');
+                            break;
+
+                        case '2': 
+                            b.Append('#');
+                            break;
+
+                        case '3': 
+                            b.Append('?'); 
+                            break;
 
                         default:
                             {

--- a/src/DurableTask.AzureStorage/Tracking/KeySanitation.cs
+++ b/src/DurableTask.AzureStorage/Tracking/KeySanitation.cs
@@ -1,0 +1,109 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureStorage.Tracking
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Text;
+    using DurableTask.Core.History;
+
+    static class KeySanitation
+    {
+        private const char escapeChar = '^';
+        private const char offset = 'À';
+
+        /// <summary>
+        /// Escape any characters that can't be used in Azure PartitionKey.
+        /// https://docs.microsoft.com/en-us/rest/api/storageservices/Understanding-the-Table-Service-Data-Model?redirectedfrom=MSDN
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns>The modified string.</returns>
+        public static string EscapePartitionKey(string key)
+        {
+            StringBuilder b = new StringBuilder();
+            foreach (char c in key)
+            {
+                switch (c)
+                {
+                    case escapeChar: b.Append(escapeChar); b.Append(escapeChar); break;
+
+                    case '/': b.Append(escapeChar); b.Append('0'); break;
+                    case '\\': b.Append(escapeChar); b.Append('1'); break;
+                    case '#': b.Append(escapeChar); b.Append('2'); break;
+                    case '?': b.Append(escapeChar); b.Append('3'); break;
+
+                    default:
+                        {
+                            uint val = (uint)c;
+
+                            if (val <= 0x1F || (val >= 0x7F && val <= 0x9F))
+                            {
+                                // characters in this range cannot be used, so we escape them 
+                                b.Append(escapeChar);
+                                // and shift them into a valid (unicode) range
+                                b.Append((char) (offset + val));
+                            }
+                            else
+                            {
+                                b.Append(c);
+                            }
+
+                            break;
+                        }
+                }
+            }
+            return b.ToString();
+        }
+
+        /// <summary>
+        /// Unescape characters that were previously escaped.
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns>The original string.</returns>
+        public static string UnescapePartitionKey(string key)
+        {
+            StringBuilder b = new StringBuilder();
+            for (int i = 0; i < key.Length; i++)
+            {
+                char c = key[i];
+                if (c != escapeChar)
+                {
+                    b.Append(c);
+                }
+                else
+                {
+                    c = key[++i];
+                    switch (c)
+                    {
+                        case escapeChar: b.Append(escapeChar); break;
+
+                        case '0': b.Append('/'); break;
+                        case '1': b.Append('\\'); break;
+                        case '2': b.Append('#'); break;
+                        case '3': b.Append('?'); break;
+
+                        default:
+                            {
+                                char shiftedBack = (c < offset) ? c : (char)(c - offset);
+                                b.Append(shiftedBack);
+                                break;
+                            }
+                    }
+                }
+            }
+            return b.ToString();
+        }
+    }
+}

--- a/src/DurableTask.AzureStorage/Tracking/KeySanitation.cs
+++ b/src/DurableTask.AzureStorage/Tracking/KeySanitation.cs
@@ -32,6 +32,11 @@ namespace DurableTask.AzureStorage.Tracking
         /// <returns>The modified string.</returns>
         public static string EscapePartitionKey(string key)
         {
+            if (key == null)
+            {
+                return null;
+            }
+
             StringBuilder b = new StringBuilder();
             foreach (char c in key)
             {
@@ -74,6 +79,11 @@ namespace DurableTask.AzureStorage.Tracking
         /// <returns>The original string.</returns>
         public static string UnescapePartitionKey(string key)
         {
+            if (key == null)
+            {
+                return null;
+            }
+
             StringBuilder b = new StringBuilder();
             for (int i = 0; i < key.Length; i++)
             {

--- a/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
+++ b/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
@@ -129,20 +129,22 @@ namespace DurableTask.AzureStorage.Tracking
 
             if (!string.IsNullOrEmpty(this.InstanceIdPrefix))
             {
-                int length = this.InstanceIdPrefix.Length - 1;
-                char incrementedLastChar = (char)(this.InstanceIdPrefix[length] + 1);
+                var sanitizedPrefix = KeySanitation.EscapePartitionKey(this.InstanceIdPrefix);
+                int length = sanitizedPrefix.Length - 1;
+                char incrementedLastChar = (char)(sanitizedPrefix[length] + 1);
 
-                string greaterThanPrefix = this.InstanceIdPrefix.Substring(0, length) + incrementedLastChar;
+                string greaterThanPrefix = sanitizedPrefix.Substring(0, length) + incrementedLastChar;
 
                 conditions.Add(TableQuery.CombineFilters(
-                    TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThanOrEqual, InstanceIdPrefix), 
+                    TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThanOrEqual, sanitizedPrefix), 
                     TableOperators.And, 
                     TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.LessThan, greaterThanPrefix)));
             }
 
             if (!string.IsNullOrEmpty(this.InstanceId))
             {
-                conditions.Add(TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, InstanceId));
+                var sanitizedInstanceId = KeySanitation.EscapePartitionKey(this.InstanceId);
+                conditions.Add(TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, sanitizedInstanceId));
             }
 
             return conditions.Count == 1 ? 

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -1906,9 +1906,11 @@ namespace DurableTask.AzureStorage.Tests
 
         private static async Task ValidateBlobUrlAsync(string taskHubName, string instanceId, string value, int originalPayloadSize = 0)
         {
+            string sanitizedInstanceId = KeySanitation.EscapePartitionKey(instanceId);
+
             CloudStorageAccount account = CloudStorageAccount.Parse(TestHelpers.GetTestStorageAccountConnectionString());
             Assert.IsTrue(value.StartsWith(account.BlobStorageUri.PrimaryUri.OriginalString));
-            Assert.IsTrue(value.Contains("/" + instanceId + "/"));
+            Assert.IsTrue(value.Contains("/" + sanitizedInstanceId + "/"));
             Assert.IsTrue(value.EndsWith(".json.gz"));
 
             string containerName = $"{taskHubName.ToLowerInvariant()}-largemessages";
@@ -1917,7 +1919,7 @@ namespace DurableTask.AzureStorage.Tests
             Assert.IsTrue(await container.ExistsAsync(), $"Blob container {containerName} is expected to exist.");
 
             await client.GetBlobReferenceFromServerAsync(new Uri(value));
-            CloudBlobDirectory instanceDirectory = container.GetDirectoryReference(instanceId);
+            CloudBlobDirectory instanceDirectory = container.GetDirectoryReference(sanitizedInstanceId);
 
             string blobName = value.Split('/').Last();
             CloudBlob blob = instanceDirectory.GetBlobReference(blobName);

--- a/test/DurableTask.AzureStorage.Tests/KeySanitationTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/KeySanitationTests.cs
@@ -41,6 +41,7 @@ namespace DurableTask.AzureStorage.Tests
         [DataRow("!@#$%^&*()_+=-0987654321d")]
         [DataRow("\'\"\\\r\n\t")]
         [DataRow("\u001F\u007F\u009F")]
+        [DataRow(null)]
 
         public void TestRoundTrip(string original)
         {
@@ -48,7 +49,11 @@ namespace DurableTask.AzureStorage.Tests
             string roundtrip = KeySanitation.UnescapePartitionKey(sanitized);
 
             Assert.AreEqual(original, roundtrip);
-            Assert.IsTrue(sanitized.All(c => IsValid(c)));
+
+            if (sanitized != null)
+            {
+                Assert.IsTrue(sanitized.All(c => IsValid(c)));
+            }
 
             bool IsValid(char c)
             {

--- a/test/DurableTask.AzureStorage.Tests/KeySanitationTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/KeySanitationTests.cs
@@ -1,0 +1,68 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureStorage.Tests
+{
+    using System;
+    using System.Linq;
+    using DurableTask.AzureStorage.Tracking;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// Extension methods for String Test
+    /// </summary>
+    [TestClass]
+    public class KeySanitationTests
+    {
+        [TestMethod]
+        [DataRow("\r")]
+        [DataRow("")]
+        [DataRow("hello")]
+        [DataRow("\uFFFF")]
+        [DataRow("\u0000")]
+        [DataRow("#")]
+        [DataRow("%")]
+        [DataRow("/")]
+        [DataRow("\\")]
+        [DataRow("?")]
+        [DataRow("^")]
+        [DataRow("^^")]
+        [DataRow("^^^")]
+        [DataRow("!@#$%^&*()_+=-0987654321d")]
+        [DataRow("\'\"\\\r\n\t")]
+        [DataRow("\u001F\u007F\u009F")]
+
+        public void TestRoundTrip(string original)
+        {
+            string sanitized = KeySanitation.EscapePartitionKey(original);
+            string roundtrip = KeySanitation.UnescapePartitionKey(sanitized);
+
+            Assert.AreEqual(original, roundtrip);
+            Assert.IsTrue(sanitized.All(c => IsValid(c)));
+
+            bool IsValid(char c)
+            {
+                if (c == '\\' || c == '?' || c == '#' || c == '/')
+                {
+                    return false;
+                }
+                uint val = (uint)c;
+                if (val <= 0x1F || (val >= 0x7F && val <= 0x9F))
+                {
+                    return false;
+                }
+                return true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Uses a mechanims for escaping/unescaping characters that are invalid for use in partition keys on Azure Tables.