### PR TITLE
Support for dynamic concurrency throttles

### DIFF
--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -5,9 +5,12 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Microsoft.Azure.DurableTask.Core</PackageId>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!--NuGet licenseUrl and PackageIconUrl/iconUrl deprecation. -->
     <NoWarn>NU5125;NU5048</NoWarn>
+    <AssemblyVersion>2.6.0</AssemblyVersion>
+    <FileVersion>2.6.0</FileVersion>
+    <Version>2.6.0</Version>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/src/DurableTask.Core/TaskActivityDispatcher.cs
+++ b/src/DurableTask.Core/TaskActivityDispatcher.cs
@@ -63,6 +63,15 @@ namespace DurableTask.Core
         }
 
         /// <summary>
+        /// Sets a work-item throttler to use for this <see cref="TaskActivityDispatcher"/>.
+        /// </summary>
+        /// <param name="workItemThrottler">The <see cref="WorkItemThrottler"/> implementation to assign.</param>
+        public void SetWorkItemThrottler(WorkItemThrottler workItemThrottler)
+        {
+            this.dispatcher.WorkItemThrottler = workItemThrottler;
+        }
+
+        /// <summary>
         /// Starts the dispatcher to start getting and processing task activities
         /// </summary>
         public async Task StartAsync()

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -76,6 +76,15 @@ namespace DurableTask.Core
         }
 
         /// <summary>
+        /// Sets a work-item throttler to use for this <see cref="TaskOrchestrationDispatcher"/>.
+        /// </summary>
+        /// <param name="workItemThrottler">The <see cref="WorkItemThrottler"/> implementation to assign.</param>
+        public void SetWorkItemThrottler(WorkItemThrottler workItemThrottler)
+        {
+            this.dispatcher.WorkItemThrottler = workItemThrottler;
+        }
+
+        /// <summary>
         /// Starts the dispatcher to start getting and processing orchestration events
         /// </summary>
         public async Task StartAsync()

--- a/src/DurableTask.Core/WorkItemThrottler.cs
+++ b/src/DurableTask.Core/WorkItemThrottler.cs
@@ -1,0 +1,30 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core
+{
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Abstract base class for types that can throttle work-item fetching.
+    /// </summary>
+    public abstract class WorkItemThrottler
+    {
+        /// <summary>
+        /// When implemented by a concrete class, blocks the work-item dispatcher thread from
+        /// fetching new work items if the throttler is in a throttled state.
+        /// </summary>
+        /// <returns>Returns a task that completes when the throttler is not in a throttled state.</returns>
+        public abstract Task WaitIfThrottledAsync();
+    }
+}

--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -5,7 +5,7 @@
     <DebugType Condition="'$(Configuration)'=='Release'">pdbonly</DebugType>
     <DebugSymbols>True</DebugSymbols>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <!-- See https://github.com/Azure/durabletask/issues/428 -->
     <NoWarn>NU5125,NU5048</NoWarn>
     <!-- Code Analysis Settings -->


### PR DESCRIPTION
This PR adds a new `WorkItemThrottler` abstraction that can be used to throttle the fetching of orchestrator and activity executions.

The original motivation for this is to support the dynamic concurrency feature of Azure Functions, but it can be used in non-Azure Functions scenarios as well.

This PR also adds incremental support for nullable reference types, something we're trying to do as we touch various parts of the code.