### PR TITLE
DT.AzureStorage: Runtime de-dupe support for orchestration start events

### DIFF
--- a/Test/DurableTask.AzureStorage.Tests/StressTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/StressTests.cs
@@ -31,9 +31,9 @@ namespace DurableTask.AzureStorage.Tests
         /// both in the case where they all share the same instance ID and when they have unique
         /// instance IDs.
         /// </summary>
-        [DataTestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
+        ////[DataTestMethod]
+        ////[DataRow(true)]
+        ////[DataRow(false)]
         public async Task ConcurrentOrchestrationStarts(bool useSameInstanceId)
         {
             // Set the minimum thread count to 64+ to make this test extra concurrent.
@@ -65,8 +65,7 @@ namespace DurableTask.AzureStorage.Tests
                     Func<int, string> inputGenerator;
                     if (useSameInstanceId)
                     {
-                        DateTime now = DateTime.Now;
-                        instanceIdGenerator = _ => $"ConcurrentInstance_{now:yyyyMMdd.hhmmss.fff}";
+                        instanceIdGenerator = _ => $"ConcurrentInstance_SINGLETON";
                         inputGenerator = _ => "World";
                     }
                     else

--- a/Test/DurableTask.AzureStorage.Tests/StressTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/StressTests.cs
@@ -1,0 +1,120 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureStorage.Tests
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using DurableTask.Core;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json;
+
+    [TestClass]
+    public class StressTests
+    {
+        /// <summary>
+        /// End-to-end test which validates a simple orchestrator function which doesn't call any activity functions.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async Task ConcurrentOrchestrationStarts(bool useSameInstanceId)
+        {
+            // Set the minimum thread count to 64+ to make this test extra concurrent.
+            ThreadPool.GetMinThreads(out int minWorkerThreads, out int minIoThreads);
+            ThreadPool.SetMinThreads(Math.Max(64, minWorkerThreads), Math.Max(64, minIoThreads));
+            try
+            {
+                using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(
+                    enableExtendedSessions: false,
+                    modifySettingsAction: settings => settings.ThrowExceptionOnInvalidDedupeStatus = false))
+                {
+                    await host.StartAsync();
+
+                    var results = new ConcurrentBag<string>();
+
+                    // We want a number sufficiently high that it results in multiple message batches
+                    const int MaxConcurrency = 40;
+
+                    TaskActivity activity = TestOrchestrationHost.MakeActivity(
+                        delegate(TaskContext ctx, string input)
+                        {
+                            string result = $"Hello, {input}!";
+                            results.Add(result);
+                            return result;
+                        });
+
+                    // Use the same instance name for all instances
+                    Func<int, string> instanceIdGenerator;
+                    Func<int, string> inputGenerator;
+                    if (useSameInstanceId)
+                    {
+                        DateTime now = DateTime.Now;
+                        instanceIdGenerator = _ => $"ConcurrentInstance_{now:yyyyMMdd.hhmmss.fff}";
+                        inputGenerator = _ => "World";
+                    }
+                    else
+                    {
+                        instanceIdGenerator = i => $"ConcurrentInstance_{i:00}";
+                        inputGenerator = i => $"{i:00}";
+                    }
+
+                    List<TestInstance<string>> instances = await host.StartInlineOrchestrations(
+                        MaxConcurrency,
+                        instanceIdGenerator,
+                        inputGenerator,
+                        orchestrationName: "SayHelloOrchestration",
+                        version: string.Empty,
+                        implementation: (ctx, input) => ctx.ScheduleTask<string>("SayHello", "", input),
+                        activities: ("SayHello", activity));
+
+                    Assert.AreEqual(MaxConcurrency, instances.Count);
+
+                    // All returned objects point to the same orchestration instance
+                    OrchestrationState[] finalStates = await Task.WhenAll(instances.Select(
+                        i => i.WaitForCompletion(timeout: TimeSpan.FromMinutes(2), expectedOutputRegex: @"Hello, \w+!")));
+
+                    if (useSameInstanceId)
+                    {
+                        // Make sure each instance is exactly the same
+                        string firstInstanceJson = JsonConvert.SerializeObject(finalStates[0]);
+                        foreach (OrchestrationState state in finalStates.Skip(1))
+                        {
+                            string json = JsonConvert.SerializeObject(state);
+                            Assert.AreEqual(firstInstanceJson, json, "Expected that all instances have the same data.");
+                        }
+                    }
+                    else
+                    {
+                        // Make sure each instance is different
+                        Assert.AreEqual(MaxConcurrency, finalStates.Select(s => s.OrchestrationInstance.InstanceId).Distinct().Count());
+                        Assert.AreEqual(MaxConcurrency, finalStates.Select(s => s.OrchestrationInstance.ExecutionId).Distinct().Count());
+                        Assert.AreEqual(MaxConcurrency, finalStates.Select(s => s.Input).Distinct().Count());
+                        Assert.AreEqual(MaxConcurrency, finalStates.Select(s => s.Output).Distinct().Count());
+                    }
+
+                    await host.StopAsync();
+                }
+            }
+            finally
+            {
+                // Reset the thread pool configuration
+                ThreadPool.SetMinThreads(minWorkerThreads, minIoThreads);
+            }
+        }
+    }
+}

--- a/Test/DurableTask.AzureStorage.Tests/StressTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/StressTests.cs
@@ -27,7 +27,9 @@ namespace DurableTask.AzureStorage.Tests
     public class StressTests
     {
         /// <summary>
-        /// End-to-end test which validates a simple orchestrator function which doesn't call any activity functions.
+        /// Starts a large'ish number of orchestrations concurrently and verifies correct behavior
+        /// both in the case where they all share the same instance ID and when they have unique
+        /// instance IDs.
         /// </summary>
         [DataTestMethod]
         [DataRow(true)]

--- a/Test/DurableTask.AzureStorage.Tests/StressTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/StressTests.cs
@@ -31,9 +31,9 @@ namespace DurableTask.AzureStorage.Tests
         /// both in the case where they all share the same instance ID and when they have unique
         /// instance IDs.
         /// </summary>
-        ////[DataTestMethod]
-        ////[DataRow(true)]
-        ////[DataRow(false)]
+        [DataTestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
         public async Task ConcurrentOrchestrationStarts(bool useSameInstanceId)
         {
             // Set the minimum thread count to 64+ to make this test extra concurrent.

--- a/Test/DurableTask.AzureStorage.Tests/TestInstance.cs
+++ b/Test/DurableTask.AzureStorage.Tests/TestInstance.cs
@@ -1,0 +1,169 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureStorage.Tests
+{
+    using System;
+    using System.Diagnostics;
+    using System.Text.RegularExpressions;
+    using System.Threading.Tasks;
+    using DurableTask.Core;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    class TestInstance<T>
+    {
+        readonly TaskHubClient client;
+        readonly OrchestrationInstance instance;
+        readonly DateTime startTime;
+        readonly T input;
+
+        public TestInstance(
+            TaskHubClient client,
+            OrchestrationInstance instance,
+            DateTime startTime,
+            T input)
+        {
+            this.client = client;
+            this.instance = instance;
+            this.startTime = startTime;
+            this.input = input;
+        }
+
+        public string InstanceId => this.instance?.InstanceId;
+
+        public string ExecutionId => this.instance?.ExecutionId;
+
+        OrchestrationInstance GetInstanceForAnyExecution() => new OrchestrationInstance
+        {
+            InstanceId = this.instance.InstanceId,
+        };
+
+        public async Task<OrchestrationState> WaitForStart(TimeSpan timeout = default)
+        {
+            AdjustTimeout(ref timeout);
+
+            Stopwatch sw = Stopwatch.StartNew();
+            do
+            {
+                OrchestrationState state = await this.GetStateAsync();
+                if (state != null && state.OrchestrationStatus != OrchestrationStatus.Pending)
+                {
+                    return state;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(500));
+
+            } while (sw.Elapsed < timeout);
+
+            throw new TimeoutException($"Orchestration with instance ID '{this.instance.InstanceId}' failed to start.");
+        }
+
+        public async Task<OrchestrationState> WaitForCompletion(
+            TimeSpan timeout = default,
+            OrchestrationStatus? expectedStatus = OrchestrationStatus.Completed,
+            object expectedOutput = null,
+            string expectedOutputRegex = null,
+            bool continuedAsNew = false)
+        {
+            AdjustTimeout(ref timeout);
+
+            OrchestrationState state = await this.client.WaitForOrchestrationAsync(this.GetInstanceForAnyExecution(), timeout);
+            Assert.IsNotNull(state);
+            if (expectedStatus != null)
+            {
+                Assert.AreEqual(expectedStatus, state.OrchestrationStatus);
+            }
+
+            if (!continuedAsNew)
+            {
+                if (this.input != null)
+                {
+                    Assert.AreEqual(JToken.FromObject(this.input).ToString(), JToken.Parse(state.Input).ToString());
+                }
+                else
+                {
+                    Assert.IsNull(state.Input);
+                }
+            }
+
+            // For created time, account for potential clock skew
+            Assert.IsTrue(state.CreatedTime >= this.startTime.AddMinutes(-5));
+            Assert.IsTrue(state.LastUpdatedTime > state.CreatedTime);
+            Assert.IsTrue(state.CompletedTime > state.CreatedTime);
+            Assert.IsNotNull(state.OrchestrationInstance);
+            Assert.AreEqual(this.instance.InstanceId, state.OrchestrationInstance.InstanceId);
+
+            // Make sure there is an ExecutionId, but don't require it to match any particular value
+            Assert.IsNotNull(state.OrchestrationInstance.ExecutionId);
+
+            if (expectedOutput != null)
+            {
+                Assert.IsNotNull(state.Output);
+                try
+                {
+                    // DTFx usually encodes outputs as JSON values. The exception is error messages.
+                    // If this is an error message, we'll throw here and try the logic in the catch block.
+                    JToken.Parse(state.Output);
+                    Assert.AreEqual(JToken.FromObject(expectedOutput).ToString(Formatting.None), state.Output);
+                }
+                catch (JsonReaderException)
+                {
+                    Assert.AreEqual(expectedOutput, state?.Output);
+                }
+            }
+
+            if (expectedOutputRegex != null)
+            {
+                Assert.IsTrue(
+                    Regex.IsMatch(state.Output, expectedOutputRegex),
+                    $"The output '{state.Output}' doesn't match the regex pattern '{expectedOutputRegex}'.");
+            }
+
+            return state;
+        }
+
+        internal Task<OrchestrationState> GetStateAsync()
+        {
+            return this.client.GetOrchestrationStateAsync(this.instance);
+        }
+
+        internal Task RaiseEventAsync(string name, object value)
+        {
+            return this.client.RaiseEventAsync(this.instance, name, value);
+        }
+
+        internal Task TerminateAsync(string reason)
+        {
+            return this.client.TerminateInstanceAsync(this.instance, reason);
+        }
+
+        static void AdjustTimeout(ref TimeSpan timeout)
+        {
+            if (timeout == default)
+            {
+                timeout = TimeSpan.FromSeconds(10);
+            }
+
+            if (Debugger.IsAttached)
+            {
+                TimeSpan debuggingTimeout = TimeSpan.FromMinutes(5);
+                if (debuggingTimeout > timeout)
+                {
+                    timeout = debuggingTimeout;
+                }
+            }
+        }
+    }
+}

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <FileVersion>1.8.5</FileVersion>
+    <FileVersion>1.8.6</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <Version>$(FileVersion)</Version>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <FileVersion>1.8.6</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -10,7 +10,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
-
+#nullable enable
 namespace DurableTask.AzureStorage.Messaging
 {
     using System;
@@ -20,7 +20,6 @@ namespace DurableTask.AzureStorage.Messaging
     using System.Threading;
     using System.Threading.Tasks;
     using DurableTask.AzureStorage.Monitoring;
-    using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Queue;
 
     class ControlQueue : TaskHubQueue, IDisposable
@@ -182,18 +181,13 @@ namespace DurableTask.AzureStorage.Messaging
             }
         }
 
-        public override Task AbandonMessageAsync(MessageData message, SessionBase session)
+        public override Task AbandonMessageAsync(MessageData message, SessionBase? session = null)
         {
             this.stats.PendingOrchestratorMessages.TryRemove(message.OriginalQueueMessage.Id, out _);
             return base.AbandonMessageAsync(message, session);
         }
 
-        public Task DeleteMessageAsync(MessageData message)
-        {
-            return this.DeleteMessageAsync(message, session: null);
-        }
-
-        public override Task DeleteMessageAsync(MessageData message, SessionBase session)
+        public override Task DeleteMessageAsync(MessageData message, SessionBase? session = null)
         {
             this.stats.PendingOrchestratorMessages.TryRemove(message.OriginalQueueMessage.Id, out _);
             return base.DeleteMessageAsync(message, session);

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -188,6 +188,11 @@ namespace DurableTask.AzureStorage.Messaging
             return base.AbandonMessageAsync(message, session);
         }
 
+        public Task DeleteMessageAsync(MessageData message)
+        {
+            return this.DeleteMessageAsync(message, session: null);
+        }
+
         public override Task DeleteMessageAsync(MessageData message, SessionBase session)
         {
             this.stats.PendingOrchestratorMessages.TryRemove(message.OriginalQueueMessage.Id, out _);

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -226,7 +226,7 @@ namespace DurableTask.AzureStorage.Messaging
             return initialVisibilityDelay;
         }
 
-        public virtual async Task AbandonMessageAsync(MessageData message, SessionBase? session)
+        public virtual async Task AbandonMessageAsync(MessageData message, SessionBase? session = null)
         {
             CloudQueueMessage queueMessage = message.OriginalQueueMessage;
             TaskMessage taskMessage = message.TaskMessage;
@@ -327,7 +327,7 @@ namespace DurableTask.AzureStorage.Messaging
             }
         }
 
-        public virtual async Task DeleteMessageAsync(MessageData message, SessionBase session)
+        public virtual async Task DeleteMessageAsync(MessageData message, SessionBase? session = null)
         {
             CloudQueueMessage queueMessage = message.OriginalQueueMessage;
             TaskMessage taskMessage = message.TaskMessage;

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -10,7 +10,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
-
+#nullable enable
 namespace DurableTask.AzureStorage.Messaging
 {
     using System;
@@ -92,7 +92,7 @@ namespace DurableTask.AzureStorage.Messaging
             return this.AddMessageAsync(message, sourceInstance, session: null);
         }
 
-        async Task<MessageData> AddMessageAsync(TaskMessage taskMessage, OrchestrationInstance sourceInstance, SessionBase session)
+        async Task<MessageData> AddMessageAsync(TaskMessage taskMessage, OrchestrationInstance sourceInstance, SessionBase? session)
         {
             MessageData data;
             try
@@ -164,7 +164,7 @@ namespace DurableTask.AzureStorage.Messaging
             return data;
         }
 
-        static string GetSerializableTraceContext(TaskMessage taskMessage)
+        static string? GetSerializableTraceContext(TaskMessage taskMessage)
         {
             TraceContextBase traceContext = CorrelationTraceContext.Current;
             if (traceContext != null)
@@ -226,7 +226,7 @@ namespace DurableTask.AzureStorage.Messaging
             return initialVisibilityDelay;
         }
 
-        public virtual async Task AbandonMessageAsync(MessageData message, SessionBase session)
+        public virtual async Task AbandonMessageAsync(MessageData message, SessionBase? session)
         {
             CloudQueueMessage queueMessage = message.OriginalQueueMessage;
             TaskMessage taskMessage = message.TaskMessage;
@@ -273,7 +273,7 @@ namespace DurableTask.AzureStorage.Messaging
                     TimeSpan.FromSeconds(numSecondsToWait),
                     MessageUpdateFields.Visibility,
                     this.QueueRequestOptions,
-                    session.StorageOperationContext);
+                    session?.StorageOperationContext ?? new OperationContext());
 
                 this.stats.MessagesUpdated.Increment();
             }
@@ -338,12 +338,12 @@ namespace DurableTask.AzureStorage.Messaging
                 taskMessage.Event.EventType.ToString(),
                 Utils.GetTaskEventId(taskMessage.Event),
                 queueMessage.Id,
-                session.Instance.InstanceId,
-                session.Instance.ExecutionId,
+                taskMessage.OrchestrationInstance.InstanceId,
+                taskMessage.OrchestrationInstance.ExecutionId,
                 this.storageQueue.Name,
                 message.SequenceNumber);
 
-            var haveRetried = false;
+            bool haveRetried = false;
             while (true)
             {
                 try
@@ -351,11 +351,11 @@ namespace DurableTask.AzureStorage.Messaging
                     await this.storageQueue.DeleteMessageAsync(
                         queueMessage,
                         this.QueueRequestOptions,
-                        session.StorageOperationContext);
+                        session?.StorageOperationContext ?? new OperationContext());
                 }
                 catch (Exception e)
                 {
-                    if (!haveRetried && IsMessageGoneException(e))
+                    if (!haveRetried && this.IsMessageGoneException(e))
                     {
                         haveRetried = true;
                         continue;
@@ -374,13 +374,13 @@ namespace DurableTask.AzureStorage.Messaging
 
         private bool IsMessageGoneException(Exception e)
         {
-            StorageException storageException = e as StorageException;
+            StorageException? storageException = e as StorageException;
             return storageException?.RequestInformation?.HttpStatusCode == 404;
         }
 
         void HandleMessagingExceptions(Exception e, MessageData message, string details)
         {
-            if (IsMessageGoneException(e))
+            if (this.IsMessageGoneException(e))
             {
                 // Message may have been processed and deleted already.
                 this.settings.Logger.MessageGone(

--- a/src/DurableTask.AzureStorage/OrchestrationInstanceStatus.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationInstanceStatus.cs
@@ -29,6 +29,7 @@ namespace DurableTask.AzureStorage
         public string CustomStatus { get; set; }
         public DateTime CreatedTime { get; set; }
         public DateTime LastUpdatedTime { get; set; }
+        public DateTime? CompletedTime { get; set; }
         public string RuntimeStatus { get; set; }
         public DateTime? ScheduledStartTime { get; set; }
     }

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -207,7 +207,10 @@ namespace DurableTask.AzureStorage
 
             foreach (MessageData message in messages)
             {
-                if (message.TaskMessage.Event.EventType == EventType.ExecutionStarted)
+                // We do de-duplication when creating top-level orchestrations but not for sub-orchestrations.
+                // De-dupe protection for sub-orchestrations is not implemented and will require a bit more work.
+                if (message.TaskMessage.Event is ExecutionStartedEvent startEvent &&
+                    startEvent.ParentInstance == null)
                 {
                     executionStartedMessages ??= new List<MessageData>(messages.Count);
                     executionStartedMessages.Add(message);

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -183,6 +183,19 @@ namespace DurableTask.AzureStorage
             }
         }
 
+        /// <summary>
+        /// This method enumerates all the provided queue messages looking for ExecutionStarted messages. If any are found, it
+        /// spins up a background thread that does de-dupe validation. The background thread queries table storage to ensure that
+        /// each message has a matching record in the Instances table. If not, this method will either discard the message or 
+        /// abandon it for reprocessing in the event that the Instances table record hasn't been written yet (this happens
+        /// asynchronously and there is no guaranteed order). Meanwhile, this method will return all the non-ExecutionStarted
+        /// messages so that they can be processed immediately.
+        /// </summary>
+        /// <param name="controlQueue">A reference to the control queue from which these messages were dequeued.</param>
+        /// <param name="messages">The full set of messages recently dequeued.</param>
+        /// <param name="traceActivityId">The trace activity ID to use when writing traces.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Returns the list of non-ExecutionStarted messages. This may be an empty list.</returns>
         IReadOnlyList<MessageData> FilterOutExecutionStartedForDedupeValidation(
             ControlQueue controlQueue,
             IReadOnlyList<MessageData> messages,
@@ -197,7 +210,7 @@ namespace DurableTask.AzureStorage
                 if (message.TaskMessage.Event.EventType == EventType.ExecutionStarted)
                 {
                     executionStartedMessages ??= new List<MessageData>(messages.Count);
-                    executionStartedMessages!.Add(message);
+                    executionStartedMessages.Add(message);
                 }
                 else
                 {
@@ -207,6 +220,8 @@ namespace DurableTask.AzureStorage
 
             if (executionStartedMessages?.Count > 0)
             {
+                // We do the de-dupe detection on a background thread to avoid delaying the processing of all the non-ExecutionStarted messages.
+                // This should ensure that we don't introduce any new latency for already-running orchestrations.
                 Task.Run(async () =>
                 {
                     var messagesToKeep = new List<MessageData>(executionStartedMessages.Count);
@@ -217,6 +232,9 @@ namespace DurableTask.AzureStorage
                         .Select(msg => msg.TaskMessage.OrchestrationInstance.InstanceId)
                         .Distinct(StringComparer.OrdinalIgnoreCase);
 
+                    // Terminology:
+                    // "Local"  -> the instance ID info comes from the local copy of the message we're examining
+                    // "Remote" -> the instance ID info comes from the Instances table that we're querying
                     IList<OrchestrationState> instances = await this.trackingStore.GetStateAsync(instanceIds);
                     IDictionary<string, OrchestrationState> remoteOrchestrationsById =
                         instances.ToDictionary(o => o.OrchestrationInstance.InstanceId);
@@ -232,11 +250,11 @@ namespace DurableTask.AzureStorage
                         }
                         else if (this.IsScheduledAfterInstanceUpdate(message, remoteInstance))
                         {
-                            // The message was inserted after the Instances table was updated.
-                            // The same machine will have generated both timestamps so time skew is not a factor.
-                            // We know almost certainly that this is a redundant message and can be safely discarded.
+                            // The message was scheduled after the Instances table was updated with the orchestration info.
+                            // We know almost certainly that this is a redundant message and can be safely discarded because
+                            // messages are *always* scheduled *before* the Instances table is inserted (or updated).
                             messagesToDiscard ??= new List<MessageData>(executionStartedMessages.Count);
-                            messagesToDiscard!.Add(message);
+                            messagesToDiscard.Add(message);
                         }
                         else if (message.OriginalQueueMessage.DequeueCount >= 10)
                         {
@@ -244,14 +262,14 @@ namespace DurableTask.AzureStorage
                             // the client failed to update the Instances table after enqueuing this message. In such a case, the client would
                             // have observed a failure and will know to retry with a new message. Discard this one.
                             messagesToDiscard ??= new List<MessageData>(executionStartedMessages.Count);
-                            messagesToDiscard!.Add(message);
+                            messagesToDiscard.Add(message);
                         }
                         else
                         {
                             // This message does not match the record in the Instances table, but we don't yet know for sure if it's invalid.
                             // Defer it in hopes that by the time we dequeue it next we'll be more confident about whether it's valid or not.
                             messagesToDefer ??= new List<MessageData>(executionStartedMessages.Count);
-                            messagesToDefer!.Add(message);
+                            messagesToDefer.Add(message);
                         }
                     }
 
@@ -289,6 +307,11 @@ namespace DurableTask.AzureStorage
             return otherMessages;
         }
 
+        /// <summary>
+        /// Returns <c>true</c> if <paramref name="msg"/> was scheduled (or rescheduled) after the corresponding
+        /// <paramref name="remoteInstance"/> record was written to the Instances table; <c>false</c> otherwise.
+        /// This logic is used to help determine whether an ExecutionStarted message is redundant and can be de-duped.
+        /// </summary>
         bool IsScheduledAfterInstanceUpdate(MessageData msg, OrchestrationState? remoteInstance)
         {
             if (remoteInstance == null)
@@ -300,7 +323,7 @@ namespace DurableTask.AzureStorage
 
             if (remoteInstance.CreatedTime < msg.TaskMessage.Event.Timestamp)
             {
-                // The message was inserted after the Instances table was updated.
+                // The message was inserted after the Instances table was updated, meaning that it's likely.
                 // The same machine will have generated both timestamps so time skew is not a factor.
                 // We know almost certainly that this is a redundant message and can be safely discarded.
                 return true;

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -1178,7 +1178,7 @@ namespace DurableTask.AzureStorage.Tracking
                         executionId,
                         historyEventBatch,
                         newEventListBuffer,
-                        newEvents.Count,
+                        allEvents.Count,
                         episodeNumber,
                         estimatedBytes,
                         eTagValue,
@@ -1200,7 +1200,7 @@ namespace DurableTask.AzureStorage.Tracking
                     executionId,
                     historyEventBatch,
                     newEventListBuffer,
-                    newEvents.Count,
+                    allEvents.Count,
                     episodeNumber,
                     estimatedBytes,
                     eTagValue,
@@ -1457,7 +1457,7 @@ namespace DurableTask.AzureStorage.Tracking
                 episodeNumber,
                 stopwatch.ElapsedMilliseconds,
                 estimatedBatchSizeInBytes,
-                string.Concat(eTagValue ?? "(null)", " -->", Environment.NewLine, newETagValue ?? "(null)"),
+                string.Concat(eTagValue ?? "(null)", " --> ", newETagValue ?? "(null)"),
                 isFinalBatch);
 
             return newETagValue;

--- a/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
@@ -101,6 +101,12 @@ namespace DurableTask.AzureStorage.Tracking
         Task<IList<OrchestrationState>> GetStateAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
+        /// Fetches instances status for multiple orchestration instances.
+        /// </summary>
+        /// <param name="instanceIds">The list of instances to query for.</param>
+        Task<IList<OrchestrationState>> GetStateAsync(IEnumerable<string> instanceIds);
+
+        /// <summary>
         /// Get The Orchestration State for querying orchestration instances by the condition
         /// </summary>
         /// <param name="createdTimeFrom">CreatedTimeFrom</param>

--- a/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
+++ b/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
@@ -61,6 +61,12 @@ namespace DurableTask.AzureStorage.Tracking
         }
 
         /// <inheritdoc />
+        public virtual Task<IList<OrchestrationState>> GetStateAsync(IEnumerable<string> instanceIds)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <inheritdoc />
         public virtual Task<IList<OrchestrationState>> GetStateAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus, CancellationToken cancellationToken = default(CancellationToken))
         {
             throw new NotSupportedException();

--- a/src/DurableTask.Core/Logging/LoggingExtensions.cs
+++ b/src/DurableTask.Core/Logging/LoggingExtensions.cs
@@ -47,5 +47,14 @@ namespace DurableTask.Core.Logging
                 eventSourceEvent.WriteEventSource();
             }
         }
+
+        /// <summary>
+        /// Sets the trace activity ID for the current logical thread.
+        /// </summary>
+        /// <param name="traceActivityId">The trace activity ID to set.</param>
+        public static void SetLogicalTraceActivityId(Guid traceActivityId)
+        {
+            StructuredEventSource.SetLogicalTraceActivityId(traceActivityId);
+        }
     }
 }

--- a/src/DurableTask.Core/Logging/StructuredEventSource.cs
+++ b/src/DurableTask.Core/Logging/StructuredEventSource.cs
@@ -24,7 +24,7 @@ namespace DurableTask.Core.Logging
     [EventSource(Name = "DurableTask-Core")]
     class StructuredEventSource : EventSource
     {
-        public static readonly StructuredEventSource Log = new StructuredEventSource();
+        internal static readonly StructuredEventSource Log = new StructuredEventSource();
 
         static readonly AsyncLocal<Guid> ActivityIdState = new AsyncLocal<Guid>();
 
@@ -49,7 +49,7 @@ namespace DurableTask.Core.Logging
         bool IsEnabled(EventLevel level) => this.IsEnabled(level, EventKeywords.None);
 
         [Event(EventIds.TaskHubWorkerStarting, Level = EventLevel.Informational, Version = 1)]
-        public void TaskHubWorkerStarting(string AppName, string ExtensionVersion)
+        internal void TaskHubWorkerStarting(string AppName, string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Informational))
             {
@@ -58,7 +58,7 @@ namespace DurableTask.Core.Logging
         }
 
         [Event(EventIds.TaskHubWorkerStarted, Level = EventLevel.Informational, Version = 1)]
-        public void TaskHubWorkerStarted(long LatencyMs, string AppName, string ExtensionVersion)
+        internal void TaskHubWorkerStarted(long LatencyMs, string AppName, string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Informational))
             {
@@ -67,7 +67,7 @@ namespace DurableTask.Core.Logging
         }
 
         [Event(EventIds.TaskHubWorkerStopping, Level = EventLevel.Informational, Version = 1)]
-        public void TaskHubWorkerStopping(bool IsForced, string AppName, string ExtensionVersion)
+        internal void TaskHubWorkerStopping(bool IsForced, string AppName, string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Informational))
             {
@@ -76,7 +76,7 @@ namespace DurableTask.Core.Logging
         }
 
         [Event(EventIds.TaskHubWorkerStopped, Level = EventLevel.Informational, Version = 1)]
-        public void TaskHubWorkerStopped(long LatencyMs, string AppName, string ExtensionVersion)
+        internal void TaskHubWorkerStopped(long LatencyMs, string AppName, string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Informational))
             {
@@ -85,7 +85,7 @@ namespace DurableTask.Core.Logging
         }
 
         [Event(EventIds.DispatcherStarting, Level = EventLevel.Verbose, Version = 1)]
-        public void DispatcherStarting(string Dispatcher, string AppName, string ExtensionVersion)
+        internal void DispatcherStarting(string Dispatcher, string AppName, string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Verbose))
             {
@@ -94,7 +94,7 @@ namespace DurableTask.Core.Logging
         }
 
         [Event(EventIds.DispatcherStopped, Level = EventLevel.Verbose, Version = 1)]
-        public void DispatcherStopped(string Dispatcher, string AppName, string ExtensionVersion)
+        internal void DispatcherStopped(string Dispatcher, string AppName, string ExtensionVersion)
         {
             if (this.IsEnabled(EventLevel.Verbose))
             {
@@ -103,7 +103,7 @@ namespace DurableTask.Core.Logging
         }
 
         [Event(EventIds.DispatchersStopping, Level = EventLevel.Verbose, Version = 1)]
-        public void DispatchersStopping(
+        internal void DispatchersStopping(
             string Dispatcher,
             int WorkItemCount,
             int ActiveFetcherCount,
@@ -247,7 +247,7 @@ namespace DurableTask.Core.Logging
         }
 
         [Event(EventIds.ProcessWorkItemFailed, Level = EventLevel.Error, Version = 1)]
-        public void ProcessWorkItemFailed(
+        internal void ProcessWorkItemFailed(
             string Dispatcher,
             string WorkItemId,
             string Details,

--- a/test/DurableTask.AzureStorage.Tests/Correlation/CorrelationScenarioTest.cs
+++ b/test/DurableTask.AzureStorage.Tests/Correlation/CorrelationScenarioTest.cs
@@ -536,12 +536,13 @@ namespace DurableTask.AzureStorage.Tests.Correlation
                     (typeof(RequestTelemetry), $"{TraceConstants.Orchestrator} MultiParentOrchestrator"),
                     (typeof(DependencyTelemetry), $"{TraceConstants.Orchestrator} {typeof(Hello).FullName}"),
                     (typeof(RequestTelemetry), $"{TraceConstants.Activity} Hello")
-                }, actual.Select(x => (x.GetType(), x.Name)).ToList());
+                },
+                actual.Select(x => (x.GetType(), x.Name)).ToList());
         }
 
         bool IsNotReadyForRaiseEvent(TestOrchestrationClient client)
         {
-            return client == null && !MultiParentOrchestrator.IsWaitForExternalEvent;
+            return client == null || !MultiParentOrchestrator.IsWaitForExternalEvent;
         }
 
         List<OperationTelemetry> Convert(Task task)
@@ -618,9 +619,10 @@ namespace DurableTask.AzureStorage.Tests.Correlation
                     (typeof(RequestTelemetry), $"{TraceConstants.Orchestrator} MultiParentChildOrchestrator"),
                     (typeof(DependencyTelemetry), $"{TraceConstants.Orchestrator} {typeof(Hello).FullName}"),
                     (typeof(RequestTelemetry), $"{TraceConstants.Activity} Hello")
-                }, actual.Select(x => (x.GetType(), x.Name)).ToList());
-            MultiParentChildOrchestrator.Reset();
+                },
+                actual.Select(x => (x.GetType(), x.Name)).ToList());
 
+            MultiParentChildOrchestrator.Reset();
         }
 
         bool IsNotReadyForTwoRaiseEvents(TestOrchestrationClient client)
@@ -644,10 +646,11 @@ namespace DurableTask.AzureStorage.Tests.Correlation
         [KnownType(typeof(Hello))]
         internal class MultiParentChildOrchestrator : TaskOrchestration<string, string>
         {
-            private static object lockExternalEvent = new object();
-            private static object lockId = new object();
-            private static int readyCountForExternalEvent = 0;
-            private static List<string> orchestrationIds = new List<string>();
+            static readonly object lockExternalEvent = new object();
+            static readonly object lockId = new object();
+            static int readyCountForExternalEvent = 0;
+            static List<string> orchestrationIds = new List<string>();
+
             public static int ReadyForExternalEvent
             {
                 get

--- a/test/DurableTask.AzureStorage.Tests/TestHelpers.cs
+++ b/test/DurableTask.AzureStorage.Tests/TestHelpers.cs
@@ -24,7 +24,8 @@ namespace DurableTask.AzureStorage.Tests
         public static TestOrchestrationHost GetTestOrchestrationHost(
             bool enableExtendedSessions,
             int extendedSessionTimeoutInSeconds = 30,
-            bool fetchLargeMessages = true)
+            bool fetchLargeMessages = true,
+            Action<AzureStorageOrchestrationServiceSettings> modifySettingsAction = null)
         {
             string storageConnectionString = GetTestStorageAccountConnectionString();
 
@@ -40,6 +41,9 @@ namespace DurableTask.AzureStorage.Tests
                 // TODO: Add a logger provider so we can collect these logs in memory.
                 LoggerFactory = new LoggerFactory(),
             };
+
+            // Give the caller a chance to make test-specific changes to the settings
+            modifySettingsAction?.Invoke(settings);
 
             return new TestOrchestrationHost(settings);
         }
@@ -89,5 +93,9 @@ namespace DurableTask.AzureStorage.Tests
 
             throw new TimeoutException("Timed out waiting for condition to be true.");
         }
+
+        public static void Await(this Task task) => task.GetAwaiter().GetResult();
+
+        public static T Await<T>(this Task<T> task) => task.GetAwaiter().GetResult();
     }
 }

--- a/test/DurableTask.AzureStorage.Tests/TestOrchestrationHost.cs
+++ b/test/DurableTask.AzureStorage.Tests/TestOrchestrationHost.cs
@@ -16,9 +16,11 @@ namespace DurableTask.AzureStorage.Tests
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Linq;
     using System.Runtime.Serialization;
     using System.Threading.Tasks;
     using DurableTask.Core;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     internal sealed class TestOrchestrationHost : IDisposable
     {
@@ -117,6 +119,133 @@ namespace DurableTask.AzureStorage.Tests
             return new TestOrchestrationClient(this.client, orchestrationType, instance.InstanceId, creationTime);
         }
 
+        public Task<TestInstance<TInput>> StartInlineOrchestration<TOutput, TInput>(
+            TInput input,
+            string orchestrationName,
+            Func<OrchestrationContext, TInput, Task<TOutput>> implementation,
+            Action<OrchestrationContext, string, string> onEvent = null,
+            params (string name, TaskActivity activity)[] activities) =>
+            this.StartInlineOrchestration(input, orchestrationName, string.Empty, implementation, onEvent, activities);
+
+        public async Task<TestInstance<TInput>> StartInlineOrchestration<TOutput, TInput>(
+            TInput input,
+            string orchestrationName,
+            string version,
+            Func<OrchestrationContext, TInput, Task<TOutput>> implementation,
+            Action<OrchestrationContext, string, string> onEvent = null,
+            params (string name, TaskActivity activity)[] activities)
+        {
+            var instances = await this.StartInlineOrchestrations(
+                count: 1,
+                instanceIdGenerator: _ => Guid.NewGuid().ToString("N"),
+                inputGenerator: _ => input,
+                orchestrationName: orchestrationName,
+                version: version,
+                implementation,
+                onEvent,
+                activities);
+
+            return instances.First();
+        }
+
+        public async Task<List<TestInstance<TInput>>> StartInlineOrchestrations<TOutput, TInput>(
+            int count,
+            Func<int, string> instanceIdGenerator,
+            Func<int, TInput> inputGenerator,
+            string orchestrationName,
+            string version,
+            Func<OrchestrationContext, TInput, Task<TOutput>> implementation,
+            Action<OrchestrationContext, string, string> onEvent = null,
+            params (string name, TaskActivity activity)[] activities)
+        {
+            // Register the inline orchestration - note that this will only work once per test
+            this.RegisterInlineOrchestration(orchestrationName, version, implementation, onEvent);
+
+            foreach ((string name, TaskActivity activity) in activities)
+            {
+                this.worker.AddTaskActivities(new TestObjectCreator<TaskActivity>(name, activity));
+            }
+
+            IEnumerable<Task<TestInstance<TInput>>> tasks = Enumerable.Range(0, count).Select(async i =>
+            {
+                string instanceId = instanceIdGenerator(i);
+                TInput input = inputGenerator(i);
+
+                DateTime utcNow = DateTime.UtcNow;
+                OrchestrationInstance instance = await this.client.CreateOrchestrationInstanceAsync(
+                    orchestrationName,
+                    version,
+                    instanceId,
+                    input);
+
+                return new TestInstance<TInput>(this.client, instance, utcNow, input);
+            });
+
+            var instances = new List<TestInstance<TInput>>(count);
+            foreach (TestInstance<TInput> instance in await Task.WhenAll(tasks))
+            {
+                // Verify that the CreateOrchestrationInstanceAsync implementation set the InstanceID and ExecutionID fields
+                Assert.IsNotNull(instance.InstanceId);
+                Assert.IsNotNull(instance.ExecutionId);
+
+                instances.Add(instance);
+            }
+
+            return instances;
+        }
+
+        public void RegisterInlineOrchestration<TOutput, TInput>(
+            string orchestrationName,
+            string version,
+            Func<OrchestrationContext, TInput, Task<TOutput>> implementation,
+            Action<OrchestrationContext, string, string> onEvent = null)
+        {
+            this.worker.AddTaskOrchestrations(new TestObjectCreator<TaskOrchestration>(
+                orchestrationName,
+                version,
+                MakeOrchestration(implementation, onEvent)));
+        }
+
+        public static TaskOrchestration MakeOrchestration<TOutput, TInput>(
+            Func<OrchestrationContext, TInput, Task<TOutput>> implementation,
+            Action<OrchestrationContext, string, string> onEvent = null)
+        {
+            return new OrchestrationShim<TOutput, TInput>(implementation, onEvent);
+        }
+
+        // This is just a wrapper around the constructor for convenience. It allows us to write 
+        // less code because generic arguments for methods can be implied, unlike constructors.
+        public static TaskActivity MakeActivity<TInput, TOutput>(
+            Func<TaskContext, TInput, TOutput> implementation)
+        {
+            return new ActivityShim<TInput, TOutput>(implementation);
+        }
+
+        static string GetFriendlyTypeName(Type type)
+        {
+            string friendlyName = type.Name;
+            if (type.IsGenericType)
+            {
+                int iBacktick = friendlyName.IndexOf('`');
+                if (iBacktick > 0)
+                {
+                    friendlyName = friendlyName.Remove(iBacktick);
+                }
+
+                friendlyName += "<";
+                Type[] typeParameters = type.GetGenericArguments();
+                for (int i = 0; i < typeParameters.Length; ++i)
+                {
+                    string typeParamName = GetFriendlyTypeName(typeParameters[i]);
+                    friendlyName += (i == 0 ? typeParamName : "," + typeParamName);
+                }
+
+                friendlyName += ">";
+            }
+
+            return friendlyName;
+        }
+
         public async Task<IList<OrchestrationState>> GetAllOrchestrationInstancesAsync()
         {
             // This API currently only exists in the service object and is not yet exposed on the TaskHubClient
@@ -124,6 +253,61 @@ namespace DurableTask.AzureStorage.Tests
             IList<OrchestrationState> instances = await service.GetOrchestrationStateAsync();
             Trace.TraceInformation($"Found {instances.Count} in the task hub instance store.");
             return instances;
+        }
+
+        class ActivityShim<TInput, TOutput> : TaskActivity<TInput, TOutput>
+        {
+            public ActivityShim(Func<TaskContext, TInput, TOutput> implementation)
+            {
+                this.Implementation = implementation;
+            }
+
+            public Func<TaskContext, TInput, TOutput> Implementation { get; }
+
+            protected override TOutput Execute(TaskContext context, TInput input)
+            {
+                return this.Implementation(context, input);
+            }
+        }
+
+        class OrchestrationShim<TOutput, TInput> : TaskOrchestration<TOutput, TInput>
+        {
+            public OrchestrationShim(
+                Func<OrchestrationContext, TInput, Task<TOutput>> implementation,
+                Action<OrchestrationContext, string, string> onEvent = null)
+            {
+                this.Implementation = implementation;
+                this.OnEventRaised = onEvent;
+            }
+
+            public Func<OrchestrationContext, TInput, Task<TOutput>> Implementation { get; set; }
+
+            public Action<OrchestrationContext, string, string> OnEventRaised { get; set; }
+
+            public override Task<TOutput> RunTask(OrchestrationContext context, TInput input)
+                => this.Implementation(context, input);
+
+            public override void RaiseEvent(OrchestrationContext context, string name, string input)
+                => this.OnEventRaised(context, name, input);
+        }
+
+        class TestObjectCreator<T> : ObjectCreator<T>
+        {
+            readonly T obj;
+
+            public TestObjectCreator(string name, T obj) 
+                : this(name, string.Empty, obj)
+            {
+            }
+
+            public TestObjectCreator(string name, string version, T obj)
+            {
+                this.Name = name;
+                this.Version = version;
+                this.obj = obj;
+            }
+
+            public override T Create() => this.obj;
         }
     }
 }

--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -45,9 +45,9 @@
   <!-- Nuget Package Settings -->
   <PropertyGroup>
     <PackageOutputPath>..\..\build_output\packages</PackageOutputPath>
-    <AssemblyVersion>2.5.2</AssemblyVersion>
-    <FileVersion>2.5.2</FileVersion>
-    <Version>2.5.2</Version>
+    <AssemblyVersion>2.5.3</AssemblyVersion>
+    <FileVersion>2.5.3</FileVersion>
+    <Version>2.5.3</Version>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
     <Product>Durable Task Framework</Product>


### PR DESCRIPTION
The DT.AzureStorage backend has always been vulnerable to concurrent starts of orchestrations with the same instance ID. This PR finally fixes that, as well as a couple other issues found along the way.

Fixes https://github.com/Azure/azure-functions-durable-extension/issues/1730 (this was the main issue being fixed)
Fixes https://github.com/Azure/durabletask/issues/527 (found this while working on ^)

## Problem
Often time users want to start an orchestration with a specific instance ID if it's not already started. To do so, they'd write code that looks like this:

```
var existing = GetOrchestrationInstance(id)
if (existing is null or existing is stopped)
    StartNewOrchestration(id)
```

The problem with this logic is that it's not thread-safe. If two threads call this logic at the same time, on the same machine or on different machines, it will create to orchestration start messages for the same instance. DT.AzureStorage did not have ideal handling for this. One instance may execute normally while another executes partially, leading to inconsistencies or duplicate executions.

In the past, we'd asked customers to implement their own concurrency management. With this PR, we should be able to automatically de-duplicate these start messages, allowing users to not worry about writing distributed locks to mitigate this race condition.

## Solution

For every `ExecutionStarted` event we dequeue from a control queue, we query the _Instances_ table to see whether the `ExecutionId` field of the start message matches that same property of the corresponding _Instances_ table. If they match, then we process the start message normally. Otherwise, we discard the message as a duplicate. We can do this because updates to the _Instances_ table are thread-safe, so the `ExecutionId` field is an easy way to uniquely associate an instance to an `ExecutionStarted` message.

The actual implementation is a bit more complex because we actually enqueue the `ExecutionStarted` message in the control queue before updating the _Instances_ table. For example, by the time we read the `ExecutionStarted` message, the corresponding _Instances_ table record may not yet exist, in which case we put the message back onto the queue so we can try processing it again later. We do this up to 10 times.

The other corner case we handle is where a _completed_ instance is being intentionally overwritten, which is something we actively support. In that case, an old `ExecutionId` values will exist temporarily until the new one can be written. To account for this, we also compare the timestamp of the message with the timestamp of the _Instances.CreatedTime_ record to distinguish this case from the duplicate start case.

### Pros
This solution is robust without introducing too much complexity.

### Cons
There is now one more Azure Table I/O request for every orchestration start. This means more storage I/O and more end-to-end latency for a single orchestration execution. I tried to avoid this but couldn't come up with anything that was sufficiently robust against all kinds of corner cases. Because the new I/O is outside of the main execution path, it shouldn't have a big impact on max throughput.

As an optimization, we will try to batch multiple Azure Table I/O requests into one to minimize overhead if there are lots of concurrent orchestration starts.

## Other alternative designs considered
I initially tried to solve this by simply de-duplicating `ExecutionStarted` messages in-memory when we dequeued them. However, this generally assumes that we dequeue all these messages in the same batch, which is not always the case. For example, if there are 40 duplicate start messages, then they would arrive it at least two different dequeue batches.

There are other potential solutions as well, such as keeping a list of all execution start messages over a period of time. However, doing this in memory can be fragile because 1) leases may move in which case some messages will show up on one VM and some on another, and 2) the list of instance IDs also needs to be kept in sync with orchestration status updates - for example, we need to know if an instance ID in our list has completed so we can remove it from the list. This becomes complicated quickly, so I did not pursue it.

## Testing

To test this, I create 40 new instances concurrently. I chose 40 to be some number larger than 32, which is out dequeue batch size (other designs I had in mind didn't work for more than one dequeue batch). The test verifies that exactly one instance runs without any duplicate activity executions.

To ensure I didn't regress anything, and to exercise the optimization I mentioned earlier, I also added a version of the test that creates 40 _unique_ orchestrations concurrently.

**NOTE**: There is a lot of new test code that I borrowed from the DT.SqlServer project. It allows us to define orchestrations and activities inline as C# lambdas without writing any classes, which is very convenient. My hope is that we can use this as the basis of a reusable test library for custom DTFx backend implementations to use.
