### PR TITLE
Introduce INameVersionProvider

### DIFF
--- a/src/DurableTask.Core/DefaultObjectCreator.cs
+++ b/src/DurableTask.Core/DefaultObjectCreator.cs
@@ -29,9 +29,14 @@ namespace DurableTask.Core
         /// </summary>
         /// <param name="type">Type to use for the creator</param>
         public DefaultObjectCreator(Type type)
+            : this(type, null)
+        {
+        }
+
+        internal DefaultObjectCreator(Type type, INameVersionProvider provider)
         {
             this.prototype = type;
-            Initialize(type);
+            Initialize(type, provider);
         }
 
         /// <summary>
@@ -39,9 +44,14 @@ namespace DurableTask.Core
         /// </summary>
         /// <param name="instance">Object instances to infer the type from</param>
         public DefaultObjectCreator(T instance)
+            : this(instance, null)
+        {
+        }
+
+        internal DefaultObjectCreator(T instance, INameVersionProvider provider)
         {
             this.instance = instance;
-            Initialize(instance);
+            Initialize(instance, provider);
         }
 
         /// <summary>
@@ -58,10 +68,11 @@ namespace DurableTask.Core
             return this.instance;
         }
 
-        void Initialize(object obj)
+        void Initialize(object obj, INameVersionProvider provider = null)
         {
-            Name = NameVersionHelper.GetDefaultName(obj);
-            Version = NameVersionHelper.GetDefaultVersion(obj);
+            provider = provider ?? NameVersionHelper.Provider;
+            Name = provider.GetName(obj);
+            Version = provider.GetVersion(obj);
         }
     }
 }

--- a/src/DurableTask.Core/INameVersionProvider.cs
+++ b/src/DurableTask.Core/INameVersionProvider.cs
@@ -1,0 +1,36 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core
+{
+    /// <summary>
+    /// An interface for supplying names and versions for a given object.
+    /// </summary>
+    public interface INameVersionProvider
+    {
+        /// <summary>
+        /// Gets the name of an Object instance.
+        /// </summary>
+        /// <param name="obj">Object to get the name for</param>
+        /// <param name="useFullyQualifiedMethodNames">Boolean indicating whether to use fully qualified names or not</param>
+        /// <returns>Name of the object instance's type</returns>
+        string GetName(object obj, bool useFullyQualifiedMethodNames = false);
+
+        /// <summary>
+        /// Gets the default version for an object.
+        /// </summary>
+        /// <param name="obj">Object to get the version for</param>
+        /// <returns>The version as string</returns>
+        string GetVersion(object obj);
+    }
+}

--- a/src/DurableTask.Core/NameVersionHelper.cs
+++ b/src/DurableTask.Core/NameVersionHelper.cs
@@ -22,6 +22,11 @@ namespace DurableTask.Core
     /// </summary>
     public static class NameVersionHelper
     {
+        /// <summary>
+        /// Gets the <see cref="INameVersionProvider"/>.
+        /// </summary>
+        public static INameVersionProvider Provider { get; } = new ProviderImpl();
+
         internal static string GetDefaultMethodName(MethodInfo methodInfo, bool useFullyQualifiedMethodNames)
         {
             string methodName = methodInfo.Name;
@@ -98,6 +103,15 @@ namespace DurableTask.Core
             }
 
             return declaringType + "." + methodName;
+        }
+
+        private class ProviderImpl : INameVersionProvider
+        {
+            public string GetName(object obj, bool useFullyQualifiedMethodNames = false)
+                => GetDefaultName(obj, useFullyQualifiedMethodNames);
+
+            public string GetVersion(object obj)
+                => GetDefaultVersion(obj);
         }
     }
 }

--- a/src/DurableTask.Core/OrchestrationContext.cs
+++ b/src/DurableTask.Core/OrchestrationContext.cs
@@ -33,6 +33,12 @@ namespace DurableTask.Core
         public static bool IsOrchestratorThread;
 
         /// <summary>
+        /// INameVersionProvider for getting names and versions when not explicitly supplied.
+        /// When null, <see cref="NameVersionHelper.Provider"/> is used.
+        /// </summary>
+        public INameVersionProvider NameVersionProvider { get; set; }
+
+        /// <summary>
         /// JsonDataConverter for message serialization settings
         /// </summary>
         public JsonDataConverter MessageDataConverter { get; set; }
@@ -53,7 +59,7 @@ namespace DurableTask.Core
         public virtual DateTime CurrentUtcDateTime { get; internal set; }
 
         /// <summary>
-        ///     True if the code is currently replaying, False if code is truly executing for the first time.
+        /// True if the code is currently replaying, False if code is truly executing for the first time.
         /// </summary>
         public bool IsReplaying { get; internal protected set; }
 
@@ -143,8 +149,7 @@ namespace DurableTask.Core
         public virtual Task<T> ScheduleWithRetry<T>(Type taskActivityType, RetryOptions retryOptions,
             params object[] parameters)
         {
-            return ScheduleWithRetry<T>(NameVersionHelper.GetDefaultName(taskActivityType),
-                NameVersionHelper.GetDefaultVersion(taskActivityType),
+            return ScheduleWithRetry<T>(GetName(taskActivityType), GetVersion(taskActivityType),
                 retryOptions, parameters);
         }
 
@@ -176,8 +181,8 @@ namespace DurableTask.Core
         public virtual Task<T> CreateSubOrchestrationInstanceWithRetry<T>(Type orchestrationType,
             RetryOptions retryOptions, object input)
         {
-            return CreateSubOrchestrationInstanceWithRetry<T>(NameVersionHelper.GetDefaultName(orchestrationType),
-                NameVersionHelper.GetDefaultVersion(orchestrationType), retryOptions, input);
+            return CreateSubOrchestrationInstanceWithRetry<T>(GetName(orchestrationType),
+                GetVersion(orchestrationType), retryOptions, input);
         }
 
         /// <summary>
@@ -192,8 +197,8 @@ namespace DurableTask.Core
         public virtual Task<T> CreateSubOrchestrationInstanceWithRetry<T>(Type orchestrationType, string instanceId,
             RetryOptions retryOptions, object input)
         {
-            return CreateSubOrchestrationInstanceWithRetry<T>(NameVersionHelper.GetDefaultName(orchestrationType),
-                NameVersionHelper.GetDefaultVersion(orchestrationType), instanceId, retryOptions, input);
+            return CreateSubOrchestrationInstanceWithRetry<T>(GetName(orchestrationType),
+                GetVersion(orchestrationType), instanceId, retryOptions, input);
         }
 
         /// <summary>
@@ -240,8 +245,8 @@ namespace DurableTask.Core
         /// <returns>Task that represents the execution of the specified TaskActivity</returns>
         public virtual Task<TResult> ScheduleTask<TResult>(Type activityType, params object[] parameters)
         {
-            return ScheduleTask<TResult>(NameVersionHelper.GetDefaultName(activityType),
-                NameVersionHelper.GetDefaultVersion(activityType), parameters);
+            return ScheduleTask<TResult>(GetName(activityType),
+                GetVersion(activityType), parameters);
         }
 
         /// <summary>
@@ -282,8 +287,8 @@ namespace DurableTask.Core
         /// <returns>Task that represents the execution of the specified sub-orchestration</returns>
         public virtual Task<T> CreateSubOrchestrationInstance<T>(Type orchestrationType, object input)
         {
-            return CreateSubOrchestrationInstance<T>(NameVersionHelper.GetDefaultName(orchestrationType),
-                NameVersionHelper.GetDefaultVersion(orchestrationType), input);
+            return CreateSubOrchestrationInstance<T>(GetName(orchestrationType),
+                GetVersion(orchestrationType), input);
         }
 
         /// <summary>
@@ -296,8 +301,8 @@ namespace DurableTask.Core
         /// <returns>Task that represents the execution of the specified sub-orchestration</returns>
         public virtual Task<T> CreateSubOrchestrationInstance<T>(Type orchestrationType, string instanceId, object input)
         {
-            return CreateSubOrchestrationInstance<T>(NameVersionHelper.GetDefaultName(orchestrationType),
-                NameVersionHelper.GetDefaultVersion(orchestrationType), instanceId, input);
+            return CreateSubOrchestrationInstance<T>(GetName(orchestrationType),
+                GetVersion(orchestrationType), instanceId, input);
         }
 
         /// <summary>
@@ -371,5 +376,11 @@ namespace DurableTask.Core
         ///     the first execution of this orchestration instance.
         /// </param>
         public abstract void ContinueAsNew(string newVersion, object input);
+
+        private string GetName(object obj, bool useFullyQualifiedMethodNames = false)
+            => (NameVersionProvider ?? NameVersionHelper.Provider).GetName(obj, useFullyQualifiedMethodNames);
+
+        private string GetVersion(object obj)
+            => (NameVersionProvider ?? NameVersionHelper.Provider).GetVersion(obj);
     }
 }

--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -70,6 +70,12 @@ namespace DurableTask.Core
         }
 
         /// <summary>
+        /// INameVersionProvider for getting names and versions when not explicitly supplied.
+        /// When null, <see cref="NameVersionHelper.Provider"/> is used.
+        /// </summary>
+        public INameVersionProvider NameVersionProvider { get; set; }
+
+        /// <summary>
         ///     Create a new orchestration of the specified type with the specified instance id, scheduled to start at an specific time
         /// </summary>
         /// <param name="orchestrationType">Type that derives from TaskOrchestration</param>
@@ -82,8 +88,8 @@ namespace DurableTask.Core
             DateTime startAt)
         {
             return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
-                NameVersionHelper.GetDefaultName(orchestrationType),
-                NameVersionHelper.GetDefaultVersion(orchestrationType),
+                GetName(orchestrationType),
+                GetVersion(orchestrationType),
                 null,
                 input,
                 null,
@@ -108,8 +114,8 @@ namespace DurableTask.Core
             DateTime startAt)
         {
             return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
-                NameVersionHelper.GetDefaultName(orchestrationType),
-                NameVersionHelper.GetDefaultVersion(orchestrationType),
+                GetName(orchestrationType),
+                GetVersion(orchestrationType),
                 instanceId,
                 input,
                 null,
@@ -128,8 +134,8 @@ namespace DurableTask.Core
         public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(Type orchestrationType, object input)
         {
             return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
-                NameVersionHelper.GetDefaultName(orchestrationType),
-                NameVersionHelper.GetDefaultVersion(orchestrationType),
+                GetName(orchestrationType),
+                GetVersion(orchestrationType),
                 orchestrationInstanceId: null,
                 orchestrationInput: input,
                 orchestrationTags: null,
@@ -148,8 +154,8 @@ namespace DurableTask.Core
         public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(Type orchestrationType, object input, DateTime startAt)
         {
             return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
-                NameVersionHelper.GetDefaultName(orchestrationType),
-                NameVersionHelper.GetDefaultVersion(orchestrationType),
+                GetName(orchestrationType),
+                GetVersion(orchestrationType),
                 null,
                 input,
                 null,
@@ -171,8 +177,8 @@ namespace DurableTask.Core
             object input)
         {
             return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
-                NameVersionHelper.GetDefaultName(orchestrationType),
-                NameVersionHelper.GetDefaultVersion(orchestrationType),
+                GetName(orchestrationType),
+                GetVersion(orchestrationType),
                 instanceId,
                 input,
                 orchestrationTags: null,
@@ -196,8 +202,8 @@ namespace DurableTask.Core
             OrchestrationStatus[] dedupeStatuses)
         {
             return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
-                NameVersionHelper.GetDefaultName(orchestrationType),
-                NameVersionHelper.GetDefaultVersion(orchestrationType),
+                GetName(orchestrationType),
+                GetVersion(orchestrationType),
                 instanceId,
                 input,
                 orchestrationTags: null,
@@ -319,8 +325,8 @@ namespace DurableTask.Core
             object eventData)
         {
             return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
-                NameVersionHelper.GetDefaultName(orchestrationType),
-                NameVersionHelper.GetDefaultVersion(orchestrationType),
+                GetName(orchestrationType),
+                GetVersion(orchestrationType),
                 orchestrationInstanceId: null,
                 orchestrationInput,
                 orchestrationTags: null,
@@ -347,8 +353,8 @@ namespace DurableTask.Core
             object eventData)
         {
             return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
-                NameVersionHelper.GetDefaultName(orchestrationType),
-                NameVersionHelper.GetDefaultVersion(orchestrationType),
+                GetName(orchestrationType),
+                GetVersion(orchestrationType),
                 instanceId,
                 orchestrationInput,
                 orchestrationTags: null,
@@ -377,8 +383,8 @@ namespace DurableTask.Core
             object eventData)
         {
             return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
-                NameVersionHelper.GetDefaultName(orchestrationType),
-                NameVersionHelper.GetDefaultVersion(orchestrationType),
+                GetName(orchestrationType),
+                GetVersion(orchestrationType),
                 instanceId,
                 orchestrationInput,
                 orchestrationTags: null,
@@ -861,5 +867,11 @@ namespace DurableTask.Core
         {
             return this.ServiceClient.PurgeOrchestrationHistoryAsync(thresholdDateTimeUtc, timeRangeFilterType);
         }
+
+        private string GetName(object obj, bool useFullyQualifiedMethodNames = false)
+            => (NameVersionProvider ?? NameVersionHelper.Provider).GetName(obj, useFullyQualifiedMethodNames);
+
+        private string GetVersion(object obj)
+            => (NameVersionProvider ?? NameVersionHelper.Provider).GetVersion(obj);
     }
 }

--- a/src/DurableTask.Core/TaskOrchestrationExecutor.cs
+++ b/src/DurableTask.Core/TaskOrchestrationExecutor.cs
@@ -34,11 +34,18 @@ namespace DurableTask.Core
         readonly bool skipCarryOverEvents;
         Task<string> result;
 
-        public TaskOrchestrationExecutor(OrchestrationRuntimeState orchestrationRuntimeState,
-            TaskOrchestration taskOrchestration, BehaviorOnContinueAsNew eventBehaviourForContinueAsNew)
+        public TaskOrchestrationExecutor(
+            OrchestrationRuntimeState orchestrationRuntimeState,
+            TaskOrchestration taskOrchestration,
+            BehaviorOnContinueAsNew eventBehaviourForContinueAsNew,
+            INameVersionProvider nameVersionProvider)
         {
             this.decisionScheduler = new SynchronousTaskScheduler();
-            this.context = new TaskOrchestrationContext(orchestrationRuntimeState.OrchestrationInstance, this.decisionScheduler);
+            this.context = new TaskOrchestrationContext(orchestrationRuntimeState.OrchestrationInstance, this.decisionScheduler)
+            {
+                NameVersionProvider = nameVersionProvider ?? NameVersionHelper.Provider,
+            };
+
             this.orchestrationRuntimeState = orchestrationRuntimeState;
             this.taskOrchestration = taskOrchestration;
             this.skipCarryOverEvents = eventBehaviourForContinueAsNew == BehaviorOnContinueAsNew.Ignore;


### PR DESCRIPTION
This PR introduces the ability to customize how DTFx derives its default name/versions for orchestrations and activities. As explained in #495, the motivation in this is to use `Type.FullName` instead of `Type.ToString()` when getting the default name so that the type params for generics contains the assembly info, allowing for fetching of the type by string when processing the orchestration or activity.

Closes #495 