### PR TITLE
Ensure storageAccountName is set correctly.

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -109,7 +109,7 @@ namespace DurableTask.AzureStorage
                 ? CloudStorageAccount.Parse(settings.StorageConnectionString)
                 : settings.StorageAccountDetails.ToCloudStorageAccount();
 
-            this.storageAccountName = account.Credentials.AccountName;
+            this.storageAccountName = account.Credentials.AccountName ?? settings.StorageAccountDetails.AccountName;
 
             string compressedMessageBlobContainerName = $"{settings.TaskHubName.ToLowerInvariant()}-largemessages";
             NameValidator.ValidateContainerName(compressedMessageBlobContainerName);

--- a/src/DurableTask.AzureStorage/Storage/AzureStorageClient.cs
+++ b/src/DurableTask.AzureStorage/Storage/AzureStorageClient.cs
@@ -36,7 +36,7 @@ namespace DurableTask.AzureStorage.Storage
                 ? CloudStorageAccount.Parse(settings.StorageConnectionString)
                 : settings.StorageAccountDetails.ToCloudStorageAccount();
 
-            this.StorageAccountName = account.Credentials.AccountName;
+            this.StorageAccountName = account.Credentials.AccountName ?? settings.StorageAccountDetails.AccountName;
 
             this.Stats = new AzureStorageOrchestrationServiceStats();
             this.queueClient = account.CreateCloudQueueClient();
@@ -52,7 +52,7 @@ namespace DurableTask.AzureStorage.Storage
             this.account = account;
             this.Settings = settings;
 
-            this.StorageAccountName = account.Credentials.AccountName;
+            this.StorageAccountName = account.Credentials.AccountName ?? settings.StorageAccountDetails.AccountName;
             this.Stats = new AzureStorageOrchestrationServiceStats();
             this.queueClient = account.CreateCloudQueueClient();
             this.queueClient.BufferManager = SimpleBufferManager.Shared;

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -79,7 +79,7 @@ namespace DurableTask.AzureStorage.Tracking
             this.tableEntityConverter = new TableEntityConverter();
             this.taskHubName = settings.TaskHubName;
 
-            this.storageAccountName = account.Credentials.AccountName;
+            this.storageAccountName = account.Credentials.AccountName ?? settings.StorageAccountDetails.AccountName;
 
             CloudTableClient tableClient = account.CreateCloudTableClient();
             tableClient.BufferManager = SimpleBufferManager.Shared;


### PR DESCRIPTION
When you instantiate AzureStorageOrchestrationService like this it hangs because AccountName isn't set on StorageCredentials when they're created this way:
```
            WindowsAzure.Storage.Auth.TokenCredential storageTokenCredential = ...
            WindowsAzure.Storage.Auth.StorageCredentials storageCreds = new WindowsAzure.Storage.Auth.StorageCredentials(storageTokenCredential);
            AzureStorageOrchestrationServiceSettings orchestrationServiceSettings = new AzureStorageOrchestrationServiceSettings
            {
                TaskHubName = "task hub name",
                StorageAccountDetails = new StorageAccountDetails
                {
                    AccountName = "XYZ",
                    StorageCredentials = storageCredentials
                }
            };
            AzureStorageOrchestrationService orchestrationService = new AzureStorageOrchestrationService(orchestrationServiceSettings);
```
I'm trying to use Durable Task Framework without relying on connection strings.  I only want to use a Managed Identity with RBAC roles set up.
This bug makes it impossible to do that.
