### PR TITLE
Fix a null-ref in the core deserialization path

### DIFF
--- a/src/DurableTask.Core/Logging/StructuredEventSource.cs
+++ b/src/DurableTask.Core/Logging/StructuredEventSource.cs
@@ -532,7 +532,7 @@ namespace DurableTask.Core.Logging
                     InstanceId,
                     ExecutionId,
                     RuntimeStatus,
-                    Details,
+                    Details ?? string.Empty,
                     SizeInBytes,
                     AppName,
                     ExtensionVersion);

--- a/src/DurableTask.Core/Serializing/DataConverter.cs
+++ b/src/DurableTask.Core/Serializing/DataConverter.cs
@@ -51,7 +51,13 @@ namespace DurableTask.Core.Serializing
         /// <returns>Deserialized Object</returns>
         public T Deserialize<T>(string data)
         {
-            return (T) Deserialize(data, typeof (T));
+            object result = this.Deserialize(data, typeof(T));
+            if (result == null)
+            {
+                return default(T);
+            }
+
+            return (T)result;
         }
     }
 }

--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -45,9 +45,9 @@
   <!-- Nuget Package Settings -->
   <PropertyGroup>
     <PackageOutputPath>..\..\build_output\packages</PackageOutputPath>
-    <AssemblyVersion>2.5.0</AssemblyVersion>
-    <FileVersion>2.5.0</FileVersion>
-    <Version>2.5.0</Version>
+    <AssemblyVersion>2.5.1</AssemblyVersion>
+    <FileVersion>2.5.1</FileVersion>
+    <Version>2.5.1</Version>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
     <Product>Durable Task Framework</Product>


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-functions-durable-extension/issues/1613.

The problem is that we're trying to cast a `null` value into `T`, which is only legal if `T` is a reference type. If it is a value type, like `int` or `Guid` then the cast fails with a `NullReferenceException`. I found this by testing Durable Entities using the SQL backend.

Also included in this PR is a small fix to our logging to handle a certain scenario where we might unintentionally log a null value.

I've also proactively incremented the version of DurableTask.Core in this PR to **2.5.1**.