### PR TITLE
Adding external events tracing

### DIFF
--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -696,6 +696,8 @@ namespace DurableTask.Core
             EventRaisedEvent eventRaisedEvent = new EventRaisedEvent(-1, serializedInput) { Name = eventName };
             eventRaisedEvent.SetParentTraceContext(Activity.Current);
 
+            using Activity traceActivity = TraceHelper.CreateActivityForNewEventRaised(eventRaisedEvent, orchestrationInstance);
+
             var taskMessage = new TaskMessage
             {
                 OrchestrationInstance = orchestrationInstance,

--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -694,8 +694,6 @@ namespace DurableTask.Core
             
             // Distributed Tracing
             EventRaisedEvent eventRaisedEvent = new EventRaisedEvent(-1, serializedInput) { Name = eventName };
-            eventRaisedEvent.SetParentTraceContext(Activity.Current);
-
             using Activity traceActivity = TraceHelper.CreateActivityForNewEventRaised(eventRaisedEvent, orchestrationInstance);
 
             var taskMessage = new TaskMessage

--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -694,7 +694,7 @@ namespace DurableTask.Core
             
             // Distributed Tracing
             EventRaisedEvent eventRaisedEvent = new EventRaisedEvent(-1, serializedInput) { Name = eventName };
-            using Activity traceActivity = TraceHelper.CreateActivityForNewEventRaised(eventRaisedEvent, orchestrationInstance);
+            eventRaisedEvent.SetParentTraceContext(Activity.Current);
 
             var taskMessage = new TaskMessage
             {
@@ -703,8 +703,7 @@ namespace DurableTask.Core
             };
 
             this.logHelper.RaisingEvent(orchestrationInstance, (EventRaisedEvent)taskMessage.Event);
-            traceActivity?.Stop();
-
+            
             await this.ServiceClient.SendTaskOrchestrationMessageAsync(taskMessage);
         }
 

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -152,11 +152,9 @@ namespace DurableTask.Core.Tracing
                 parentContext: activityContext,
                 tags: new KeyValuePair<string, object?>[]
                 {
-                    new("dt.type", "external event"),
+                    new("dt.type", "externalevent"),
                     new("dt.instanceid", instance.InstanceId),
-                    new("dt.executionid", instance.ExecutionId),
-                    new("dt.taskid", eventRaisedEvent.EventId),
-                    new("dt.input", eventRaisedEvent.Input)
+                    new("dt.executionid", instance.ExecutionId)
                 });
         }
 

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -121,7 +121,7 @@ namespace DurableTask.Core.Tracing
                 parentContext: Activity.Current?.Context ?? default,
                 tags: new KeyValuePair<string, object?>[]
                 {
-                    new("dt.type", "external event"),
+                    new("dt.type", "externalevent"),
                     new("dt.instanceid", instance.InstanceId),
                     new("dt.executionid", instance.ExecutionId),
                 });

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -147,8 +147,8 @@ namespace DurableTask.Core.Tracing
             }
 
             return ActivityTraceSource.StartActivity(
-                name: $"{eventRaisedEvent.Name} (#{eventRaisedEvent.EventId})",
-                kind: ActivityKind.Consumer,
+                name: $"{eventRaisedEvent.Name}",
+                kind: ActivityKind.Producer,
                 parentContext: activityContext,
                 tags: new KeyValuePair<string, object?>[]
                 {

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -147,7 +147,7 @@ namespace DurableTask.Core.Tracing
             }
 
             return ActivityTraceSource.StartActivity(
-                name: $"{eventRaisedEvent.Name}",
+                name: eventRaisedEvent.Name,
                 kind: ActivityKind.Producer,
                 parentContext: activityContext,
                 tags: new KeyValuePair<string, object?>[]


### PR DESCRIPTION
This PR adds distributed tracing for external events and builds on PR #648.

There are 2 main scenarios that this PR covers for External Events;
1. An event is raised using `OrchestrationContext` by calling `context.SendEvent()`
2. An event is raised using `TaskHubClient` by calling `client.RaiseEventAsync()`

Resolves #563 
