### PR TITLE
Fix retry interceptor sleeps

### DIFF
--- a/Test/DurableTask.Core.Tests/RetryInterceptorTests.cs
+++ b/Test/DurableTask.Core.Tests/RetryInterceptorTests.cs
@@ -1,0 +1,100 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ---------------------------------------------------------------
+
+namespace DurableTask.Core.Tests
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class RetryInterceptorTests
+    {
+        MockOrchestrationContext context;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            this.context = new MockOrchestrationContext(new OrchestrationInstance(), TaskScheduler.Default);
+        }
+
+        [TestMethod]
+        public async Task Invoke_WithFailingRetryCall_ShouldThrowCorrectException()
+        {
+            var interceptor = new RetryInterceptor<object>(this.context, new RetryOptions(TimeSpan.FromMilliseconds(100), 1), () => throw new IOException());
+            async Task Invoke() => await interceptor.Invoke();
+
+            await Assert.ThrowsExceptionAsync<IOException>(Invoke, "Interceptor should throw the original exception after exceeding max retry attempts.");
+        }
+
+        [TestMethod]
+        [DataRow(1)]
+        [DataRow(2)]
+        [DataRow(3)]
+        [DataRow(10)]
+        public async Task Invoke_WithFailingRetryCall_ShouldHaveCorrectNumberOfCalls(int maxAttempts)
+        {
+            var callCount = 0;
+            var interceptor = new RetryInterceptor<object>(
+                this.context,
+                new RetryOptions(TimeSpan.FromMilliseconds(1), maxAttempts),
+                () =>
+                {
+                    callCount++;
+                    throw new Exception();
+                });
+            try
+            {
+                await interceptor.Invoke();
+            }
+            catch
+            {
+                // ignored
+            }
+
+            Assert.AreEqual(maxAttempts, callCount, 0, $"There should be {maxAttempts} function calls for {maxAttempts} max attempts.");
+        }
+
+        [TestMethod]
+        [DataRow(1)]
+        [DataRow(2)]
+        [DataRow(3)]
+        [DataRow(10)]
+        public async Task Invoke_WithFailingRetryCall_ShouldHaveCorrectNumberOfSleeps(int maxAttempts)
+        {
+            var interceptor = new RetryInterceptor<object>(this.context, new RetryOptions(TimeSpan.FromMilliseconds(1), maxAttempts), () => throw new Exception());
+            try
+            {
+                await interceptor.Invoke();
+            }
+            catch
+            {
+                // ignored
+            }
+
+            Assert.AreEqual(maxAttempts - 1, this.context.TimerCalls, 0, $"There should be {maxAttempts - 1} sleeps for {maxAttempts} function calls");
+        }
+
+        sealed class MockOrchestrationContext : TaskOrchestrationContext
+        {
+            public MockOrchestrationContext(OrchestrationInstance orchestrationInstance, TaskScheduler taskScheduler)
+                : base(orchestrationInstance, taskScheduler)
+            {
+                CurrentUtcDateTime = DateTime.UtcNow;
+            }
+
+            public int TimerCalls { get; private set; }
+
+            public override async Task<T> CreateTimer<T>(DateTime fireAt, T state)
+            {
+                TimerCalls++;
+
+                await Task.Delay(fireAt - CurrentUtcDateTime);
+
+                return state;
+            }
+        }
+    }
+}

--- a/src/DurableTask.Core/RetryInterceptor.cs
+++ b/src/DurableTask.Core/RetryInterceptor.cs
@@ -1,4 +1,4 @@
-﻿//  ----------------------------------------------------------------------------------
+//  ----------------------------------------------------------------------------------
 //  Copyright Microsoft Corporation
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -64,8 +64,9 @@ namespace DurableTask.Core
                     lastException = e;
                 }
 
+                bool isLastRetry = retryCount + 1 == this.retryOptions.MaxNumberOfAttempts;
                 TimeSpan nextDelay = ComputeNextDelay(retryCount, firstAttempt, lastException);
-                if (nextDelay == TimeSpan.Zero)
+                if (isLastRetry || nextDelay == TimeSpan.Zero)
                 {
                     break;
                 }


### PR DESCRIPTION
The final sleep inside the retry loop is redundant. 

The sleep period should take place between two retries. 

For example: If the max number of attempts is three, the total number of sleep periods should be two, as illustrated below.
![image](https://user-images.githubusercontent.com/19733434/144718597-f6dd1982-52a3-42d7-a785-587a50663a10.png)

This effect is amplified when retry intervals are relatively big (e.g., 30 mins), leading to undesirable side effects in the client code.

I created a couple of test cases reproducing the defect and verifying that the applied fix is working as intended.