### PR TITLE
Improve FetchedInstanceStatus logs

### DIFF
--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -900,12 +900,13 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(EventIds.FetchedInstanceStatus, Level = EventLevel.Informational, Version = 2)]
+        [Event(EventIds.FetchedInstanceStatus, Level = EventLevel.Informational, Version = 3)]
         public void FetchedInstanceStatus(
             string Account,
             string TaskHub,
             string InstanceId,
             string ExecutionId,
+            string RuntimeStatus,
             long LatencyMs,
             string AppName,
             string ExtensionVersion)
@@ -916,6 +917,7 @@ namespace DurableTask.AzureStorage
                 TaskHub,
                 InstanceId,
                 ExecutionId ?? string.Empty,
+                RuntimeStatus ?? string.Empty,
                 LatencyMs,
                 AppName,
                 ExtensionVersion);

--- a/src/DurableTask.AzureStorage/Logging/LogEvents.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogEvents.cs
@@ -2153,12 +2153,14 @@ namespace DurableTask.AzureStorage.Logging
                 string taskHub,
                 string instanceId,
                 string executionId,
+                string runtimeStatus,
                 long latencyMs)
             {
                 this.Account = account;
                 this.TaskHub = taskHub;
                 this.InstanceId = instanceId;
                 this.ExecutionId = executionId;
+                this.RuntimeStatus = runtimeStatus;
                 this.LatencyMs = latencyMs;
             }
 
@@ -2173,6 +2175,9 @@ namespace DurableTask.AzureStorage.Logging
 
             [StructuredLogField]
             public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string RuntimeStatus { get; }
 
             [StructuredLogField]
             public long LatencyMs { get; }
@@ -2190,6 +2195,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.TaskHub,
                 this.InstanceId,
                 this.ExecutionId,
+                this.RuntimeStatus,
                 this.LatencyMs,
                 Utils.AppName,
                 Utils.ExtensionVersion);

--- a/src/DurableTask.AzureStorage/Logging/LogHelper.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogHelper.cs
@@ -706,6 +706,7 @@ namespace DurableTask.AzureStorage.Logging
             string taskHub,
             string instanceId,
             string executionId,
+            string runtimeStatus,
             long latencyMs)
         {
             var logEvent = new LogEvents.FetchedInstanceStatus(
@@ -713,6 +714,7 @@ namespace DurableTask.AzureStorage.Logging
                 taskHub,
                 instanceId,
                 executionId,
+                runtimeStatus,
                 latencyMs);
             this.WriteStructuredLog(logEvent);
         }

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -411,22 +411,22 @@ namespace DurableTask.AzureStorage.Tracking
         {
             return new[] { await this.GetStateAsync(instanceId, executionId: null, fetchInput: fetchInput) };
         }
-
+#nullable enable
         /// <inheritdoc />
-        public override async Task<OrchestrationState> GetStateAsync(string instanceId, string executionId, bool fetchInput)
+        public override async Task<OrchestrationState?> GetStateAsync(string instanceId, string executionId, bool fetchInput)
         {
-            InstanceStatus instanceStatus = await this.FetchInstanceStatusInternalAsync(instanceId, executionId, fetchInput);
+            InstanceStatus? instanceStatus = await this.FetchInstanceStatusInternalAsync(instanceId, fetchInput);
             return instanceStatus?.State;
         }
 
         /// <inheritdoc />
-        public override Task<InstanceStatus> FetchInstanceStatusAsync(string instanceId)
+        public override Task<InstanceStatus?> FetchInstanceStatusAsync(string instanceId)
         {
-            return this.FetchInstanceStatusInternalAsync(instanceId, executionId: null, fetchInput: false);
+            return this.FetchInstanceStatusInternalAsync(instanceId, fetchInput: false);
         }
-#nullable enable
+
         /// <inheritdoc />
-        async Task<InstanceStatus?> FetchInstanceStatusInternalAsync(string instanceId, string executionId, bool fetchInput)
+        async Task<InstanceStatus?> FetchInstanceStatusInternalAsync(string instanceId, bool fetchInput)
         {
             if (instanceId == null)
             {
@@ -453,7 +453,7 @@ namespace DurableTask.AzureStorage.Tracking
                 this.storageAccountName,
                 this.taskHubName,
                 instanceId,
-                orchestrationState?.OrchestrationInstance.ExecutionId ?? executionId ?? string.Empty,
+                orchestrationState?.OrchestrationInstance.ExecutionId ?? string.Empty,
                 orchestrationState?.OrchestrationStatus.ToString() ?? "NotFound",
                 tableEntitiesResponseInfo.ElapsedMilliseconds);
 


### PR DESCRIPTION
I was debugging a customer issue and noticed that it would be really nice if the _FetchedInstanceStatus_ log event had more information. This PR adds the following columns:

* **ExecutionId**: We already had this column, but it was always empty. This PR populates it with whatever execution ID we actually found in table storage.
* **RuntimeStatus**: This column is new and includes the status of the found orchestration instance or "NotFound" if none was found. This is helpful for debugging issues related to dedupe or for simply verifying what the status of an instance really is.

This is just a quality-of-life improvement for debugging.