### PR TITLE
Public ReflectionBasedTaskActivity.DataConverter setter

### DIFF
--- a/src/DurableTask.Core/ReflectionBasedTaskActivity.cs
+++ b/src/DurableTask.Core/ReflectionBasedTaskActivity.cs
@@ -26,6 +26,8 @@ namespace DurableTask.Core
     /// </summary>
     public class ReflectionBasedTaskActivity : TaskActivity
     {
+        private DataConverter dataConverter;
+
         /// <summary>
         /// Creates a new ReflectionBasedTaskActivity based on an activity object and method info
         /// </summary>
@@ -41,7 +43,11 @@ namespace DurableTask.Core
         /// <summary>
         /// The DataConverter to use for input and output serialization/deserialization
         /// </summary>
-        public DataConverter DataConverter { get; private set; }
+        public DataConverter DataConverter
+        {
+            get => dataConverter;
+            set => dataConverter = value ?? throw new ArgumentNullException(nameof(value));
+        }
 
         /// <summary>
         /// The activity object to invoke methods on


### PR DESCRIPTION
Small PR to make this property have a public setter, but also enforce non-null values. The justification is that it may be useful to override this value in the dispatcher middleware with a custom converter - for example our system has a DI-enabled converter.