### PR TITLE
Update access modifiers

### DIFF
--- a/src/DurableTask.Core/Common/Utils.cs
+++ b/src/DurableTask.Core/Common/Utils.cs
@@ -81,7 +81,12 @@ namespace DurableTask.Core.Common
             return input;
         }
 
-        internal static JArray ConvertToJArray(string input)
+        /// <summary>
+        /// Convert input string to JArray
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static JArray ConvertToJArray(string input)
         {
             JArray jArray;
             using (var stringReader = new StringReader(input))

--- a/src/DurableTask.Core/ReflectionBasedTaskActivity.cs
+++ b/src/DurableTask.Core/ReflectionBasedTaskActivity.cs
@@ -166,7 +166,11 @@ namespace DurableTask.Core
             return MethodInfo.Invoke(ActivityObject, inputParameters);
         }
 
-        string MethodInfoString()
+        /// <summary>
+        /// Get method info string
+        /// </summary>
+        /// <returns></returns>
+        public string MethodInfoString()
         {
             return $"{MethodInfo.ReflectedType?.FullName}.{MethodInfo.Name}";
         }


### PR DESCRIPTION
Update two access modifiers to `public`, which is helpful when users want to inherit `ReflectionBasedTaskActivity`