### PR TITLE
Update packages to address CVE-2018-8269

### DIFF
--- a/samples/DurableTask.Samples/DurableTask.Samples.csproj
+++ b/samples/DurableTask.Samples/DurableTask.Samples.csproj
@@ -10,13 +10,13 @@
     <PackageReference Include="CommandLineParser" version="1.9.71" />
     <PackageReference Include="EnterpriseLibrary.SemanticLogging" Version="2.0.1406.1" />
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" version="1.0.0" />
-    <PackageReference Include="Microsoft.Data.Edm" version="5.6.4" />
-    <PackageReference Include="Microsoft.Data.OData" version="5.6.4" />
-    <PackageReference Include="Microsoft.Data.Services.Client" version="5.6.4" />
+    <PackageReference Include="Microsoft.Data.Edm" version="5.8.5" />
+    <PackageReference Include="Microsoft.Data.OData" version="5.8.5" />
+    <PackageReference Include="Microsoft.Data.Services.Client" version="5.8.5" />
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" />
     <PackageReference Include="ncrontab" version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" version="11.0.2" />
-    <PackageReference Include="System.Spatial" version="5.6.4" />
+    <PackageReference Include="System.Spatial" version="5.8.5" />
     <PackageReference Include="WindowsAzure.Storage" version="9.3.3" />
   </ItemGroup>
 

--- a/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
+++ b/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
@@ -9,12 +9,12 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="ImpromptuInterface" version="6.2.2" />
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" version="1.0.0" />
-    <PackageReference Include="Microsoft.Data.Edm" version="5.6.4" />
-    <PackageReference Include="Microsoft.Data.OData" version="5.6.4" />
-    <PackageReference Include="Microsoft.Data.Services.Client" version="5.6.4" />
+    <PackageReference Include="Microsoft.Data.Edm" version="5.8.5" />
+    <PackageReference Include="Microsoft.Data.OData" version="5.8.5" />
+    <PackageReference Include="Microsoft.Data.Services.Client" version="5.8.5" />
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" />
     <PackageReference Include="Newtonsoft.Json" version="7.0.1" />
-    <PackageReference Include="System.Spatial" version="5.6.4" />
+    <PackageReference Include="System.Spatial" version="5.8.5" />
     <PackageReference Include="WindowsAzure.ServiceBus" version="4.1.3" />
     <PackageReference Include="WindowsAzure.Storage" version="7.0.0" />
     <Reference Include="System.Transactions" />

--- a/test/DurableTask.ServiceBus.Tests/DurableTask.ServiceBus.Tests.csproj
+++ b/test/DurableTask.ServiceBus.Tests/DurableTask.ServiceBus.Tests.csproj
@@ -10,16 +10,16 @@
     <PackageReference Include="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" />
     <PackageReference Include="ImpromptuInterface" version="6.2.2" />
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" version="1.0.0" />
-    <PackageReference Include="Microsoft.Data.Edm" version="5.6.4" />
-    <PackageReference Include="Microsoft.Data.OData" version="5.6.4" />
-    <PackageReference Include="Microsoft.Data.Services.Client" version="5.6.4" />
+    <PackageReference Include="Microsoft.Data.Edm" version="5.8.5" />
+    <PackageReference Include="Microsoft.Data.OData" version="5.8.5" />
+    <PackageReference Include="Microsoft.Data.Services.Client" version="5.8.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Microsoft.Tpl.Dataflow" version="4.5.24" />
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="Newtonsoft.Json" version="7.0.1" />
-    <PackageReference Include="System.Spatial" version="5.6.4" />
+    <PackageReference Include="System.Spatial" version="5.8.5" />
     <PackageReference Include="WindowsAzure.ServiceBus" version="4.1.3" />
     <PackageReference Include="WindowsAzure.Storage" version="7.0.0" />
   </ItemGroup>

--- a/test/DurableTask.Stress.Tests/DurableTask.Stress.Tests.csproj
+++ b/test/DurableTask.Stress.Tests/DurableTask.Stress.Tests.csproj
@@ -33,12 +33,12 @@
     <PackageReference Include="EnterpriseLibrary.SemanticLogging.TextFile" version="2.0.1406.1" />
     <PackageReference Include="ImpromptuInterface" version="6.2.2" />
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" version="1.0.0" />
-    <PackageReference Include="Microsoft.Data.Edm" version="5.6.4" />
-    <PackageReference Include="Microsoft.Data.OData" version="5.6.4" />
-    <PackageReference Include="Microsoft.Data.Services.Client" version="5.6.4" />
+    <PackageReference Include="Microsoft.Data.Edm" version="5.8.5" />
+    <PackageReference Include="Microsoft.Data.OData" version="5.8.5" />
+    <PackageReference Include="Microsoft.Data.Services.Client" version="5.8.5" />
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" />
     <PackageReference Include="Newtonsoft.Json" version="7.0.1" />
-    <PackageReference Include="System.Spatial" version="5.6.4" />
+    <PackageReference Include="System.Spatial" version="5.8.5" />
     <PackageReference Include="WindowsAzure.ServiceBus" version="4.1.3" />
     <PackageReference Include="WindowsAzure.Storage" version="7.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Fixes [CVE-2018-8269](https://github.com/advisories/GHSA-mv2r-q4g5-j8q5)

Upgrades Microsoft.Data.OData from v5.6.4 to v5.8.5 (latest version) and other packages that depend on Microsoft.Data.OData:
- System.Spatial
- Microsoft.Data.Edm
- Microsoft.Data.Services.Client

Verified that there were no vulnerabilities after these changes by running `dotnet list package --vulnerable`