### PR TITLE
Adding provision to perform graceful shutdown before process kill due to max timeout hits

### DIFF
--- a/Test/DurableTask.AzureStorage.Tests/TimeoutHandlerTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/TimeoutHandlerTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DurableTask.AzureStorage.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="TimeoutHandler"/>.
+    /// </summary>
+    [TestClass]
+    public class TimeoutHandlerTests
+    {
+        /// <summary>
+        /// Ensures that process graceful action is executed before process is killed.
+        /// </summary>
+        /// <returns>Task tracking operation.</returns>
+        [TestMethod]
+        public async Task EnsureTimeoutHandlerRunsProcessShutdownEventsBeforeProcessKill()
+        {
+            int executionCount = 0;
+            int killCount = 0;
+            int shutdownCount = 0;
+
+            Action<string> killAction = (errorString) => killCount++;
+            typeof(TimeoutHandler)
+                .GetField("ProcessKillAction", BindingFlags.NonPublic | BindingFlags.Static)
+                .SetValue(null, killAction);
+
+            // TimeoutHandler at the moment invokes shutdown on 5th call failure.
+            await TimeoutHandler.ExecuteWithTimeout(
+                "test",
+                "account",
+                new AzureStorageOrchestrationServiceSettings
+                {
+                    ProcessGracefulShutdownAction = (errorString) =>
+                    {
+                        shutdownCount++;
+                        return Task.CompletedTask;
+                    }
+                },
+                async (operationContext, cancellationToken) =>
+                {
+                    executionCount++;
+                    await Task.Delay(TimeSpan.FromMinutes(3));
+                    return 1;
+                });
+
+            Assert.AreEqual(5, executionCount);
+            Assert.AreEqual(1, shutdownCount);
+            Assert.AreEqual(1, killCount);
+        }
+    }
+}

--- a/Test/DurableTask.AzureStorage.Tests/TimeoutHandlerTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/TimeoutHandlerTests.cs
@@ -35,10 +35,91 @@ namespace DurableTask.AzureStorage.Tests
                 "account",
                 new AzureStorageOrchestrationServiceSettings
                 {
-                    ProcessGracefulShutdownAction = (errorString) =>
+                    OnImminentFailFast = (errorString) =>
                     {
                         shutdownCount++;
-                        return Task.CompletedTask;
+                        return Task.FromResult(true);
+                    }
+                },
+                async (operationContext, cancellationToken) =>
+                {
+                    executionCount++;
+                    await Task.Delay(TimeSpan.FromMinutes(3));
+                    return 1;
+                });
+
+            Assert.AreEqual(5, executionCount);
+            Assert.AreEqual(1, shutdownCount);
+            Assert.AreEqual(1, killCount);
+        }
+
+        /// <summary>
+        /// Ensures that process graceful action is executed and failfast is skipped.
+        /// </summary>
+        /// <returns>Task tracking operation.</returns>
+        [TestMethod]
+        public async Task EnsureTimeoutHandlerRunsProcessShutdownEventsAndSkipsProcessKill()
+        {
+            int executionCount = 0;
+            int killCount = 0;
+            int shutdownCount = 0;
+
+            Action<string> killAction = (errorString) => killCount++;
+            typeof(TimeoutHandler)
+                .GetField("ProcessKillAction", BindingFlags.NonPublic | BindingFlags.Static)
+                .SetValue(null, killAction);
+
+            // TimeoutHandler at the moment invokes shutdown on 5th call failure.
+            await TimeoutHandler.ExecuteWithTimeout(
+                "test",
+                "account",
+                new AzureStorageOrchestrationServiceSettings
+                {
+                    OnImminentFailFast = (errorString) =>
+                    {
+                        shutdownCount++;
+                        return Task.FromResult(false);
+                    }
+                },
+                async (operationContext, cancellationToken) =>
+                {
+                    executionCount++;
+                    await Task.Delay(TimeSpan.FromMinutes(3));
+                    return 1;
+                });
+
+            Assert.AreEqual(5, executionCount);
+            Assert.AreEqual(1, shutdownCount);
+            Assert.AreEqual(0, killCount);
+        }
+
+        /// <summary>
+        /// Ensures that process graceful action is executed before process is killed.
+        /// </summary>
+        /// <returns>Task tracking operation.</returns>
+        [TestMethod]
+        public async Task EnsureTimeoutHandlerExecutesProcessKillIfGracefulShutdownFails()
+        {
+            int executionCount = 0;
+            int killCount = 0;
+            int shutdownCount = 0;
+
+            Action<string> killAction = (errorString) => killCount++;
+            typeof(TimeoutHandler)
+                .GetField("ProcessKillAction", BindingFlags.NonPublic | BindingFlags.Static)
+                .SetValue(null, killAction);
+
+            // TimeoutHandler at the moment invokes shutdown on 5th call failure.
+            await TimeoutHandler.ExecuteWithTimeout(
+                "test",
+                "account",
+                new AzureStorageOrchestrationServiceSettings
+                {
+                    OnImminentFailFast = (errorString) =>
+                    {
+                        shutdownCount++;
+
+                        throw new Exception("Breaking graceful shutdown");
                     }
                 },
                 async (operationContext, cancellationToken) =>

--- a/Test/DurableTask.AzureStorage.Tests/TimeoutHandlerTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/TimeoutHandlerTests.cs
@@ -58,6 +58,7 @@ namespace DurableTask.AzureStorage.Tests
         /// </summary>
         /// <returns>Task tracking operation.</returns>
         [TestMethod]
+        [ExpectedException(typeof(TimeoutException))]
         public async Task EnsureTimeoutHandlerRunsProcessShutdownEventsAndSkipsProcessKill()
         {
             int executionCount = 0;

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -21,6 +21,7 @@ namespace DurableTask.AzureStorage
     using Microsoft.WindowsAzure.Storage.Queue;
     using Microsoft.WindowsAzure.Storage.Table;
     using System.Runtime.Serialization;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Settings that impact the runtime behavior of the <see cref="AzureStorageOrchestrationService"/>.
@@ -213,6 +214,13 @@ namespace DurableTask.AzureStorage
         /// Gets or sets the optional <see cref="ILoggerFactory"/> to use for diagnostic logging.
         /// </summary>
         public ILoggerFactory LoggerFactory { get; set; } = NoOpLoggerFactory.Instance;
+
+        /// <summary>
+        /// Gets or sets an optional action to be executed before the app is recycled. Reason for shutdown is passed as a string parameter.
+        /// This can be used to perform any pending cleanup tasks or just do a graceful shutdown.
+        /// A wait time of 35 seconds will be given for the task to finish, if the task does not finish in required time, <see cref="Environment.FailFast(string)"/> will be executed.
+        /// </summary>
+        public Func<string, Task> ProcessGracefulShutdownAction { get; set; } = (message) => Task.CompletedTask;
 
         /// <summary>
         /// Returns bool indicating is the TrackingStoreStorageAccount has been set.

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -216,11 +216,15 @@ namespace DurableTask.AzureStorage
         public ILoggerFactory LoggerFactory { get; set; } = NoOpLoggerFactory.Instance;
 
         /// <summary>
-        /// Gets or sets an optional action to be executed before the app is recycled. Reason for shutdown is passed as a string parameter.
+        /// Gets or sets an optional function to be executed before the app is recycled. Reason for shutdown is passed as a string parameter.
         /// This can be used to perform any pending cleanup tasks or just do a graceful shutdown.
+        /// The function returns a <see cref="bool"/>. If 'true' is returned <see cref="Environment.FailFast(string)"/> is executed, if 'false' is returned,
+        /// process kill is skipped.
         /// A wait time of 35 seconds will be given for the task to finish, if the task does not finish in required time, <see cref="Environment.FailFast(string)"/> will be executed.
         /// </summary>
-        public Func<string, Task> ProcessGracefulShutdownAction { get; set; } = (message) => Task.CompletedTask;
+        /// <remarks>Skipping process kill by returning false might have negative consequences if since Storage SDK might be in deadlock. Ensure if you return
+        /// false a process shutdown is executed by you.</remarks>
+        public Func<string, Task<bool>> OnImminentFailFast { get; set; } = (message) => Task.FromResult(true);
 
         /// <summary>
         /// Returns bool indicating is the TrackingStoreStorageAccount has been set.

--- a/src/DurableTask.AzureStorage/TimeoutHandler.cs
+++ b/src/DurableTask.AzureStorage/TimeoutHandler.cs
@@ -103,7 +103,7 @@ namespace DurableTask.AzureStorage
                                 TimeoutHandler.ProcessKillAction(message);
                             }
 
-                            return default(T);
+                            throw new TimeoutException(message);
                         }
 
                     }

--- a/src/DurableTask.AzureStorage/TimeoutHandler.cs
+++ b/src/DurableTask.AzureStorage/TimeoutHandler.cs
@@ -102,8 +102,12 @@ namespace DurableTask.AzureStorage
                             {
                                 TimeoutHandler.ProcessKillAction(message);
                             }
-
-                            throw new TimeoutException(message);
+                            else
+                            {
+                                // Technically we don't need else as the action above would have killed the process.
+                                // However tests don't kill the process so putting in else.
+                                throw new TimeoutException(message);
+                            }
                         }
 
                     }


### PR DESCRIPTION
In AzureStorage variant, if maximum number of timeouts are hit per call (5) app gets recycled. This is to bring system back into healthy state. However, this kill can result in issues with requests in flight (as `Environment.FailFast` does not perform graceful shutdown). Adding provision to allow graceful shutdown (e.g. `IHostApplicationLifetime.StopApplication` in AspNetCore).

Graceful shutdown tasks are given 35 seconds to finish (aligning with the 30 second host shutdown that .Net has).