### PR TITLE
Add SBOM task to release pipeline

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -1,8 +1,10 @@
 trigger: none
 pr: none
 
-pool:
-  vmImage: 'windows-latest'
+ pool:
+  name: '1ES-Hosted-DurableTaskFramework'
+  demands:
+    - ImageOverride -equals MMS2022TLS
 
 steps:
 # Start by restoring all the dependencies. This needs to be its own task

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -60,12 +60,6 @@ steps:
           }
       ]
 
-- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-  displayName: 'SBOM Generation Task'
-  inputs:
-    BuildDropPath: '$(build.artifactStagingDirectory)'
-    Verbosity: 'Information'
-
 # Packaging needs to be a separate step from build.
 # This will automatically pick up the signed DLLs.
 - task: DotNetCoreCLI@2
@@ -104,6 +98,12 @@ steps:
             "ToolVersion": "1.0"
         }
      ]
+
+- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+  displayName: 'SBOM Generation Task'
+  inputs:
+    BuildDropPath: '$(build.artifactStagingDirectory)'
+    Verbosity: 'Information'
 
 # Make the nuget packages available for download in the ADO portal UI
 - publish: $(build.artifactStagingDirectory)

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -97,7 +97,7 @@ steps:
         }
      ]
 
-- task: ManifestGeneratorTask@0
+- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
   displayName: 'SBOM Generation Task'
   inputs:
     BuildDropPath: '$(Build.ArtifactStagingDirectory)'

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -58,6 +58,12 @@ steps:
           }
       ]
 
+- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+  displayName: 'SBOM Generation Task'
+  inputs:
+    BuildDropPath: '$(Build.ArtifactStagingDirectory)'
+    Verbosity: 'Information'
+
 # Packaging needs to be a separate step from build.
 # This will automatically pick up the signed DLLs.
 - task: DotNetCoreCLI@2
@@ -96,12 +102,6 @@ steps:
             "ToolVersion": "1.0"
         }
      ]
-
-- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-  displayName: 'SBOM Generation Task'
-  inputs:
-    BuildDropPath: '$(Build.ArtifactStagingDirectory)'
-    Verbosity: 'Information'
 
 # Make the nuget packages available for download in the ADO portal UI
 - publish: $(build.artifactStagingDirectory)

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -63,7 +63,7 @@ steps:
 - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
   displayName: 'SBOM Generation Task'
   inputs:
-    BuildDropPath: '$(Build.ArtifactStagingDirectory)'
+    BuildDropPath: '$(build.artifactStagingDirectory)'
     Verbosity: 'Information'
 
 # Packaging needs to be a separate step from build.

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -1,7 +1,7 @@
 trigger: none
 pr: none
 
- pool:
+pool:
   name: '1ES-Hosted-DurableTaskFramework'
   demands:
     - ImageOverride -equals MMS2022TLS

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -97,6 +97,12 @@ steps:
         }
      ]
 
+- task: ManifestGeneratorTask@0
+  displayName: 'SBOM Generation Task'
+  inputs:
+    BuildDropPath: '$(Build.ArtifactStagingDirectory)'
+    Verbosity: 'Information'
+
 # Make the nuget packages available for download in the ADO portal UI
 - publish: $(build.artifactStagingDirectory)
   displayName: 'Publish nuget packages to Artifacts'


### PR DESCRIPTION
Includes SBOM-generation task to our pipeline, which documents our dependencies for cybersecurity compliance, It also uses the new 1ES-approved VM, another compliance requirement.