### PR TITLE
change OrchestrationInstance and IsReplaying to virtual make it mockable

### DIFF
--- a/src/DurableTask.Core/OrchestrationContext.cs
+++ b/src/DurableTask.Core/OrchestrationContext.cs
@@ -45,7 +45,7 @@ namespace DurableTask.Core
         /// <summary>
         /// Instance of the currently executing orchestration
         /// </summary>
-        public OrchestrationInstance OrchestrationInstance { get; internal protected set; }
+        public virtual OrchestrationInstance OrchestrationInstance { get; internal protected set; }
 
         /// <summary>
         /// Replay-safe current UTC datetime
@@ -55,7 +55,7 @@ namespace DurableTask.Core
         /// <summary>
         ///     True if the code is currently replaying, False if code is truly executing for the first time.
         /// </summary>
-        public bool IsReplaying { get; internal protected set; }
+        public virtual bool IsReplaying { get; internal protected set; }
 
         /// <summary>
         ///     Create a proxy client class to schedule remote TaskActivities via a strongly typed interface.

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -41,7 +41,7 @@ namespace DurableTask.Core
             continueAsNew.CarryoverEvents.Add(he);
         }
 
-        public TaskOrchestrationContext(OrchestrationInstance orchestrationInstance, TaskScheduler taskScheduler)
+        public TaskOrchestrationContext(TaskScheduler taskScheduler)
         {
             Utils.UnusedParameter(taskScheduler);
 
@@ -50,8 +50,6 @@ namespace DurableTask.Core
             this.idCounter = 0;
             this.MessageDataConverter = new JsonDataConverter();
             this.ErrorDataConverter = new JsonDataConverter();
-            OrchestrationInstance = orchestrationInstance;
-            IsReplaying = false;
         }
 
         public IEnumerable<OrchestratorAction> OrchestratorActions => this.orchestratorActionsMap.Values;

--- a/src/DurableTask.Core/TaskOrchestrationExecutor.cs
+++ b/src/DurableTask.Core/TaskOrchestrationExecutor.cs
@@ -38,7 +38,11 @@ namespace DurableTask.Core
             TaskOrchestration taskOrchestration, BehaviorOnContinueAsNew eventBehaviourForContinueAsNew)
         {
             this.decisionScheduler = new SynchronousTaskScheduler();
-            this.context = new TaskOrchestrationContext(orchestrationRuntimeState.OrchestrationInstance, this.decisionScheduler);
+            this.context = new TaskOrchestrationContext(this.decisionScheduler)
+            {
+                OrchestrationInstance = orchestrationRuntimeState.OrchestrationInstance, 
+                IsReplaying = false
+            };
             this.orchestrationRuntimeState = orchestrationRuntimeState;
             this.taskOrchestration = taskOrchestration;
             this.skipCarryOverEvents = eventBehaviourForContinueAsNew == BehaviorOnContinueAsNew.Ignore;


### PR DESCRIPTION
Add unit test for orchestrations is a strong requirement. But the `OrchestrationInstance` and `IsReplaying` do not support mock, also the `internal protected set;` access modifiers prevented us update them.

```
[TestMethod]
        public async Task RunTest()
        {
            var mockContext = new Mock<OrchestrationContext>();
            mockContext.Setup(c => c.OrchestrationInstance).Returns(
                () => new OrchestrationInstance()
                {
                    InstanceId = Guid.NewGuid().ToString()
                });
            mockContext.Setup(c => c.CreateClient<ITask>()).Returns(
                () => new MockTask());
            //other mock

            //Test orchestration
            TestOrchestration orchestration = new TestOrchestration();
            var result = await orchestration.RunTask(mockContext.Object, "input");
            Assert.AreEqual("Succeeded", result);
        }
```