### PR TITLE
Remove noisy logs in SafePartitionManager

### DIFF
--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -79,15 +79,6 @@ namespace DurableTask.AzureStorage
             {
                 controlQueue.Release();
             }
-            else
-            {
-                this.settings.Logger.PartitionManagerWarning(
-                    this.storageAccountName,
-                    this.settings.TaskHubName,
-                    this.settings.WorkerId,
-                    partitionId,
-                    $"Attempted to remove control queue {partitionId}, which wasn't being watched!");
-            }
         }
 
 
@@ -96,15 +87,6 @@ namespace DurableTask.AzureStorage
             if (this.ownedControlQueues.TryGetValue(partitionId, out ControlQueue controlQueue))
             {
                 controlQueue.Release();
-            }
-            else
-            {
-                this.settings.Logger.PartitionManagerWarning(
-                    this.storageAccountName,
-                    this.settings.TaskHubName,
-                    this.settings.WorkerId,
-                    partitionId,
-                    $"Attempted to release control queue {partitionId}, which wasn't being watched!");
             }
         }
 

--- a/src/DurableTask.AzureStorage/Partitioning/LeaseCollectionBalancer.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/LeaseCollectionBalancer.cs
@@ -639,7 +639,6 @@ namespace DurableTask.AzureStorage.Partitioning
                 }
                 catch (LeaseLostException)
                 {
-                    // We have already shutdown the processor so we can ignore any LeaseLost at this point
                     this.settings.Logger.LeaseRemovalFailed(
                         this.accountName,
                         this.taskHub,
@@ -715,12 +714,6 @@ namespace DurableTask.AzureStorage.Partitioning
                     catch (LeaseLostException)
                     {
                         // We have already shutdown the processor so we can ignore any LeaseLost at this point
-                        this.settings.Logger.LeaseRemovalFailed(
-                            this.accountName,
-                            this.taskHub,
-                            this.workerName,
-                            lease.PartitionId,
-                            lease.Token);
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
Some of the warnings being emitted by the SafePartitionManager happen
more frequently than initially thought, but are not really a concern. To
avoid taking up too much App Insights space and concerning customers
with unnecessary noise, we are removing these logs.