### PR TITLE
Fix retry interceptor regression

### DIFF
--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -5,7 +5,7 @@
     <DebugType Condition="'$(Configuration)'=='Release'">pdbonly</DebugType>
     <DebugSymbols>True</DebugSymbols>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <!-- See https://github.com/Azure/durabletask/issues/428 -->
     <NoWarn>NU5125,NU5048</NoWarn>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>


### PR DESCRIPTION
PR https://github.com/Azure/durabletask/pull/652 introduced a breaking change in history replay by removing a timer from the history when a retry policy executes all retries. The fix was "correct", but it was a breaking change for existing orchestration instances. This PR re-introduces the removed timer to fix the breaking change but sets the final timer delay to zero seconds to mitigate the impact of scheduling an extra timer.

This PR also updates the C# version to 9.0 in order to allow nullable generic type references.