### PR TITLE
Fix compatibility issue between older clients and newer workers on DT.AzureStorage

### DIFF
--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -238,8 +238,8 @@ namespace DurableTask.AzureStorage
                 if (remoteOrchestrationsById.TryGetValue(localInstance.InstanceId, out OrchestrationState remoteInstance) &&
                     (remoteInstance.OrchestrationInstance.ExecutionId == null || string.Equals(localInstance.ExecutionId, remoteInstance.OrchestrationInstance.ExecutionId, StringComparison.OrdinalIgnoreCase)))
                 {
-                    // Happy path: The message matches the table status -OR- the table doesn't have an execution ID field (older clients, pre-v1.8.5),
-                    // in which case we have no way of knowing whether it's a duplicate. Allow it to run.
+                    // Happy path: The message matches the table status. Alternatively, if the table doesn't have an ExecutionId field (older clients, pre-v1.8.5),
+                    // then we have no way of knowing if it's a duplicate. Either way, allow it to run.
                 }
                 else if (this.IsScheduledAfterInstanceUpdate(message, remoteInstance))
                 {

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -236,9 +236,10 @@ namespace DurableTask.AzureStorage
             {
                 OrchestrationInstance localInstance = message.TaskMessage.OrchestrationInstance;
                 if (remoteOrchestrationsById.TryGetValue(localInstance.InstanceId, out OrchestrationState remoteInstance) &&
-                    string.Equals(localInstance.ExecutionId, remoteInstance.OrchestrationInstance.ExecutionId, StringComparison.OrdinalIgnoreCase))
+                    (remoteInstance.OrchestrationInstance.ExecutionId == null || string.Equals(localInstance.ExecutionId, remoteInstance.OrchestrationInstance.ExecutionId, StringComparison.OrdinalIgnoreCase)))
                 {
-                    // Happy path: The message matches the table status. Allow it to run.
+                    // Happy path: The message matches the table status -OR- the table doesn't have an execution ID field (older clients, pre-v1.8.5),
+                    // in which case we have no way of knowing whether it's a duplicate. Allow it to run.
                 }
                 else if (this.IsScheduledAfterInstanceUpdate(message, remoteInstance))
                 {


### PR DESCRIPTION
Fixes https://github.com/Azure/durabletask/issues/650.

The fix is to essentially short-circuit out of de-dupe detection if the Instances table has a record with a null value for ExecutionId. This will be true only for orchestrations that are started with clients on v1.8.4 or earlier (ExecutionId wasn't added until after the orchestration checkpointed once). For newer clients that do add ExecutionId when scheduling an orchestration, de-dupe detection should continue to work as normal - no change in behavior.