### PR TITLE
DT.AzureStorage: Fix a missed exception handling scenario

### DIFF
--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <FileVersion>1.9.0</FileVersion>
+    <FileVersion>1.9.1</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <Version>$(FileVersion)</Version>
     <IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
## Issue summary

Failing to deserialize a control queue message can result in orchestrations getting stuck and lots of duplicate message warnings to be logged. This is because we don't properly abandon the message after we've dequeued it. The result is that the orchestration service internally thinks we're still holding onto the message and refuses to process any new dequeued copies of the message.

## Issue details

We observed a case with users in the M365 org where orchestrations would get stuck for extremely long periods of time. When this happens, only a lease failover or a machine restart would cause the orchestration to continue. When investigating, we noticed two things:

* There were many "Received a duplicate message" warnings for the same message, one every 5 minutes. There was also no "MessageReceived" trace when this happened.
* Around the time this started happening, the following error was observed on this partition:

```
An error occurred while processing messages on xxx-control-08: System.IO.InvalidDataException: The archive entry was compressed using an unsupported compression method.
  at System.IO.Compression.Inflater.Inflate(FlushCode flushCode)
  at System.IO.Compression.Inflater.ReadInflateOutput(Byte* bufPtr, Int32 length, FlushCode flushCode, Int32& bytesRead)
  at System.IO.Compression.Inflater.ReadOutput(Byte* bufPtr, Int32 length, Int32& bytesRead)
  at System.IO.Compression.Inflater.InflateVerified(Byte* bufPtr, Int32 length)
  at System.IO.Compression.DeflateStream.ReadCore(Span`1 buffer)
  at System.IO.Compression.DeflateStream.Read(Byte[] array, Int32 offset, Int32 count)
  at DurableTask.AzureStorage.MessageManager.Decompress(Stream blobStream) in C:\source\durabletask\src\DurableTask.AzureStorage\MessageManager.cs:line 242
  at DurableTask.AzureStorage.MessageManager.DownloadAndDecompressAsBytesAsync(Blob blob) in C:\source\durabletask\src\DurableTask.AzureStorage\MessageManager.cs:line 212
  at DurableTask.AzureStorage.MessageManager.DownloadAndDecompressAsBytesAsync(String blobName) in C:\source\durabletask\src\DurableTask.AzureStorage\MessageManager.cs:line 194
  at DurableTask.AzureStorage.MessageManager.DeserializeQueueMessageAsync(QueueMessage queueMessage, String queueName) in C:\source\durabletask\src\DurableTask.AzureStorage\MessageManager.cs:line 149
  at DurableTask.AzureStorage.Messaging.ControlQueue.<>c__DisplayClass11_0.<<GetMessagesAsync>b__0>d.MoveNext() in C:\source\durabletask\src\DurableTask.AzureStorage\Messaging\ControlQueue.cs:line 126
--- End of stack trace from previous location where exception was thrown ---
  at DurableTask.AzureStorage.Utils.ParallelForEachAsync[TSource](IEnumerable`1 enumerable, Func`2 action) in C:\source\durabletask\src\DurableTask.AzureStorage\Utils.cs:line 50
  at DurableTask.AzureStorage.Messaging.ControlQueue.GetMessagesAsync(CancellationToken cancellationToken) in C:\source\durabletask\src\DurableTask.AzureStorage\Messaging\ControlQueue.cs:line 165
```

We don't know the cause for the above exception, however, after examining the code, I realized that this exception could cause orchestrations to get stuck because we don't correctly handle it. The following sequence of events can happen inside of [ControlQueue.cs](https://github.com/Azure/durabletask/blob/e8b169ac97d2a2a4926412a1dcffbbca5e4c0e78/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs#L102-L126):

1. We dequeue up to 32 messages and process them as a batch ([here](https://github.com/Azure/durabletask/blob/main/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs#L102-L126)).
2. For every message that's deserialized correctly, we add them to [`this.stats.PendingOrchestratorMessages`](https://github.com/Azure/durabletask/blob/e8b169ac97d2a2a4926412a1dcffbbca5e4c0e78/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs#L109). If that message ID is already in this dictionary, then we log a duplicate-message warning. After we're done processing those messages, they get removed from this dictionary.
3. If any one of those 32 messages fail to deserialize, then the entire try-block fails, we log an error, delay, and try to dequeue messages again ([source](https://github.com/Azure/durabletask/blob/e8b169ac97d2a2a4926412a1dcffbbca5e4c0e78/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs#L142-L158)). However, we never remove the successful entries from `this.stats.PendingOrchestratorMessages`!
4. 5-minutes later when we dequeue those same 32 messages again, all of them (except for the one that failed to deserialize, ironically) get blocked by the [`this.stats.PendingOrchestratorMessages.TryAdd`](https://github.com/Azure/durabletask/blob/e8b169ac97d2a2a4926412a1dcffbbca5e4c0e78/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs#L109) duplicate message check since those message IDs were never removed from the dictionary. These messages are now forever stuck until the app process gets recycled.

## Fix summary

The fix is to properly handle message download/dequeue exceptions to ensure that we clean up our internal data structures (PendingOrchestratorMessages) if a failure occurs. This PR required some refactoring of the abandon message path because we didn't have any code that allowed us to abandon a raw Azure Storage queue message. We only had code to abandon the fully-deserialized version of a message.

This PR also increments the DT.AzureStorage package version to v1.9.1.