### PR TITLE
Service Fabric provider: Identify stale partition endpoints and force refresh SF resolver cache in such a scenario

### DIFF
--- a/src/DurableTask.AzureServiceFabric/Constants.cs
+++ b/src/DurableTask.AzureServiceFabric/Constants.cs
@@ -24,5 +24,6 @@ namespace DurableTask.AzureServiceFabric
         internal const string ScheduledMessagesDictionaryName = CollectionNameUniquenessPrefix + "ScheduledMessages";
         internal const string TaskHubProxyServiceName = "DurableTask-TaskHubProxyService";
         internal const string TaskHubProxyListenerEndpointName = "DtfxServiceEndpoint";
+        internal const string ActivityIdHeaderName = "x-ms-durabletask-activityid";
     }
 }

--- a/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
+++ b/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>net461</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Microsoft.Azure.DurableTask.AzureServiceFabric</PackageId>
-    <Version>2.3.3</Version>
+    <Version>2.3.4</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
   </PropertyGroup>

--- a/src/DurableTask.AzureServiceFabric/Extensions.cs
+++ b/src/DurableTask.AzureServiceFabric/Extensions.cs
@@ -50,25 +50,5 @@ namespace DurableTask.AzureServiceFabric
                 throw new InvalidInstanceIdException(instanceId);
             }
         }
-
-        internal static Task<string> GetStringResponseAsync(this HttpClient httpClient, string requestUri)
-        {
-            requestUri = requestUri ?? throw new ArgumentNullException(nameof(requestUri));
-            return httpClient.GetStringResponseAsync(new Uri(requestUri));
-        }
-
-        internal static async Task<string> GetStringResponseAsync(this HttpClient httpClient, Uri requestUri)
-        {
-            httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
-            requestUri = requestUri ?? throw new ArgumentNullException(nameof(requestUri));
-            HttpResponseMessage response = await httpClient.GetAsync(requestUri);
-            string content = await response.Content.ReadAsStringAsync();
-            if (response.IsSuccessStatusCode)
-            {
-                return content;
-            }
-
-            throw new HttpRequestException($"Request failed with status code '{response.StatusCode}' and content '{content}'");
-        }
     }
 }

--- a/src/DurableTask.AzureServiceFabric/IPartitionEndpointResolver.cs
+++ b/src/DurableTask.AzureServiceFabric/IPartitionEndpointResolver.cs
@@ -36,5 +36,14 @@ namespace DurableTask.AzureServiceFabric
         /// <param name="cancellationToken">Token to inform when a task is cancelled.</param>
         /// <returns> Partition end point </returns>
         Task<string> GetPartitionEndPointAsync(string instanceId, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Indicates to the resolver that the current endpoint may be stale and requests
+        /// for the endpoint to be refreshed.
+        /// </summary>
+        /// <param name="instanceId">InstanceId of orchestration</param>
+        /// <param name="cancellationToken">Token to inform when a task is cancelled.</param>
+        /// <returns>An asynchronous task to monitor the completion of this operation.</returns>
+        Task RefreshPartitionEndpointAsync(string instanceId, CancellationToken cancellationToken);
     }
 }

--- a/src/DurableTask.AzureServiceFabric/Service/ProxyServiceExceptionHandler.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/ProxyServiceExceptionHandler.cs
@@ -18,16 +18,10 @@ namespace DurableTask.AzureServiceFabric.Service
     using System.Web.Http.ExceptionHandling;
     using System.Web.Http.Results;
 
-    using DurableTask.AzureServiceFabric.Tracing;
-
     internal class ProxyServiceExceptionHandler : ExceptionHandler
     {
         public override void Handle(ExceptionHandlerContext context)
         {
-            ServiceFabricProviderEventSource.Tracing.LogProxyServiceError(context.Request.Method.ToString(),
-                                                                          context.Request.RequestUri.AbsolutePath,
-                                                                          context.Exception);
-
             HttpResponseMessage response = context.Request.CreateResponse(HttpStatusCode.InternalServerError, context.Exception);
             context.Result = new ResponseMessageResult(response);
         }

--- a/src/DurableTask.AzureServiceFabric/Service/ProxyServiceExceptionHandler.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/ProxyServiceExceptionHandler.cs
@@ -13,15 +13,24 @@
 
 namespace DurableTask.AzureServiceFabric.Service
 {
+    using System;
     using System.Net;
     using System.Net.Http;
     using System.Web.Http.ExceptionHandling;
     using System.Web.Http.Results;
 
+    using DurableTask.AzureServiceFabric.Tracing;
+
     internal class ProxyServiceExceptionHandler : ExceptionHandler
     {
         public override void Handle(ExceptionHandlerContext context)
         {
+            var activityId = Guid.NewGuid().ToString("D");
+            ServiceFabricProviderEventSource.Tracing.LogProxyServiceError(activityId,
+                context.Request.Method.ToString(),
+                context.Request.RequestUri.AbsolutePath,
+                context.Exception);
+
             HttpResponseMessage response = context.Request.CreateResponse(HttpStatusCode.InternalServerError, context.Exception);
             context.Result = new ResponseMessageResult(response);
         }

--- a/src/DurableTask.AzureServiceFabric/Service/ProxyServiceExceptionLogger.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/ProxyServiceExceptionLogger.cs
@@ -13,6 +13,7 @@
 
 namespace DurableTask.AzureServiceFabric.Service
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using System.Web.Http.ExceptionHandling;
@@ -27,7 +28,8 @@ namespace DurableTask.AzureServiceFabric.Service
         /// <inheritdoc />
         public async override Task LogAsync(ExceptionLoggerContext context, CancellationToken cancellationToken)
         {
-            ServiceFabricProviderEventSource.Tracing.LogProxyServiceError(context.Request.Method.ToString(), context.Request.RequestUri.AbsolutePath, context.Exception);
+            var activityId = Guid.NewGuid().ToString("D");
+            ServiceFabricProviderEventSource.Tracing.LogProxyServiceError(activityId, context.Request.Method.ToString(), context.Request.RequestUri.AbsolutePath, context.Exception);
             await base.LogAsync(context, cancellationToken);
         }
     }

--- a/src/DurableTask.AzureServiceFabric/Tracing/TracingExtensions.cs
+++ b/src/DurableTask.AzureServiceFabric/Tracing/TracingExtensions.cs
@@ -33,10 +33,10 @@ namespace DurableTask.AzureServiceFabric.Tracing
                 formattedMessage);
         }
 
-        internal static void LogProxyServiceError(this ServiceFabricProviderEventSource eventSource, string requestUri, string requestMethod, Exception exception)
+        internal static void LogProxyServiceError(this ServiceFabricProviderEventSource eventSource, string activityId, string requestUri, string requestMethod, Exception exception)
         {
             string exceptionDetails = $"Type: {exception.GetType()}, Message: {exception.Message}, StackTrace: {exception.StackTrace}, InnerException: {exception.InnerException}";
-            string logMessage = $"Proxy service request {requestUri} with method {requestMethod} resulted in error. Exception Details - {exceptionDetails}";
+            string logMessage = $"{activityId} : Proxy service request {requestUri} with method {requestMethod} resulted in error. Exception Details - {exceptionDetails}";
 
             eventSource.LogProxyServiceError(logMessage);
         }


### PR DESCRIPTION
## Problem
Service Fabric's `ServicePartitionResolver` class maintains an internal cache of `ResolvedServicePartition` objects for each partition which is served by an internal reference of `FabricClient`. The cache is refreshed via 2 different processes:

-  A notification protocol through which the `FabricClient` notifies resolver that a given value is stale and needs to be updated.
-  A complaint based resolution, as part of which, the client passes in the previously retrieved `ResolvedServicePartition` object to the `ResolveAsync()` API call. This API call notifies the resolver that the previously provided object is stale and a new one should be fetched from the `FabricClient`

Service Fabric also states in their documentation that the notification mechanism cannot be completely relied upon since it is an internal network call which is prone to failures. This is the one of the reason for the existence of complaint based resolution. In our current implementation, we were only relying on notifications and thus occasionally ran into failures due to non-existent/badendpoints.

## Proposal
We will implement a new API in `IPartitionEndpointResolver` `RefreshPartitionEndpointAsync()` which will retrieve the existing `ResolvedServicePartition` object via `ResolveAsync()` and then call another overload of `ResolveAsync()` with the retrieved object. This will force the internal cache to be refreshed so that subsequent calls to `ResolveAsync()` would retrieve the newer version, if available.
This API will be invoked by `RemoteOrchestrationServiceClient` whenever it detects a stale endpoint.

#### Now, how do we detect stale endpoints?
The ideal situation would be if our endpoint would simply fail to respond which would clearly indicate a non-existent endpoint. However, this situation is complicated by the default http.sys behavior. If the previous service process failed to clean up the urlacl entry from http.sys, let's say due to a process crash, http.sys will still respond to requests for that endpoint. The response will be a HTTP 503.
Another situation which is possible, is that Service Fabric decides to reuse that port for another replica. Since we suffix a partition endpoint with the partition id, http.sys is going to return a HTTP 404 instead.
In order to distinguish these error codes from genuine service error codes, I'm adding a header which will be part of a response from the service. Presence of such a header will help us distinguish between http.sys response and our service response. To make the header slightly more useful, I'm adding a ActivityId header which will be unique for each request/response combination. We could potentially use this header in the future to trace this request within the service.