### PR TITLE
Updated TableQuery filter condition string generation

### DIFF
--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -415,7 +415,6 @@ namespace DurableTask.AzureStorage.Tracking
             failedQuerySegment = TableQuery.CombineFilters(failedQuerySegment, TableOperators.Or, failedEventFilter);
             failedQuerySegment = TableQuery.CombineFilters(failedQuerySegment, TableOperators.Or, failedSubOrchestrationEventFilter);
 
-
             rowsToUpdateFilterCondition = TableQuery.CombineFilters(rowsToUpdateFilterCondition, TableOperators.And, failedQuerySegment);
 
             var rowsToUpdateQuery = new TableQuery().Where(rowsToUpdateFilterCondition);


### PR DESCRIPTION
This PR updates AzureTableTrackingStore to no longer manually create the filter condition for TableQuery, instead using the TableQuery methods to generate it for us.

In GetHistoryEventsAsync, we generated the filter condition containing InstanceId. If customers used an apostrophe in their InstanceId this query would fail as a bad request. Using TableQuery.GenerateFilterCondition handles this case for us and generates a filter condition that does not result in a bad request.

All manual filter condition creation code has been swapped with TableQuery generation methods.