### PR TITLE
Fixes for DurableTask.AzureServiceFabric and DurableTask.Core

### DIFF
--- a/src/DurableTask.AzureServiceFabric/Extensions.cs
+++ b/src/DurableTask.AzureServiceFabric/Extensions.cs
@@ -45,7 +45,8 @@ namespace DurableTask.AzureServiceFabric
 
         internal static void EnsureValidInstanceId(this string instanceId)
         {
-            // Do not enforce InstanceId validation here. Let the application/user decide.
+            // For now do not enforce InstanceId validation here. Let the application/user decide.
+            // Revist or enable this logic after finding out the chars that are not allowed in the InstanceID
             //if (!instanceId.IsValidInstanceId())
             //{
             //    throw new InvalidInstanceIdException(instanceId);

--- a/src/DurableTask.AzureServiceFabric/Extensions.cs
+++ b/src/DurableTask.AzureServiceFabric/Extensions.cs
@@ -45,10 +45,11 @@ namespace DurableTask.AzureServiceFabric
 
         internal static void EnsureValidInstanceId(this string instanceId)
         {
-            if (!instanceId.IsValidInstanceId())
-            {
-                throw new InvalidInstanceIdException(instanceId);
-            }
+            // Do not enforce InstanceId validation here. Let the application/user decide.
+            //if (!instanceId.IsValidInstanceId())
+            //{
+            //    throw new InvalidInstanceIdException(instanceId);
+            //}
         }
     }
 }

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -31,7 +31,7 @@ namespace DurableTask.Core
         private readonly IDictionary<int, OpenTaskInfo> openTasks;
         private readonly IDictionary<int, OrchestratorAction> orchestratorActionsMap;
         private OrchestrationCompleteOrchestratorAction continueAsNew;
-        private bool executionTerminated;
+        private bool executionCompletedOrTerminated;
         private int idCounter;
 
         public bool HasContinueAsNew => continueAsNew != null;
@@ -473,12 +473,12 @@ namespace DurableTask.Core
             }
             else
             {
-                if (executionTerminated)
+                if (this.executionCompletedOrTerminated)
                 {
                     return;
                 }
 
-                executionTerminated = true;
+                this.executionCompletedOrTerminated = true;
 
                 completedOrchestratorAction = new OrchestrationCompleteOrchestratorAction();
                 completedOrchestratorAction.Result = result;

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -427,19 +427,12 @@ namespace DurableTask.Core
 
         public void HandleExecutionTerminatedEvent(ExecutionTerminatedEvent terminatedEvent)
         {
-            if (!this.executionTerminated)
-            {
-                this.executionTerminated = true;
-                CompleteOrchestration(terminatedEvent.Input, null, OrchestrationStatus.Terminated);
-            }
+            CompleteOrchestration(terminatedEvent.Input, null, OrchestrationStatus.Terminated);
         }
 
         public void CompleteOrchestration(string result)
         {
-            if (!this.executionTerminated)
-            {
-                CompleteOrchestration(result, null, OrchestrationStatus.Completed);
-            }
+            CompleteOrchestration(result, null, OrchestrationStatus.Completed);
         }
 
         public void FailOrchestration(Exception failure)
@@ -480,6 +473,13 @@ namespace DurableTask.Core
             }
             else
             {
+                if (executionTerminated)
+                {
+                    return;
+                }
+
+                executionTerminated = true;
+
                 completedOrchestratorAction = new OrchestrationCompleteOrchestratorAction();
                 completedOrchestratorAction.Result = result;
                 completedOrchestratorAction.Details = details;

--- a/test/DurableTask.AzureServiceFabric.Integration.Tests/DeploymentUtil/ApplicationInfoReader.cs
+++ b/test/DurableTask.AzureServiceFabric.Integration.Tests/DeploymentUtil/ApplicationInfoReader.cs
@@ -69,9 +69,15 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests.DeploymentUtil
                    GetSingleNodeAttributeValue(serviceManifestRoot, serviceManifestNamespaceManager, StatelessServiceNodePath, ServiceTypeNameAttribute);
         }
 
-        public NameValueCollection GetApplicationParameters()
+        public NameValueCollection GetApplicationParameters(int nodeCount)
         {
-            var applicationParametersPath = Path.Combine(applicationRootPath, @"ApplicationParameters\Local.5Node.xml");
+            string paramFileName = "Local.1Node.xml";
+            if (nodeCount >= 5)
+            {
+                paramFileName = "Local.5Node.xml";
+            }
+
+            var applicationParametersPath = Path.Combine(applicationRootPath, @"ApplicationParameters\" + paramFileName);
 
             var applicationParameters = new XmlDocument();
             applicationParameters.Load(applicationParametersPath);

--- a/test/DurableTask.AzureServiceFabric.Integration.Tests/DeploymentUtil/DeploymentHelper.cs
+++ b/test/DurableTask.AzureServiceFabric.Integration.Tests/DeploymentUtil/DeploymentHelper.cs
@@ -30,12 +30,13 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests.DeploymentUtil
         {
             var appInfoReader = new ApplicationInfoReader(applicationRootPath);
             var serviceName = new Uri(Constants.TestFabricApplicationAddress);
+            var nodeList = await client.QueryManager.GetNodeListAsync();
             var applicationDescription =
                 new ApplicationDescription(
                     new Uri($"fabric:/{appInfoReader.GetApplicationName()}"),
                     appInfoReader.GetApplicationName(),
                     appInfoReader.GetApplicationVersion(),
-                    appInfoReader.GetApplicationParameters());
+                    appInfoReader.GetApplicationParameters(nodeList.Count));
 
             await DeployAsync(appInfoReader.ApplicationPackagePath, applicationDescription);
             await WaitForHealthStatusAsync(applicationDescription, serviceName);

--- a/test/DurableTask.AzureServiceFabric.Integration.Tests/FunctionalTests.cs
+++ b/test/DurableTask.AzureServiceFabric.Integration.Tests/FunctionalTests.cs
@@ -46,6 +46,17 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests
         }
 
         [TestMethod]
+        public async Task Orchestration_With_InstanceId_SpecialChars()
+        {
+            var instanceId = typeof(SimpleOrchestrationWithTasks) + "$abc";
+            var instance = await this.taskHubClient.CreateOrchestrationInstanceAsync(typeof(SimpleOrchestrationWithTasks), instanceId, null);
+            var result = await this.taskHubClient.WaitForOrchestrationAsync(instance, TimeSpan.FromMinutes(2));
+
+            Assert.AreEqual(OrchestrationStatus.Completed, result.OrchestrationStatus);
+            Assert.AreEqual("\"Hello Gabbar\"", result.Output);
+        }
+
+        [TestMethod]
         public async Task Orchestration_With_Timer_Finishes_After_The_Wait_Time()
         {
             var waitTime = 37;


### PR DESCRIPTION
2 changes in this PR:
1. DurableTask.AzureServiceFabric: Disabled instanceId validation to alllow any chars to let the application decide on the chars to be allowed.
2. DurableTask.Core: Fix the issue "Multiple ExecutionCompletedEvent found, potential corruption in state storage"
    Multiple ExecutionCompletedEvents possible when orchestration's termination and completion happens at the same time.