### PR TITLE
Add extra logging in table-storage path

### DIFF
--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -5,9 +5,9 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <FileVersion>1.9.4</FileVersion>
+    <FileVersion>1.9.5</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
-    <Version>$(FileVersion)</Version>
+    <Version>$(FileVersion)-alpha</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <Description>Azure Storage provider extension for the Durable Task Framework.</Description>
     <PackageTags>Azure Task Durable Orchestration Workflow Activity Reliable AzureStorage</PackageTags>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -7,7 +7,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <FileVersion>1.9.5</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
-    <Version>$(FileVersion)-alpha</Version>
+    <Version>$(FileVersion)-private</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <Description>Azure Storage provider extension for the Durable Task Framework.</Description>
     <PackageTags>Azure Task Durable Orchestration Workflow Activity Reliable AzureStorage</PackageTags>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -5,9 +5,9 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <FileVersion>1.9.5</FileVersion>
+    <FileVersion>1.9.4</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
-    <Version>$(FileVersion)-private</Version>
+    <Version>$(FileVersion)</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <Description>Azure Storage provider extension for the Durable Task Framework.</Description>
     <PackageTags>Azure Task Durable Orchestration Workflow Activity Reliable AzureStorage</PackageTags>

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -1235,7 +1235,7 @@ namespace DurableTask.AzureStorage.Tracking
                                 }
                             });
                             var message = string.Join(Environment.NewLine, logs);
-                            this.settings.Logger.GeneralWarning(this.storageAccountName, this.taskHubName, message, instanceId);
+                            this.settings.Logger.GeneralWarning(this.storageAccountName, this.taskHubName, "Unexpected history persistence exception: " + ex + Environment.NewLine + message, instanceId);
                         }
                     }
 #endif

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -1208,31 +1208,35 @@ namespace DurableTask.AzureStorage.Tracking
                         stopwatch.ElapsedMilliseconds,
                         eTagValue);
                 }
-
-#if NETSTANDARD2_0
-                foreach(var tableOperation in historyEventBatch)
+                else
                 {
-                    if (tableOperation.Entity is DynamicTableEntity entity)
+#if NETSTANDARD2_0
+                    foreach (var tableOperation in historyEventBatch)
                     {
-                        foreach (var propertyName in entity.Properties.Keys)
+                        if (tableOperation.Entity is DynamicTableEntity entity)
                         {
-                            entity.Properties.TryGetValue(propertyName, out EntityProperty property);
-                            try
+                            foreach (var propertyName in entity.Properties.Keys)
                             {
-                                if (this.ExceedsMaxTablePropertySize(property.StringValue) &&
-                                    !VariableSizeEntityProperties.Contains(propertyName))
+                                entity.Properties.TryGetValue(propertyName, out EntityProperty property);
+                                try
                                 {
-                                    var numBytes = Encoding.Unicode.GetByteCount(property.StringValue);
-                                    var message = $"Detected field that exceeds Azure Storage Table's max size - {propertyName} with {numBytes} bytes";
-                                    this.settings.Logger.GeneralError(this.storageAccountName, this.taskHubName, message);
+                                    if (this.ExceedsMaxTablePropertySize(property.StringValue) &&
+                                        !VariableSizeEntityProperties.Contains(propertyName))
+                                    {
+                                        var numBytes = Encoding.Unicode.GetByteCount(property.StringValue);
+                                        var message = $"Detected field that exceeds Azure Storage Table's max size - {propertyName} with {numBytes} bytes";
+                                        this.settings.Logger.GeneralWarning(this.storageAccountName, this.taskHubName, message, instanceId);
+                                    }
                                 }
-                            }
-                            catch { } // ignore exceptions in this logging-only path
+                                catch { } // ignore exceptions in this logging-only path
 
+                            }
                         }
                     }
-                }
 #endif
+                }
+
+
 
                 throw;
             }

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -1212,49 +1212,6 @@ namespace DurableTask.AzureStorage.Tracking
                         stopwatch.ElapsedMilliseconds,
                         eTagValue);
                 }
-                else
-                {
-#if NETSTANDARD2_0
-                    foreach (var tableOperation in historyEventBatch)
-                    {
-                        if (tableOperation.Entity is DynamicTableEntity entity)
-                        {
-                            var logs = entity.Properties.Select((pair) =>
-                            {
-
-                                var propertyName = pair.Key;
-                                var property = pair.Value;
-
-                                try
-                                {
-                                    if (property is null)
-                                    {
-                                        return $"Property {propertyName} | is NULL .";
-                                    }
-                                    else if (!property.PropertyType.Equals(EdmType.String))
-                                    {
-                                        return $"Property {propertyName} | is of type {property.PropertyType} , it's size is expected to be fixed.";
-
-                                    }
-                                    var stringValue = property.StringValue;
-                                    var exceedsPropertySize = this.ExceedsMaxTablePropertySize(stringValue);
-                                    var numBytes = Encoding.Unicode.GetByteCount(property.StringValue);
-                                    var inVariableSizeProps = VariableSizeEntityProperties.Contains(propertyName);
-                                    return $"Property {propertyName} | numBytes: {numBytes}, exceedsSize: {exceedsPropertySize}, inVariableSizeProps: {inVariableSizeProps} .";
-                                }
-                                catch (Exception ex)
-                                {
-                                    return $"Property {propertyName} | Exception: {ex}.";
-                                }
-                            });
-                            var message = $"Attempted to store the following fields:{Environment.NewLine}{string.Join(Environment.NewLine, logs)}";
-                            this.settings.Logger.GeneralWarning(this.storageAccountName, this.taskHubName, "Unexpected history persistence exception: " + ex + Environment.NewLine + message, instanceId);
-                        }
-                    }
-#endif
-                }
-
-
 
                 throw;
             }

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -1215,11 +1215,14 @@ namespace DurableTask.AzureStorage.Tracking
                     {
                         if (tableOperation.Entity is DynamicTableEntity entity)
                         {
-                            var logs = entity.Properties.Keys.Select((propertyName) =>
+                            var logs = entity.Properties.Select((pair) =>
                             {
+
+                                var propertyName = pair.Key;
+                                var property = pair.Value;
+
                                 try
                                 {
-                                    entity.Properties.TryGetValue(propertyName, out EntityProperty property);
                                     var stringValue = property.StringValue;
                                     var exceedsPropertySize = this.ExceedsMaxTablePropertySize(stringValue);
                                     var numBytes = Encoding.Unicode.GetByteCount(property.StringValue);
@@ -1231,9 +1234,8 @@ namespace DurableTask.AzureStorage.Tracking
                                     return $"Property {propertyName} | Exception: {ex}.";
                                 }
                             });
-                            var message = string.Join("\n", logs);
+                            var message = string.Join(Environment.NewLine, logs);
                             this.settings.Logger.GeneralWarning(this.storageAccountName, this.taskHubName, message, instanceId);
-
                         }
                     }
 #endif

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -1224,7 +1224,7 @@ namespace DurableTask.AzureStorage.Tracking
                                 {
                                     var numBytes = Encoding.Unicode.GetByteCount(property.StringValue);
                                     var message = $"Detected field that exceeds Azure Storage Table's max size - {propertyName} with {numBytes} bytes";
-                                    this.settings.Logger.GeneralError(this.storageAccountName, this.taskHubName, "");
+                                    this.settings.Logger.GeneralError(this.storageAccountName, this.taskHubName, message);
                                 }
                             }
                             catch { } // ignore exceptions in this logging-only path


### PR DESCRIPTION
In the presence of an AzureStorage exception, this PR logs sizing information about every property that was attempted to be saved in to a Table column. The hope is to use this to help determine if any of those columns is responsible for exceeding the AzureStorage size limits.