### PR TITLE
Updating System.Diagnostics.DiagnosticSource version

### DIFF
--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
     <PackageReference Include="System.Reactive.Core" Version="4.4.1" />
     <PackageReference Include="System.Reactive.Compatibility" Version="4.4.1" />
   </ItemGroup>


### PR DESCRIPTION
This PR updates the System.Diagnostics.DiagnosticSource package from 4.6.0 to 5.0.1.

Note: Updating the package to the latest version (v6.0.0) shows many errors in the test projects.

Resolves #602 