### PR TITLE
Fixed bug with BlobContainer permissions

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -101,7 +101,7 @@ namespace DurableTask.AzureStorage
 
             this.settings = settings;
 
-            this.azureStorageClient = new AzureStorageClient(settings, storageAccountName);
+            this.azureStorageClient = new AzureStorageClient(settings);
 
             this.stats = this.azureStorageClient.Stats;
  

--- a/src/DurableTask.AzureStorage/Storage/AzureStorageClient.cs
+++ b/src/DurableTask.AzureStorage/Storage/AzureStorageClient.cs
@@ -28,14 +28,15 @@ namespace DurableTask.AzureStorage.Storage
         readonly CloudBlobClient blobClient;
         readonly CloudQueueClient queueClient;
 
-        public AzureStorageClient(AzureStorageOrchestrationServiceSettings settings, string storageAccountName)
+        public AzureStorageClient(AzureStorageOrchestrationServiceSettings settings)
         {
             this.Settings = settings;
-            this.StorageAccountName = storageAccountName;
 
             this.account = settings.StorageAccountDetails == null
                 ? CloudStorageAccount.Parse(settings.StorageConnectionString)
                 : settings.StorageAccountDetails.ToCloudStorageAccount();
+
+            this.StorageAccountName = account.Credentials.AccountName;
 
             this.Stats = new AzureStorageOrchestrationServiceStats();
             this.queueClient = account.CreateCloudQueueClient();

--- a/src/DurableTask.AzureStorage/Storage/BlobContainer.cs
+++ b/src/DurableTask.AzureStorage/Storage/BlobContainer.cs
@@ -46,7 +46,7 @@ namespace DurableTask.AzureStorage.Storage
         public async Task<bool> CreateIfNotExistsAsync()
         {
             return await this.azureStorageClient.MakeStorageRequest<bool>(
-                (context, cancellationToken) => this.cloudBlobContainer.CreateIfNotExistsAsync(BlobContainerPublicAccessType.Container, null, context, cancellationToken),
+                (context, cancellationToken) => this.cloudBlobContainer.CreateIfNotExistsAsync(BlobContainerPublicAccessType.Off, null, context, cancellationToken),
                 "Create Container");
         }
 


### PR DESCRIPTION
Updated BlobContainerPublicAccessType on CreateIfNotExistsAsync in BlobContainer that was causing an error with storage accounts without public blob access.

Updated AzureStorageClient constructor by removing storageAccountName. AzureStorageClient now sets it's own StorageAccountName.