### PR TITLE
Service Fabric provider: Overload for orchestration registration delegate, adding a TaskHubClient for querying state

### DIFF
--- a/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
+++ b/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
@@ -6,7 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Microsoft.Azure.DurableTask.AzureServiceFabric</PackageId>
     <Version>2.3.3</Version>
-    <AssemblyVersion>2.3.3</AssemblyVersion>
+    <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
   </PropertyGroup>
 

--- a/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
+++ b/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
@@ -5,8 +5,8 @@
     <TargetFrameworks>net461</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Microsoft.Azure.DurableTask.AzureServiceFabric</PackageId>
-    <Version>2.3.2</Version>
-    <AssemblyVersion>$(Version)</AssemblyVersion>
+    <Version>2.3.3</Version>
+    <AssemblyVersion>2.3.3</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
   </PropertyGroup>
 

--- a/src/DurableTask.AzureServiceFabric/Service/TaskHubProxyListener.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/TaskHubProxyListener.cs
@@ -47,7 +47,7 @@ namespace DurableTask.AzureServiceFabric.Service
     /// </remarks>
     /// <param name="taskHubWorker">Instance of <see cref="TaskHubWorker"/></param>
     /// <param name="taskHubLocalClient">Instance of <see cref="TaskHubClient"/> connected to local instance of <see cref="TaskHubWorker"/></param>
-    public delegate void RegisterOrchestrationArtifacts(TaskHubWorker taskHubWorker, TaskHubClient taskHubLocalClient);
+    public delegate void RegisterOrchestrations2(TaskHubWorker taskHubWorker, TaskHubClient taskHubLocalClient);
 
     /// <summary>
     /// An instance of this class is created for each service replica by the Service Fabric runtime.
@@ -56,7 +56,7 @@ namespace DurableTask.AzureServiceFabric.Service
     public sealed class TaskHubProxyListener : IServiceListener
     {
         readonly RegisterOrchestrations registerOrchestrations;
-        readonly RegisterOrchestrationArtifacts registerOrchestrationArtifacts;
+        readonly RegisterOrchestrations2 registerOrchestrations2;
         readonly FabricOrchestrationProviderSettings fabricOrchestrationProviderSettings;
         FabricOrchestrationProviderFactory fabricProviderFactory;
         FabricOrchestrationProvider fabricOrchestrationProvider;
@@ -104,14 +104,14 @@ namespace DurableTask.AzureServiceFabric.Service
         /// when registering orchestration artifacts with <see cref="TaskHubWorker"/>
         /// </remarks>
         /// <param name="fabricOrchestrationProviderSettings">instance of <see cref="FabricOrchestrationProviderSettings"/></param>
-        /// <param name="registerOrchestrationArtifacts">Delegate invoked before starting the worker.</param>
+        /// <param name="registerOrchestrations2">Delegate invoked before starting the worker.</param>
         /// <param name="enableHttps">Whether to enable https or http</param>
         public TaskHubProxyListener(FabricOrchestrationProviderSettings fabricOrchestrationProviderSettings,
-                RegisterOrchestrationArtifacts registerOrchestrationArtifacts,
+                RegisterOrchestrations2 registerOrchestrations2,
                 bool enableHttps = true)
         {
             this.fabricOrchestrationProviderSettings = fabricOrchestrationProviderSettings ?? throw new ArgumentNullException(nameof(fabricOrchestrationProviderSettings));
-            this.registerOrchestrationArtifacts = registerOrchestrationArtifacts ?? throw new ArgumentNullException(nameof(registerOrchestrationArtifacts));
+            this.registerOrchestrations2 = registerOrchestrations2 ?? throw new ArgumentNullException(nameof(registerOrchestrations2));
             this.enableHttps = enableHttps;
         }
 
@@ -194,10 +194,10 @@ namespace DurableTask.AzureServiceFabric.Service
 
                 this.worker = new TaskHubWorker(this.fabricOrchestrationProvider.OrchestrationService);
 
-                if (this.registerOrchestrationArtifacts != null)
+                if (this.registerOrchestrations2 != null)
                 {
                     this.localClient = new TaskHubClient(this.fabricOrchestrationProvider.OrchestrationServiceClient);
-                    this.registerOrchestrationArtifacts(this.worker, this.localClient);
+                    this.registerOrchestrations2(this.worker, this.localClient);
                 }
                 else
                 {

--- a/src/DurableTask.AzureServiceFabric/Service/TaskHubProxyListener.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/TaskHubProxyListener.cs
@@ -36,16 +36,32 @@ namespace DurableTask.AzureServiceFabric.Service
     public delegate void RegisterOrchestrations(TaskHubWorker taskHubWorker);
 
     /// <summary>
+    /// Delegate invoked before starting the worker to register artifiacts with TaskHubWorker.
+    /// Provides an instance to <see cref="TaskHubClient"/> which can be optionally used
+    /// when registering delegates
+    /// </summary>
+    /// <remarks>
+    /// The provided <see cref="TaskHubClient"/> is only connected to the local instance of
+    /// <see cref="TaskHubWorker"/>. It cannot be used to query orchestrations running in other
+    /// worker instances.
+    /// </remarks>
+    /// <param name="taskHubWorker">Instance of <see cref="TaskHubWorker"/></param>
+    /// <param name="taskHubLocalClient">Instance of <see cref="TaskHubClient"/> connected to local instance of <see cref="TaskHubWorker"/></param>
+    public delegate void RegisterOrchestrationArtifacts(TaskHubWorker taskHubWorker, TaskHubClient taskHubLocalClient);
+
+    /// <summary>
     /// An instance of this class is created for each service replica by the Service Fabric runtime.
     /// Listening on HTTP port will expose security risk, use this listener at your own discretation.
     /// </summary>
     public sealed class TaskHubProxyListener : IServiceListener
     {
         readonly RegisterOrchestrations registerOrchestrations;
+        readonly RegisterOrchestrationArtifacts registerOrchestrationArtifacts;
         readonly FabricOrchestrationProviderSettings fabricOrchestrationProviderSettings;
         FabricOrchestrationProviderFactory fabricProviderFactory;
         FabricOrchestrationProvider fabricOrchestrationProvider;
         TaskHubWorker worker;
+        TaskHubClient localClient;
         ReplicaRole currentRole;
         StatefulService statefulService;
         bool enableHttps = true;
@@ -77,6 +93,25 @@ namespace DurableTask.AzureServiceFabric.Service
         {
             this.fabricOrchestrationProviderSettings = fabricOrchestrationProviderSettings ?? throw new ArgumentNullException(nameof(fabricOrchestrationProviderSettings));
             this.registerOrchestrations = registerOrchestrations ?? throw new ArgumentNullException(nameof(registerOrchestrations));
+            this.enableHttps = enableHttps;
+        }
+
+        /// <summary>
+        /// Creates instance of <see cref="TaskHubProxyListener"/>
+        /// </summary>
+        /// <remarks>
+        /// Use this constructor when there is a need to access <see cref="TaskHubClient"/>
+        /// when registering orchestration artifacts with <see cref="TaskHubWorker"/>
+        /// </remarks>
+        /// <param name="fabricOrchestrationProviderSettings">instance of <see cref="FabricOrchestrationProviderSettings"/></param>
+        /// <param name="registerOrchestrationArtifacts">Delegate invoked before starting the worker.</param>
+        /// <param name="enableHttps">Whether to enable https or http</param>
+        public TaskHubProxyListener(FabricOrchestrationProviderSettings fabricOrchestrationProviderSettings,
+                RegisterOrchestrationArtifacts registerOrchestrationArtifacts,
+                bool enableHttps = true)
+        {
+            this.fabricOrchestrationProviderSettings = fabricOrchestrationProviderSettings ?? throw new ArgumentNullException(nameof(fabricOrchestrationProviderSettings));
+            this.registerOrchestrationArtifacts = registerOrchestrationArtifacts ?? throw new ArgumentNullException(nameof(registerOrchestrationArtifacts));
             this.enableHttps = enableHttps;
         }
 
@@ -159,7 +194,15 @@ namespace DurableTask.AzureServiceFabric.Service
 
                 this.worker = new TaskHubWorker(this.fabricOrchestrationProvider.OrchestrationService);
 
-                this.registerOrchestrations(this.worker);
+                if (this.registerOrchestrationArtifacts != null)
+                {
+                    this.localClient = new TaskHubClient(this.fabricOrchestrationProvider.OrchestrationServiceClient);
+                    this.registerOrchestrationArtifacts(this.worker, this.localClient);
+                }
+                else
+                {
+                    this.registerOrchestrations(this.worker);
+                }
 
                 await this.worker.StartAsync();
 
@@ -182,6 +225,7 @@ namespace DurableTask.AzureServiceFabric.Service
                     await this.worker.StopAsync(isForced: true);
                     this.worker.Dispose();
                     this.worker = null;
+                    this.localClient = null;
                     this.fabricOrchestrationProvider.Dispose();
                     this.fabricOrchestrationProvider = null;
                     ServiceFabricProviderEventSource.Tracing.LogFabricServiceInformation(this.statefulService, "Stopped Taskhub Worker");


### PR DESCRIPTION
## Problem
When utilizing Service Fabric provider in durable task, during the initialization phase of `TaskHubWorker` artifacts, there is no available API to access the corresponding `TaskHubClient`. The only available option is to create a `TaskHubClient` with the `RemoteOrchestrationServiceClient` which routes the request via HTTP. This is not ideal due to the fact that we will be routing requests to the outside of the process back into the same process again.

## Proposal
There is a version of orchestration client named `FabricOrchestrationServiceClient` which is capable of querying the orchestration state within the process itself by querying the underlying reliable collections. However, this client is not publicly exposed. The proposed solution creates a new `TaskHubClient` based on the `FabricOrchestrationServiceClient` and passes it on to the clients initializing the `TaskHubWorker` as an overload. The clients may choose to use this overload to query the orchestration state. 