### PR TITLE
Update DurableTask.props to work with different sln file locations

### DIFF
--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <FileVersion>1.9.1</FileVersion>
+    <FileVersion>1.9.2</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <Version>$(FileVersion)</Version>
     <IncludeSymbols>true</IncludeSymbols>

--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -23,9 +23,9 @@
   </ItemGroup>
 
   <!-- Sign assemblies if the snk file is present -->
-  <PropertyGroup Condition="Exists('$(SolutionDir)\tools\sign.snk') And $(Configuration) == 'Release'">
+  <PropertyGroup Condition="Exists('$(MSBuildProjectDirectory)\..\..\tools\sign.snk') And $(Configuration) == 'Release'">
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(SolutionDir)\tools\sign.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>$(MSBuildProjectDirectory)\..\..\tools\sign.snk</AssemblyOriginatorKeyFile>
     <DefineConstants>$(DefineConstants);SIGN_ASSEMBLY</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
This is to fix a build signing issue in the alternate release pipeline (azure-pipelines-release.yml)