### PR TITLE
Prepare DurableTask.Core and DurableTask.AzureStorage release

### DIFF
--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <FileVersion>1.8.8</FileVersion>
+    <FileVersion>1.8.9</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <Version>$(FileVersion)</Version>
     <IncludeSymbols>true</IncludeSymbols>

--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -45,9 +45,9 @@
   <!-- Nuget Package Settings -->
   <PropertyGroup>
     <PackageOutputPath>..\..\build_output\packages</PackageOutputPath>
-    <AssemblyVersion>2.5.5</AssemblyVersion>
-    <FileVersion>2.5.5</FileVersion>
-    <Version>2.5.5</Version>
+    <AssemblyVersion>2.5.6</AssemblyVersion>
+    <FileVersion>2.5.6</FileVersion>
+    <Version>2.5.6</Version>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
     <Product>Durable Task Framework</Product>


### PR DESCRIPTION
The previous fix #560 was not actually released as the fix is contained
in DurableTask.Core, which was not released as a part of
DurableTask.AzureStorage v1.8.8.

The fix in #560 is more severe than we thought as it makes a
TaskHubWorker lose an entire partition when it completes an
orchestration, so we are also releasing a new version of
DurableTask.AzureStorage that depends on DurableTask.Core having this
fix.