### PR TITLE
Refactor: First iteration blob storage refactor

### DIFF
--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -18,12 +18,10 @@ namespace DurableTask.AzureStorage
     using System.IO;
     using System.IO.Compression;
     using System.Reflection;
-    using System.Runtime.Serialization;
     using System.Text;
     using System.Threading.Tasks;
     using DurableTask.AzureStorage.Monitoring;
-    using Microsoft.WindowsAzure.Storage;
-    using Microsoft.WindowsAzure.Storage.Blob;
+    using DurableTask.AzureStorage.Storage;
     using Microsoft.WindowsAzure.Storage.Queue;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Serialization;
@@ -39,23 +37,20 @@ namespace DurableTask.AzureStorage
         const int DefaultBufferSize = 64 * 2014; // 64KB
 
         readonly AzureStorageOrchestrationServiceSettings settings;
-        readonly string blobContainerName;
-        readonly CloudBlobContainer cloudBlobContainer;
+        readonly AzureStorageClient azureStorageClient;
+        readonly BlobContainer blobContainer;
         readonly JsonSerializerSettings taskMessageSerializerSettings;
 
         bool containerInitialized;
 
-        /// <summary>
-        /// The message manager.
-        /// </summary>
         public MessageManager(
             AzureStorageOrchestrationServiceSettings settings,
-            CloudBlobClient cloudBlobClient,
+            AzureStorageClient azureStorageClient,
             string blobContainerName)
         {
             this.settings = settings;
-            this.blobContainerName = blobContainerName;
-            this.cloudBlobContainer = cloudBlobClient.GetContainerReference(blobContainerName);
+            this.azureStorageClient = azureStorageClient;
+            this.blobContainer = this.azureStorageClient.GetBlobContainerReference(blobContainerName);
             this.taskMessageSerializerSettings = new JsonSerializerSettings
             {
                 TypeNameHandling = TypeNameHandling.Objects,
@@ -78,7 +73,7 @@ namespace DurableTask.AzureStorage
 
             if (!this.containerInitialized)
             {
-                created = await this.cloudBlobContainer.CreateIfNotExistsAsync();
+                created = await this.blobContainer.CreateIfNotExistsAsync();
                 this.containerInitialized = true;
             }
 
@@ -87,16 +82,11 @@ namespace DurableTask.AzureStorage
 
         public async Task<bool> DeleteContainerAsync()
         {
-            bool deleted = await this.cloudBlobContainer.DeleteIfExistsAsync();
+            bool deleted = await this.blobContainer.DeleteIfExistsAsync();
             this.containerInitialized = false;
             return deleted;
         }
 
-        /// <summary>
-        /// Serializes the MessageData object
-        /// </summary>
-        /// <param name="messageData">Instance of <see cref="MessageData"/></param>
-        /// <returns>JSON for the <see cref="MessageData"/> object</returns>
         public async Task<string> SerializeMessageDataAsync(MessageData messageData)
         {
             string rawContent = JsonConvert.SerializeObject(messageData, this.taskMessageSerializerSettings);
@@ -137,9 +127,6 @@ namespace DurableTask.AzureStorage
             }
         }
 
-        /// <summary>
-        /// Deserializes the MessageData object
-        /// </summary>
         public async Task<MessageData> DeserializeQueueMessageAsync(CloudQueueMessage queueMessage, string queueName)
         {
             MessageData envelope = JsonConvert.DeserializeObject<MessageData>(
@@ -161,14 +148,14 @@ namespace DurableTask.AzureStorage
             return envelope;
         }
 
-        internal Task CompressAndUploadAsBytesAsync(byte[] payloadBuffer, string blobName)
+        public Task CompressAndUploadAsBytesAsync(byte[] payloadBuffer, string blobName)
         {
             ArraySegment<byte> compressedSegment = this.Compress(payloadBuffer);
             return this.UploadToBlobAsync(compressedSegment.Array, compressedSegment.Count, blobName);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:DoNotDisposeObjectsMultipleTimes", Justification = "This GZipStream will not dispose the MemoryStream.")]
-        internal ArraySegment<byte> Compress(byte[] payloadBuffer)
+        public ArraySegment<byte> Compress(byte[] payloadBuffer)
         {
             using (var originStream = new MemoryStream(payloadBuffer, 0, payloadBuffer.Length))
             {
@@ -198,25 +185,25 @@ namespace DurableTask.AzureStorage
             }
         }
 
-        internal async Task<string> DownloadAndDecompressAsBytesAsync(string blobName)
+        public async Task<string> DownloadAndDecompressAsBytesAsync(string blobName)
         {
             await this.EnsureContainerAsync();
 
-            CloudBlockBlob cloudBlockBlob = this.cloudBlobContainer.GetBlockBlobReference(blobName);
-            return await DownloadAndDecompressAsBytesAsync(cloudBlockBlob);
+            Blob blob = this.blobContainer.GetBlobReference(blobName);
+            return await DownloadAndDecompressAsBytesAsync(blob);
         }
 
-        internal Task<string> DownloadAndDecompressAsBytesAsync(Uri blobUri)
+        public Task<string> DownloadAndDecompressAsBytesAsync(Uri blobUri)
         {
-            CloudBlockBlob cloudBlockBlob = new CloudBlockBlob(blobUri, this.cloudBlobContainer.ServiceClient.Credentials);
-            return DownloadAndDecompressAsBytesAsync(cloudBlockBlob);
+            Blob blob = this.azureStorageClient.GetBlobReference(blobUri);
+            return DownloadAndDecompressAsBytesAsync(blob);
         }
 
-        private async Task<string> DownloadAndDecompressAsBytesAsync(CloudBlockBlob cloudBlockBlob)
+        private async Task<string> DownloadAndDecompressAsBytesAsync(Blob blob)
         {
             using (MemoryStream memory = new MemoryStream(MaxStorageQueuePayloadSizeInBytes * 2))
             {
-                await cloudBlockBlob.DownloadToStreamAsync(memory);
+                await blob.DownloadToStreamAsync(memory);
                 memory.Position = 0;
 
                 ArraySegment<byte> decompressedSegment = this.Decompress(memory);
@@ -224,12 +211,12 @@ namespace DurableTask.AzureStorage
             }
         }
 
-        internal string GetBlobUrl(string blobName)
+        public string GetBlobUrl(string blobName)
         {
-            return this.cloudBlobContainer.GetBlockBlobReference(blobName).Uri.AbsoluteUri;
+            return this.blobContainer.GetBlobReference(blobName).GetAbsoluteUri();
         }
 
-        internal ArraySegment<byte> Decompress(Stream blobStream)
+        public ArraySegment<byte> Decompress(Stream blobStream)
         {
             using (GZipStream gZipStream = new GZipStream(blobStream, CompressionMode.Decompress))
             {
@@ -254,7 +241,7 @@ namespace DurableTask.AzureStorage
             }
         }
 
-        internal MessageFormatFlags GetMessageFormatFlags(MessageData messageData)
+        public MessageFormatFlags GetMessageFormatFlags(MessageData messageData)
         {
             MessageFormatFlags messageFormatFlags = MessageFormatFlags.InlineJson;
 
@@ -266,18 +253,15 @@ namespace DurableTask.AzureStorage
             return messageFormatFlags;
         }
 
-        /// <summary>
-        /// Uploads MessageData as bytes[] to blob container
-        /// </summary>
-        internal async Task UploadToBlobAsync(byte[] data, int dataByteCount, string blobName)
+        public async Task UploadToBlobAsync(byte[] data, int dataByteCount, string blobName)
         {
             await this.EnsureContainerAsync();
 
-            CloudBlockBlob cloudBlockBlob = this.cloudBlobContainer.GetBlockBlobReference(blobName);
-            await cloudBlockBlob.UploadFromByteArrayAsync(data, 0, dataByteCount);
+            Blob blob = this.blobContainer.GetBlobReference(blobName);
+            await blob.UploadFromByteArrayAsync(data, 0, dataByteCount);
         }
 
-        internal string GetNewLargeMessageBlobName(MessageData message)
+        public string GetNewLargeMessageBlobName(MessageData message)
         {
             string instanceId = message.TaskMessage.OrchestrationInstance.InstanceId;
             string eventType = message.TaskMessage.Event.EventType.ToString();
@@ -286,50 +270,22 @@ namespace DurableTask.AzureStorage
             return $"{instanceId}/message-{activityId}-{eventType}.json.gz";
         }
 
-        internal async Task DeleteLargeMessageBlobs(string sanitizedInstanceId, AzureStorageOrchestrationServiceStats stats)
+        public async Task DeleteLargeMessageBlobs(string sanitizedInstanceId, AzureStorageOrchestrationServiceStats stats)
         {
-            var blobForDeletionTaskList = new List<Task>();
-            if (!await this.cloudBlobContainer.ExistsAsync())
+            if (!await this.blobContainer.ExistsAsync())
             {
                 return;
             }
 
-            CloudBlobDirectory instanceDirectory = this.cloudBlobContainer.GetDirectoryReference(sanitizedInstanceId);
-            BlobContinuationToken blobContinuationToken = null;
-            while (true)
+            IEnumerable<Blob> blobList = await this.blobContainer.ListBlobsAsync(sanitizedInstanceId);
+
+            var blobForDeletionTaskList = new List<Task>();
+            foreach (Blob blob in blobList)
             {
-                BlobResultSegment segment = await TimeoutHandler.ExecuteWithTimeout(
-                    operationName: "DeleteLargeMessageBlobs",
-                    account: cloudBlobContainer?.ServiceClient?.Credentials?.AccountName,
-                    settings: this.settings,
-                    operation: (context, timeoutToken) =>
-                    {
-                        return instanceDirectory.ListBlobsSegmentedAsync(
-                            useFlatBlobListing: true,
-                            blobListingDetails: BlobListingDetails.Metadata,
-                            maxResults: null,
-                            currentToken: blobContinuationToken,
-                            options: null,
-                            operationContext: context,
-                            cancellationToken: timeoutToken);
-                    });
-                
-                stats.StorageRequests.Increment();
-                foreach (IListBlobItem blobListItem in segment.Results)
-                {
-                    var cloudBlockBlob = blobListItem as CloudBlockBlob;
-                    CloudBlockBlob blob = this.cloudBlobContainer.GetBlockBlobReference(cloudBlockBlob?.Name);
-                    blobForDeletionTaskList.Add(blob.DeleteIfExistsAsync());
-                }
-
-                await Task.WhenAll(blobForDeletionTaskList);
-
-                stats.StorageRequests.Increment(blobForDeletionTaskList.Count);
-                if (blobContinuationToken == null)
-                {
-                    break;
-                }
+                blobForDeletionTaskList.Add(blob.DeleteIfExistsAsync());
             }
+
+            await Task.WhenAll(blobForDeletionTaskList);
         }
     }
 

--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -18,6 +18,7 @@ namespace DurableTask.AzureStorage
     using System.IO;
     using System.IO.Compression;
     using System.Reflection;
+    using System.Runtime.Serialization;
     using System.Text;
     using System.Threading.Tasks;
     using DurableTask.AzureStorage.Monitoring;

--- a/src/DurableTask.AzureStorage/Partitioning/BlobLease.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/BlobLease.cs
@@ -13,7 +13,8 @@
 
 namespace DurableTask.AzureStorage.Partitioning
 {
-    using Microsoft.WindowsAzure.Storage.Blob;
+    using System.Threading.Tasks;
+    using DurableTask.AzureStorage.Storage;
     using Newtonsoft.Json;
 
     class BlobLease : Lease
@@ -23,7 +24,7 @@ namespace DurableTask.AzureStorage.Partitioning
         {
         }
 
-        public BlobLease(CloudBlockBlob leaseBlob)
+        public BlobLease(Blob leaseBlob)
             : this()
         {
             this.Blob = leaseBlob;
@@ -36,11 +37,11 @@ namespace DurableTask.AzureStorage.Partitioning
         }
 
         [JsonIgnore]
-        internal CloudBlockBlob Blob { get; set; }
+        internal Blob Blob { get; set; }
 
-        public override bool IsExpired()
+        public override async Task<bool> IsExpired()
         {
-            return this.Blob.Properties.LeaseState != LeaseState.Leased;
+            return !await this.Blob.IsLeased();
         }
     }
 }

--- a/src/DurableTask.AzureStorage/Partitioning/BlobLease.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/BlobLease.cs
@@ -37,11 +37,9 @@ namespace DurableTask.AzureStorage.Partitioning
         }
 
         [JsonIgnore]
-        internal Blob Blob { get; set; }
+        public Blob Blob { get; set; }
 
-        public override async Task<bool> IsExpired()
-        {
-            return !await this.Blob.IsLeased();
-        }
+        [JsonIgnore]
+        public override bool IsExpired => !Blob.IsLeased;
     }
 }

--- a/src/DurableTask.AzureStorage/Partitioning/BlobLeaseManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/BlobLeaseManager.cs
@@ -19,79 +19,51 @@ namespace DurableTask.AzureStorage.Partitioning
     using System.Linq;
     using System.Net;
     using System.Threading.Tasks;
-    using DurableTask.AzureStorage.Monitoring;
-    using Microsoft.WindowsAzure.Storage;
-    using Microsoft.WindowsAzure.Storage.Blob;
-    using Microsoft.WindowsAzure.Storage.Blob.Protocol;
+    using DurableTask.AzureStorage.Storage;
     using Newtonsoft.Json;
 
     sealed class BlobLeaseManager : ILeaseManager<BlobLease>
     {
         const string TaskHubInfoBlobName = "taskhub.json";
-        static readonly TimeSpan StorageMaximumExecutionTime = TimeSpan.FromMinutes(2);
 
+        readonly AzureStorageClient azureStorageClient;
         readonly AzureStorageOrchestrationServiceSettings settings;
         readonly string storageAccountName;
         readonly string taskHubName;
         readonly string workerName;
-        readonly string blobPrefix;
         readonly string leaseContainerName;
-        readonly string leaseType;
-        readonly bool skipBlobContainerCreation;
         readonly TimeSpan leaseInterval;
-        readonly CloudBlobClient storageClient;
-        readonly BlobRequestOptions renewRequestOptions;
-        readonly AzureStorageOrchestrationServiceStats stats;
 
-        CloudBlobContainer taskHubContainer;
-        CloudBlobDirectory leaseDirectory;
-        CloudBlockBlob taskHubInfoBlob;
+        BlobContainer taskHubContainer;
+        private string blobDirectoryName;
+        Blob taskHubInfoBlob;
 
         public BlobLeaseManager(
-            AzureStorageOrchestrationServiceSettings settings,
+            AzureStorageClient azureStorageClient,
             string leaseContainerName,
-            string blobPrefix,
-            string leaseType,
-            CloudBlobClient storageClient,
-            bool skipBlobContainerCreation,
-            AzureStorageOrchestrationServiceStats stats)
+            string leaseType)
         {
-            this.settings = settings;
-            this.storageAccountName = storageClient.Credentials.AccountName;
-            this.taskHubName = settings.TaskHubName;
-            this.workerName = settings.WorkerId;
+            this.azureStorageClient = azureStorageClient;
+            this.settings = this.azureStorageClient.Settings;
+            this.storageAccountName = this.azureStorageClient.StorageAccountName;
+            this.taskHubName = this.settings.TaskHubName;
+            this.workerName = this.settings.WorkerId;
             this.leaseContainerName = leaseContainerName;
-            this.blobPrefix = blobPrefix;
-            this.leaseType = leaseType;
-            this.storageClient = storageClient;
-            this.leaseInterval = settings.LeaseInterval;
-            this.skipBlobContainerCreation = skipBlobContainerCreation;
-            this.renewRequestOptions = new BlobRequestOptions { ServerTimeout = settings.LeaseRenewInterval };
-            this.stats = stats ?? new AzureStorageOrchestrationServiceStats();
+            this.blobDirectoryName = leaseType;
+            this.leaseInterval = this.settings.LeaseInterval;
 
             this.Initialize();
         }
 
         public async Task<bool> LeaseStoreExistsAsync()
         {
-            try
-            {
-                return await this.taskHubContainer.ExistsAsync();
-            }
-            finally
-            {
-                this.stats.StorageRequests.Increment();
-            }
+            return await taskHubContainer.ExistsAsync();
         }
 
         public async Task<bool> CreateLeaseStoreIfNotExistsAsync(TaskHubInfo eventHubInfo, bool checkIfStale)
         {
             bool result = false;
-            if (!this.skipBlobContainerCreation)
-            {
-                result = await this.taskHubContainer.CreateIfNotExistsAsync();
-                this.stats.StorageRequests.Increment();
-            }
+            result = await taskHubContainer.CreateIfNotExistsAsync();
 
             await this.GetOrCreateTaskHubInfoAsync(eventHubInfo, checkIfStale: checkIfStale);
 
@@ -102,45 +74,24 @@ namespace DurableTask.AzureStorage.Partitioning
         {
             var blobLeases = new List<BlobLease>();
 
-            BlobContinuationToken continuationToken = null;
-            do
+            IEnumerable<Blob> blobs = await this.taskHubContainer.ListBlobsAsync(this.blobDirectoryName);
+
+            var downloadTasks = new List<Task<BlobLease>>();
+            foreach (Blob blob in blobs)
             {
-                BlobResultSegment segment = await TimeoutHandler.ExecuteWithTimeout("ListLeases", this.storageAccountName, this.settings, (context, timeoutToken) =>
-                {
-                    return this.leaseDirectory.ListBlobsSegmentedAsync(
-                        useFlatBlobListing: true,
-                        blobListingDetails: BlobListingDetails.Metadata,
-                        maxResults: null,
-                        currentToken: continuationToken,
-                        options: null,
-                        operationContext: context,
-                        cancellationToken: timeoutToken);
-                });
-                
-                continuationToken = segment.ContinuationToken;
-
-                var downloadTasks = new List<Task<BlobLease>>();
-                foreach (IListBlobItem blob in segment.Results)
-                {
-                    CloudBlockBlob lease = blob as CloudBlockBlob;
-                    if (lease != null)
-                    {
-                        downloadTasks.Add(this.DownloadLeaseBlob(lease));
-                    }
-                }
-
-                await Task.WhenAll(downloadTasks);
-
-                blobLeases.AddRange(downloadTasks.Select(t => t.Result));
+                downloadTasks.Add(this.DownloadLeaseBlob(blob));
             }
-            while (continuationToken != null);
+
+            await Task.WhenAll(downloadTasks);
+
+            blobLeases.AddRange(downloadTasks.Select(t => t.Result));
 
             return blobLeases;
         }
 
         public async Task CreateLeaseIfNotExistAsync(string partitionId)
         {
-            CloudBlockBlob leaseBlob = this.leaseDirectory.GetBlockBlobReference(partitionId);
+            Blob leaseBlob = this.taskHubContainer.GetBlobReference(partitionId, this.blobDirectoryName);
             BlobLease lease = new BlobLease(leaseBlob) { PartitionId = partitionId };
             string serializedLease = JsonConvert.SerializeObject(lease);
             try
@@ -154,17 +105,16 @@ namespace DurableTask.AzureStorage.Partitioning
                         CultureInfo.InvariantCulture,
                         "CreateLeaseIfNotExistAsync - leaseContainerName: {0}, leaseType: {1}, partitionId: {2}. blobPrefix: {3}",
                         this.leaseContainerName,
-                        this.leaseType,
-                        partitionId,
-                        this.blobPrefix ?? string.Empty));
+                        this.blobDirectoryName,
+                        partitionId));
 
-                await leaseBlob.UploadTextAsync(serializedLease, null, AccessCondition.GenerateIfNoneMatchCondition("*"), null, null);
+                await leaseBlob.UploadTextAsync(serializedLease, ifDoesntExist: true);
             }
-            catch (StorageException se)
+            catch (DurableTaskStorageException se)
             {
                 // eat any storage exception related to conflict
                 // this means the blob already exist
-                if (se.RequestInformation.HttpStatusCode != 409)
+                if (se.HttpStatusCode != 409)
                 {
                     this.settings.Logger.PartitionManagerInfo(
                         this.storageAccountName,
@@ -175,21 +125,16 @@ namespace DurableTask.AzureStorage.Partitioning
                             CultureInfo.InvariantCulture,
                             "CreateLeaseIfNotExistAsync - leaseContainerName: {0}, leaseType: {1}, partitionId: {2}, blobPrefix: {3}, exception: {4}",
                             this.leaseContainerName,
-                            this.leaseType,
+                            this.blobDirectoryName,
                             partitionId,
-                            this.blobPrefix ?? string.Empty,
                             se.Message));
                 }
             }
-            finally
-            {
-                this.stats.StorageRequests.Increment();
-            }
         }
 
-        public async Task<BlobLease> GetLeaseAsync(string paritionId)
+        public async Task<BlobLease> GetLeaseAsync(string partitionId)
         {
-            CloudBlockBlob leaseBlob = this.leaseDirectory.GetBlockBlobReference(paritionId);
+            Blob leaseBlob = this.taskHubContainer.GetBlobReference(partitionId, this.blobDirectoryName);
             if (await leaseBlob.ExistsAsync())
             {
                 return await this.DownloadLeaseBlob(leaseBlob);
@@ -200,18 +145,14 @@ namespace DurableTask.AzureStorage.Partitioning
 
         public async Task<bool> RenewAsync(BlobLease lease)
         {
-            CloudBlockBlob leaseBlob = lease.Blob;
+            Blob leaseBlob = lease.Blob;
             try
             {
-                await leaseBlob.RenewLeaseAsync(accessCondition: AccessCondition.GenerateLeaseCondition(lease.Token), options: this.renewRequestOptions, operationContext: null);
+                await leaseBlob.RenewLeaseAsync(lease.Token);
             }
-            catch (StorageException storageException)
+            catch (DurableTaskStorageException storageException)
             {
                 throw HandleStorageException(lease, storageException);
-            }
-            finally
-            {
-                this.stats.StorageRequests.Increment();
             }
 
             return true;
@@ -219,30 +160,26 @@ namespace DurableTask.AzureStorage.Partitioning
 
         public async Task<bool> AcquireAsync(BlobLease lease, string owner)
         {
-            CloudBlockBlob leaseBlob = lease.Blob;
+            Blob leaseBlob = lease.Blob;
             try
             {
-                await leaseBlob.FetchAttributesAsync();
                 string newLeaseId = Guid.NewGuid().ToString();
-                if (leaseBlob.Properties.LeaseState == LeaseState.Leased)
+                if (await leaseBlob.IsLeased())
                 {
-                    lease.Token = await leaseBlob.ChangeLeaseAsync(newLeaseId, accessCondition: AccessCondition.GenerateLeaseCondition(lease.Token));
+                    lease.Token = await leaseBlob.ChangeLeaseAsync(newLeaseId, currentLeaseId: lease.Token);
                 }
                 else
                 {
                     lease.Token = await leaseBlob.AcquireLeaseAsync(this.leaseInterval, newLeaseId);
                 }
 
-                this.stats.StorageRequests.Increment();
                 lease.Owner = owner;
                 // Increment Epoch each time lease is acquired or stolen by new host
                 lease.Epoch += 1;
-                await leaseBlob.UploadTextAsync(JsonConvert.SerializeObject(lease), null, AccessCondition.GenerateLeaseCondition(lease.Token), null, null);
-                this.stats.StorageRequests.Increment();
+                await leaseBlob.UploadTextAsync(JsonConvert.SerializeObject(lease), leaseId: lease.Token);
             }
-            catch (StorageException storageException)
+            catch (DurableTaskStorageException storageException)
             {
-                this.stats.StorageRequests.Increment();
                 throw HandleStorageException(lease, storageException);
             }
 
@@ -251,7 +188,7 @@ namespace DurableTask.AzureStorage.Partitioning
 
         public async Task<bool> ReleaseAsync(BlobLease lease)
         {
-            CloudBlockBlob leaseBlob = lease.Blob;
+            Blob leaseBlob = lease.Blob;
             try
             {
                 string leaseId = lease.Token;
@@ -259,14 +196,11 @@ namespace DurableTask.AzureStorage.Partitioning
                 BlobLease copy = new BlobLease(lease);
                 copy.Token = null;
                 copy.Owner = null;
-                await leaseBlob.UploadTextAsync(JsonConvert.SerializeObject(copy), null, AccessCondition.GenerateLeaseCondition(leaseId), null, null);
-                this.stats.StorageRequests.Increment();
-                await leaseBlob.ReleaseLeaseAsync(accessCondition: AccessCondition.GenerateLeaseCondition(leaseId));
-                this.stats.StorageRequests.Increment();
+                await leaseBlob.UploadTextAsync(JsonConvert.SerializeObject(copy), leaseId);
+                await leaseBlob.ReleaseLeaseAsync(leaseId);
             }
-            catch (StorageException storageException)
+            catch (DurableTaskStorageException storageException)
             {
-                this.stats.StorageRequests.Increment();
                 throw HandleStorageException(lease, storageException);
             }
 
@@ -275,27 +209,12 @@ namespace DurableTask.AzureStorage.Partitioning
 
         public async Task DeleteAsync(BlobLease lease)
         {
-            CloudBlockBlob leaseBlob = lease.Blob;
-            try
-            {
-                await leaseBlob.DeleteIfExistsAsync();
-            }
-            finally
-            {
-                this.stats.StorageRequests.Increment();
-            }
+            await lease.Blob.DeleteIfExistsAsync();
         }
 
         public async Task DeleteAllAsync()
         {
-            try
-            {
-                await this.taskHubContainer.DeleteIfExistsAsync();
-            }
-            finally
-            {
-                this.stats.StorageRequests.Increment();
-            }
+            await this.taskHubContainer.DeleteIfExistsAsync();
         }
 
         public async Task<bool> UpdateAsync(BlobLease lease)
@@ -305,32 +224,24 @@ namespace DurableTask.AzureStorage.Partitioning
                 return false;
             }
 
-            CloudBlockBlob leaseBlob = lease.Blob;
+            Blob leaseBlob = lease.Blob;
             try
             {
                 // First renew the lease to make sure checkpoint will go through
-                await leaseBlob.RenewLeaseAsync(accessCondition: AccessCondition.GenerateLeaseCondition(lease.Token));
+                await leaseBlob.ReleaseLeaseAsync(lease.Token);
             }
-            catch (StorageException storageException)
+            catch (DurableTaskStorageException storageException)
             {
                 throw HandleStorageException(lease, storageException);
-            }
-            finally
-            {
-                this.stats.StorageRequests.Increment();
             }
 
             try
             {
-                await leaseBlob.UploadTextAsync(JsonConvert.SerializeObject(lease), null, AccessCondition.GenerateLeaseCondition(lease.Token), null, null);
+                await leaseBlob.UploadTextAsync(JsonConvert.SerializeObject(lease), lease.Token);
             }
-            catch (StorageException storageException)
+            catch (DurableTaskStorageException storageException)
             {
                 throw HandleStorageException(lease, storageException, true);
-            }
-            finally
-            {
-                this.stats.StorageRequests.Increment();
             }
 
             return true;
@@ -341,16 +252,12 @@ namespace DurableTask.AzureStorage.Partitioning
             string serializedInfo = JsonConvert.SerializeObject(taskHubInfo);
             try
             {
-                await this.taskHubInfoBlob.UploadTextAsync(serializedInfo, null, AccessCondition.GenerateIfNoneMatchCondition("*"), null, null);
+                await this.taskHubInfoBlob.UploadTextAsync(serializedInfo, ifDoesntExist: true);
             }
-            catch (StorageException)
+            catch (DurableTaskStorageException)
             {
                 // eat any storage exception related to conflict
                 // this means the blob already exist
-            }
-            finally
-            {
-                this.stats.StorageRequests.Increment();
             }
         }
 
@@ -371,16 +278,12 @@ namespace DurableTask.AzureStorage.Partitioning
                     try
                     {
                         string serializedInfo = JsonConvert.SerializeObject(newTaskHubInfo);
-                        await this.taskHubInfoBlob.UploadTextAsync(serializedInfo, null, AccessCondition.GenerateEmptyCondition(), null, null);
+                        await this.taskHubInfoBlob.UploadTextAsync(serializedInfo);
                     } 
-                    catch (StorageException)
+                    catch (DurableTaskStorageException)
                     {
                         // eat any storage exception as this is a best effort to
                         // to update the metadata used by Azure Functions scaling logic
-                    }
-                    finally
-                    {
-                        this.stats.StorageRequests.Increment();
                     }
 
                 }
@@ -399,20 +302,9 @@ namespace DurableTask.AzureStorage.Partitioning
 
         void Initialize()
         {
-            this.storageClient.DefaultRequestOptions.MaximumExecutionTime = StorageMaximumExecutionTime;
+            this.taskHubContainer = this.azureStorageClient.GetBlobContainerReference(this.leaseContainerName);
 
-            this.taskHubContainer = this.storageClient.GetContainerReference(this.leaseContainerName);
-
-            string leaseDirectoryName = string.IsNullOrWhiteSpace(this.blobPrefix)
-                ? this.leaseType
-                : this.blobPrefix + this.leaseType;
-            this.leaseDirectory = this.taskHubContainer.GetDirectoryReference(leaseDirectoryName);
-
-            string taskHubInfoBlobFileName = string.IsNullOrWhiteSpace(this.blobPrefix)
-                ? TaskHubInfoBlobName
-                : this.blobPrefix + TaskHubInfoBlobName;
-
-            this.taskHubInfoBlob = this.taskHubContainer.GetBlockBlobReference(taskHubInfoBlobFileName);
+            this.taskHubInfoBlob = this.taskHubContainer.GetBlobReference(TaskHubInfoBlobName);
         }
 
         async Task<TaskHubInfo> GetTaskHubInfoAsync()
@@ -420,37 +312,31 @@ namespace DurableTask.AzureStorage.Partitioning
             if (await this.taskHubInfoBlob.ExistsAsync())
             {
                 await taskHubInfoBlob.FetchAttributesAsync();
-                this.stats.StorageRequests.Increment();
                 string serializedEventHubInfo = await this.taskHubInfoBlob.DownloadTextAsync();
-                this.stats.StorageRequests.Increment();
                 return JsonConvert.DeserializeObject<TaskHubInfo>(serializedEventHubInfo);
             }
 
-            this.stats.StorageRequests.Increment();
             return null;
         }
 
-        async Task<BlobLease> DownloadLeaseBlob(CloudBlockBlob blob)
+        async Task<BlobLease> DownloadLeaseBlob(Blob blob)
         {
             string serializedLease = await blob.DownloadTextAsync();
-            this.stats.StorageRequests.Increment();
             BlobLease deserializedLease = JsonConvert.DeserializeObject<BlobLease>(serializedLease);
             deserializedLease.Blob = blob;
 
             // Workaround: for some reason storage client reports incorrect blob properties after downloading the blob
             await blob.FetchAttributesAsync();
-            this.stats.StorageRequests.Increment();
             return deserializedLease;
         }
 
-        static Exception HandleStorageException(Lease lease, StorageException storageException, bool ignoreLeaseLost = false)
+        static Exception HandleStorageException(Lease lease, DurableTaskStorageException storageException, bool ignoreLeaseLost = false)
         {
-            if (storageException.RequestInformation.HttpStatusCode == (int)HttpStatusCode.Conflict
-                || storageException.RequestInformation.HttpStatusCode == (int)HttpStatusCode.PreconditionFailed)
+            if (storageException.HttpStatusCode == (int)HttpStatusCode.Conflict
+                || storageException.HttpStatusCode == (int)HttpStatusCode.PreconditionFailed)
             {
                 // Don't throw LeaseLostException if caller chooses to ignore it.
-                StorageExtendedErrorInformation extendedErrorInfo = storageException.RequestInformation.ExtendedErrorInformation;
-                if (!ignoreLeaseLost || extendedErrorInfo == null || extendedErrorInfo.ErrorCode != BlobErrorCodeStrings.LeaseLost)
+                if (!ignoreLeaseLost && storageException.LeaseLost)
                 {
                     return new LeaseLostException(lease, storageException);
                 }

--- a/src/DurableTask.AzureStorage/Partitioning/BlobLeaseManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/BlobLeaseManager.cs
@@ -164,7 +164,7 @@ namespace DurableTask.AzureStorage.Partitioning
             try
             {
                 string newLeaseId = Guid.NewGuid().ToString();
-                if (await leaseBlob.IsLeased())
+                if (leaseBlob.IsLeased)
                 {
                     lease.Token = await leaseBlob.ChangeLeaseAsync(newLeaseId, currentLeaseId: lease.Token);
                 }

--- a/src/DurableTask.AzureStorage/Partitioning/BlobLeaseManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/BlobLeaseManager.cs
@@ -103,7 +103,7 @@ namespace DurableTask.AzureStorage.Partitioning
                     partitionId,
                     string.Format(
                         CultureInfo.InvariantCulture,
-                        "CreateLeaseIfNotExistAsync - leaseContainerName: {0}, leaseType: {1}, partitionId: {2}. blobPrefix: {3}",
+                        "CreateLeaseIfNotExistAsync - leaseContainerName: {0}, leaseType: {1}, partitionId: {2}",
                         this.leaseContainerName,
                         this.blobDirectoryName,
                         partitionId));
@@ -123,7 +123,7 @@ namespace DurableTask.AzureStorage.Partitioning
                         partitionId,
                         string.Format(
                             CultureInfo.InvariantCulture,
-                            "CreateLeaseIfNotExistAsync - leaseContainerName: {0}, leaseType: {1}, partitionId: {2}, blobPrefix: {3}, exception: {4}",
+                            "CreateLeaseIfNotExistAsync - leaseContainerName: {0}, leaseType: {1}, partitionId: {2}, exception: {4}",
                             this.leaseContainerName,
                             this.blobDirectoryName,
                             partitionId,

--- a/src/DurableTask.AzureStorage/Partitioning/BlobLeaseManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/BlobLeaseManager.cs
@@ -228,7 +228,7 @@ namespace DurableTask.AzureStorage.Partitioning
             try
             {
                 // First renew the lease to make sure checkpoint will go through
-                await leaseBlob.ReleaseLeaseAsync(lease.Token);
+                await leaseBlob.RenewLeaseAsync(lease.Token);
             }
             catch (DurableTaskStorageException storageException)
             {

--- a/src/DurableTask.AzureStorage/Partitioning/Lease.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/Lease.cs
@@ -11,6 +11,8 @@
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
 
+using System.Threading.Tasks;
+
 namespace DurableTask.AzureStorage.Partitioning
 {
     /// <summary>Contains partition ownership information.</summary>
@@ -53,9 +55,9 @@ namespace DurableTask.AzureStorage.Partitioning
 
         /// <summary>Determines whether the lease is expired.</summary>
         /// <returns>true if the lease is expired; otherwise, false.</returns>
-        public virtual bool IsExpired()
+        public virtual async Task<bool> IsExpired()
         {
-            return false;
+            return await Task.FromResult(false);
         }
 
         /// <summary>Determines whether this instance is equal to the specified object.</summary>

--- a/src/DurableTask.AzureStorage/Partitioning/Lease.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/Lease.cs
@@ -55,9 +55,9 @@ namespace DurableTask.AzureStorage.Partitioning
 
         /// <summary>Determines whether the lease is expired.</summary>
         /// <returns>true if the lease is expired; otherwise, false.</returns>
-        public virtual async Task<bool> IsExpired()
+        public virtual Task<bool> IsExpired()
         {
-            return await Task.FromResult(false);
+            return Task.FromResult(false);
         }
 
         /// <summary>Determines whether this instance is equal to the specified object.</summary>

--- a/src/DurableTask.AzureStorage/Partitioning/Lease.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/Lease.cs
@@ -11,8 +11,6 @@
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
 
-using System.Threading.Tasks;
-
 namespace DurableTask.AzureStorage.Partitioning
 {
     /// <summary>Contains partition ownership information.</summary>
@@ -55,10 +53,7 @@ namespace DurableTask.AzureStorage.Partitioning
 
         /// <summary>Determines whether the lease is expired.</summary>
         /// <returns>true if the lease is expired; otherwise, false.</returns>
-        public virtual Task<bool> IsExpired()
-        {
-            return Task.FromResult(false);
-        }
+        public virtual bool IsExpired { get => false; }
 
         /// <summary>Determines whether this instance is equal to the specified object.</summary>
         /// <param name="obj">The object to compare.</param>

--- a/src/DurableTask.AzureStorage/Partitioning/LeaseCollectionBalancer.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/LeaseCollectionBalancer.cs
@@ -347,7 +347,7 @@ namespace DurableTask.AzureStorage.Partitioning
                 }
 
                 allShards.Add(lease.PartitionId, lease);
-                if (await lease.IsExpired() || string.IsNullOrWhiteSpace(lease.Owner))
+                if (lease.IsExpired || string.IsNullOrWhiteSpace(lease.Owner))
                 {
                     expiredLeases.Add(lease);
                 }

--- a/src/DurableTask.AzureStorage/Partitioning/LeaseCollectionBalancer.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/LeaseCollectionBalancer.cs
@@ -347,7 +347,7 @@ namespace DurableTask.AzureStorage.Partitioning
                 }
 
                 allShards.Add(lease.PartitionId, lease);
-                if (lease.IsExpired() || string.IsNullOrWhiteSpace(lease.Owner))
+                if (await lease.IsExpired() || string.IsNullOrWhiteSpace(lease.Owner))
                 {
                     expiredLeases.Add(lease);
                 }

--- a/src/DurableTask.AzureStorage/Storage/Blob.cs
+++ b/src/DurableTask.AzureStorage/Storage/Blob.cs
@@ -29,6 +29,8 @@ namespace DurableTask.AzureStorage.Storage
 
         public string Name { get; }
 
+        public bool IsLeased { get => this.cloudBlockBlob.Properties.LeaseState == LeaseState.Leased; }
+
         public Blob(AzureStorageClient azureStorageClient, CloudBlobClient blobClient, string containerName, string blobName, string blobDirectory = null)
         {
             this.azureStorageClient = azureStorageClient;
@@ -132,12 +134,6 @@ namespace DurableTask.AzureStorage.Storage
             await this.azureStorageClient.MakeStorageRequest(
                 (context, cancellationToken) => this.cloudBlockBlob.ReleaseLeaseAsync(AccessCondition.GenerateLeaseCondition(leaseId), null, context, cancellationToken),
                 "Blob ReleaseLease");
-        }
-
-        public async Task<bool> IsLeased()
-        {
-            await this.FetchAttributesAsync();
-            return this.cloudBlockBlob.Properties.LeaseState == LeaseState.Leased;
         }
 
         public string GetAbsoluteUri()

--- a/src/DurableTask.AzureStorage/Storage/Blob.cs
+++ b/src/DurableTask.AzureStorage/Storage/Blob.cs
@@ -1,0 +1,140 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureStorage.Storage
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+    using Microsoft.WindowsAzure.Storage;
+    using Microsoft.WindowsAzure.Storage.Blob;
+
+    class Blob
+    {
+        readonly AzureStorageClient azureStorageClient;
+        readonly CloudBlobClient blobClient;
+        readonly string blobDirectory;
+        readonly string fullBlobPath;
+        readonly CloudBlockBlob cloudBlockBlob;
+
+        public string Name { get; }
+
+        [Obsolete("Use BlobContainer.GetBlobReference() or AzureStorageClient.GetBlobReference()")]
+        public Blob(AzureStorageClient azureStorageClient, CloudBlobClient blobClient, string containerName, string blobName, string blobDirectory = null)
+        {
+            this.azureStorageClient = azureStorageClient;
+            this.blobClient = blobClient;
+            this.Name = blobName;
+            this.blobDirectory = blobDirectory;
+            this.fullBlobPath = this.blobDirectory != null ? Path.Combine(this.blobDirectory, this.Name) : blobName;
+
+            this.cloudBlockBlob = this.blobClient.GetContainerReference(containerName).GetBlockBlobReference(fullBlobPath);
+        }
+
+        [Obsolete("Use AzureStorageClient.GetBlobReference()")]
+        public Blob(AzureStorageClient azureStorageClient, CloudBlobClient blobClient, Uri blobUri)
+        {
+            this.azureStorageClient = azureStorageClient;
+            this.blobClient = blobClient;
+            this.cloudBlockBlob = new CloudBlockBlob(blobUri, blobClient.Credentials);
+        }
+
+        public async Task<bool> ExistsAsync()
+        {
+            return await this.azureStorageClient.MakeStorageRequest<bool>(() => this.cloudBlockBlob.ExistsAsync(), "Blob Exists");
+        }
+
+        public async Task<bool> DeleteIfExistsAsync()
+        {
+            return await this.azureStorageClient.MakeStorageRequest<bool>(() => this.cloudBlockBlob.DeleteIfExistsAsync(), "Blob Delete");
+        }
+
+        public async Task UploadTextAsync(string content, string leaseId = null, bool ifDoesntExist = false)
+        {
+            AccessCondition accessCondition = null;
+            if (ifDoesntExist)
+            {
+                accessCondition = AccessCondition.GenerateIfNoneMatchCondition("*");
+            }
+            else if (leaseId != null)
+            {
+                accessCondition = AccessCondition.GenerateLeaseCondition(leaseId);
+            }
+
+            Func<Task> storageFunction;
+            if (accessCondition != null)
+            {
+                storageFunction = () => this.cloudBlockBlob.UploadTextAsync(content, null, accessCondition, null, null);
+            }
+            else
+            {
+                storageFunction = () => this.cloudBlockBlob.UploadTextAsync(content);
+            }
+
+            await this.azureStorageClient.MakeStorageRequest(storageFunction, "Blob UploadText");
+        }
+
+        public async Task UploadFromByteArrayAsync(byte[] buffer, int index, int byteCount)
+        {
+            await this.azureStorageClient.MakeStorageRequest(() => this.cloudBlockBlob.UploadFromByteArrayAsync(buffer, index, byteCount), "Blob UploadFromByeArray");
+        }
+
+        public async Task<string> DownloadTextAsync()
+        {
+            return await this.azureStorageClient.MakeStorageRequest(() => this.cloudBlockBlob.DownloadTextAsync(), "Blob DownloadText");
+        }
+
+        public async Task DownloadToStreamAsync(MemoryStream memory)
+        {
+            await this.cloudBlockBlob.DownloadToStreamAsync(memory);
+        }
+
+        public async Task FetchAttributesAsync()
+        {
+            await this.azureStorageClient.MakeStorageRequest(() => this.cloudBlockBlob.FetchAttributesAsync(), "Blob FetchAttributes");
+        }
+
+        public async Task<string> AcquireLeaseAsync(TimeSpan leaseInterval, string leaseId)
+        {
+            return await this.azureStorageClient.MakeStorageRequest<string>(() => this.cloudBlockBlob.AcquireLeaseAsync(leaseInterval, leaseId), "Blob AcquireLease");
+        }
+
+
+        public async Task<string> ChangeLeaseAsync(string proposedLeaseId, string currentLeaseId)
+        {
+            return await this.azureStorageClient.MakeStorageRequest<string>(() => this.cloudBlockBlob.ChangeLeaseAsync(proposedLeaseId, accessCondition: AccessCondition.GenerateLeaseCondition(currentLeaseId)), "Blob ChangeLease");
+        }
+
+        public async Task RenewLeaseAsync(string leaseId)
+        {
+            var requestOptions = new BlobRequestOptions { ServerTimeout = azureStorageClient.Settings.LeaseRenewInterval };
+            await this.azureStorageClient.MakeStorageRequest(() => this.cloudBlockBlob.RenewLeaseAsync(accessCondition: AccessCondition.GenerateLeaseCondition(leaseId), options: requestOptions, operationContext: null), "Blob RenewLease");
+        }
+
+        public async Task ReleaseLeaseAsync(string leaseId)
+        {
+            await this.azureStorageClient.MakeStorageRequest(() => this.cloudBlockBlob.ReleaseLeaseAsync(accessCondition: AccessCondition.GenerateLeaseCondition(leaseId)), "Blob ReleaseLease");
+        }
+
+        public async Task<bool> IsLeased()
+        {
+            await this.FetchAttributesAsync();
+            return this.cloudBlockBlob.Properties.LeaseState == LeaseState.Leased;
+        }
+
+        public string GetAbsoluteUri()
+        {
+            return this.cloudBlockBlob.Uri.AbsoluteUri;
+        }
+    }
+}

--- a/src/DurableTask.AzureStorage/Storage/BlobContainer.cs
+++ b/src/DurableTask.AzureStorage/Storage/BlobContainer.cs
@@ -1,0 +1,111 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureStorage.Storage
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.WindowsAzure.Storage;
+    using Microsoft.WindowsAzure.Storage.Blob;
+
+    class BlobContainer
+    {
+        readonly AzureStorageClient azureStorageClient;
+        readonly CloudBlobClient blobClient;
+        readonly string containerName;
+        readonly CloudBlobContainer cloudBlobContainer;
+
+        [Obsolete("Use AzureStorageClient.GetBlobContainerReference()")]
+        public BlobContainer(AzureStorageClient azureStorageClient, CloudBlobClient blobClient, string name)
+        {
+            this.azureStorageClient = azureStorageClient;
+            this.blobClient = blobClient;
+            this.containerName = name;
+
+            this.cloudBlobContainer = this.blobClient.GetContainerReference(this.containerName);
+        }
+
+        public Blob GetBlobReference(string blobName, string blobPrefix = null)
+        {
+            return this.azureStorageClient.GetBlobReference(this.containerName, Path.Combine(blobPrefix, blobName));
+        }
+
+        public async Task<bool> CreateIfNotExistsAsync()
+        {
+            return await this.azureStorageClient.MakeStorageRequest<bool>(() => this.cloudBlobContainer.CreateIfNotExistsAsync(), "Create Container");
+        }
+
+        public async Task<bool> ExistsAsync()
+        {
+            return await this.azureStorageClient.MakeStorageRequest<bool>(() => this.cloudBlobContainer.ExistsAsync(), "Container Exists");
+        }
+
+        public async Task<bool> DeleteIfExistsAsync()
+        {
+            return await this.azureStorageClient.MakeStorageRequest<bool>(() => this.cloudBlobContainer.DeleteIfExistsAsync(), "Delete Container");
+        }
+
+        public async Task<IEnumerable<Blob>> ListBlobsAsync(string blobDirectory = null)
+        {
+            BlobContinuationToken continuationToken = null;
+            Func<OperationContext, CancellationToken, Task<BlobResultSegment>> listBlobsFunction;
+            if (blobDirectory != null)
+            {
+                var cloudBlobDirectory = this.cloudBlobContainer.GetDirectoryReference(blobDirectory);
+
+                listBlobsFunction = (context, timeoutToken) => cloudBlobDirectory.ListBlobsSegmentedAsync(
+                    useFlatBlobListing: true,
+                    blobListingDetails: BlobListingDetails.Metadata,
+                    maxResults: null,
+                    currentToken: continuationToken,
+                    options: null,
+                    operationContext: context,
+                    cancellationToken: timeoutToken);
+            }
+            else
+            {
+                listBlobsFunction = (context, timeoutToken) => this.cloudBlobContainer.ListBlobsSegmentedAsync(
+                    null,
+                    useFlatBlobListing: true,
+                    blobListingDetails: BlobListingDetails.Metadata,
+                    maxResults: null,
+                    currentToken: continuationToken,
+                    options: null,
+                    operationContext: context,
+                    cancellationToken: timeoutToken);
+            }
+
+            var blobList = new List<Blob>();
+            do
+            {
+                BlobResultSegment segment = await this.azureStorageClient.MakeStorageRequest(listBlobsFunction, "ListBlobs");
+
+                continuationToken = segment.ContinuationToken;
+
+                foreach (IListBlobItem listBlobItem in segment.Results)
+                {
+                    CloudBlockBlob cloudBlockBlob = listBlobItem as CloudBlockBlob;
+                    var blobName = cloudBlockBlob.Name;
+                    Blob blob = this.GetBlobReference(blobName);
+                    blobList.Add(blob);
+                }
+            }
+            while (continuationToken != null);
+
+            return blobList;
+        }
+    }
+}

--- a/src/DurableTask.AzureStorage/Storage/BlobContainer.cs
+++ b/src/DurableTask.AzureStorage/Storage/BlobContainer.cs
@@ -39,7 +39,8 @@ namespace DurableTask.AzureStorage.Storage
 
         public Blob GetBlobReference(string blobName, string blobPrefix = null)
         {
-            return this.azureStorageClient.GetBlobReference(this.containerName, Path.Combine(blobPrefix, blobName));
+            var fullBlobName = blobPrefix != null ? Path.Combine(blobPrefix, blobName) : blobName;
+            return this.azureStorageClient.GetBlobReference(this.containerName, fullBlobName);
         }
 
         public async Task<bool> CreateIfNotExistsAsync()

--- a/src/DurableTask.AzureStorage/Storage/DurableTaskStorageException.cs
+++ b/src/DurableTask.AzureStorage/Storage/DurableTaskStorageException.cs
@@ -1,0 +1,52 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureStorage.Storage
+{
+    using System;
+    using Microsoft.WindowsAzure.Storage;
+    using Microsoft.WindowsAzure.Storage.Blob.Protocol;
+
+    [Serializable]
+    class DurableTaskStorageException : Exception
+    {
+        public DurableTaskStorageException()
+        {
+        }
+
+        public DurableTaskStorageException(string message)
+            : base(message)
+        {
+        }
+
+        public DurableTaskStorageException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+
+        public DurableTaskStorageException(StorageException storageException)
+            : base(storageException.Message, storageException)
+        {
+            this.HttpStatusCode = storageException.RequestInformation.HttpStatusCode;
+            StorageExtendedErrorInformation extendedErrorInfo = storageException.RequestInformation.ExtendedErrorInformation;
+            if (extendedErrorInfo.ErrorCode == BlobErrorCodeStrings.LeaseLost)
+            {
+                LeaseLost = true;
+            }
+        }
+
+        public int HttpStatusCode { get; }
+
+        public bool LeaseLost { get; }
+    }
+}

--- a/src/DurableTask.AzureStorage/TimeoutHandler.cs
+++ b/src/DurableTask.AzureStorage/TimeoutHandler.cs
@@ -13,6 +13,7 @@
 
 namespace DurableTask.AzureStorage
 {
+    using DurableTask.AzureStorage.Monitoring;
     using Microsoft.WindowsAzure.Storage;
     using System;
     using System.Diagnostics;
@@ -35,7 +36,8 @@ namespace DurableTask.AzureStorage
             string operationName,
             string account,
             AzureStorageOrchestrationServiceSettings settings,
-            Func<OperationContext, CancellationToken, Task<T>> operation)
+            Func<OperationContext, CancellationToken, Task<T>> operation,
+            AzureStorageOrchestrationServiceStats stats = null)
         {
             OperationContext context = new OperationContext() { ClientRequestID = Guid.NewGuid().ToString() };
             if (Debugger.IsAttached)
@@ -51,6 +53,10 @@ namespace DurableTask.AzureStorage
                     Task timeoutTask = Task.Delay(DefaultTimeout, cts.Token);
                     Task<T> operationTask = operation(context, cts.Token);
 
+                    if (stats != null)
+                    {
+                        stats.StorageRequests.Increment();
+                    }
                     Task completedTask = await Task.WhenAny(timeoutTask, operationTask);
 
                     if (Equals(timeoutTask, completedTask))

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScaleTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScaleTests.cs
@@ -254,14 +254,13 @@ namespace DurableTask.AzureStorage.Tests
                             lease => new
                             {
                                 Name = lease.Blob.Name,
-                                State = lease.Blob.Properties.LeaseState,
                                 Owner = lease.Owner,
                             })
                         .Where(lease => !string.IsNullOrEmpty(lease.Owner))
                         .ToArray();
 
                     Array.ForEach(leases, lease => Trace.TraceInformation(
-                        $"Blob: {lease.Name}, State: {lease.State}, Owner: {lease.Owner}"));
+                        $"Blob: {lease.Name}, Owner: {lease.Owner}"));
 
                     isBalanced = false;
                     var workersWithLeases = leases.GroupBy(l => l.Owner).ToArray();
@@ -449,7 +448,7 @@ namespace DurableTask.AzureStorage.Tests
             BlobLease lease = (await service.ListBlobLeasesAsync()).Single();
             await lease.Blob.ChangeLeaseAsync(
                 proposedLeaseId: Guid.NewGuid().ToString(),
-                accessCondition: AccessCondition.GenerateLeaseCondition(lease.Token));
+                currentLeaseId: lease.Token);
             await TestHelpers.WaitFor(
                 condition: () => !service.OwnedControlQueues.Any(),
                 timeout: TimeSpan.FromSeconds(10));


### PR DESCRIPTION
This PR is the first in a series of AzureStorage refactor PRs. Part of this work item: https://github.com/Azure/durabletask/issues/514

The goal of this refactor is to centralize all AzureStorage types and make storage calls in a single place. With this PR, all storage types will be contained in a new folder called "Storage." All storage request calls will go through a method in a class AzureStorageClient. Types Blob, BlobContainer, and DurableTaskStorageException were also added to wrap around related AzureStorage types.

This PR is primarily focused on changes related to Blob storage, so the main changes are to BlobLeaseManager and MessageManager, with the exception of AppLeaseManager.