### PR TITLE
Add interface for TaskHubWorker.

### DIFF
--- a/samples/Correlation.Samples/TestOrchestrationHost.cs
+++ b/samples/Correlation.Samples/TestOrchestrationHost.cs
@@ -24,7 +24,7 @@ namespace Correlation.Samples
     internal sealed class TestOrchestrationHost : IDisposable
     {
         readonly AzureStorageOrchestrationServiceSettings settings;
-        readonly TaskHubWorker worker;
+        readonly ITaskHubWorker worker;
         readonly TaskHubClient client;
         readonly HashSet<Type> addedOrchestrationTypes;
         readonly HashSet<Type> addedActivityTypes;

--- a/src/DurableTask.Core/ITaskHubWorker.cs
+++ b/src/DurableTask.Core/ITaskHubWorker.cs
@@ -1,0 +1,125 @@
+//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core
+{
+    using System;
+    using System.Threading.Tasks;
+    using DurableTask.Core.Middleware;
+
+    /// <summary>
+    /// TaskHubWorker interface for performing task hub worker operations
+    /// </summary>
+    public interface ITaskHubWorker : IDisposable
+    {
+        /// <summary>
+        /// Gets the orchestration dispatcher
+        /// </summary>
+        TaskOrchestrationDispatcher TaskOrchestrationDispatcher { get; }
+
+        /// <summary>
+        /// Gets the task activity dispatcher
+        /// </summary>
+        TaskActivityDispatcher TaskActivityDispatcher { get; }
+
+        /// <summary>
+        /// Adds a middleware delegate to the orchestration dispatch pipeline.
+        /// </summary>
+        /// <param name="middleware">Delegate to invoke whenever a message is dispatched to an orchestration.</param>
+        void AddOrchestrationDispatcherMiddleware(Func<DispatchMiddlewareContext, Func<Task>, Task> middleware);
+
+        /// <summary>
+        /// Adds a middleware delegate to the activity dispatch pipeline.
+        /// </summary>
+        /// <param name="middleware">Delegate to invoke whenever a message is dispatched to an activity.</param>
+        void AddActivityDispatcherMiddleware(Func<DispatchMiddlewareContext, Func<Task>, Task> middleware);
+
+        /// <summary>
+        ///     Starts the TaskHubWorker so it begins processing orchestrations and activities
+        /// </summary>
+        /// <returns></returns>
+        Task<ITaskHubWorker> StartAsync();
+
+        /// <summary>
+        ///     Gracefully stops the TaskHubWorker
+        /// </summary>
+        Task StopAsync();
+
+        /// <summary>
+        ///     Stops the TaskHubWorker
+        /// </summary>
+        /// <param name="isForced">True if forced shutdown, false if graceful shutdown</param>
+        Task StopAsync(bool isForced);
+
+        /// <summary>
+        ///     Loads user defined TaskOrchestration classes in the TaskHubWorker
+        /// </summary>
+        /// <param name="taskOrchestrationTypes">Types deriving from TaskOrchestration class</param>
+        /// <returns></returns>
+        ITaskHubWorker AddTaskOrchestrations(params Type[] taskOrchestrationTypes);
+
+        /// <summary>
+        ///     Loads user defined TaskOrchestration classes in the TaskHubWorker
+        /// </summary>
+        /// <param name="taskOrchestrationCreators">
+        ///     User specified ObjectCreators that will
+        ///     create classes deriving TaskOrchestrations with specific names and versions
+        /// </param>
+        ITaskHubWorker AddTaskOrchestrations(params ObjectCreator<TaskOrchestration>[] taskOrchestrationCreators);
+
+        /// <summary>
+        ///     Loads user defined TaskActivity objects in the TaskHubWorker
+        /// </summary>
+        /// <param name="taskActivityObjects">Objects of with TaskActivity base type</param>
+        ITaskHubWorker AddTaskActivities(params TaskActivity[] taskActivityObjects);
+
+        /// <summary>
+        ///     Loads user defined TaskActivity classes in the TaskHubWorker
+        /// </summary>
+        /// <param name="taskActivityTypes">Types deriving from TaskOrchestration class</param>
+        ITaskHubWorker AddTaskActivities(params Type[] taskActivityTypes);
+
+        /// <summary>
+        ///     Loads user defined TaskActivity classes in the TaskHubWorker
+        /// </summary>
+        /// <param name="taskActivityCreators">
+        ///     User specified ObjectCreators that will
+        ///     create classes deriving TaskActivity with specific names and versions
+        /// </param>
+        ITaskHubWorker AddTaskActivities(params ObjectCreator<TaskActivity>[] taskActivityCreators);
+
+        /// <summary>
+        ///     Infers and adds every method in the specified interface T on the
+        ///     passed in object as a different TaskActivity with Name set to the method name
+        ///     and version set to an empty string. Methods can then be invoked from task orchestrations
+        ///     by calling ScheduleTask(name, version) with name as the method name and string.Empty as the version.
+        /// </summary>
+        /// <typeparam name="T">Interface</typeparam>
+        /// <param name="activities">Object that implements this interface</param>
+        ITaskHubWorker AddTaskActivitiesFromInterface<T>(T activities);
+
+        /// <summary>
+        ///     Infers and adds every method in the specified interface T on the
+        ///     passed in object as a different TaskActivity with Name set to the method name
+        ///     and version set to an empty string. Methods can then be invoked from task orchestrations
+        ///     by calling ScheduleTask(name, version) with name as the method name and string.Empty as the version.
+        /// </summary>
+        /// <typeparam name="T">Interface</typeparam>
+        /// <param name="activities">Object that implements this interface</param>
+        /// <param name="useFullyQualifiedMethodNames">
+        ///     If true, the method name translation from the interface contains
+        ///     the interface name, if false then only the method name is used
+        /// </param>
+        ITaskHubWorker AddTaskActivitiesFromInterface<T>(T activities, bool useFullyQualifiedMethodNames);
+    }
+}

--- a/src/DurableTask.Core/TaskHubWorker.cs
+++ b/src/DurableTask.Core/TaskHubWorker.cs
@@ -26,7 +26,7 @@ namespace DurableTask.Core
     ///     Allows users to load the TaskOrchestration and TaskActivity classes and start
     ///     dispatching to these. Also allows CRUD operations on the Task Hub itself.
     /// </summary>
-    public sealed class TaskHubWorker : IDisposable
+    public sealed class TaskHubWorker : ITaskHubWorker
     {
         readonly INameVersionObjectManager<TaskActivity> activityManager;
         readonly INameVersionObjectManager<TaskOrchestration> orchestrationManager;
@@ -145,7 +145,7 @@ namespace DurableTask.Core
         ///     Starts the TaskHubWorker so it begins processing orchestrations and activities
         /// </summary>
         /// <returns></returns>
-        public async Task<TaskHubWorker> StartAsync()
+        public async Task<ITaskHubWorker> StartAsync()
         {
             await this.slimLock.WaitAsync();
             try
@@ -231,7 +231,7 @@ namespace DurableTask.Core
         /// </summary>
         /// <param name="taskOrchestrationTypes">Types deriving from TaskOrchestration class</param>
         /// <returns></returns>
-        public TaskHubWorker AddTaskOrchestrations(params Type[] taskOrchestrationTypes)
+        public ITaskHubWorker AddTaskOrchestrations(params Type[] taskOrchestrationTypes)
         {
             foreach (Type type in taskOrchestrationTypes)
             {
@@ -249,7 +249,7 @@ namespace DurableTask.Core
         ///     User specified ObjectCreators that will
         ///     create classes deriving TaskOrchestrations with specific names and versions
         /// </param>
-        public TaskHubWorker AddTaskOrchestrations(params ObjectCreator<TaskOrchestration>[] taskOrchestrationCreators)
+        public ITaskHubWorker AddTaskOrchestrations(params ObjectCreator<TaskOrchestration>[] taskOrchestrationCreators)
         {
             foreach (ObjectCreator<TaskOrchestration> creator in taskOrchestrationCreators)
             {
@@ -263,7 +263,7 @@ namespace DurableTask.Core
         ///     Loads user defined TaskActivity objects in the TaskHubWorker
         /// </summary>
         /// <param name="taskActivityObjects">Objects of with TaskActivity base type</param>
-        public TaskHubWorker AddTaskActivities(params TaskActivity[] taskActivityObjects)
+        public ITaskHubWorker AddTaskActivities(params TaskActivity[] taskActivityObjects)
         {
             foreach (TaskActivity instance in taskActivityObjects)
             {
@@ -278,7 +278,7 @@ namespace DurableTask.Core
         ///     Loads user defined TaskActivity classes in the TaskHubWorker
         /// </summary>
         /// <param name="taskActivityTypes">Types deriving from TaskOrchestration class</param>
-        public TaskHubWorker AddTaskActivities(params Type[] taskActivityTypes)
+        public ITaskHubWorker AddTaskActivities(params Type[] taskActivityTypes)
         {
             foreach (Type type in taskActivityTypes)
             {
@@ -296,7 +296,7 @@ namespace DurableTask.Core
         ///     User specified ObjectCreators that will
         ///     create classes deriving TaskActivity with specific names and versions
         /// </param>
-        public TaskHubWorker AddTaskActivities(params ObjectCreator<TaskActivity>[] taskActivityCreators)
+        public ITaskHubWorker AddTaskActivities(params ObjectCreator<TaskActivity>[] taskActivityCreators)
         {
             foreach (ObjectCreator<TaskActivity> creator in taskActivityCreators)
             {
@@ -314,7 +314,7 @@ namespace DurableTask.Core
         /// </summary>
         /// <typeparam name="T">Interface</typeparam>
         /// <param name="activities">Object that implements this interface</param>
-        public TaskHubWorker AddTaskActivitiesFromInterface<T>(T activities)
+        public ITaskHubWorker AddTaskActivitiesFromInterface<T>(T activities)
         {
             return this.AddTaskActivitiesFromInterface(activities, false);
         }
@@ -331,7 +331,7 @@ namespace DurableTask.Core
         ///     If true, the method name translation from the interface contains
         ///     the interface name, if false then only the method name is used
         /// </param>
-        public TaskHubWorker AddTaskActivitiesFromInterface<T>(T activities, bool useFullyQualifiedMethodNames)
+        public ITaskHubWorker AddTaskActivitiesFromInterface<T>(T activities, bool useFullyQualifiedMethodNames)
         {
             Type @interface = typeof(T);
             if (!@interface.IsInterface)

--- a/test/DurableTask.AzureStorage.Tests/TestOrchestrationHost.cs
+++ b/test/DurableTask.AzureStorage.Tests/TestOrchestrationHost.cs
@@ -28,7 +28,7 @@ namespace DurableTask.AzureStorage.Tests
         internal readonly AzureStorageOrchestrationService service;
 
         readonly AzureStorageOrchestrationServiceSettings settings;
-        readonly TaskHubWorker worker;
+        readonly ITaskHubWorker worker;
         readonly TaskHubClient client;
         readonly HashSet<Type> addedOrchestrationTypes;
         readonly HashSet<Type> addedActivityTypes;

--- a/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
+++ b/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
@@ -25,7 +25,7 @@ namespace DurableTask.Core.Tests
     [TestClass]
     public class DispatcherMiddlewareTests
     {
-        TaskHubWorker worker;
+        ITaskHubWorker worker;
         TaskHubClient client;
 
         [TestInitialize]


### PR DESCRIPTION
Add an interface for `TaskHubWorker` to make the developer's code easy to do the unit tests. Also, I'd like to add an interface for `TaskHubClient`

```
Mock<ITaskHubWorker> mockTaskHubWorker = new Mock<ITaskHubWorker>();
mockTaskHubWorker.Setup(w => w.StartAsync()).Returns(mockTaskHubWorker );
```