### PR TITLE
JsonSerializerSettings made static

### DIFF
--- a/src/DurableTask.Emulator/LocalOrchestrationService.cs
+++ b/src/DurableTask.Emulator/LocalOrchestrationService.cs
@@ -53,6 +53,7 @@ namespace DurableTask.Emulator
         readonly object timerLock = new object();
 
         readonly ConcurrentDictionary<string, TaskCompletionSource<OrchestrationState>> orchestrationWaiters;
+        static readonly JsonSerializerSettings StateJsonSettings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto };
 
         /// <summary>
         ///     Creates a new instance of the LocalOrchestrationService with default settings
@@ -636,8 +637,7 @@ namespace DurableTask.Emulator
                 return null;
             }
 
-            string serializeState = JsonConvert.SerializeObject(runtimeState.Events,
-                new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto });
+            string serializeState = JsonConvert.SerializeObject(runtimeState.Events, StateJsonSettings);
             return Encoding.UTF8.GetBytes(serializeState);
         }
 
@@ -649,7 +649,7 @@ namespace DurableTask.Emulator
             }
 
             string serializedState = Encoding.UTF8.GetString(stateBytes);
-            var events = JsonConvert.DeserializeObject<IList<HistoryEvent>>(serializedState, new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto });
+            var events = JsonConvert.DeserializeObject<IList<HistoryEvent>>(serializedState, StateJsonSettings);
             return new OrchestrationRuntimeState(events);
         }
 


### PR DESCRIPTION
This PR makes a few `JsonSerializerSettings` static. This was partially a result of profiling `AzureTableOrchestrationHistoryEventEntity` behavior when reading/writing entities. `JsonSerializerSettings` isn't the smallest class, allocating it less won't hurt 😉 