### PR TITLE
Add more robust determinism checks in orchestration replay logic

### DIFF
--- a/samples/DurableTask.Samples/DurableTask.Samples.csproj
+++ b/samples/DurableTask.Samples/DurableTask.Samples.csproj
@@ -31,7 +31,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Update="Greetings\GetUserName.cs" />
+    <Compile Update="Greetings\GetUserName.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Update="Greetings\GetUserName.Designer.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/samples/DurableTask.Samples/DurableTask.Samples.csproj
+++ b/samples/DurableTask.Samples/DurableTask.Samples.csproj
@@ -31,9 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Update="Greetings\GetUserName.cs">
-      <SubType>Form</SubType>
-    </Compile>
+    <Compile Update="Greetings\GetUserName.cs" />
     <Compile Update="Greetings\GetUserName.Designer.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -323,9 +323,9 @@ namespace DurableTask.Core
             if (!this.orchestratorActionsMap.ContainsKey(taskId))
             {
                 throw new NonDeterministicOrchestrationException(subOrchestrationCreateEvent.EventId,
-                   $"A previous execution of this orchestration scheduled a suborchestration task with sequence ID {taskId} "
+                   $"A previous execution of this orchestration scheduled a sub-orchestration task with sequence ID {taskId} "
                    + $"and name '{subOrchestrationCreateEvent.Name}' (version '{subOrchestrationCreateEvent.Version}', "
-                   + $"instance id '{subOrchestrationCreateEvent.InstanceId}'), but the current replay execution hasn't (yet?) "
+                   + $"instance ID '{subOrchestrationCreateEvent.InstanceId}'), but the current replay execution hasn't (yet?) "
                    + "scheduled this task. Was a change made to the orchestrator code after this instance had already started running?");
             }
 
@@ -333,9 +333,9 @@ namespace DurableTask.Core
             if (!(orchestrationAction is CreateSubOrchestrationAction currentReplayAction))
             {
                 throw new NonDeterministicOrchestrationException(subOrchestrationCreateEvent.EventId,
-                   $"A previous execution of this orchestration scheduled a suborchestration task with sequence ID {taskId} "
+                   $"A previous execution of this orchestration scheduled a sub-orchestration task with sequence ID {taskId} "
                    + $"and name '{subOrchestrationCreateEvent.Name}' (version '{subOrchestrationCreateEvent.Version}', "
-                   + $"instance id '{subOrchestrationCreateEvent.InstanceId}'), but the current orchestration replay instead "
+                   + $"instance ID '{subOrchestrationCreateEvent.InstanceId}'), but the current orchestration replay instead "
                    + $"scheduled a {orchestrationAction.GetType().Name} task at this sequence number. Was a change made to "
                    + "the orchestrator code after this instance had already started running?");
             }
@@ -343,10 +343,10 @@ namespace DurableTask.Core
             if (!string.Equals(subOrchestrationCreateEvent.Name, currentReplayAction.Name, StringComparison.OrdinalIgnoreCase))
             {
                 throw new NonDeterministicOrchestrationException(subOrchestrationCreateEvent.EventId,
-                   $"A previous execution of this orchestration scheduled a suborchestration task with sequence ID {taskId} "
+                   $"A previous execution of this orchestration scheduled a sub-orchestration task with sequence ID {taskId} "
                    + $"and name '{subOrchestrationCreateEvent.Name}' (version '{subOrchestrationCreateEvent.Version}', "
-                   + $"instance id '{subOrchestrationCreateEvent.InstanceId}'), but the current orchestration replay instead "
-                   + $"scheduled a suborchestration task with name {currentReplayAction.Name} at this sequence number. "
+                   + $"instance ID '{subOrchestrationCreateEvent.InstanceId}'), but the current orchestration replay instead "
+                   + $"scheduled a sub-orchestration task with name {currentReplayAction.Name} at this sequence number. "
                    + "Was a change made to the orchestrator code after this instance had already started running?");
             }
 
@@ -360,7 +360,7 @@ namespace DurableTask.Core
             {
                 throw new NonDeterministicOrchestrationException(eventSentEvent.EventId,
                    $"A previous execution of this orchestration scheduled a send event task with sequence ID {taskId}, "
-                   + $"type '{eventSentEvent.EventType}' name '{eventSentEvent.Name}', instance id '{eventSentEvent.InstanceId}', "
+                   + $"type '{eventSentEvent.EventType}' name '{eventSentEvent.Name}', instance ID '{eventSentEvent.InstanceId}', "
                    + $"but the current replay execution hasn't (yet?) scheduled this task. Was a change made to the orchestrator code "
                    + $"after this instance had already started running?");
             }
@@ -370,7 +370,7 @@ namespace DurableTask.Core
             {
                 throw new NonDeterministicOrchestrationException(eventSentEvent.EventId,
                    $"A previous execution of this orchestration scheduled a send event task with sequence ID {taskId}, "
-                   + $"type '{eventSentEvent.EventType}', name '{eventSentEvent.Name}', instance id '{eventSentEvent.InstanceId}', "
+                   + $"type '{eventSentEvent.EventType}', name '{eventSentEvent.Name}', instance ID '{eventSentEvent.InstanceId}', "
                    + $"but the current orchestration replay instead scheduled a {orchestrationAction.GetType().Name} task "
                    + "at this sequence number. Was a change made to the orchestrator code after this instance had already "
                    + "started running?");
@@ -381,7 +381,7 @@ namespace DurableTask.Core
             {
                 throw new NonDeterministicOrchestrationException(eventSentEvent.EventId,
                    $"A previous execution of this orchestration scheduled a send event task with sequence ID {taskId}, "
-                   + $"type '{eventSentEvent.EventType}', name '{eventSentEvent.Name}', instance id '{eventSentEvent.InstanceId}'), "
+                   + $"type '{eventSentEvent.EventType}', name '{eventSentEvent.Name}', instance ID '{eventSentEvent.InstanceId}'), "
                    + $"but the current orchestration replay instead scheduled a send event task with name {currentReplayAction.EventName}"
                    + "at this sequence number. Was a change made to the orchestrator code after this instance had already "
                    + "started running?");

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -275,7 +275,7 @@ namespace DurableTask.Core
                     + "orchestrator code after this instance had already started running?");
             }
 
-            if (string.Equals(scheduledEvent.Name, currentReplayAction.Name, StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(scheduledEvent.Name, currentReplayAction.Name, StringComparison.OrdinalIgnoreCase))
             {
                 throw new NonDeterministicOrchestrationException(scheduledEvent.EventId,
                     $"A previous execution of this orchestration scheduled an activity task with sequence number {taskId} "
@@ -340,7 +340,7 @@ namespace DurableTask.Core
                    + "the orchestrator code after this instance had already started running?");
             }
 
-            if (string.Equals(subOrchestrationCreateEvent.Name, currentReplayAction.Name, StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(subOrchestrationCreateEvent.Name, currentReplayAction.Name, StringComparison.OrdinalIgnoreCase))
             {
                 throw new NonDeterministicOrchestrationException(subOrchestrationCreateEvent.EventId,
                    $"A previous execution of this orchestration scheduled a suborchestration task with sequence ID {taskId} "
@@ -377,7 +377,7 @@ namespace DurableTask.Core
 
             }
 
-            if (string.Equals(eventSentEvent.Name, currentReplayAction.EventName, StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(eventSentEvent.Name, currentReplayAction.EventName, StringComparison.OrdinalIgnoreCase))
             {
                 throw new NonDeterministicOrchestrationException(eventSentEvent.EventId,
                    $"A previous execution of this orchestration scheduled a send event task with sequence ID {taskId}, "

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -259,27 +259,29 @@ namespace DurableTask.Core
             if (!this.orchestratorActionsMap.ContainsKey(taskId))
             {
                 throw new NonDeterministicOrchestrationException(scheduledEvent.EventId,
-                    $"A previous execution of this orchestration scheduled an activity task with sequence ID {taskId} and name '{scheduledEvent.Name}' (version '{scheduledEvent.Version'), but the current replay execution hasn't (yet?) scheduled this task. Was a change made to the orchestrator code after this instance had already started running?");
+                    $"A previous execution of this orchestration scheduled an activity task with sequence ID {taskId} and name "
+                    + $"'{scheduledEvent.Name}' (version '{scheduledEvent.Version}'), but the current replay execution hasn't "
+                    + "(yet?) scheduled this task. Was a change made to the orchestrator code after this instance had already "
+                    + "started running?");
             }
 
             var orchestrationAction = this.orchestratorActionsMap[taskId];
             if (!(orchestrationAction is ScheduleTaskOrchestratorAction currentReplayAction))
             {
                 throw new NonDeterministicOrchestrationException(scheduledEvent.EventId,
-                    $"A previous execution of this orchestration scheduled a task with sequence number {taskId} named '{scheduledEvent.Name}', but the current orchestration replay instead scheduled a {orchestrationAction.GetType().Name} task with this sequence number.  Was a change made to the orchestrator code after this instance had already started running?");
-
+                    $"A previous execution of this orchestration scheduled an activity task with sequence number {taskId} named "
+                    + $"'{scheduledEvent.Name}', but the current orchestration replay instead scheduled a "
+                    + $"{orchestrationAction.GetType().Name} task with this sequence number. Was a change made to the "
+                    + "orchestrator code after this instance had already started running?");
             }
 
-            if (scheduledEvent.Name != currentReplayAction.Name)
+            if (string.Equals(scheduledEvent.Name, currentReplayAction.Name, StringComparison.OrdinalIgnoreCase))
             {
                 throw new NonDeterministicOrchestrationException(scheduledEvent.EventId,
-                    $"A previous execution of this orchestration scheduled an activity task with sequence number {taskId} named '{scheduledEvent.Name}', but the current orchestration replay instead scheduled an activity task named '{currentReplayAction.Name}' with this sequence number.  Was a change made to the orchestrator code after this instance had already started running?");
-            }
-
-            if (scheduledEvent.Input != currentReplayAction.Input)
-            {
-                throw new NonDeterministicOrchestrationException(scheduledEvent.EventId,
-                    $"TaskScheduledEvent {scheduledEvent.EventId} has a different input this replay than it was scheduled with.");
+                    $"A previous execution of this orchestration scheduled an activity task with sequence number {taskId} "
+                    + $"named '{scheduledEvent.Name}', but the current orchestration replay instead scheduled an activity "
+                    + $"task named '{currentReplayAction.Name}' with this sequence number.  Was a change made to the "
+                    + "orchestrator code after this instance had already started running?");
             }
 
             this.orchestratorActionsMap.Remove(taskId);
@@ -297,15 +299,19 @@ namespace DurableTask.Core
             if (!this.orchestratorActionsMap.ContainsKey(taskId))
             {
                 throw new NonDeterministicOrchestrationException(timerCreatedEvent.EventId,
-                    $"Scheduled event not run this replay: TimerCreatedEvent {timerCreatedEvent.EventId} {timerCreatedEvent.EventType}");
+                    $"A previous execution of this orchestration scheduled a timer task with sequence number {taskId} but "
+                    + "the current replay execution hasn't (yet?) scheduled this task. Was a change made to the orchestrator"
+                    + "code after this instance had already started running?");
             }
 
             var orchestrationAction = this.orchestratorActionsMap[taskId];
-            if (!(orchestrationAction is CreateTimerOrchestratorAction currentReplayAction))
+            if (!(orchestrationAction is CreateTimerOrchestratorAction))
             {
                 throw new NonDeterministicOrchestrationException(timerCreatedEvent.EventId,
-                    $"Event id {timerCreatedEvent.EventId} on previous replays was {nameof(TimerCreatedEvent)} but is now {orchestrationAction.GetType().Name}.");
-
+                    $"A previous execution of this orchestration scheduled a timer task with sequence number {taskId} named "
+                    + $"but the current orchestration replay instead scheduled a {orchestrationAction.GetType().Name} task with "
+                    + "this sequence number. Was a change made to the orchestrator code after this instance had already "
+                    + "started running?");
             }
 
             this.orchestratorActionsMap.Remove(taskId);
@@ -317,33 +323,31 @@ namespace DurableTask.Core
             if (!this.orchestratorActionsMap.ContainsKey(taskId))
             {
                 throw new NonDeterministicOrchestrationException(subOrchestrationCreateEvent.EventId,
-                    // ReSharper disable once UseStringInterpolation
-                    string.Format("Scheduled event not run this replay: SubOrchestrationInstanceCreatedEvent {0} {1} {2} {3} {4}",
-                        subOrchestrationCreateEvent.EventId,
-                        subOrchestrationCreateEvent.EventType,
-                        subOrchestrationCreateEvent.Name,
-                        subOrchestrationCreateEvent.Version,
-                        subOrchestrationCreateEvent.InstanceId));
+                   $"A previous execution of this orchestration scheduled a suborchestration task with sequence ID {taskId} "
+                   + $"and name '{subOrchestrationCreateEvent.Name}' (version '{subOrchestrationCreateEvent.Version}', "
+                   + $"instance id '{subOrchestrationCreateEvent.InstanceId}'), but the current replay execution hasn't (yet?) "
+                   + "scheduled this task. Was a change made to the orchestrator code after this instance had already started running?");
             }
 
             var orchestrationAction = this.orchestratorActionsMap[taskId];
             if (!(orchestrationAction is CreateSubOrchestrationAction currentReplayAction))
             {
                 throw new NonDeterministicOrchestrationException(subOrchestrationCreateEvent.EventId,
-                    $"Event id {subOrchestrationCreateEvent.EventId} on previous replays was {nameof(SubOrchestrationInstanceCreatedEvent)} but is now {orchestrationAction.GetType().Name}.");
-
+                   $"A previous execution of this orchestration scheduled a suborchestration task with sequence ID {taskId} "
+                   + $"and name '{subOrchestrationCreateEvent.Name}' (version '{subOrchestrationCreateEvent.Version}', "
+                   + $"instance id '{subOrchestrationCreateEvent.InstanceId}'), but the current orchestration replay instead "
+                   + $"scheduled a {orchestrationAction.GetType().Name} task at this sequence number. Was a change made to "
+                   + "the orchestrator code after this instance had already started running?");
             }
 
             if (subOrchestrationCreateEvent.Name != currentReplayAction.Name)
             {
                 throw new NonDeterministicOrchestrationException(subOrchestrationCreateEvent.EventId,
-                    $"Event id {subOrchestrationCreateEvent.EventId} on previous replays scheduled orchestration with name {subOrchestrationCreateEvent.Name}) but is now {currentReplayAction.Name}.");
-            }
-
-            if (subOrchestrationCreateEvent.Input != currentReplayAction.Input)
-            {
-                throw new NonDeterministicOrchestrationException(subOrchestrationCreateEvent.EventId,
-                    $"SubOrchestrationInstanceCreatedEvent {subOrchestrationCreateEvent.EventId} has a different input this replay than it was scheduled with.");
+                   $"A previous execution of this orchestration scheduled a suborchestration task with sequence ID {taskId} "
+                   + $"and name '{subOrchestrationCreateEvent.Name}' (version '{subOrchestrationCreateEvent.Version}', "
+                   + $"instance id '{subOrchestrationCreateEvent.InstanceId}'), but the current orchestration replay instead "
+                   + $"scheduled a suborchestration task with name {currentReplayAction.Name} at this sequence number. "
+                   + "Was a change made to the orchestrator code after this instance had already started running?");
             }
 
             this.orchestratorActionsMap.Remove(taskId);
@@ -355,33 +359,32 @@ namespace DurableTask.Core
             if (!this.orchestratorActionsMap.ContainsKey(taskId))
             {
                 throw new NonDeterministicOrchestrationException(eventSentEvent.EventId,
-                    $"Scheduled event not run this replay: EventSentEvent: {eventSentEvent.EventId} {eventSentEvent.EventType} {eventSentEvent.Name} {eventSentEvent.InstanceId}.");
+                   $"A previous execution of this orchestration scheduled a send event task with sequence ID {taskId}, "
+                   + $"type '{eventSentEvent.EventType}' name '{eventSentEvent.Name}', instance id '{eventSentEvent.InstanceId}', "
+                   + $"but the current replay execution hasn't (yet?) scheduled this task. Was a change made to the orchestrator code "
+                   + $"after this instance had already started running?");
             }
 
             var orchestrationAction = this.orchestratorActionsMap[taskId];
             if (!(orchestrationAction is SendEventOrchestratorAction currentReplayAction))
             {
                 throw new NonDeterministicOrchestrationException(eventSentEvent.EventId,
-                    $"Event id {eventSentEvent.EventId} on previous replays was {nameof(EventSentEvent)} but is now {orchestrationAction.GetType().Name}.");
+                   $"A previous execution of this orchestration scheduled a send event task with sequence ID {taskId}, "
+                   + $"type '{eventSentEvent.EventType}', name '{eventSentEvent.Name}', instance id '{eventSentEvent.InstanceId}', "
+                   + $"but the current orchestration replay instead scheduled a {orchestrationAction.GetType().Name} task "
+                   + "at this sequence number. Was a change made to the orchestrator code after this instance had already "
+                   + "started running?");
 
             }
 
             if (eventSentEvent.Name != currentReplayAction.EventName)
             {
                 throw new NonDeterministicOrchestrationException(eventSentEvent.EventId,
-                    $"Event id {eventSentEvent.EventId} on previous replays scheduled task with name {eventSentEvent.Name}) but is now {currentReplayAction.EventName}.");
-            }
-
-            if (eventSentEvent.Input != currentReplayAction.EventData)
-            {
-                throw new NonDeterministicOrchestrationException(eventSentEvent.EventId,
-                    $"EventSentEvent {eventSentEvent.EventId} has different data this replay than it was scheduled with.");
-            }
-
-            if (eventSentEvent.InstanceId != currentReplayAction.Instance.InstanceId)
-            {
-                throw new NonDeterministicOrchestrationException(eventSentEvent.EventId,
-                    $"EventSentEvent {eventSentEvent.EventId} has different data this replay than it was scheduled with.");
+                   $"A previous execution of this orchestration scheduled a send event task with sequence ID {taskId}, "
+                   + $"type '{eventSentEvent.EventType}', name '{eventSentEvent.Name}', instance id '{eventSentEvent.InstanceId}'), "
+                   + $"but the current orchestration replay instead scheduled a send event task with name {currentReplayAction.EventName}"
+                   + "at this sequence number. Was a change made to the orchestrator code after this instance had already "
+                   + "started running?");
             }
 
             this.orchestratorActionsMap.Remove(taskId);

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -340,7 +340,7 @@ namespace DurableTask.Core
                    + "the orchestrator code after this instance had already started running?");
             }
 
-            if (subOrchestrationCreateEvent.Name != currentReplayAction.Name)
+            if (string.Equals(subOrchestrationCreateEvent.Name, currentReplayAction.Name, StringComparison.OrdinalIgnoreCase))
             {
                 throw new NonDeterministicOrchestrationException(subOrchestrationCreateEvent.EventId,
                    $"A previous execution of this orchestration scheduled a suborchestration task with sequence ID {taskId} "
@@ -377,7 +377,7 @@ namespace DurableTask.Core
 
             }
 
-            if (eventSentEvent.Name != currentReplayAction.EventName)
+            if (string.Equals(eventSentEvent.Name, currentReplayAction.EventName, StringComparison.OrdinalIgnoreCase))
             {
                 throw new NonDeterministicOrchestrationException(eventSentEvent.EventId,
                    $"A previous execution of this orchestration scheduled a send event task with sequence ID {taskId}, "

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -259,21 +259,21 @@ namespace DurableTask.Core
             if (!this.orchestratorActionsMap.ContainsKey(taskId))
             {
                 throw new NonDeterministicOrchestrationException(scheduledEvent.EventId,
-                    $"Scheduled event not run this replay: TaskScheduledEvent {scheduledEvent.EventId} {scheduledEvent.EventType} {scheduledEvent.Name} {scheduledEvent.Version}.");
+                    $"A previous execution of this orchestration scheduled an activity task with sequence ID {taskId} and name '{scheduledEvent.Name}' (version '{scheduledEvent.Version'), but the current replay execution hasn't (yet?) scheduled this task. Was a change made to the orchestrator code after this instance had already started running?");
             }
 
             var orchestrationAction = this.orchestratorActionsMap[taskId];
             if (!(orchestrationAction is ScheduleTaskOrchestratorAction currentReplayAction))
             {
                 throw new NonDeterministicOrchestrationException(scheduledEvent.EventId,
-                    $"Event id {scheduledEvent.EventId} on previous replays was {nameof(TaskScheduledEvent)} but is now {orchestrationAction.GetType().Name}.");
+                    $"A previous execution of this orchestration scheduled a task with sequence number {taskId} named '{scheduledEvent.Name}', but the current orchestration replay instead scheduled a {orchestrationAction.GetType().Name} task with this sequence number.  Was a change made to the orchestrator code after this instance had already started running?");
 
             }
 
             if (scheduledEvent.Name != currentReplayAction.Name)
             {
                 throw new NonDeterministicOrchestrationException(scheduledEvent.EventId,
-                    $"Event id {scheduledEvent.EventId} on previous replays scheduled task with name {scheduledEvent.Name}) but is now {currentReplayAction.Name}.");
+                    $"A previous execution of this orchestration scheduled an activity task with sequence number {taskId} named '{scheduledEvent.Name}', but the current orchestration replay instead scheduled an activity task named '{currentReplayAction.Name}' with this sequence number.  Was a change made to the orchestrator code after this instance had already started running?");
             }
 
             if (scheduledEvent.Input != currentReplayAction.Input)

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -300,7 +300,7 @@ namespace DurableTask.Core
             {
                 throw new NonDeterministicOrchestrationException(timerCreatedEvent.EventId,
                     $"A previous execution of this orchestration scheduled a timer task with sequence number {taskId} but "
-                    + "the current replay execution hasn't (yet?) scheduled this task. Was a change made to the orchestrator"
+                    + "the current replay execution hasn't (yet?) scheduled this task. Was a change made to the orchestrator "
                     + "code after this instance had already started running?");
             }
 

--- a/test/DurableTask.ServiceBus.Tests/DispatcherTests.cs
+++ b/test/DurableTask.ServiceBus.Tests/DispatcherTests.cs
@@ -239,7 +239,7 @@ namespace DurableTask.ServiceBus.Tests
 
             state = await this.client.GetOrchestrationStateAsync(instance);
             Assert.AreEqual(OrchestrationStatus.Failed, state.OrchestrationStatus);
-            Assert.IsTrue(state.Output.Contains("suborchestration task"));
+            Assert.IsTrue(state.Output.Contains("sub-orchestration task"));
             Assert.IsTrue(state.Output.Contains("Was a change made to the orchestrator code after this instance had already started running?"));
 
 
@@ -279,7 +279,7 @@ namespace DurableTask.ServiceBus.Tests
 
             state = await this.client.GetOrchestrationStateAsync(instance);
             Assert.AreEqual(OrchestrationStatus.Failed, state.OrchestrationStatus);
-            Assert.IsTrue(state.Output.Contains("suborchestration task"));
+            Assert.IsTrue(state.Output.Contains("sub-orchestration task"));
             Assert.IsTrue(state.Output.Contains("Was a change made to the orchestrator code after this instance had already started running?"));
         }
 


### PR DESCRIPTION
Current checks for nondeterminism are fairly limited, and only catch
major control flow changes. This PR attempts to improve our best-effort
attempts to catch non-determinism by validating that this replay's api
call signatures match the API calls scheduled by the orchestration
originally.

Resolves #594.