### PR TITLE
[Azure Storage] Support cancellation of operations during Creation phase

### DIFF
--- a/src/DurableTask.AzureServiceFabric/FabricOrchestrationServiceClient.cs
+++ b/src/DurableTask.AzureServiceFabric/FabricOrchestrationServiceClient.cs
@@ -45,7 +45,7 @@ namespace DurableTask.AzureServiceFabric
         }
 
         #region IOrchestrationServiceClient
-        public async Task CreateTaskOrchestrationAsync(TaskMessage creationMessage)
+        public async Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (creationMessage.Event is ExecutionStartedEvent executionStarted && executionStarted.ScheduledStartTime.HasValue)
             {
@@ -54,6 +54,8 @@ namespace DurableTask.AzureServiceFabric
 
             creationMessage.OrchestrationInstance.InstanceId.EnsureValidInstanceId();
             ExecutionStartedEvent startEvent = creationMessage.Event as ExecutionStartedEvent;
+
+            cancellationToken.ThrowIfCancellationRequested();
             if (startEvent == null)
             {
                 await this.SendTaskOrchestrationMessageAsync(creationMessage);
@@ -89,7 +91,7 @@ namespace DurableTask.AzureServiceFabric
             }
         }
 
-        public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, OrchestrationStatus[] dedupeStatuses)
+        public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, OrchestrationStatus[] dedupeStatuses, CancellationToken cancellationToken = default(CancellationToken))
         {
             // Todo: Support for dedupeStatuses?
             if (dedupeStatuses != null)
@@ -97,7 +99,7 @@ namespace DurableTask.AzureServiceFabric
                 throw new NotSupportedException($"DedupeStatuses are not supported yet with service fabric provider");
             }
 
-            return CreateTaskOrchestrationAsync(creationMessage);
+            return CreateTaskOrchestrationAsync(creationMessage, cancellationToken);
         }
 
         public Task SendTaskOrchestrationMessageAsync(TaskMessage message)

--- a/src/DurableTask.AzureServiceFabric/Remote/RemoteOrchestrationServiceClient.cs
+++ b/src/DurableTask.AzureServiceFabric/Remote/RemoteOrchestrationServiceClient.cs
@@ -81,11 +81,12 @@ namespace DurableTask.AzureServiceFabric.Remote
         /// Creates a new orchestration
         /// </summary>
         /// <param name="creationMessage">Orchestration creation message</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         /// <exception cref="OrchestrationAlreadyExistsException">Will throw an OrchestrationAlreadyExistsException exception If any orchestration with the same instance Id exists in the instance store.</exception>
         /// <returns></returns>
-        public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage)
+        public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.CreateTaskOrchestrationAsync(creationMessage, null);
+            return this.CreateTaskOrchestrationAsync(creationMessage, null, cancellationToken);
         }
 
         /// <summary>
@@ -93,16 +94,17 @@ namespace DurableTask.AzureServiceFabric.Remote
         /// </summary>
         /// <param name="creationMessage">Orchestration creation message</param>
         /// <param name="dedupeStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         /// <exception cref="OrchestrationAlreadyExistsException">Will throw an OrchestrationAlreadyExistsException exception If any orchestration with the same instance Id exists in the instance store and it has a status specified in dedupeStatuses.</exception>
         /// <returns></returns>
-        public async Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, OrchestrationStatus[] dedupeStatuses)
+        public async Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, OrchestrationStatus[] dedupeStatuses, CancellationToken cancellationToken = default(CancellationToken))
         {
             creationMessage.OrchestrationInstance.InstanceId.EnsureValidInstanceId();
             await this.PutJsonAsync(
                 creationMessage.OrchestrationInstance.InstanceId,
                 this.GetOrchestrationFragment(creationMessage.OrchestrationInstance.InstanceId),
                 new CreateTaskOrchestrationParameters() { TaskMessage = creationMessage, DedupeStatuses = dedupeStatuses },
-                CancellationToken.None);
+                cancellationToken);
         }
 
         /// <summary>

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -75,10 +75,11 @@ namespace DurableTask.AzureStorage.Messaging
         /// </summary>
         /// <param name="message">Instance of <see cref="TaskMessage"/></param>
         /// <param name="sourceSession">Instance of <see cref="SessionBase"/></param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns></returns>
-        public Task AddMessageAsync(TaskMessage message, SessionBase sourceSession)
+        public Task AddMessageAsync(TaskMessage message, SessionBase sourceSession, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.AddMessageAsync(message, sourceSession.Instance, sourceSession);
+            return this.AddMessageAsync(message, sourceSession.Instance, sourceSession, cancellationToken);
         }
 
         /// <summary>
@@ -86,13 +87,14 @@ namespace DurableTask.AzureStorage.Messaging
         /// </summary>
         /// <param name="message">Instance of <see cref="TaskMessage"/></param>
         /// <param name="sourceInstance">Instnace of <see cref="OrchestrationInstance"/></param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns></returns>
-        public Task<MessageData> AddMessageAsync(TaskMessage message, OrchestrationInstance sourceInstance)
+        public Task<MessageData> AddMessageAsync(TaskMessage message, OrchestrationInstance sourceInstance, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.AddMessageAsync(message, sourceInstance, session: null);
+            return this.AddMessageAsync(message, sourceInstance, session: null, cancellationToken);
         }
 
-        async Task<MessageData> AddMessageAsync(TaskMessage taskMessage, OrchestrationInstance sourceInstance, SessionBase? session)
+        async Task<MessageData> AddMessageAsync(TaskMessage taskMessage, OrchestrationInstance sourceInstance, SessionBase? session, CancellationToken cancellationToken = default(CancellationToken))
         {
             MessageData data;
             try
@@ -111,7 +113,7 @@ namespace DurableTask.AzureStorage.Messaging
                 CorrelationTraceClient.Propagate(
                     () => { data.SerializableTraceContext = GetSerializableTraceContext(taskMessage); });
                 
-                string rawContent = await this.messageManager.SerializeMessageDataAsync(data);
+                string rawContent = await this.messageManager.SerializeMessageDataAsync(data, cancellationToken);
 
                 CloudQueueMessage queueMessage = new CloudQueueMessage(rawContent);
 
@@ -135,7 +137,8 @@ namespace DurableTask.AzureStorage.Messaging
                     null /* timeToLive */,
                     GetVisibilityDelay(taskMessage),
                     this.QueueRequestOptions,
-                    session?.StorageOperationContext);
+                    session?.StorageOperationContext,
+                    cancellationToken);
 
                 this.stats.MessagesSent.Increment();
 

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -1030,7 +1030,8 @@ namespace DurableTask.AzureStorage.Tracking
         public override async Task<bool> SetNewExecutionAsync(
             ExecutionStartedEvent executionStartedEvent,
             string eTag,
-            string inputStatusOverride)
+            string inputStatusOverride,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             string sanitizedInstanceId = KeySanitation.EscapePartitionKey(executionStartedEvent.OrchestrationInstance.InstanceId);
             DynamicTableEntity entity = new DynamicTableEntity(sanitizedInstanceId, "")
@@ -1072,7 +1073,8 @@ namespace DurableTask.AzureStorage.Tracking
                     operationName: "NewOrchestrationHistory",
                     account: this.storageAccountName,
                     settings: this.settings,
-                    operation: (context, timeoutToken) => this.InstancesTable.ExecuteAsync(operation, new TableRequestOptions(), context, timeoutToken));
+                    operation: (context, timeoutToken) => this.InstancesTable.ExecuteAsync(operation, new TableRequestOptions(), context, timeoutToken),
+                    cancellationToken);
             }
             catch (StorageException e) when (
                 e.RequestInformation?.HttpStatusCode == 409 /* Conflict */ ||

--- a/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
@@ -144,8 +144,9 @@ namespace DurableTask.AzureStorage.Tracking
         /// <param name="executionStartedEvent">The Execution Started Event being queued</param>
         /// <param name="eTag">The eTag value to use for optimistic concurrency or <c>null</c> to overwrite any existing execution status.</param>
         /// <param name="inputStatusOverride">An override value to use for the Input column. If not specified, uses <see cref="ExecutionStartedEvent.Input"/>.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Returns <c>true</c> if the record was created successfully; <c>false</c> otherwise.</returns>
-        Task<bool> SetNewExecutionAsync(ExecutionStartedEvent executionStartedEvent, string eTag, string inputStatusOverride);
+        Task<bool> SetNewExecutionAsync(ExecutionStartedEvent executionStartedEvent, string eTag, string inputStatusOverride, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Used to update a state in the tracking store to pending whenever a rewind is initiated from the client

--- a/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
@@ -102,7 +102,8 @@ namespace DurableTask.AzureStorage.Tracking
         public override async Task<bool> SetNewExecutionAsync(
             ExecutionStartedEvent executionStartedEvent,
             string eTag /* not used */,
-            string inputStatusOverride)
+            string inputStatusOverride,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             var orchestrationState = new OrchestrationState()
             {

--- a/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
+++ b/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
@@ -99,7 +99,7 @@ namespace DurableTask.AzureStorage.Tracking
         }
 
         /// <inheritdoc />
-        public abstract Task<bool> SetNewExecutionAsync(ExecutionStartedEvent executionStartedEvent, string eTag, string inputStatusOverride);
+        public abstract Task<bool> SetNewExecutionAsync(ExecutionStartedEvent executionStartedEvent, string eTag, string inputStatusOverride, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <inheritdoc />
         public virtual Task UpdateStatusForRewindAsync(string instanceId)

--- a/src/DurableTask.Core/IOrchestrationServiceClient.cs
+++ b/src/DurableTask.Core/IOrchestrationServiceClient.cs
@@ -28,18 +28,20 @@ namespace DurableTask.Core
         /// Creates a new orchestration
         /// </summary>
         /// <param name="creationMessage">Orchestration creation message</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         /// <exception cref="OrchestrationAlreadyExistsException">Will throw an OrchestrationAlreadyExistsException exception If any orchestration with the same instance Id exists in the instance store.</exception>
         /// <returns></returns>
-        Task CreateTaskOrchestrationAsync(TaskMessage creationMessage);
+        Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Creates a new orchestration and specifies a subset of states which should be de duplicated on in the client side
         /// </summary>
         /// <param name="creationMessage">Orchestration creation message</param>
         /// <param name="dedupeStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         /// <exception cref="OrchestrationAlreadyExistsException">Will throw an OrchestrationAlreadyExistsException exception If any orchestration with the same instance Id exists in the instance store and it has a status specified in dedupeStatuses.</exception>
         /// <returns></returns>
-        Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, OrchestrationStatus[] dedupeStatuses);
+        Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, OrchestrationStatus[] dedupeStatuses, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Send a new message for an orchestration

--- a/src/DurableTask.Emulator/LocalOrchestrationService.cs
+++ b/src/DurableTask.Emulator/LocalOrchestrationService.cs
@@ -167,13 +167,13 @@ namespace DurableTask.Emulator
         // client methods
         /******************************/
         /// <inheritdoc />
-        public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage)
+        public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return CreateTaskOrchestrationAsync(creationMessage, null);
+            return CreateTaskOrchestrationAsync(creationMessage, null, cancellationToken);
         }
 
         /// <inheritdoc />
-        public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, OrchestrationStatus[] dedupeStatuses)
+        public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, OrchestrationStatus[] dedupeStatuses, CancellationToken cancellationToken = default(CancellationToken))
         {
             var ee = creationMessage.Event as ExecutionStartedEvent;
 
@@ -214,8 +214,10 @@ namespace DurableTask.Emulator
                     ScheduledStartTime = ee.ScheduledStartTime,
                 };
 
+                cancellationToken.ThrowIfCancellationRequested();
                 ed.Add(creationMessage.OrchestrationInstance.ExecutionId, newState);
 
+                cancellationToken.ThrowIfCancellationRequested();
                 this.orchestratorQueue.SendMessage(creationMessage);
             }
 

--- a/src/DurableTask.Redis/RedisOrchestrationService.cs
+++ b/src/DurableTask.Redis/RedisOrchestrationService.cs
@@ -355,7 +355,7 @@ namespace DurableTask.Redis
 
         #region Client Methods
         /// <inheritdoc />
-        public async Task CreateTaskOrchestrationAsync(TaskMessage creationMessage)
+        public async Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (this.partitionOrchestrationManager == null)
             {
@@ -365,7 +365,7 @@ namespace DurableTask.Redis
         }
 
         /// <inheritdoc />
-        public async Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, OrchestrationStatus[] dedupeStatuses)
+        public async Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, OrchestrationStatus[] dedupeStatuses, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (this.partitionOrchestrationManager == null)
             {


### PR DESCRIPTION
Fixes one small part of the issue brought up in https://github.com/Azure/durabletask/issues/565

Adds support for cancellation of queuing of orchestration for Azure Storage based orchestrations. 