### PR TITLE
Fixed a message order regression caused by the de-dupe PR (#528)

### DIFF
--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -362,7 +362,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(EventIds.OrchestrationServiceStats, Level = EventLevel.Verbose, Version = 3)]
+        [Event(EventIds.OrchestrationServiceStats, Level = EventLevel.Informational, Version = 3)]
         public void OrchestrationServiceStats(
             string Account,
             string TaskHub,

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -216,6 +216,11 @@ namespace DurableTask.AzureStorage
         public ILoggerFactory LoggerFactory { get; set; } = NoOpLoggerFactory.Instance;
 
         /// <summary>
+        /// Gets or sets a value indicating whether to disable the ExecutionStarted de-duplication logic.
+        /// </summary>
+        public bool DisableExecutionStartedDeduplication { get; set; }
+
+        /// <summary>
         /// Gets or sets an optional function to be executed before the app is recycled. Reason for shutdown is passed as a string parameter.
         /// This can be used to perform any pending cleanup tasks or just do a graceful shutdown.
         /// The function returns a <see cref="bool"/>. If 'true' is returned <see cref="Environment.FailFast(string)"/> is executed, if 'false' is returned,

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -214,23 +214,18 @@ namespace DurableTask.AzureStorage.Messaging
             public int Compare(MessageData x, MessageData y)
             {
                 // Azure Storage is the ultimate authority on the order in which messages were received.
-                if (x.OriginalQueueMessage.InsertionTime < y.OriginalQueueMessage.InsertionTime)
+                // Insertion time only has full second precision, however, so it's not always useful.
+                DateTimeOffset insertionTimeX = x.OriginalQueueMessage.InsertionTime.GetValueOrDefault();
+                DateTimeOffset insertionTimeY = y.OriginalQueueMessage.InsertionTime.GetValueOrDefault();
+                if (insertionTimeX != insertionTimeY)
                 {
-                    return -1;
-                }
-                else if (x.OriginalQueueMessage.InsertionTime > y.OriginalQueueMessage.InsertionTime)
-                {
-                    return 1;
+                    return insertionTimeX.CompareTo(insertionTimeY);
                 }
 
                 // As a tie-breaker, messages will be ordered based on client-side sequence numbers.
-                if (x.SequenceNumber < y.SequenceNumber)
+                if (x.SequenceNumber != y.SequenceNumber)
                 {
-                    return -1;
-                }
-                else if (x.SequenceNumber > y.SequenceNumber)
-                {
-                    return 1;
+                    return x.SequenceNumber.CompareTo(y.SequenceNumber);
                 }
 
                 return 0;

--- a/src/DurableTask.AzureStorage/Partitioning/LeaseCollectionBalancer.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/LeaseCollectionBalancer.cs
@@ -342,7 +342,7 @@ namespace DurableTask.AzureStorage.Partitioning
                         this.taskHub,
                         this.workerName,
                         string.Empty /* partitionId */,
-                        $"Skiping {this.leaseType} lease aquiring for {lease.PartitionId}");
+                        $"Skipping {this.leaseType} lease aquiring for {lease.PartitionId}");
                     continue;
                 }
 
@@ -353,7 +353,7 @@ namespace DurableTask.AzureStorage.Partitioning
                 }
                 else
                 {
-                    int count = 0;
+                    int count;
                     string assignedTo = lease.Owner;
                     if (workerToShardCount.TryGetValue(assignedTo, out count))
                     {

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScaleTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScaleTests.cs
@@ -715,6 +715,10 @@ namespace DurableTask.AzureStorage.Tests
         public async Task ScaleDecision_WorkItemLatency_Low()
         {
             var mock = GetFakePerformanceMonitor();
+
+            // This test explicitly validates the random behavior
+            mock.EnableRandomScaleDownOnLowLatency = true;
+
             mock.AddLatencies(10, new[] { 0, 0, 0, 0 });
             mock.AddLatencies(10, new[] { 0, 0, 0, 0 });
             mock.AddLatencies(10, new[] { 0, 0, 0, 0 });
@@ -911,6 +915,9 @@ namespace DurableTask.AzureStorage.Tests
         public void ScaleDecision_AdHoc_WorkItemLatency_Low()
         {
             var mock = GetFakePerformanceMonitor();
+
+            // This test explicitly validates the random behavior
+            mock.EnableRandomScaleDownOnLowLatency = true;
 
             var latencies = new List<int> { 10, 10, 10, 10, 10 };
             var heartbeats = new List<PerformanceHeartbeat>();
@@ -1839,6 +1846,9 @@ namespace DurableTask.AzureStorage.Tests
                 {
                     this.ControlQueueLatencies.Add(new QueueMetricHistory(5));
                 }
+
+                // Disable random behavior to ensure deterministic execution during tests
+                this.EnableRandomScaleDownOnLowLatency = false;
             }
 
             internal override int PartitionCount { get; }


### PR DESCRIPTION
The key issue being fixed is a problem where execution started messages are executed out of order after https://github.com/Azure/durabletask/pull/528 was merged. None of the existing tests were sensitive to this. However, some of the Durable Functions tests were.

Durable Functions tests to verify:
- [x] WaitForEventAndCallActivity_DroppedEventsTest
- [x] ActorOrchestration_NoWaiting
- [x] BatchedActorOrchestration
- [x] BatchedActorOrchestrationDeleteLastItemAlways
- [x] ParallelBatchedActorOrchestration