### PR TITLE
Initial implementation of out-of-proc support

### DIFF
--- a/samples/Correlation.Samples/Correlation.Samples.csproj
+++ b/samples/Correlation.Samples/Correlation.Samples.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -629,7 +629,7 @@ namespace DurableTask.AzureStorage
                     CorrelationTraceClient.Propagate(
                         () =>
                         {
-                            bool isReplaying = session.RuntimeState.ExecutionStartedEvent != null;
+                            var isReplaying = session.RuntimeState.ExecutionStartedEvent?.IsPlayed ?? false;
                             TraceContextBase parentTraceContext = GetParentTraceContext(session);
                             currentRequestTraceContext = GetRequestTraceContext(isReplaying, parentTraceContext);
                         });

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -629,7 +629,7 @@ namespace DurableTask.AzureStorage
                     CorrelationTraceClient.Propagate(
                         () =>
                         {
-                            var isReplaying = session.RuntimeState.ExecutionStartedEvent?.IsPlayed ?? false;
+                            bool isReplaying = session.RuntimeState.ExecutionStartedEvent != null;
                             TraceContextBase parentTraceContext = GetParentTraceContext(session);
                             currentRequestTraceContext = GetRequestTraceContext(isReplaying, parentTraceContext);
                         });

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <FileVersion>1.10.0</FileVersion>
+    <FileVersion>1.10.1</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <Version>$(FileVersion)</Version>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/DurableTask.Core/ActivityExecutionResult.cs
+++ b/src/DurableTask.Core/ActivityExecutionResult.cs
@@ -11,24 +11,19 @@
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
 #nullable enable
-namespace DurableTask.Core.Command
+namespace DurableTask.Core
 {
-    using Newtonsoft.Json;
+    using DurableTask.Core.History;
 
     /// <summary>
-    /// Defines a set of base properties for an orchestrator action.
+    /// The result of an activity execution.
     /// </summary>
-    [JsonConverter(typeof(OrchestrationActionConverter))]
-    public abstract class OrchestratorAction
+    public class ActivityExecutionResult
     {
         /// <summary>
-        /// The task ID associated with this orchestrator action.
+        /// This history event associated with the activity execution result.
+        /// This is expected to be <see cref="TaskCompletedEvent"/> or <see cref="TaskFailedEvent"/>.
         /// </summary>
-        public int Id { get; set; }
-
-        /// <summary>
-        /// The type of the orchestrator action.
-        /// </summary>
-        public abstract OrchestratorActionType OrchestratorActionType { get; }
+        public HistoryEvent? ResponseEvent { get; set; }
     }
 }

--- a/src/DurableTask.Core/Command/CreateSubOrchestrationAction.cs
+++ b/src/DurableTask.Core/Command/CreateSubOrchestrationAction.cs
@@ -10,23 +10,45 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
-
+#nullable enable
 namespace DurableTask.Core.Command
 {
     using System.Collections.Generic;
 
-    internal class CreateSubOrchestrationAction : OrchestratorAction
+    /// <summary>
+    /// Orchestrator action for creating sub-orchestrations.
+    /// </summary>
+    public class CreateSubOrchestrationAction : OrchestratorAction
     {
+        // NOTE: Actions must be serializeable by a variety of different serializer types to support out-of-process execution.
+        //       To ensure maximum compatibility, all properties should be public and settable by default.
+
+        /// <inheritdoc/>
         public override OrchestratorActionType OrchestratorActionType => OrchestratorActionType.CreateSubOrchestration;
 
-        public string Name { get; set; }
+        /// <summary>
+        /// The name of the sub-orchestrator to start.
+        /// </summary>
+        public string? Name { get; set; }
 
-        public string Version { get; set; }
+        /// <summary>
+        /// The version of the sub-orchestrator to start.
+        /// </summary>
+        public string? Version { get; set; }
 
-        public string InstanceId { get; set; }
+        /// <summary>
+        /// The instance ID of the created sub-orchestration.
+        /// </summary>
+        public string? InstanceId { get; set; }
 
-        public string Input { get; set; }
+        /// <summary>
+        /// The input of the sub-orchestration.
+        /// </summary>
+        public string? Input { get; set; }
 
-        public IDictionary<string, string> Tags { get; set; }
+        /// <summary>
+        /// Tags to be applied to the sub-orchestration.
+        /// </summary>
+        public IDictionary<string, string>? Tags { get; set; }
     }
 }

--- a/src/DurableTask.Core/Command/CreateSubOrchestrationAction.cs
+++ b/src/DurableTask.Core/Command/CreateSubOrchestrationAction.cs
@@ -20,7 +20,7 @@ namespace DurableTask.Core.Command
     /// </summary>
     public class CreateSubOrchestrationAction : OrchestratorAction
     {
-        // NOTE: Actions must be serializeable by a variety of different serializer types to support out-of-process execution.
+        // NOTE: Actions must be serializable by a variety of different serializer types to support out-of-process execution.
         //       To ensure maximum compatibility, all properties should be public and settable by default.
 
         /// <inheritdoc/>

--- a/src/DurableTask.Core/Command/CreateTimerOrchestratorAction.cs
+++ b/src/DurableTask.Core/Command/CreateTimerOrchestratorAction.cs
@@ -10,15 +10,25 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
-
+#nullable enable
 namespace DurableTask.Core.Command
 {
     using System;
 
-    internal class CreateTimerOrchestratorAction : OrchestratorAction
+    /// <summary>
+    /// Orchestrator action for creating durable timers.
+    /// </summary>
+    public class CreateTimerOrchestratorAction : OrchestratorAction
     {
+        // NOTE: Actions must be serializeable by a variety of different serializer types to support out-of-process execution.
+        //       To ensure maximum compatibility, all properties should be public and settable by default.
+
+        /// <inheritdoc/>
         public override OrchestratorActionType OrchestratorActionType => OrchestratorActionType.CreateTimer;
 
+        /// <summary>
+        /// The time at which the created timer should fire.
+        /// </summary>
         public DateTime FireAt { get; set; }
     }
 }

--- a/src/DurableTask.Core/Command/CreateTimerOrchestratorAction.cs
+++ b/src/DurableTask.Core/Command/CreateTimerOrchestratorAction.cs
@@ -20,7 +20,7 @@ namespace DurableTask.Core.Command
     /// </summary>
     public class CreateTimerOrchestratorAction : OrchestratorAction
     {
-        // NOTE: Actions must be serializeable by a variety of different serializer types to support out-of-process execution.
+        // NOTE: Actions must be serializable by a variety of different serializer types to support out-of-process execution.
         //       To ensure maximum compatibility, all properties should be public and settable by default.
 
         /// <inheritdoc/>

--- a/src/DurableTask.Core/Command/OrchestrationCompleteOrchestratorAction.cs
+++ b/src/DurableTask.Core/Command/OrchestrationCompleteOrchestratorAction.cs
@@ -10,29 +10,46 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
-
+#nullable enable
 namespace DurableTask.Core.Command
 {
     using System.Collections.Generic;
     using DurableTask.Core.History;
 
-    internal class OrchestrationCompleteOrchestratorAction : OrchestratorAction
+    /// <summary>
+    /// Action associated with an orchestrator reaching a terminal state.
+    /// </summary>
+    public class OrchestrationCompleteOrchestratorAction : OrchestratorAction
     {
-        public OrchestrationCompleteOrchestratorAction()
-        {
-            CarryoverEvents = new List<HistoryEvent>();
-        }
+        // NOTE: Actions must be serializeable by a variety of different serializer types to support out-of-process execution.
+        //       To ensure maximum compatibility, all properties should be public and settable by default.
 
-        public OrchestrationStatus OrchestrationStatus;
+        /// <summary>
+        /// Gets the completion status of the orchestration.
+        /// </summary>
+        public OrchestrationStatus OrchestrationStatus { get; set; }
 
+        /// <inheritdoc/>
         public override OrchestratorActionType OrchestratorActionType => OrchestratorActionType.OrchestrationComplete;
 
-        public string Result { get; set; }
+        /// <summary>
+        /// Gets or sets the result of the orchestration.
+        /// </summary>
+        public string? Result { get; set; }
 
-        public string Details { get; set; }
+        /// <summary>
+        /// More details about how an orchestration completed, such as unhandled exception details.
+        /// </summary>
+        public string? Details { get; set; }
 
-        public string NewVersion { get; set; }
+        /// <summary>
+        /// For continue-as-new scenarios, gets the new version of the orchestrator to start.
+        /// </summary>
+        public string? NewVersion { get; set; }
 
-        public IList<HistoryEvent> CarryoverEvents { get; }
+        /// <summary>
+        /// Gets a list of events that should be carried over when continuing an orchestration as new.
+        /// </summary>
+        public IList<HistoryEvent> CarryoverEvents { get; } = new List<HistoryEvent>();
     }
 }

--- a/src/DurableTask.Core/Command/OrchestrationCompleteOrchestratorAction.cs
+++ b/src/DurableTask.Core/Command/OrchestrationCompleteOrchestratorAction.cs
@@ -21,7 +21,7 @@ namespace DurableTask.Core.Command
     /// </summary>
     public class OrchestrationCompleteOrchestratorAction : OrchestratorAction
     {
-        // NOTE: Actions must be serializeable by a variety of different serializer types to support out-of-process execution.
+        // NOTE: Actions must be serializable by a variety of different serializer types to support out-of-process execution.
         //       To ensure maximum compatibility, all properties should be public and settable by default.
 
         /// <summary>

--- a/src/DurableTask.Core/Command/OrchestratorActionType.cs
+++ b/src/DurableTask.Core/Command/OrchestratorActionType.cs
@@ -13,12 +13,34 @@
 
 namespace DurableTask.Core.Command
 {
-    internal enum OrchestratorActionType
+    /// <summary>
+    /// Enumeration of orchestrator actions.
+    /// </summary>
+    public enum OrchestratorActionType
     {
+        /// <summary>
+        /// A new task was scheduled by the orchestrator.
+        /// </summary>
         ScheduleOrchestrator,
+
+        /// <summary>
+        /// A sub-orchestration was scheduled by the orchestrator.
+        /// </summary>
         CreateSubOrchestration,
+
+        /// <summary>
+        /// A timer was scheduled by the orchestrator.
+        /// </summary>
         CreateTimer,
+
+        /// <summary>
+        /// An outgoing external event was scheduled by the orchestrator.
+        /// </summary>
         SendEvent,
+
+        /// <summary>
+        /// The orchestrator completed.
+        /// </summary>
         OrchestrationComplete,
     }
 }

--- a/src/DurableTask.Core/Command/ScheduleTaskOrchestratorAction.cs
+++ b/src/DurableTask.Core/Command/ScheduleTaskOrchestratorAction.cs
@@ -18,7 +18,7 @@ namespace DurableTask.Core.Command
     /// </summary>
     public class ScheduleTaskOrchestratorAction : OrchestratorAction
     {
-        // NOTE: Actions must be serializeable by a variety of different serializer types to support out-of-process execution.
+        // NOTE: Actions must be serializable by a variety of different serializer types to support out-of-process execution.
         //       To ensure maximum compatibility, all properties should be public and settable by default.
 
         /// <inheritdoc/>

--- a/src/DurableTask.Core/Command/ScheduleTaskOrchestratorAction.cs
+++ b/src/DurableTask.Core/Command/ScheduleTaskOrchestratorAction.cs
@@ -10,19 +10,36 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
-
+#nullable enable
 namespace DurableTask.Core.Command
 {
-    internal class ScheduleTaskOrchestratorAction : OrchestratorAction
+    /// <summary>
+    /// Orchestrator action for scheduling activity tasks.
+    /// </summary>
+    public class ScheduleTaskOrchestratorAction : OrchestratorAction
     {
+        // NOTE: Actions must be serializeable by a variety of different serializer types to support out-of-process execution.
+        //       To ensure maximum compatibility, all properties should be public and settable by default.
+
+        /// <inheritdoc/>
         public override OrchestratorActionType OrchestratorActionType => OrchestratorActionType.ScheduleOrchestrator;
 
-        public string Name { get; set; }
+        /// <summary>
+        /// Gets or sets the name of the activity to schedule.
+        /// </summary>
+        public string? Name { get; set; }
 
-        public string Version { get; set; }
+        /// <summary>
+        /// Gets or sets the version of the activity to schedule.
+        /// </summary>
+        public string? Version { get; set; }
 
-        public string Input { get; set; }
+        /// <summary>
+        /// Gets or sets the input of the activity to schedule.
+        /// </summary>
+        public string? Input { get; set; }
 
-        public string Tasklist { get; set; }
+        // TODO: This property is not used and should be removed or made obsolete
+        internal string? Tasklist { get; set; }
     }
 }

--- a/src/DurableTask.Core/Command/SendEventOrchestratorAction.cs
+++ b/src/DurableTask.Core/Command/SendEventOrchestratorAction.cs
@@ -18,7 +18,7 @@ namespace DurableTask.Core.Command
     /// </summary>
     public class SendEventOrchestratorAction : OrchestratorAction
     {
-        // NOTE: Actions must be serializeable by a variety of different serializer types to support out-of-process execution.
+        // NOTE: Actions must be serializable by a variety of different serializer types to support out-of-process execution.
         //       To ensure maximum compatibility, all properties should be public and settable by default.
 
         /// <inheritdoc/>

--- a/src/DurableTask.Core/Command/SendEventOrchestratorAction.cs
+++ b/src/DurableTask.Core/Command/SendEventOrchestratorAction.cs
@@ -10,19 +10,33 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
-
+#nullable enable
 namespace DurableTask.Core.Command
 {
-    using System;
-
-    internal class SendEventOrchestratorAction : OrchestratorAction
+    /// <summary>
+    /// Orchestrator action for sending external events to other orchestrations.
+    /// </summary>
+    public class SendEventOrchestratorAction : OrchestratorAction
     {
+        // NOTE: Actions must be serializeable by a variety of different serializer types to support out-of-process execution.
+        //       To ensure maximum compatibility, all properties should be public and settable by default.
+
+        /// <inheritdoc/>
         public override OrchestratorActionType OrchestratorActionType => OrchestratorActionType.SendEvent;
 
-        public OrchestrationInstance Instance { get; set; }
+        /// <summary>
+        /// The orchestration instance to receive the event.
+        /// </summary>
+        public OrchestrationInstance? Instance { get; set; }
 
-        public string EventName { get; set; }
+        /// <summary>
+        /// The name of the external event.
+        /// </summary>
+        public string? EventName { get; set; }
 
-        public string EventData { get; set; }
+        /// <summary>
+        /// The payload data of the external event.
+        /// </summary>
+        public string? EventData { get; set; }
     }
 }

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -4,10 +4,17 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <PackageId>Microsoft.Azure.DurableTask.Core</PackageId>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <!--NuGet licenseUrl and PackageIconUrl/iconUrl deprecation. -->
     <NoWarn>NU5125;NU5048</NoWarn>
+  </PropertyGroup>
+  
+  <!-- Package Info -->
+  <PropertyGroup>
+    <PackageId>Microsoft.Azure.DurableTask.Core</PackageId>
+    <AssemblyVersion>2.7.0</AssemblyVersion>
+    <FileVersion>2.7.0</FileVersion>
+    <Version>2.7.0</Version>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/src/DurableTask.Core/History/HistoryEvent.cs
+++ b/src/DurableTask.Core/History/HistoryEvent.cs
@@ -75,7 +75,6 @@ namespace DurableTask.Core.History
         /// Gets the IsPlayed status
         /// </summary>
         [DataMember]
-        [Obsolete("The IsPlayed property is no longer being set")]
         public bool IsPlayed { get; set; }
 
         /// <summary>

--- a/src/DurableTask.Core/History/HistoryEvent.cs
+++ b/src/DurableTask.Core/History/HistoryEvent.cs
@@ -10,7 +10,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
-
+#nullable enable
 namespace DurableTask.Core.History
 {
     using System;
@@ -25,7 +25,7 @@ namespace DurableTask.Core.History
     [KnownType(nameof(KnownTypes))]
     public abstract class HistoryEvent : IExtensibleDataObject
     {
-        private static IReadOnlyCollection<Type> knownTypes;
+        private static IReadOnlyCollection<Type>? knownTypes;
 
         /// <summary>
         /// List of all event classes, for use by the DataContractSerializer
@@ -52,7 +52,6 @@ namespace DurableTask.Core.History
         /// </summary>
         internal HistoryEvent()
         {
-            IsPlayed = false;
             Timestamp = DateTime.UtcNow;
         }
 
@@ -63,7 +62,6 @@ namespace DurableTask.Core.History
         protected HistoryEvent(int eventId)
         {
             EventId = eventId;
-            IsPlayed = false;
             Timestamp = DateTime.UtcNow;
         }
 
@@ -77,6 +75,7 @@ namespace DurableTask.Core.History
         /// Gets the IsPlayed status
         /// </summary>
         [DataMember]
+        [Obsolete("The IsPlayed property is no longer being set")]
         public bool IsPlayed { get; set; }
 
         /// <summary>
@@ -94,7 +93,6 @@ namespace DurableTask.Core.History
         /// <summary>
         /// Implementation for <see cref="IExtensibleDataObject.ExtensionData"/>.
         /// </summary>
-        public ExtensionDataObject ExtensionData { get; set; }
-
+        public ExtensionDataObject? ExtensionData { get; set; }
     }
 }

--- a/src/DurableTask.Core/History/TaskScheduledEvent.cs
+++ b/src/DurableTask.Core/History/TaskScheduledEvent.cs
@@ -10,9 +10,10 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
-
+#nullable enable
 namespace DurableTask.Core.History
 {
+    using System;
     using System.Runtime.Serialization;
 
     /// <summary>
@@ -21,10 +22,36 @@ namespace DurableTask.Core.History
     [DataContract]
     public class TaskScheduledEvent : HistoryEvent
     {
+        // Private ctor for JSON deserialization (required by some storage providers and out-of-proc executors)
+        TaskScheduledEvent()
+            : base(-1)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="TaskScheduledEvent"/> with the supplied event ID.
+        /// </summary>
+        /// <param name="eventId">The ID of the history event.</param>
+        /// <param name="name">The name of the scheduled task activity.</param>
+        /// <param name="version">The version of the scheduled task activity.</param>
+        /// <param name="input">The input of the activity task.</param>
+        public TaskScheduledEvent(
+            int eventId,
+            string name,
+            string? version = null,
+            string? input = null)
+            : base(eventId)
+        {
+            this.Name = name;
+            this.Version = version;
+            this.Input = input;
+        }
+
         /// <summary>
         /// Creates a new TaskScheduledEvent with the supplied event id
         /// </summary>
         /// <param name="eventId">The event id of the history event</param>
+        [Obsolete("Use the other constructor overload")]
         public TaskScheduledEvent(int eventId)
             : base(eventId)
         {
@@ -39,18 +66,18 @@ namespace DurableTask.Core.History
         /// Gets or sets the orchestration Name
         /// </summary>
         [DataMember]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// Gets or sets the orchestration Version
         /// </summary>
         [DataMember]
-        public string Version { get; set; }
+        public string? Version { get; set; }
 
         /// <summary>
         /// Gets or sets the task's serialized input
         /// </summary>
         [DataMember]
-        public string Input { get; set; }
+        public string? Input { get; set; }
     }
 }

--- a/src/DurableTask.Core/History/TaskScheduledEvent.cs
+++ b/src/DurableTask.Core/History/TaskScheduledEvent.cs
@@ -51,7 +51,6 @@ namespace DurableTask.Core.History
         /// Creates a new TaskScheduledEvent with the supplied event id
         /// </summary>
         /// <param name="eventId">The event id of the history event</param>
-        [Obsolete("Use the other constructor overload")]
         public TaskScheduledEvent(int eventId)
             : base(eventId)
         {

--- a/src/DurableTask.Core/History/TimerCreatedEvent.cs
+++ b/src/DurableTask.Core/History/TimerCreatedEvent.cs
@@ -22,6 +22,24 @@ namespace DurableTask.Core.History
     [DataContract]
     public class TimerCreatedEvent : HistoryEvent
     {
+        // Private ctor for JSON deserialization (required by some storage providers and out-of-proc executors)
+        TimerCreatedEvent()
+            : base(-1)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="TimerCreatedEvent"/> with the supplied event ID
+        /// and <paramref name="fireAt"/> timestamp.
+        /// </summary>
+        /// <param name="eventId">The ID of the timer event.</param>
+        /// <param name="fireAt">The time at which the timer should fire.</param>
+        public TimerCreatedEvent(int eventId, DateTime fireAt)
+            : base(eventId)
+        {
+            this.FireAt = fireAt;
+        }
+
         /// <summary>
         /// Creates a new TimerCreatedEvent with the supplied event id
         /// </summary>

--- a/src/DurableTask.Core/History/TimerFiredEvent.cs
+++ b/src/DurableTask.Core/History/TimerFiredEvent.cs
@@ -22,6 +22,24 @@ namespace DurableTask.Core.History
     [DataContract]
     public class TimerFiredEvent : HistoryEvent
     {
+        // Private ctor for JSON deserialization (required by some storage providers and out-of-proc executors)
+        TimerFiredEvent()
+            : base(-1)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="TimerFiredEvent"/> with the supplied event ID
+        /// and <paramref name="fireAt"/> timestamp.
+        /// </summary>
+        /// <param name="eventId">The ID of the timer event.</param>
+        /// <param name="fireAt">The time at which the timer was scheduled to fire.</param>
+        public TimerFiredEvent(int eventId, DateTime fireAt)
+            : base(eventId)
+        {
+            this.FireAt = fireAt;
+        }
+
         /// <summary>
         /// Creates a new TimerFiredEvent with the supplied event id
         /// </summary>

--- a/src/DurableTask.Core/INameVersionObjectManager.cs
+++ b/src/DurableTask.Core/INameVersionObjectManager.cs
@@ -10,7 +10,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
-
+#nullable enable
 namespace DurableTask.Core
 {
     /// <summary>
@@ -30,6 +30,6 @@ namespace DurableTask.Core
         /// <param name="name">Name of the class to return the creator for</param>
         /// <param name="version">Version of the class to return the creator for</param>
         /// <returns>Class instance based on the matching creator class for the supplied name and version</returns>
-        T GetObject(string name, string version);
+        T? GetObject(string name, string? version);
     }
 }

--- a/src/DurableTask.Core/OrchestrationRuntimeState.cs
+++ b/src/DurableTask.Core/OrchestrationRuntimeState.cs
@@ -77,8 +77,8 @@ namespace DurableTask.Core
         /// <param name="events">List of events for this runtime state</param>
         public OrchestrationRuntimeState(IList<HistoryEvent>? events)
         {
-            Events = new List<HistoryEvent>(events?.Count ?? 32);
-            PastEvents = new List<HistoryEvent>(events?.Count ?? 32);
+            Events = events != null ? new List<HistoryEvent>(events.Count) : new List<HistoryEvent>();
+            PastEvents = events != null ? new List<HistoryEvent>(events.Count) : new List<HistoryEvent>();
             NewEvents = new List<HistoryEvent>();
             completedEventIds = new HashSet<int>();
 
@@ -310,17 +310,21 @@ namespace DurableTask.Core
 
             if (evt is TaskScheduledEvent taskScheduledEvent)
             {
-                returnedEvent = new TaskScheduledEvent(
-                    eventId: taskScheduledEvent.EventId,
-                    name: taskScheduledEvent?.Name ?? "(unnamed)",
-                    version: taskScheduledEvent?.Version,
-                    input: "[..snipped..]");
+                returnedEvent = new TaskScheduledEvent(taskScheduledEvent.EventId)
+                {
+                    Timestamp = taskScheduledEvent.Timestamp,
+                    IsPlayed = taskScheduledEvent.IsPlayed,
+                    Name = taskScheduledEvent.Name,
+                    Version = taskScheduledEvent.Version,
+                    Input = "[..snipped..]",
+                };
             }
             else if (evt is TaskCompletedEvent taskCompletedEvent)
             {
                 returnedEvent = new TaskCompletedEvent(taskCompletedEvent.EventId, taskCompletedEvent.TaskScheduledId, "[..snipped..]")
                 {
                     Timestamp = taskCompletedEvent.Timestamp,
+                    IsPlayed = taskCompletedEvent.IsPlayed,
                 };
             }
             else if (evt is SubOrchestrationInstanceCreatedEvent subOrchestrationInstanceCreatedEvent)
@@ -328,6 +332,7 @@ namespace DurableTask.Core
                 returnedEvent = new SubOrchestrationInstanceCreatedEvent(subOrchestrationInstanceCreatedEvent.EventId)
                 {
                     Timestamp = subOrchestrationInstanceCreatedEvent.Timestamp,
+                    IsPlayed = subOrchestrationInstanceCreatedEvent.IsPlayed,
                     Name = subOrchestrationInstanceCreatedEvent.Name,
                     Version = subOrchestrationInstanceCreatedEvent.Version,
                     Input = "[..snipped..]",
@@ -339,6 +344,7 @@ namespace DurableTask.Core
                     subOrchestrationInstanceCompletedEvent.TaskScheduledId, "[..snipped..]")
                 {
                     Timestamp = subOrchestrationInstanceCompletedEvent.Timestamp,
+                    IsPlayed = subOrchestrationInstanceCompletedEvent.IsPlayed,
                 };
             }
             else if (evt is TaskFailedEvent taskFailedEvent)
@@ -347,6 +353,7 @@ namespace DurableTask.Core
                     taskFailedEvent.TaskScheduledId, taskFailedEvent.Reason, "[..snipped..]")
                 {
                     Timestamp = taskFailedEvent.Timestamp,
+                    IsPlayed = taskFailedEvent.IsPlayed,
                 };
             }
             else if (evt is SubOrchestrationInstanceFailedEvent subOrchestrationInstanceFailedEvent)
@@ -355,6 +362,7 @@ namespace DurableTask.Core
                     subOrchestrationInstanceFailedEvent.TaskScheduledId, subOrchestrationInstanceFailedEvent.Reason, "[..snipped..]")
                 {
                     Timestamp = subOrchestrationInstanceFailedEvent.Timestamp,
+                    IsPlayed = subOrchestrationInstanceFailedEvent.IsPlayed,
                 };
             }
             else if (evt is ExecutionStartedEvent executionStartedEvent)
@@ -362,6 +370,7 @@ namespace DurableTask.Core
                 returnedEvent = new ExecutionStartedEvent(executionStartedEvent.EventId, "[..snipped..]")
                 {
                     Timestamp = executionStartedEvent.Timestamp,
+                    IsPlayed = executionStartedEvent.IsPlayed,
                 };
             }
             else if (evt is ExecutionCompletedEvent executionCompletedEvent)
@@ -370,6 +379,7 @@ namespace DurableTask.Core
                     executionCompletedEvent.OrchestrationStatus)
                 {
                     Timestamp = executionCompletedEvent.Timestamp,
+                    IsPlayed = executionCompletedEvent.IsPlayed,
                 };
             }
             else if (evt is ExecutionTerminatedEvent executionTerminatedEvent)
@@ -377,6 +387,7 @@ namespace DurableTask.Core
                 returnedEvent = new ExecutionTerminatedEvent(executionTerminatedEvent.EventId, "[..snipped..]")
                 {
                     Timestamp = executionTerminatedEvent.Timestamp,
+                    IsPlayed = executionTerminatedEvent.IsPlayed,
                 };
             }
             // ContinueAsNewEvent is covered by the ExecutionCompletedEvent block

--- a/src/DurableTask.Core/OrchestrationRuntimeState.cs
+++ b/src/DurableTask.Core/OrchestrationRuntimeState.cs
@@ -37,7 +37,7 @@ namespace DurableTask.Core
         public IList<HistoryEvent> NewEvents { get; }
 
         /// <summary>
-        /// A subset of <see cref="this.Events"/> that contains only events that have been previously played and should not be serialized
+        /// A subset of <see cref="Events"/> that contains only events that have been previously played and should not be serialized
         /// </summary>
         public IList<HistoryEvent> PastEvents { get; }
 

--- a/src/DurableTask.Core/OrchestratorExecutionResult.cs
+++ b/src/DurableTask.Core/OrchestratorExecutionResult.cs
@@ -1,0 +1,70 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+#nullable enable
+namespace DurableTask.Core
+{
+    using System;
+    using System.Collections.Generic;
+    using DurableTask.Core.Command;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// The result of an orchestration execution.
+    /// </summary>
+    public class OrchestratorExecutionResult
+    {
+        /// <summary>
+        /// The list of actions resulting from the orchestrator execution.
+        /// </summary>
+        [JsonProperty("actions")]
+        public IEnumerable<OrchestratorAction> Actions { get; set; } = Array.Empty<OrchestratorAction>();
+
+        /// <summary>
+        /// The custom status, if any, of the orchestrator.
+        /// </summary>
+        [JsonProperty("customStatus")]
+        public string? CustomStatus { get; set; }
+
+        /// <summary>
+        /// Creates an orchestrator failure result with a specified message and exception.
+        /// </summary>
+        /// <param name="message">The simple failure message.</param>
+        /// <param name="e">The exception that triggered the failure.</param>
+        /// <returns>The orchestrator failure result.</returns>
+        public static OrchestratorExecutionResult ForFailure(string message, Exception e)
+        {
+            return ForFailure(message, e.ToString());
+        }
+
+        /// <summary>
+        /// Creates an orchestrator failure result with a specified message and details.
+        /// </summary>
+        /// <param name="message">The simple failure message.</param>
+        /// <param name="details">The failure details that give more information about what triggered the failure.</param>
+        /// <returns>The orchestrator failure result.</returns>
+        public static OrchestratorExecutionResult ForFailure(string message, string? details)
+        {
+            return new OrchestratorExecutionResult
+            {
+                Actions = new List<OrchestratorAction>
+                {
+                    new OrchestrationCompleteOrchestratorAction
+                    {
+                        OrchestrationStatus = OrchestrationStatus.Failed,
+                        Result = JsonConvert.SerializeObject(new { message, details }),
+                    },
+                },
+            };
+        }
+    }
+}

--- a/src/DurableTask.Core/TaskActivityDispatcher.cs
+++ b/src/DurableTask.Core/TaskActivityDispatcher.cs
@@ -170,7 +170,6 @@ namespace DurableTask.Core
                             throw new TypeMissingException($"TaskActivity {scheduledEvent.Name} version {scheduledEvent.Version} was not found");
                         }
 
-                        // TODO : pass workflow instance data
                         var context = new TaskContext(taskMessage.OrchestrationInstance);
                         HistoryEvent? responseEvent;
 

--- a/src/DurableTask.Core/TaskActivityDispatcher.cs
+++ b/src/DurableTask.Core/TaskActivityDispatcher.cs
@@ -10,12 +10,11 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
-
+#nullable enable
 namespace DurableTask.Core
 {
     using System;
     using System.Diagnostics;
-    using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
     using DurableTask.Core.Common;
@@ -91,13 +90,13 @@ namespace DurableTask.Core
 
         async Task OnProcessWorkItemAsync(TaskActivityWorkItem workItem)
         {
-            Task renewTask = null;
-            var renewCancellationTokenSource = new CancellationTokenSource();
+            Task? renewTask = null;
+            using var renewCancellationTokenSource = new CancellationTokenSource();
 
             TaskMessage taskMessage = workItem.TaskMessage;
             OrchestrationInstance orchestrationInstance = taskMessage.OrchestrationInstance;
-            TaskScheduledEvent scheduledEvent = null;
-            Activity diagnosticActivity = null;
+            TaskScheduledEvent? scheduledEvent = null;
+            Activity? diagnosticActivity = null;
             try
             {
                 if (string.IsNullOrWhiteSpace(orchestrationInstance?.InstanceId))
@@ -123,14 +122,19 @@ namespace DurableTask.Core
                                                   taskMessage.Event.EventType));
                 }
 
-                // call and get return message
                 scheduledEvent = (TaskScheduledEvent)taskMessage.Event;
-                this.logHelper.TaskActivityStarting(orchestrationInstance, scheduledEvent);
-                TaskActivity taskActivity = this.objectManager.GetObject(scheduledEvent.Name, scheduledEvent.Version);
-                if (taskActivity == null)
+                if (scheduledEvent.Name == null)
                 {
-                    throw new TypeMissingException($"TaskActivity {scheduledEvent.Name} version {scheduledEvent.Version} was not found");
+                    string message = $"The activity worker received a {nameof(EventType.TaskScheduled)} event that does not specify an activity name.";
+                    this.logHelper.TaskActivityDispatcherError(workItem, message);
+                    throw TraceHelper.TraceException(
+                        TraceEventType.Error,
+                        "TaskActivityDispatcher-MissingActivityName",
+                        new InvalidOperationException(message));
                 }
+
+                this.logHelper.TaskActivityStarting(orchestrationInstance, scheduledEvent);
+                TaskActivity? taskActivity = this.objectManager.GetObject(scheduledEvent.Name, scheduledEvent.Version);
 
                 if (workItem.LockedUntilUtc < DateTime.MaxValue)
                 {
@@ -139,10 +143,6 @@ namespace DurableTask.Core
                         () => this.RenewUntil(workItem, renewCancellationTokenSource.Token),
                         renewCancellationTokenSource.Token);
                 }
-
-                // TODO : pass workflow instance data
-                var context = new TaskContext(taskMessage.OrchestrationInstance);
-                HistoryEvent eventToRespond = null;
 
                 var dispatchContext = new DispatchMiddlewareContext();
                 dispatchContext.SetProperty(taskMessage.OrchestrationInstance);
@@ -156,36 +156,73 @@ namespace DurableTask.Core
                     diagnosticActivity = workItem.TraceContextBase?.CurrentActivity;
                 });
 
-                await this.dispatchPipeline.RunAsync(dispatchContext, async _ =>
+                ActivityExecutionResult? result;
+                try
                 {
-                    try
+                    await this.dispatchPipeline.RunAsync(dispatchContext, async _ =>
                     {
-                        string output = await taskActivity.RunAsync(context, scheduledEvent.Input);
-                        eventToRespond = new TaskCompletedEvent(-1, scheduledEvent.EventId, output);
-                    }
-                    catch (TaskFailureException e)
-                    {
-                        TraceHelper.TraceExceptionInstance(TraceEventType.Error, "TaskActivityDispatcher-ProcessTaskFailure", taskMessage.OrchestrationInstance, e);
-                        string details = this.IncludeDetails ? e.Details : null;
-                        eventToRespond = new TaskFailedEvent(-1, scheduledEvent.EventId, e.Message, details);
-                        this.logHelper.TaskActivityFailure(orchestrationInstance, scheduledEvent.Name, (TaskFailedEvent)eventToRespond, e);
-                        CorrelationTraceClient.Propagate(() => CorrelationTraceClient.TrackException(e));
-                    }
-                    catch (Exception e) when (!Utils.IsFatal(e) && !Utils.IsExecutionAborting(e))
-                    {
-                        TraceHelper.TraceExceptionInstance(TraceEventType.Error, "TaskActivityDispatcher-ProcessException", taskMessage.OrchestrationInstance, e);
-                        string details = this.IncludeDetails
-                            ? $"Unhandled exception while executing task: {e}\n\t{e.StackTrace}"
-                            : null;
-                        eventToRespond = new TaskFailedEvent(-1, scheduledEvent.EventId, e.Message, details);
-                        this.logHelper.TaskActivityFailure(orchestrationInstance, scheduledEvent.Name, (TaskFailedEvent)eventToRespond, e);
-                    }
+                        if (taskActivity == null)
+                        {
+                            // This likely indicates a deployment error of some kind. Because these unhandled exceptions are
+                            // automatically retried, resolving this may require redeploying the app code so that the activity exists again.
+                            // CONSIDER: Should this be changed into a permanent error that fails the orchestration? Perhaps
+                            //           the app owner doesn't care to preserve existing instances when doing code deployments?
+                            throw new TypeMissingException($"TaskActivity {scheduledEvent.Name} version {scheduledEvent.Version} was not found");
+                        }
 
-                    if (eventToRespond is TaskCompletedEvent completedEvent)
-                    {
-                        this.logHelper.TaskActivityCompleted(orchestrationInstance, scheduledEvent.Name, completedEvent);
-                    }
-                });
+                        // TODO : pass workflow instance data
+                        var context = new TaskContext(taskMessage.OrchestrationInstance);
+                        HistoryEvent? responseEvent;
+
+                        try
+                        {
+                            string? output = await taskActivity.RunAsync(context, scheduledEvent.Input);
+                            responseEvent = new TaskCompletedEvent(-1, scheduledEvent.EventId, output);
+                        }
+                        catch (Exception e) when (!Utils.IsFatal(e) && !Utils.IsExecutionAborting(e))
+                        {
+                            TraceHelper.TraceExceptionInstance(TraceEventType.Error, "TaskActivityDispatcher-ProcessException", taskMessage.OrchestrationInstance, e);
+                            string? details = this.IncludeDetails
+                                ? $"Unhandled exception while executing task: {e}"
+                                : null;
+                            responseEvent = new TaskFailedEvent(-1, scheduledEvent.EventId, e.Message, details);
+                            this.logHelper.TaskActivityFailure(orchestrationInstance, scheduledEvent.Name, (TaskFailedEvent)responseEvent, e);
+                        }
+
+                        var result = new ActivityExecutionResult { ResponseEvent = responseEvent };
+                        dispatchContext.SetProperty(result);
+                    });
+
+                    result = dispatchContext.GetProperty<ActivityExecutionResult>();
+                }
+                catch (TaskFailureException e)
+                {
+                    // These are normal task activity failures. They can come from Activity implementations or from middleware.
+                    TraceHelper.TraceExceptionInstance(TraceEventType.Error, "TaskActivityDispatcher-ProcessTaskFailure", taskMessage.OrchestrationInstance, e);
+                    string? details = this.IncludeDetails ? e.Details : null;
+                    var failureEvent = new TaskFailedEvent(-1, scheduledEvent.EventId, e.Message, details);
+                    this.logHelper.TaskActivityFailure(orchestrationInstance, scheduledEvent.Name, failureEvent, e);
+                    CorrelationTraceClient.Propagate(() => CorrelationTraceClient.TrackException(e));
+                    result = new ActivityExecutionResult { ResponseEvent = failureEvent };
+                }
+                catch (Exception middlewareException) when (!Utils.IsFatal(middlewareException))
+                {
+                    // These are considered retriable
+                    this.logHelper.TaskActivityDispatcherError(workItem, $"Unhandled exception in activity middleware pipeline: {middlewareException}");
+                    throw;
+                }
+
+                HistoryEvent? eventToRespond = result?.ResponseEvent;
+
+                if (eventToRespond is TaskCompletedEvent completedEvent)
+                {
+                    this.logHelper.TaskActivityCompleted(orchestrationInstance, scheduledEvent.Name, completedEvent);
+                }
+                else if (eventToRespond is null)
+                {
+                    // Default response if middleware prevents a response from being generated
+                    eventToRespond = new TaskCompletedEvent(-1, scheduledEvent.EventId, null);
+                }
 
                 var responseTaskMessage = new TaskMessage
                 {
@@ -199,7 +236,7 @@ namespace DurableTask.Core
             {
                 // The activity aborted its execution
                 this.logHelper.TaskActivityAborted(orchestrationInstance, scheduledEvent, e.Message);
-                TraceHelper.TraceInstance(TraceEventType.Warning, "TaskActivityDispatcher-ExecutionAborted", orchestrationInstance, "{0}: {1}", scheduledEvent.Name, e.Message);
+                TraceHelper.TraceInstance(TraceEventType.Warning, "TaskActivityDispatcher-ExecutionAborted", orchestrationInstance, "{0}: {1}", scheduledEvent?.Name, e.Message);
                 await this.orchestrationService.AbandonTaskActivityWorkItemAsync(workItem);
             }
             finally

--- a/src/DurableTask.Core/TaskActivityDispatcher.cs
+++ b/src/DurableTask.Core/TaskActivityDispatcher.cs
@@ -179,8 +179,11 @@ namespace DurableTask.Core
                             string? output = await taskActivity.RunAsync(context, scheduledEvent.Input);
                             responseEvent = new TaskCompletedEvent(-1, scheduledEvent.EventId, output);
                         }
-                        catch (Exception e) when (!Utils.IsFatal(e) && !Utils.IsExecutionAborting(e))
+                        catch (Exception e) when (e is not TaskFailureException && !Utils.IsFatal(e) && !Utils.IsExecutionAborting(e))
                         {
+                            // These are unexpected exceptions that occur in the task activity abstraction. Normal exceptions from 
+                            // activities are expected to be translated into TaskFailureException and handled outside the middleware
+                            // context (see further below).
                             TraceHelper.TraceExceptionInstance(TraceEventType.Error, "TaskActivityDispatcher-ProcessException", taskMessage.OrchestrationInstance, e);
                             string? details = this.IncludeDetails
                                 ? $"Unhandled exception while executing task: {e}"

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -524,9 +524,6 @@ namespace DurableTask.Core
                                 await this.orchestrationService.RenewTaskOrchestrationWorkItemLockAsync(workItem);
                             }
 
-                            // REVIEW: This is a behavior change from v2.6.x, where ContinueAsNew went through the Cursor/Resume path.
-                            //         It's not clear if that was ever necessary, or if there are potentially breaking changes if we move
-                            //         away from Cursor/Resume for ContinueAsNew.
                             workItem.Cursor = null;
                         }
 

--- a/src/DurableTask.Core/TaskOrchestrationExecutor.cs
+++ b/src/DurableTask.Core/TaskOrchestrationExecutor.cs
@@ -10,7 +10,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
-
+#nullable enable
 namespace DurableTask.Core
 {
     using System;
@@ -20,20 +20,28 @@ namespace DurableTask.Core
     using System.Runtime.ExceptionServices;
     using System.Threading;
     using System.Threading.Tasks;
-    using DurableTask.Core.Command;
     using DurableTask.Core.Common;
     using DurableTask.Core.Exceptions;
     using DurableTask.Core.History;
 
-    internal class TaskOrchestrationExecutor
+    /// <summary>
+    /// Utility for executing task orchestrators.
+    /// </summary>
+    public class TaskOrchestrationExecutor
     {
         readonly TaskOrchestrationContext context;
         readonly TaskScheduler decisionScheduler;
         readonly OrchestrationRuntimeState orchestrationRuntimeState;
         readonly TaskOrchestration taskOrchestration;
         readonly bool skipCarryOverEvents;
-        Task<string> result;
+        Task<string>? result;
 
+        /// <summary>
+        /// Initializes a new instances of the <see cref="TaskOrchestrationExecutor"/> class.
+        /// </summary>
+        /// <param name="orchestrationRuntimeState"></param>
+        /// <param name="taskOrchestration"></param>
+        /// <param name="eventBehaviourForContinueAsNew"></param>
         public TaskOrchestrationExecutor(OrchestrationRuntimeState orchestrationRuntimeState,
             TaskOrchestration taskOrchestration, BehaviorOnContinueAsNew eventBehaviourForContinueAsNew)
         {
@@ -44,20 +52,36 @@ namespace DurableTask.Core
             this.skipCarryOverEvents = eventBehaviourForContinueAsNew == BehaviorOnContinueAsNew.Ignore;
         }
 
-        public bool IsCompleted => this.result != null && (this.result.IsCompleted || this.result.IsFaulted);
+        internal bool IsCompleted => this.result != null && (this.result.IsCompleted || this.result.IsFaulted);
 
-        public IEnumerable<OrchestratorAction> Execute()
+        /// <summary>
+        /// Executes an orchestration from the beginning.
+        /// </summary>
+        /// <returns>
+        /// The result of the orchestration execution, including any actions scheduled by the orchestrator.
+        /// </returns>
+        public OrchestratorExecutionResult Execute()
         {
-            return this.ExecuteCore(this.orchestrationRuntimeState.Events);
+            return this.ExecuteCore(
+                pastEvents: this.orchestrationRuntimeState.PastEvents,
+                newEvents: this.orchestrationRuntimeState.NewEvents);
         }
 
-        public IEnumerable<OrchestratorAction> ExecuteNewEvents()
+        /// <summary>
+        /// Resumes an orchestration
+        /// </summary>
+        /// <returns>
+        /// The result of the orchestration execution, including any actions scheduled by the orchestrator.
+        /// </returns>
+        public OrchestratorExecutionResult ExecuteNewEvents()
         {
             this.context.ClearPendingActions();
-            return this.ExecuteCore(this.orchestrationRuntimeState.NewEvents);
+            return this.ExecuteCore(
+                pastEvents: Enumerable.Empty<HistoryEvent>(),
+                newEvents: this.orchestrationRuntimeState.NewEvents);
         }
 
-        IEnumerable<OrchestratorAction> ExecuteCore(IEnumerable<HistoryEvent> eventHistory)
+        OrchestratorExecutionResult ExecuteCore(IEnumerable<HistoryEvent> pastEvents, IEnumerable<HistoryEvent> newEvents)
         {
             SynchronizationContext prevCtx = SynchronizationContext.Current;
 
@@ -69,28 +93,41 @@ namespace DurableTask.Core
 
                 try
                 {
-                    foreach (HistoryEvent historyEvent in eventHistory)
+                    void ProcessEvents(IEnumerable<HistoryEvent> events)
                     {
-                        if (historyEvent.EventType == EventType.OrchestratorStarted)
+                        foreach (HistoryEvent historyEvent in events)
                         {
-                            var decisionStartedEvent = (OrchestratorStartedEvent)historyEvent;
-                            this.context.CurrentUtcDateTime = decisionStartedEvent.Timestamp;
-                            continue;
-                        }
+                            if (historyEvent.EventType == EventType.OrchestratorStarted)
+                            {
+                                var decisionStartedEvent = (OrchestratorStartedEvent)historyEvent;
+                                this.context.CurrentUtcDateTime = decisionStartedEvent.Timestamp;
+                                continue;
+                            }
 
-                        this.context.IsReplaying = historyEvent.IsPlayed;
-                        this.ProcessEvent(historyEvent);
-                        historyEvent.IsPlayed = true;
+                            this.ProcessEvent(historyEvent);
+                        }
                     }
 
+                    // Replay the old history to rebuild the local state of the orchestration.
+                    // TODO: Log a verbose message indicating that the replay has started (include event count?)
+                    this.context.IsReplaying = true;
+                    ProcessEvents(pastEvents);
+
+                    // Play the newly arrived events to determine the next action to take.
+                    // TODO: Log a verbose message indicating that new events are being processed (include event count?)
+                    this.context.IsReplaying = false;
+                    ProcessEvents(newEvents);
+
                     // check if workflow is completed after this replay
+                    // TODO: Create a setting that allows orchestrations to complete when the orchestrator
+                    //       function completes, even if there are open tasks.
                     if (!this.context.HasOpenTasks)
                     {
-                        if (this.result.IsCompleted)
+                        if (this.result!.IsCompleted)
                         {
                             if (this.result.IsFaulted)
                             {
-                                Exception exception = this.result.Exception?.InnerExceptions.FirstOrDefault();
+                                Exception? exception = this.result.Exception?.InnerExceptions.FirstOrDefault();
                                 Debug.Assert(exception != null);
 
                                 if (Utils.IsExecutionAborting(exception))
@@ -116,11 +153,14 @@ namespace DurableTask.Core
                     this.context.FailOrchestration(exception);
                 }
 
-                return this.context.OrchestratorActions;
+                return new OrchestratorExecutionResult
+                {
+                    Actions = this.context.OrchestratorActions,
+                    CustomStatus = this.taskOrchestration.GetStatus(),
+                };
             }
             finally
             {
-                this.orchestrationRuntimeState.Status = this.taskOrchestration.GetStatus();
                 SynchronizationContext.SetSynchronizationContext(prevCtx);
                 OrchestrationContext.IsOrchestratorThread = false;
             }

--- a/src/DurableTask.Core/TaskOrchestrationExecutor.cs
+++ b/src/DurableTask.Core/TaskOrchestrationExecutor.cs
@@ -105,6 +105,7 @@ namespace DurableTask.Core
                             }
 
                             this.ProcessEvent(historyEvent);
+                            historyEvent.IsPlayed = true;
                         }
                     }
 

--- a/src/DurableTask.Core/TaskOrchestrationExecutor.cs
+++ b/src/DurableTask.Core/TaskOrchestrationExecutor.cs
@@ -37,7 +37,7 @@ namespace DurableTask.Core
         Task<string>? result;
 
         /// <summary>
-        /// Initializes a new instances of the <see cref="TaskOrchestrationExecutor"/> class.
+        /// Initializes a new instance of the <see cref="TaskOrchestrationExecutor"/> class.
         /// </summary>
         /// <param name="orchestrationRuntimeState"></param>
         /// <param name="taskOrchestration"></param>

--- a/test/DurableTask.AzureStorage.Tests/DataContractJsonConverterTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/DataContractJsonConverterTests.cs
@@ -94,6 +94,7 @@ namespace DurableTask.AzureStorage.Tests
             Assert.AreEqual(expected.GetType(), actual.GetType());
             Assert.AreEqual(expected.EventId, actual.EventId);
             Assert.AreEqual(expected.EventType, actual.EventType);
+            Assert.AreEqual(expected.IsPlayed, actual.IsPlayed);
             Assert.AreEqual(expected.Timestamp, actual.Timestamp);
             Assert.IsNotNull(actual.ExtensionData);
         }

--- a/test/DurableTask.AzureStorage.Tests/DataContractJsonConverterTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/DataContractJsonConverterTests.cs
@@ -94,7 +94,6 @@ namespace DurableTask.AzureStorage.Tests
             Assert.AreEqual(expected.GetType(), actual.GetType());
             Assert.AreEqual(expected.EventId, actual.EventId);
             Assert.AreEqual(expected.EventType, actual.EventType);
-            Assert.AreEqual(expected.IsPlayed, actual.IsPlayed);
             Assert.AreEqual(expected.Timestamp, actual.Timestamp);
             Assert.IsNotNull(actual.ExtensionData);
         }

--- a/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj
+++ b/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
@@ -13,7 +13,7 @@
     <PackageReference Include="Newtonsoft.Json" version="7.0.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer.NetCore" Version="2.0.1406.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />

--- a/test/DurableTask.Redis.Tests/DurableTask.Redis.Tests.csproj
+++ b/test/DurableTask.Redis.Tests/DurableTask.Redis.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/DurableTask.ServiceBus.Tests/DurableTask.ServiceBus.Tests.csproj
+++ b/test/DurableTask.ServiceBus.Tests/DurableTask.ServiceBus.Tests.csproj
@@ -2,7 +2,7 @@
 
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+		<TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
 	</PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
@@ -24,7 +24,7 @@
     <PackageReference Include="WindowsAzure.Storage" version="7.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
@@ -54,7 +54,7 @@
     <Reference Include="System.Configuration" />
   </ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
 	  <None Update="testhost.dll.config">
 	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </None>

--- a/test/DurableTask.SqlServer.Tests/DurableTask.SqlServer.Tests.csproj
+++ b/test/DurableTask.SqlServer.Tests/DurableTask.SqlServer.Tests.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/DurableTask.Stress.Tests/DurableTask.Stress.Tests.csproj
+++ b/test/DurableTask.Stress.Tests/DurableTask.Stress.Tests.csproj
@@ -2,22 +2,22 @@
 
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
 	<PropertyGroup>
-	  <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+	  <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
 	  <StartupObject>DurableTask.Stress.Tests.Program</StartupObject>
 	  <ApplicationIcon />
 	  <OutputType>Exe</OutputType>
 	</PropertyGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
 	  <None Remove="eventFlowConfig.json" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
 	  <Content Include="eventFlowConfig.json">
 	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </Content>
 	</ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
 	  <PackageReference Include="CommandLineParser" Version="2.4.3" />
 	  <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
 	  <PackageReference Include="Microsoft.Diagnostics.EventFlow.Core" Version="1.5.6" />
@@ -49,7 +49,7 @@
 		<ProjectReference Include="..\DurableTask.Test.Orchestrations\DurableTask.Test.Orchestrations.csproj" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
 	  <None Update="DurableTask.Stress.Tests.dll.config">
 	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </None>

--- a/test/DurableTask.Stress.Tests/Options.cs
+++ b/test/DurableTask.Stress.Tests/Options.cs
@@ -18,7 +18,7 @@ namespace DurableTask.Stress.Tests
 
     internal class Options
     {
-#if NETCOREAPP2_1
+#if NETCOREAPP
         [Option('c', "create-hub", Default = false,
             HelpText = "Create Orchestration Hub.")]
         public bool CreateHub { get; set; }

--- a/test/DurableTask.Stress.Tests/Program.cs
+++ b/test/DurableTask.Stress.Tests/Program.cs
@@ -11,7 +11,7 @@
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
 
-#if NETCOREAPP2_1
+#if NETCOREAPP
 [assembly: System.Runtime.InteropServices.ComVisible(false)]
 
 namespace DurableTask.Stress.Tests

--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -5,7 +5,7 @@
     <DebugType Condition="'$(Configuration)'=='Release'">pdbonly</DebugType>
     <DebugSymbols>True</DebugSymbols>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <!-- See https://github.com/Azure/durabletask/issues/428 -->
     <NoWarn>NU5125,NU5048</NoWarn>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>


### PR DESCRIPTION
This PR introduces changes to the DT.Core middleware implementation to enable injecting a custom orchestration processor. **See the new unit tests for a primitive example of how this works.** The intent is to leverage this for out-of-process execution of orchestrations in Durable Functions and elsewhere.

Part of the change requires a stronger decoupling of the orchestration executor from the dispatcher layer. In particular, two important changes were made:

- Removed usage of the `IsPlayed` property. This value was set in the executor, which is not a change that could be persisted across process boundaries. For that reason, I've decoupled event history into PastEvents and NewEvents as a way to distinguished "played" and "not-yet-played" history events.
- Similarly, custom status is now being saved in the dispatcher layer instead of in the executor layer.

In order to implement .NET-based out-of-process handlers, several internal types were made public.