### PR TITLE
Increment version for DT.Core and DT.ServiceBus

### DIFF
--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -39,9 +39,9 @@
   <!-- Nuget Package Settings -->
   <PropertyGroup>
     <PackageOutputPath>..\..\build_output\packages</PackageOutputPath>
-    <AssemblyVersion>2.5.6</AssemblyVersion>
-    <FileVersion>2.5.6</FileVersion>
-    <Version>2.5.6</Version>
+    <AssemblyVersion>2.6.0</AssemblyVersion>
+    <FileVersion>2.6.0</FileVersion>
+    <Version>2.6.0</Version>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
     <Product>Durable Task Framework</Product>


### PR DESCRIPTION
Updating from 2.5.6 to 2.6.0 since new public API surface area has been added to both DT.Core and DT.ServiceBus, specifically #625, #623, and #595.