### PR TITLE
Fixed NullRef when querying instance status on execution started

### DIFF
--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -656,7 +656,7 @@ namespace DurableTask.AzureStorage.Tracking
             // to only be a small handful of parallel requests, so keeping the code simple until the storage refactor adds global throttling.
             var instanceQueries = instanceIds.Select(instance => this.GetStateAsync(instance, allExecutions: true, fetchInput: false));
             IEnumerable<IList<OrchestrationState>> instanceQueriesResults = await Task.WhenAll(instanceQueries);
-            return instanceQueriesResults.SelectMany(result => result).ToList();
+            return instanceQueriesResults.SelectMany(result => result).Where(x => x.OrchestrationInstance.InstanceId != null).ToList();
         }
 
         /// <inheritdoc />

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -656,7 +656,7 @@ namespace DurableTask.AzureStorage.Tracking
             // to only be a small handful of parallel requests, so keeping the code simple until the storage refactor adds global throttling.
             var instanceQueries = instanceIds.Select(instance => this.GetStateAsync(instance, allExecutions: true, fetchInput: false));
             IEnumerable<IList<OrchestrationState>> instanceQueriesResults = await Task.WhenAll(instanceQueries);
-            return instanceQueriesResults.SelectMany(result => result).Where(x => x.OrchestrationInstance.InstanceId != null).ToList();
+            return instanceQueriesResults.SelectMany(result => result).Where(orchestrationState => orchestrationState != null).ToList();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
This PR addresses a race condition leading to a NullReferenceException when starting an orchestrator.

When the instances table is not yet updated, OrchestrationSessionManager throws a NullRef on InstanceId after attempting to query for existing OrchestrationStates here:
https://github.com/Azure/durabletask/blob/6be1e3a2a23b81fdf681147c9b433610915adfae/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs#L218

This fix changes the result returned from GetStateAsync, called above, to only return non-null OrchestrationStates.