### PR TITLE
Fix null reference exception in DurableTask.AzureStorage

### DIFF
--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -910,9 +910,9 @@ namespace DurableTask.AzureStorage
         }
 
         [Event(EventIds.GeneralWarning, Level = EventLevel.Warning, Version = 2)]
-        public void GeneralWarning(string Account, string TaskHub, string Details, string AppName, string ExtensionVersion)
+        public void GeneralWarning(string Account, string TaskHub, string Details, string AppName, string ExtensionVersion, string InstanceId)
         {
-            this.WriteEvent(EventIds.GeneralWarning, Account, TaskHub, Details, AppName, ExtensionVersion);
+            this.WriteEvent(EventIds.GeneralWarning, Account, TaskHub, Details, AppName, ExtensionVersion, InstanceId);
         }
 
         [Event(EventIds.SplitBrainDetected, Level = EventLevel.Warning, Version = 2)]

--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -912,7 +912,7 @@ namespace DurableTask.AzureStorage
         [Event(EventIds.GeneralWarning, Level = EventLevel.Warning, Version = 2)]
         public void GeneralWarning(string Account, string TaskHub, string Details, string AppName, string ExtensionVersion, string InstanceId)
         {
-            this.WriteEvent(EventIds.GeneralWarning, Account, TaskHub, Details, AppName, ExtensionVersion, InstanceId);
+            this.WriteEvent(EventIds.GeneralWarning, Account, TaskHub, Details, AppName, ExtensionVersion, InstanceId ?? string.Empty);
         }
 
         [Event(EventIds.SplitBrainDetected, Level = EventLevel.Warning, Version = 2)]

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1069,7 +1069,8 @@ namespace DurableTask.AzureStorage
                 this.settings.Logger.GeneralWarning(
                     this.storageAccountName,
                     this.settings.TaskHubName,
-                    $"{nameof(CompleteTaskOrchestrationWorkItemAsync)}: Could not find execution id for instance {instanceId}.");
+                    $"{nameof(CompleteTaskOrchestrationWorkItemAsync)}: Could not find execution id.",
+                    instanceId: instanceId);
             }
 
             // Correlation

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1063,10 +1063,16 @@ namespace DurableTask.AzureStorage
             OrchestrationRuntimeState runtimeState = newOrchestrationRuntimeState ?? workItem.OrchestrationRuntimeState;
 
             string instanceId = workItem.InstanceId;
-            string executionId = runtimeState.OrchestrationInstance.ExecutionId;
+            string executionId = runtimeState.OrchestrationInstance?.ExecutionId;
+            if (executionId == null)
+            {
+                this.settings.Logger.GeneralWarning(
+                    this.storageAccountName,
+                    this.settings.TaskHubName,
+                    $"{nameof(CompleteTaskOrchestrationWorkItemAsync)}: Could not find execution id for instance {instanceId}.");
+            }
 
             // Correlation
-
             CorrelationTraceClient.Propagate(() =>
                 {
                     // In case of Extended Session, Emit the Dependency Telemetry. 

--- a/src/DurableTask.AzureStorage/Logging/LogEvents.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogEvents.cs
@@ -2200,11 +2200,13 @@ namespace DurableTask.AzureStorage.Logging
             public GeneralWarning(
                 string account,
                 string taskHub,
-                string details)
+                string details,
+                string instanceId)
             {
                 this.Account = account;
                 this.TaskHub = taskHub;
                 this.Details = details;
+                this.InstanceId = instanceId;
             }
 
             [StructuredLogField]
@@ -2215,6 +2217,9 @@ namespace DurableTask.AzureStorage.Logging
 
             [StructuredLogField]
             public string Details { get; }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
 
             public override EventId EventId => new EventId(
                 EventIds.GeneralWarning,
@@ -2229,7 +2234,8 @@ namespace DurableTask.AzureStorage.Logging
                 this.TaskHub,
                 this.Details,
                 Utils.AppName,
-                Utils.ExtensionVersion);
+                Utils.ExtensionVersion,
+                this.InstanceId);
         }
 
         internal class SplitBrainDetected : StructuredLogEvent, IEventSourceEvent

--- a/src/DurableTask.AzureStorage/Logging/LogHelper.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogHelper.cs
@@ -720,12 +720,14 @@ namespace DurableTask.AzureStorage.Logging
         internal void GeneralWarning(
             string account,
             string taskHub,
-            string details)
+            string details,
+            string instanceId = null)
         {
             var logEvent = new LogEvents.GeneralWarning(
                 account,
                 taskHub,
-                details);
+                details,
+                instanceId ?? string.Empty);
             this.WriteStructuredLog(logEvent);
         }
 


### PR DESCRIPTION
A null value for OrchestrationInstance on the runtimeState object in
AzureStorageOrchestrationService.CompleteTaskOrchestrationWorkItemAsync
causes rare null reference exceptions for some customers. Unfortunately,
due to the lack of helpful information when this exception is
encountered, we don't know what scenarios cause the orchestration
instance to be null.

This PR currently just adds null coalescing + a warning log. It's
possible that a null execution id that this results in will cause issues
down the line in this method, but this will at least make sure we know
which orchestration instance hit this code path, which makes it far
easier to diagnose the issue.

Attempts to address #487