### PR TITLE
Add System.Reactive.Compatibility as a dependency to DurableTask.Core 

### DIFF
--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -24,6 +24,8 @@
 
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0" />
+    <PackageReference Include="System.Reactive.Core" Version="4.4.1" />
+    <PackageReference Include="System.Reactive.Compatibility" Version="4.4.1" />
   </ItemGroup>
   
 </Project>

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -23,7 +23,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reactive.Core" Version="3.1.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0" />
   </ItemGroup>
   


### PR DESCRIPTION
The Distributed Tracing work required adding System.Reactive.Core as a
dependency. However, if the customer app was using a different major
version of System.Reactive, it could lead to ambiguous compilation
issues.

Adding this package (and upgrading to use v4 of System.Reactive.Core)
should resolve this issue.

Addresses https://github.com/Azure/azure-functions-durable-extension/issues/1620