### PR TITLE
DT.AzureStorage: Fix message loss bug in ContinueAsNew scenarios

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -976,7 +976,7 @@ namespace DurableTask.AzureStorage
                 }
                 else
                 {
-                    message = runtimeState.Events.Count == 0 ? "No such instance" : "Instance is corrupted";
+                    message = runtimeState.Events.Count == 0 ? "No such instance" : "Invalid history (may have been overwritten by a newer instance)";
                     return false;
                 }
             }

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -976,6 +976,13 @@ namespace DurableTask.AzureStorage
                 }
                 else
                 {
+                    // A non-zero event count usually happens when an instance's history is overwritten by a
+                    // new instance or by a ContinueAsNew. When history is overwritten by new instances, we
+                    // overwrite the old history with new history (with a new execution ID), but this is done
+                    // gradually as we build up the new history over time. If we haven't yet overwritten *all*
+                    // the old history and we receive a message from the old instance (this happens frequently
+                    // with canceled durable timer messages) we'll end up loading just the history that hasn't
+                    // been fully overwritten. We know it's invalid because it's missing the ExecutionStartedEvent.
                     message = runtimeState.Events.Count == 0 ? "No such instance" : "Invalid history (may have been overwritten by a newer instance)";
                     return false;
                 }

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <FileVersion>1.8.6</FileVersion>
+    <FileVersion>1.8.7</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <Version>$(FileVersion)</Version>
     <IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
Fixes #543

We have some logic that incorrectly deletes messages when we see messages from multiple generations at the same time. The logic is both wrong and seems to be unnecessary, so this PR mostly just removes code and adjusts the comments.

A couple things I want to verify before merging:

- [x] Existing test cases continue to pass across both DTFx and Durable Functions
- [x] Invalid timer messages still get discarded appropriately in ContinueAsNew scenarios