### PR TITLE
TypeNameHandling.None on MessageData.Sender

### DIFF
--- a/src/DurableTask.AzureStorage/MessageData.cs
+++ b/src/DurableTask.AzureStorage/MessageData.cs
@@ -17,6 +17,7 @@ namespace DurableTask.AzureStorage
     using System.Runtime.Serialization;
     using DurableTask.Core;
     using Microsoft.WindowsAzure.Storage.Queue;
+    using Newtonsoft.Json;
 
     /// <summary>
     /// Protocol class for all Azure Queue messages.
@@ -86,6 +87,7 @@ namespace DurableTask.AzureStorage
         /// The sender of the message.
         /// </summary>
         [DataMember(EmitDefaultValue = false)]
+        [JsonProperty(TypeNameHandling = TypeNameHandling.None)]
         public OrchestrationInstance Sender { get; private set; }
 
         /// <summary>


### PR DESCRIPTION
Fix for #491 

Overall, AzureStorage owners should re-evaluate their use of `TypeNameHandling.Object` while serializing here, as it makes the whole system very fragile to type renames and namespace changes. My suggestion is to use `TypeNameHandling.None` and to implement `IExtensibleDataObject` on `MessageData` to give this the ability to round trip between difference versions of DurableTask.AzureStorage and not lose any data.

This change should not break existing orchestrations, Newtonsoft.Json can handle mismatch between `$type` property and `TypeNameHandling` setting.