### PR TITLE
Updated Out of Order message checks to include call entity results

### DIFF
--- a/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
+++ b/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
@@ -136,7 +136,8 @@ namespace DurableTask.AzureStorage.Messaging
                 message.TaskMessage.Event.EventType != EventType.TaskFailed &&
                 message.TaskMessage.Event.EventType != EventType.SubOrchestrationInstanceCompleted &&
                 message.TaskMessage.Event.EventType != EventType.SubOrchestrationInstanceFailed &&
-                message.TaskMessage.Event.EventType != EventType.TimerFired)
+                message.TaskMessage.Event.EventType != EventType.TimerFired &&
+                !(message.TaskMessage.Event.EventType == EventType.EventRaised && message.Sender.InstanceId.StartsWith("@")))
             {
                 // The above message types are the only ones that can potentially be considered out-of-order.
                 return false;


### PR DESCRIPTION
Currently, if an EventRaised is returned from a CallEntityAsync call before the orchestrator writes itself in history the message will be discarded and the orchestrator will be stuck.

This change updates our Out of Order message checks to allow EventRaised events to be considered Out of Order messages when the message came from an Entity.