### PR TITLE
Fix null ref in instance completion trace

### DIFF
--- a/src/DurableTask.Core/OrchestrationRuntimeState.cs
+++ b/src/DurableTask.Core/OrchestrationRuntimeState.cs
@@ -288,6 +288,8 @@ namespace DurableTask.Core
             {
                 EventCount = Events.Count,
                 NewEventsCount = NewEvents.Count,
+                Events = new List<HistoryEvent>(),
+                NewEvents = new List<HistoryEvent>(),
             };
 #endif
         }

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -725,7 +725,7 @@ namespace DurableTask.Core
                 TraceEventType.Information,
                 "TaskOrchestrationDispatcher-InstanceCompletionEvents",
                 runtimeState.OrchestrationInstance,
-                () => Utils.EscapeJson(DataConverter.Serialize(runtimeState.GetOrchestrationRuntimeStateDump().Events, true)));
+                () => Utils.EscapeJson(DataConverter.Serialize(runtimeState.GetOrchestrationRuntimeStateDump(), true)));
 
             // Check to see if we need to start a new execution
             if (completeOrchestratorAction.OrchestrationStatus == OrchestrationStatus.ContinuedAsNew)


### PR DESCRIPTION
A recent change to log only the history dump instead of the history
itself resulted in a null-ref when running Release code. This is because
in release builds, the Events field on OrchestrationRuntimeStateDump is
null.

This PR fixes that by:

1. Logging the entire dump instead of just Events so we at least get the
   number of Events in the instance completion events trace.
2. Including an empty list of Events and NewEvents on the dump in
   Release mode so we don't run into future NRE.