### PR TITLE
Fix exception when Task returns void

### DIFF
--- a/Test/DurableTask.AzureStorage.Tests/ScheduleTaskTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/ScheduleTaskTests.cs
@@ -45,8 +45,8 @@ namespace DurableTask.AzureStorage.Tests
 
                 // The expectedOutput value is the string that's passed into the InvalidOperationException
                 await Task.WhenAll(instance.WaitForCompletion(
-                    expectedStatus: OrchestrationStatus.Failed,
-                    expectedOutput: "Task result is null and cannot be cast to TResult. Please use the non-generic overload method."));
+                    expectedStatus: OrchestrationStatus.Completed,
+                    expectedOutput: 0));
 
                 await host.StopAsync();
             }

--- a/Test/DurableTask.AzureStorage.Tests/ScheduleTaskTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/ScheduleTaskTests.cs
@@ -1,0 +1,55 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureStorage.Tests
+{
+    using System.Threading.Tasks;
+    using DurableTask.Core;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class ScheduleTaskTests
+    {
+        /// <summary>
+        /// This test checks that an orchestration fails with an InvalidOperationException
+        /// when a typed CallActivityAsync() call that expects a Task actually returns void.
+        /// </summary>
+        [TestMethod]
+        public async Task TaskReturnsVoid_OrchestratorFails()
+        {
+            using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(false))
+            {
+                await host.StartAsync();
+
+                TaskActivity activity = TestOrchestrationHost.MakeActivity<int, Task>(
+                    delegate (TaskContext ctx, int input)
+                    {
+                        return null;
+                    });
+
+                TestInstance<int> instance = await host.StartInlineOrchestration(
+                    input: 123,
+                    orchestrationName: "TestOrchestration",
+                    implementation: (ctx, input) => ctx.ScheduleTask<int>("Activity", "", input),
+                    activities: ("Activity", activity));
+
+                // The expectedOutput value is the string that's passed into the InvalidOperationException
+                await Task.WhenAll(instance.WaitForCompletion(
+                    expectedStatus: OrchestrationStatus.Failed,
+                    expectedOutput: "Task result is null and cannot be cast to TResult. Please use the non-generic overload method."));
+
+                await host.StopAsync();
+            }
+        }
+    }
+}

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -77,6 +77,11 @@ namespace DurableTask.Core
         {
             object result = await ScheduleTaskInternal(name, version, taskList, typeof(TResult), parameters);
 
+            if (result == null && typeof(TResult).IsPrimitive)
+            {
+                throw new InvalidOperationException("Task result is null and cannot be cast to TResult. Please use the non-generic overload method.");
+            }
+
             return (TResult)result;
         }
 

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -79,7 +79,7 @@ namespace DurableTask.Core
 
             if (result == null && typeof(TResult).IsPrimitive)
             {
-                throw new InvalidOperationException("Task result is null and cannot be cast to TResult. Please use the non-generic overload method.");
+                return default(TResult);
             }
 
             return (TResult)result;

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -77,7 +77,7 @@ namespace DurableTask.Core
         {
             object result = await ScheduleTaskInternal(name, version, taskList, typeof(TResult), parameters);
 
-            if (result == null && typeof(TResult).IsPrimitive)
+            if (result == null)
             {
                 return default(TResult);
             }


### PR DESCRIPTION
This PR changes the behavior to return the default value of a type instead of a `NullReferenceException` when a user calls `CallActivityAsync()` with a typed call (e.g. `await context.CallActivityAsync<bool>("MyFunctions_RunTaskAsync", input)`) and expects a Task, but the function returns void.

Example from GitHub issue:
```
[FunctionName("MyFunctions_RunTaskAsync")]
public async Task RunTaskAsync([ActivityTrigger] string input)
{
    ...
}
```
```
await context.CallActivityAsync<bool>("MyFunctions_RunTaskAsync", input);
```
```
Function 'MyFunctions (Orchestrator)' failed with an error.Reason: System.NullReferenceException: Object reference not set to an instance of an object.
at DurableTask.Core.TaskOrchestrationContext.ScheduleTaskToWorker[TResult](String name, String version, String taskList, Object[] parameters) in C:\source\durabletask\src\DurableTask.Core\TaskOrchestrationContext.cs:line 80
at DurableTask.Core.TaskOrchestrationContext.ScheduleTask[TResult](String name, String version, Object[] parameters) in C:\source\durabletask\src\DurableTask.Core\TaskOrchestrationContext.cs:line 70
at Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableOrchestrationContext.CallDurableTaskFunctionAsync[TResult](String functionName, FunctionType functionType, Boolean oneWay, String instanceId, String operation, RetryOptions retryOptions, Object input, Nullable`1 scheduledTimeUtc) in d:\a\r1\a\azure-functions-durable-extension\src\WebJobs.Extensions.DurableTask\ContextImplementations\DurableOrchestrationContext.cs:line 607
at MyNamespace.MyFunctions.RunOrchestrator(IDurableOrchestrationContext context)
```


With this fix, the function would return the default value for the type (e.g. 0 for int).

Resolves https://github.com/Azure/azure-functions-durable-extension/issues/1245