### PR TITLE
Fix large inputs for pending orchestrations on Azure Storage

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1568,7 +1568,11 @@ namespace DurableTask.AzureStorage
                 creationMessage);
 
             // CompressedBlobName either has a blob path for large messages or is null.
-            string inputStatusOverride = internalMessage.CompressedBlobName;
+            string inputStatusOverride = null;
+            if (internalMessage.CompressedBlobName != null)
+            {
+                inputStatusOverride = this.messageManager.GetBlobUrl(internalMessage.CompressedBlobName);
+            }
 
             await this.trackingStore.SetNewExecutionAsync(
                 executionStartedEvent,


### PR DESCRIPTION
Pending orchestrations for large messages stored in blobs in the Azure
Storage implementation stored the blob name in the Input field in the
status table. This does not comply with the expectations that the
Input/Output fields should have either the raw value or an absolute URL
to the blob containing the raw values.

This PR addresses replaces the blob name with the blob URL.