### PR TITLE
Updated Queue TTL to infinite

### DIFF
--- a/src/DurableTask.AzureStorage/Storage/Queue.cs
+++ b/src/DurableTask.AzureStorage/Storage/Queue.cs
@@ -45,10 +45,16 @@ namespace DurableTask.AzureStorage.Storage
 
         public async Task AddMessageAsync(QueueMessage queueMessage, TimeSpan? visibilityDelay, Guid? clientRequestId = null)
         {
+            // Infinite time to live
+            TimeSpan? timeToLive = TimeSpan.FromSeconds(-1);
+#if NET461
+            // When using net461 SDK version WindowsAzure.Storage 7.2.1 does not allow infinite time to live. Passing in null will default the time to live to 7 days.
+            timeToLive = null;
+#endif
             await this.azureStorageClient.MakeStorageRequest(
                 (context, cancellationToken) => this.cloudQueue.AddMessageAsync(
                     queueMessage.CloudQueueMessage,
-                    TimeSpan.FromSeconds(-1) /* disable TTL */,
+                    timeToLive,
                     visibilityDelay,
                     null,
                     context),

--- a/src/DurableTask.AzureStorage/Storage/Queue.cs
+++ b/src/DurableTask.AzureStorage/Storage/Queue.cs
@@ -48,7 +48,7 @@ namespace DurableTask.AzureStorage.Storage
             await this.azureStorageClient.MakeStorageRequest(
                 (context, cancellationToken) => this.cloudQueue.AddMessageAsync(
                     queueMessage.CloudQueueMessage,
-                    TimeSpan.FromSeconds(-1) /* timeToLive */,
+                    TimeSpan.FromSeconds(-1) /* disable TTL */,
                     visibilityDelay,
                     null,
                     context),

--- a/src/DurableTask.AzureStorage/Storage/Queue.cs
+++ b/src/DurableTask.AzureStorage/Storage/Queue.cs
@@ -48,7 +48,7 @@ namespace DurableTask.AzureStorage.Storage
             await this.azureStorageClient.MakeStorageRequest(
                 (context, cancellationToken) => this.cloudQueue.AddMessageAsync(
                     queueMessage.CloudQueueMessage,
-                    null /* timeToLive */,
+                    TimeSpan.FromSeconds(-1) /* timeToLive */,
                     visibilityDelay,
                     null,
                     context),


### PR DESCRIPTION
Updated queue time to live to infinite to avoid messages from being deleted after 7 days resulting in stuck orchestrations.

resolves #660 