### PR TITLE
Remove possible nullPtr exception in OnProcessWorkItemAsync

### DIFF
--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -544,9 +544,9 @@ namespace DurableTask.Core
             runtimeState.Status = runtimeState.Status ?? carryOverStatus;
 
             // If we entered the if-statement above, `instanceState` might be null
-            // In that case, we keep instanceState consistent with the runtimeState
             if (instanceState == null)
             {
+                // In that case, we keep instanceState consistent with the runtimeState
                 instanceState = Utils.BuildOrchestrationState(runtimeState);
             }
 

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -544,12 +544,11 @@ namespace DurableTask.Core
             runtimeState.Status = runtimeState.Status ?? carryOverStatus;
 
             // If we entered the if-statement above, `instanceState` might be null
-            if (instanceState == null)
+            if (instanceState != null)
             {
-                instanceState = new OrchestrationState();
+                instanceState.Status = runtimeState.Status;
             }
 
-            instanceState.Status = runtimeState.Status;
 
             await this.orchestrationService.CompleteTaskOrchestrationWorkItemAsync(
                 workItem,

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -298,7 +298,7 @@ namespace DurableTask.Core
 
             OrchestrationRuntimeState originalOrchestrationRuntimeState = runtimeState;
 
-            OrchestrationState instanceState = null; // A good nullable types candidate
+            OrchestrationState instanceState = null;
 
 
             // Assumes that: if the batch contains a new "ExecutionStarted" event, it is the first message in the batch.

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -298,6 +298,8 @@ namespace DurableTask.Core
 
             OrchestrationRuntimeState originalOrchestrationRuntimeState = runtimeState;
 
+            // This is dangerous because instanceState might not get assigned before use.
+            // We should explore providing a non-null default value here.
             OrchestrationState instanceState = null;
 
 
@@ -542,6 +544,14 @@ namespace DurableTask.Core
             workItem.OrchestrationRuntimeState = originalOrchestrationRuntimeState;
 
             runtimeState.Status = runtimeState.Status ?? carryOverStatus;
+
+            // If we entered the if-statement above, `instanceState` might be null
+            // In that case, we keep instanceState consistent with the runtimeState
+            if (instanceState == null)
+            {
+                instanceState = Utils.BuildOrchestrationState(runtimeState);
+            }
+
             instanceState.Status = runtimeState.Status;
 
             await this.orchestrationService.CompleteTaskOrchestrationWorkItemAsync(

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -543,7 +543,6 @@ namespace DurableTask.Core
 
             runtimeState.Status = runtimeState.Status ?? carryOverStatus;
 
-            // If we entered the if-statement above, `instanceState` might be null
             if (instanceState != null)
             {
                 instanceState.Status = runtimeState.Status;

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -298,9 +298,7 @@ namespace DurableTask.Core
 
             OrchestrationRuntimeState originalOrchestrationRuntimeState = runtimeState;
 
-            // This is dangerous because instanceState might not get assigned before use.
-            // We should explore providing a non-null default value here.
-            OrchestrationState instanceState = null;
+            OrchestrationState instanceState = null; // A good nullable types candidate
 
 
             // Assumes that: if the batch contains a new "ExecutionStarted" event, it is the first message in the batch.

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -546,8 +546,7 @@ namespace DurableTask.Core
             // If we entered the if-statement above, `instanceState` might be null
             if (instanceState == null)
             {
-                // In that case, we keep instanceState consistent with the runtimeState
-                instanceState = Utils.BuildOrchestrationState(runtimeState);
+                instanceState = new OrchestrationState();
             }
 
             instanceState.Status = runtimeState.Status;


### PR DESCRIPTION
This PR keeps `instanceState` consistent with `runtimeState` in case `instanceState` has not been initialized before use in `OnProcessWorkItemAsync`.

Previously, this caused a nullPtr exception that would prevent orchestrators from checkpointing their progress, therefore getting stuck.