### PR TITLE
Fixed an InvalidOperationException if an empty string is provided for an instance ID query

### DIFF
--- a/test/DurableTask.AzureStorage.Tests/OrchestrationInstanceStatusQueryConditionTest.cs
+++ b/test/DurableTask.AzureStorage.Tests/OrchestrationInstanceStatusQueryConditionTest.cs
@@ -179,5 +179,17 @@ namespace DurableTask.AzureStorage.Tests
                 "(PartitionKey ge 'aaab') and (PartitionKey lt 'aaac')",
                 condition.ToTableQuery<OrchestrationInstanceStatus>().FilterString);
         }
+
+        [TestMethod]
+        public void OrchestrationInstanceQuery_EmptyInstanceId()
+        {
+            var condition = new OrchestrationInstanceStatusQueryCondition
+            {
+                InstanceId = "", // This is technically legal
+            };
+
+            string result = condition.ToTableQuery<OrchestrationInstanceStatus>().FilterString;
+            Assert.AreEqual("PartitionKey eq ''", result);
+        }
     }
 }


### PR DESCRIPTION
Minor issue I discovered while running a Java app against this backend. I didn't mean to provide an empty instance ID, but I do expect we handle it more gracefully if one does show up.

Also added nullable type information to the updated file as part of slowly modernizing this codebase.