### PR TITLE
TimeoutHandler for DurableTask.AzureStorage optimized

### DIFF
--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScaleTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScaleTests.cs
@@ -175,23 +175,19 @@ namespace DurableTask.AzureStorage.Tests
         {
             BlobContinuationToken continuationToken = null;
             var results = new List<IListBlobItem>();
+            var timeoutHandler = new TimeoutHandler("dummyName", new AzureStorageOrchestrationServiceSettings());
             do
             {
-                BlobResultSegment response = await TimeoutHandler.ExecuteWithTimeout(
+                BlobResultSegment response = await timeoutHandler.ExecuteWithTimeout(
                     "ListBobs",
-                    "dummyName",
-                    new AzureStorageOrchestrationServiceSettings(),
-                    (context, timeoutToken) =>
-                    {
-                        return client.ListBlobsSegmentedAsync(
-                                useFlatBlobListing: true,
-                                blobListingDetails: BlobListingDetails.Metadata,
-                                maxResults: null,
-                                currentToken: continuationToken,
-                                options: null,
-                                operationContext: context,
-                                cancellationToken: timeoutToken);
-                    });
+                    (context, timeoutToken) => client.ListBlobsSegmentedAsync(
+                        useFlatBlobListing: true,
+                        blobListingDetails: BlobListingDetails.Metadata,
+                        maxResults: null,
+                        currentToken: continuationToken,
+                        options: null,
+                        operationContext: context,
+                        cancellationToken: timeoutToken));
 
                 continuationToken = response.ContinuationToken;
                 results.AddRange(response.Results);

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -513,9 +513,12 @@ namespace DurableTask.AzureStorage.Tests
             CloudBlobDirectory instanceDirectory = cloudBlobContainer.GetDirectoryReference(directoryName);
             int blobCount = 0;
             BlobContinuationToken blobContinuationToken = null;
+
+            var timeoutHandler = new TimeoutHandler("dummyAccount", new AzureStorageOrchestrationServiceSettings());
+
             do
             {
-                BlobResultSegment results = await TimeoutHandler.ExecuteWithTimeout("GetBlobCount", "dummyAccount", new AzureStorageOrchestrationServiceSettings(), (context, timeoutToken) =>
+                BlobResultSegment results = await timeoutHandler.ExecuteWithTimeout("GetBlobCount", (context, timeoutToken) =>
                 {
                     return instanceDirectory.ListBlobsSegmentedAsync(
                             useFlatBlobListing: true,


### PR DESCRIPTION
This PR optimizes TimeoutHandler which is frequently used in `DurableTask.AzureStorage` to wrap Storage calls.

**Work in progress**