### PR TITLE
Updated AppLeaseManager hash algorithm to be FIPS compliant

### DIFF
--- a/src/DurableTask.AzureStorage/Partitioning/AppLeaseManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/AppLeaseManager.cs
@@ -15,8 +15,6 @@ namespace DurableTask.AzureStorage.Partitioning
 {
     using System;
     using System.Net;
-    using System.Security.Cryptography;
-    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using DurableTask.AzureStorage.Storage;
@@ -71,7 +69,9 @@ namespace DurableTask.AzureStorage.Partitioning
             this.appLeaseContainer = this.azureStorageClient.GetBlobContainerReference(this.appLeaseContainerName);
             this.appLeaseInfoBlob = this.appLeaseContainer.GetBlobReference(this.appLeaseInfoBlobName);
 
-            this.appLeaseId = Fnv1aHashHelper.ComputeHash(this.appName).ToString();
+            var appNameHashInBytes = BitConverter.GetBytes(Fnv1aHashHelper.ComputeHash(this.appName));
+            Array.Resize(ref appNameHashInBytes, 16);
+            this.appLeaseId = new Guid(appNameHashInBytes).ToString();
 
             this.isLeaseOwner = false;
             this.shutdownCompletedEvent = new AsyncManualResetEvent();

--- a/src/DurableTask.AzureStorage/Partitioning/AppLeaseManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/AppLeaseManager.cs
@@ -71,11 +71,7 @@ namespace DurableTask.AzureStorage.Partitioning
             this.appLeaseContainer = this.azureStorageClient.GetBlobContainerReference(this.appLeaseContainerName);
             this.appLeaseInfoBlob = this.appLeaseContainer.GetBlobReference(this.appLeaseInfoBlobName);
 
-            using (MD5 md5 = MD5.Create())
-            {
-               byte[] hash = md5.ComputeHash(Encoding.Default.GetBytes(this.appName));
-               this.appLeaseId = new Guid(hash).ToString();
-            }
+            this.appLeaseId = Fnv1aHashHelper.ComputeHash(this.appName).ToString();
 
             this.isLeaseOwner = false;
             this.shutdownCompletedEvent = new AsyncManualResetEvent();


### PR DESCRIPTION
AppLeaseManager is currently using MD5 to create a hash of the appName used for appLeaseId, which is not FIPS compliant. This PR replaces that hash algorithm with an existing algorithm we use to group instanceIds to partitions.

resolves #637 