### PR TITLE
Add Storage deadlock mitigation to MessageManager

### DIFF
--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -39,7 +39,6 @@ namespace DurableTask.AzureStorage
         const int DefaultBufferSize = 64 * 2014; // 64KB
 
         readonly AzureStorageOrchestrationServiceSettings settings;
-        readonly string blobContainerName;
         readonly CloudBlobContainer cloudBlobContainer;
         readonly JsonSerializerSettings taskMessageSerializerSettings;
 
@@ -54,7 +53,6 @@ namespace DurableTask.AzureStorage
             string blobContainerName)
         {
             this.settings = settings;
-            this.blobContainerName = blobContainerName;
             this.cloudBlobContainer = cloudBlobClient.GetContainerReference(blobContainerName);
             this.taskMessageSerializerSettings = new JsonSerializerSettings
             {
@@ -216,7 +214,7 @@ namespace DurableTask.AzureStorage
         {
             return TimeoutHandler.ExecuteWithTimeout<string>(
                 operationName: "DownloadLargeMessageBlob", 
-                account: this.settings.StorageAccountDetails.AccountName,
+                account: cloudBlockBlob?.ServiceClient?.Credentials?.AccountName,
                 this.settings,
                 async (opContext, timeoutToken) => {
                     using (MemoryStream memory = new MemoryStream(MaxStorageQueuePayloadSizeInBytes * 2))
@@ -284,7 +282,7 @@ namespace DurableTask.AzureStorage
         {
             await TimeoutHandler.ExecuteWithTimeout<bool>(
                 operationName: "UploadLargeMessageBlob",
-                account: this.settings.StorageAccountDetails.AccountName,
+                account: cloudBlobContainer?.ServiceClient?.Credentials?.AccountName,
                 settings: this.settings,
                 operation: async (opContext, timeoutToken) =>
                 {

--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -282,7 +282,7 @@ namespace DurableTask.AzureStorage
         /// </summary>
         internal async Task UploadToBlobAsync(byte[] data, int dataByteCount, string blobName)
         {
-            await TimeoutHandler.ExecuteWithTimeout<object>(
+            await TimeoutHandler.ExecuteWithTimeout<bool>(
                 operationName: "UploadLargeMessageBlob",
                 account: this.settings.StorageAccountDetails.AccountName,
                 settings: this.settings,
@@ -300,7 +300,7 @@ namespace DurableTask.AzureStorage
                         cancellationToken: timeoutToken);
 
                     // This is just to satisfy type restraints of TimeoutHandler.ExecuteWithTimeout
-                    return null;
+                    return true;
                 });
         }
 


### PR DESCRIPTION
This code path is important to protect, as blobs can often be quite
large which means the requests take longer and are more likely to be
interupted by network issues.

This is going to be replaced shortly by the AzureStorageClient refactor,
but this is easy enough to squeeze into 1.8.8.