### PR TITLE
Patch correlation compression

### DIFF
--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -5,9 +5,9 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <FileVersion>1.9.4</FileVersion>
+    <FileVersion>1.9.5</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
-    <Version>$(FileVersion)</Version>
+    <Version>$(FileVersion)-alpha</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <Description>Azure Storage provider extension for the Durable Task Framework.</Description>
     <PackageTags>Azure Task Durable Orchestration Workflow Activity Reliable AzureStorage</PackageTags>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -7,7 +7,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <FileVersion>1.9.5</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
-    <Version>$(FileVersion)-alpha</Version>
+    <Version>$(FileVersion)-private</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <Description>Azure Storage provider extension for the Durable Task Framework.</Description>
     <PackageTags>Azure Task Durable Orchestration Workflow Activity Reliable AzureStorage</PackageTags>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -5,9 +5,9 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <FileVersion>1.9.5</FileVersion>
+    <FileVersion>1.9.4</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
-    <Version>$(FileVersion)-private</Version>
+    <Version>$(FileVersion)</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <Description>Azure Storage provider extension for the Durable Task Framework.</Description>
     <PackageTags>Azure Task Durable Orchestration Workflow Activity Reliable AzureStorage</PackageTags>

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -1235,7 +1235,7 @@ namespace DurableTask.AzureStorage.Tracking
                                 }
                             });
                             var message = string.Join(Environment.NewLine, logs);
-                            this.settings.Logger.GeneralWarning(this.storageAccountName, this.taskHubName, message, instanceId);
+                            this.settings.Logger.GeneralWarning(this.storageAccountName, this.taskHubName, "Unexpected history persistence exception: " + ex + Environment.NewLine + message, instanceId);
                         }
                     }
 #endif

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -1208,31 +1208,35 @@ namespace DurableTask.AzureStorage.Tracking
                         stopwatch.ElapsedMilliseconds,
                         eTagValue);
                 }
-
-#if NETSTANDARD2_0
-                foreach(var tableOperation in historyEventBatch)
+                else
                 {
-                    if (tableOperation.Entity is DynamicTableEntity entity)
+#if NETSTANDARD2_0
+                    foreach (var tableOperation in historyEventBatch)
                     {
-                        foreach (var propertyName in entity.Properties.Keys)
+                        if (tableOperation.Entity is DynamicTableEntity entity)
                         {
-                            entity.Properties.TryGetValue(propertyName, out EntityProperty property);
-                            try
+                            foreach (var propertyName in entity.Properties.Keys)
                             {
-                                if (this.ExceedsMaxTablePropertySize(property.StringValue) &&
-                                    !VariableSizeEntityProperties.Contains(propertyName))
+                                entity.Properties.TryGetValue(propertyName, out EntityProperty property);
+                                try
                                 {
-                                    var numBytes = Encoding.Unicode.GetByteCount(property.StringValue);
-                                    var message = $"Detected field that exceeds Azure Storage Table's max size - {propertyName} with {numBytes} bytes";
-                                    this.settings.Logger.GeneralError(this.storageAccountName, this.taskHubName, message);
+                                    if (this.ExceedsMaxTablePropertySize(property.StringValue) &&
+                                        !VariableSizeEntityProperties.Contains(propertyName))
+                                    {
+                                        var numBytes = Encoding.Unicode.GetByteCount(property.StringValue);
+                                        var message = $"Detected field that exceeds Azure Storage Table's max size - {propertyName} with {numBytes} bytes";
+                                        this.settings.Logger.GeneralWarning(this.storageAccountName, this.taskHubName, message, instanceId);
+                                    }
                                 }
-                            }
-                            catch { } // ignore exceptions in this logging-only path
+                                catch { } // ignore exceptions in this logging-only path
 
+                            }
                         }
                     }
-                }
 #endif
+                }
+
+
 
                 throw;
             }

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -1212,49 +1212,6 @@ namespace DurableTask.AzureStorage.Tracking
                         stopwatch.ElapsedMilliseconds,
                         eTagValue);
                 }
-                else
-                {
-#if NETSTANDARD2_0
-                    foreach (var tableOperation in historyEventBatch)
-                    {
-                        if (tableOperation.Entity is DynamicTableEntity entity)
-                        {
-                            var logs = entity.Properties.Select((pair) =>
-                            {
-
-                                var propertyName = pair.Key;
-                                var property = pair.Value;
-
-                                try
-                                {
-                                    if (property is null)
-                                    {
-                                        return $"Property {propertyName} | is NULL .";
-                                    }
-                                    else if (!property.PropertyType.Equals(EdmType.String))
-                                    {
-                                        return $"Property {propertyName} | is of type {property.PropertyType} , it's size is expected to be fixed.";
-
-                                    }
-                                    var stringValue = property.StringValue;
-                                    var exceedsPropertySize = this.ExceedsMaxTablePropertySize(stringValue);
-                                    var numBytes = Encoding.Unicode.GetByteCount(property.StringValue);
-                                    var inVariableSizeProps = VariableSizeEntityProperties.Contains(propertyName);
-                                    return $"Property {propertyName} | numBytes: {numBytes}, exceedsSize: {exceedsPropertySize}, inVariableSizeProps: {inVariableSizeProps} .";
-                                }
-                                catch (Exception ex)
-                                {
-                                    return $"Property {propertyName} | Exception: {ex}.";
-                                }
-                            });
-                            var message = $"Attempted to store the following fields:{Environment.NewLine}{string.Join(Environment.NewLine, logs)}";
-                            this.settings.Logger.GeneralWarning(this.storageAccountName, this.taskHubName, "Unexpected history persistence exception: " + ex + Environment.NewLine + message, instanceId);
-                        }
-                    }
-#endif
-                }
-
-
 
                 throw;
             }

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -890,16 +890,6 @@ namespace DurableTask.AzureStorage.Tracking
                 historyEntity.RowKey = sequenceNumber.ToString("X16");
                 historyEntity.Properties["ExecutionId"] = new EntityProperty(executionId);
 
-                CorrelationTraceClient.Propagate(() =>
-                {
-                    if (historyEvent.EventType == EventType.ExecutionStarted)
-                    {
-                        ExecutionStartedEvent executionStartedEvent = (ExecutionStartedEvent)historyEvent;
-                        historyEntity.Properties["Correlation"] = new EntityProperty(executionStartedEvent.Correlation);
-                        estimatedBytes += Encoding.Unicode.GetByteCount(executionStartedEvent.Correlation);
-                    }
-                });
-
                 await this.CompressLargeMessageAsync(historyEntity);
 
                 // Replacement can happen if the orchestration episode gets replayed due to a commit failure in one of the steps below.

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -1215,11 +1215,14 @@ namespace DurableTask.AzureStorage.Tracking
                     {
                         if (tableOperation.Entity is DynamicTableEntity entity)
                         {
-                            var logs = entity.Properties.Keys.Select((propertyName) =>
+                            var logs = entity.Properties.Select((pair) =>
                             {
+
+                                var propertyName = pair.Key;
+                                var property = pair.Value;
+
                                 try
                                 {
-                                    entity.Properties.TryGetValue(propertyName, out EntityProperty property);
                                     var stringValue = property.StringValue;
                                     var exceedsPropertySize = this.ExceedsMaxTablePropertySize(stringValue);
                                     var numBytes = Encoding.Unicode.GetByteCount(property.StringValue);
@@ -1231,9 +1234,8 @@ namespace DurableTask.AzureStorage.Tracking
                                     return $"Property {propertyName} | Exception: {ex}.";
                                 }
                             });
-                            var message = string.Join("\n", logs);
+                            var message = string.Join(Environment.NewLine, logs);
                             this.settings.Logger.GeneralWarning(this.storageAccountName, this.taskHubName, message, instanceId);
-
                         }
                     }
 #endif

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -1224,7 +1224,7 @@ namespace DurableTask.AzureStorage.Tracking
                                 {
                                     var numBytes = Encoding.Unicode.GetByteCount(property.StringValue);
                                     var message = $"Detected field that exceeds Azure Storage Table's max size - {propertyName} with {numBytes} bytes";
-                                    this.settings.Logger.GeneralError(this.storageAccountName, this.taskHubName, "");
+                                    this.settings.Logger.GeneralError(this.storageAccountName, this.taskHubName, message);
                                 }
                             }
                             catch { } // ignore exceptions in this logging-only path


### PR DESCRIPTION
Supersedes: https://github.com/Azure/durabletask/pull/639

**Bug description:** After enabling Distributed Tracing, Azure Table Storage would sometimes raise an exception claiming that some field exceeded the size limitations for an entry.  After investigation, it was determined that this field was the `Correlation` Property of the History table, which distributed tracing populates and relies upon.

**Root cause:** The cause of this issue was in the `UpdateStateAsync` method of `AzureTableTrackingStore`. Normally, our property-compression step (`CompressLargeMessageAsync`) should have avoided any size-limitation exceptions, but Distributed Tracing updates the `Correlation" field the History table with "raw correlation data" *after* the compression step.

**How to fix (this PR):** This exception was simply due to an ordering issue: we should make sure Correlation Tracing propagates/updates all its correlation data **prior** to the compression step. To do this, we simply move the `CorrelationTraceClient.Propagate(...` call in `UpdateStateAsync` to be immediately before the call to `CompressLargeMessageAsync`.

**On tests:** I would like to test this but, after spending a few hours fiddling with the Correlation Tracing infrastructure, I'm starting to suspect that we don't currently have a means of testing this without making very intrusive changes into the Correlation Tracing design. Let me explain below.

In spirit, the test is simple: we simply need to create a large enough correlation-data-string so that it triggers our compression step. Then, we want to validate that Azure Table Storage does not error out, which means that no _raw_ Correlation data escaped the compression.

The are two challenges with that.

(1) we don't know _exactly_ what causes Correlation data to grow very large. This means that I don't have a "natural" way of generating a large Correlation payload. This means that, to test this, I'm currently opting to simply _set_ the Correlation data string to a very large value.

(2) However, during unit-testing, it seems to me that we don't have granular enough control to set this large Correlation payload past the initial (client) trace.

In Distributed Tracing, we associate several "traces" with one another. For example, we associate a durable client's "trace" with an orchestration "trace" later in the execution. The issue here is that, while we  do have access to the client's trace when setting up a test (which would allow us to make its correlation-string arbitrarily long), we do not have direct access to the orchestrator's trace, **and _that_ is the relevant trace to modify to trigger this behavior.** 

In other words, we need to have a means to set the correlation-data-string at the time when the orchestration trace is generated, and currently I don't know of any good ways of doing that without refactoring the `CorrelationTraceClient` into a more unit-testing friendly design, which  would make this tiny PR much larger in scope.

My bias here would be to create a new Distributed Tracing work item to consider a refactor of Distributed Tracing that facilitates this scenario and then to merge this PR after all tests pass. I feel comfortable suggesting this since the change is quite small, the fix was validated by the affected user, and because it applies to a still in-preview feature. 

All that said, I'm always open to discussion and I'm open to pair program this in case we can think of a clear way to test this :) . Perhaps my unfamiliarity with this side of the codebase prevents me from seeing an easier way. Thanks ! 