### PR TITLE
Allow Implicit (and Multiple) Azure Storage Accounts for Services

### DIFF
--- a/Test/DurableTask.AzureStorage.Tests/Storage/StorageUriExtensionsTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/Storage/StorageUriExtensionsTests.cs
@@ -1,0 +1,38 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureStorage.Tests.Storage
+{
+    using System;
+    using DurableTask.AzureStorage.Storage;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Microsoft.WindowsAzure.Storage;
+
+    [TestClass]
+    public class StorageUriExtensionsTests
+    {
+        [TestMethod]
+        [DataRow("https://foo.blob.core.windows.net", "foo")]
+        [DataRow("https://bar.queue.unit.test", "bar")]
+        [DataRow("https://baz.table", "baz")]
+        [DataRow("https://dev.file.core.windows.net", "dev")]
+        [DataRow("https://dev.unknown.core.windows.net", "dev.unknown.core.windows.net")]
+        [DataRow("http://127.0.0.1:10000/devstoreaccount1", "devstoreaccount1")]
+        [DataRow("http://[::1]/devstoreaccount1", "devstoreaccount1")]
+        [DataRow("http://unit.test/custom/uri", "unit.test/custom/uri")]
+        public void GetAccountName(string uri, string accountName)
+        {
+            Assert.AreEqual(accountName, new StorageUri(new Uri(uri, UriKind.Absolute)).GetAccountName());
+        }
+    }
+}

--- a/Test/DurableTask.AzureStorage.Tests/Storage/StorageUriExtensionsTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/Storage/StorageUriExtensionsTests.cs
@@ -22,17 +22,16 @@ namespace DurableTask.AzureStorage.Tests.Storage
     public class StorageUriExtensionsTests
     {
         [TestMethod]
-        [DataRow("https://foo.blob.core.windows.net", "foo")]
-        [DataRow("https://bar.queue.unit.test", "bar")]
-        [DataRow("https://baz.table", "baz")]
-        [DataRow("https://dev.file.core.windows.net", "dev")]
-        [DataRow("https://dev.unknown.core.windows.net", "dev.unknown.core.windows.net")]
-        [DataRow("http://127.0.0.1:10000/devstoreaccount1", "devstoreaccount1")]
-        [DataRow("http://[::1]/devstoreaccount1", "devstoreaccount1")]
-        [DataRow("http://unit.test/custom/uri", "unit.test/custom/uri")]
-        public void GetAccountName(string uri, string accountName)
-        {
-            Assert.AreEqual(accountName, new StorageUri(new Uri(uri, UriKind.Absolute)).GetAccountName());
-        }
+        [DataRow("https://foo.blob.core.windows.net", "blob", "foo")]
+        [DataRow("https://bar.queue.unit.test", "queue", "bar")]
+        [DataRow("https://baz.table", "table", "baz")]
+        [DataRow("https://dev.account.file.core.windows.net", "file", "dev")]
+        [DataRow("https://dev.unknown.core.windows.net", "blob", null)]
+        [DataRow("https://host/path", "blob", null)]
+        [DataRow("http://127.0.0.1:10000/devstoreaccount1", "file", "devstoreaccount1")]
+        [DataRow("http://host:10102/devstoreaccount2/more", "blob", "devstoreaccount2")]
+        [DataRow("http://unit.test/custom/uri", "queue", null)]
+        public void GetAccountName(string uri, string service, string accountName) =>
+            Assert.AreEqual(accountName, new StorageUri(new Uri(uri, UriKind.Absolute)).GetAccountName(service));
     }
 }

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -52,7 +52,6 @@ namespace DurableTask.AzureStorage
         readonly AzureStorageClient azureStorageClient;
         readonly AzureStorageOrchestrationServiceSettings settings;
         readonly AzureStorageOrchestrationServiceStats stats;
-        readonly string storageAccountName;
         readonly ConcurrentDictionary<string, ControlQueue> allControlQueues;
         readonly WorkItemQueue workItemQueue;
         readonly ConcurrentDictionary<string, ActivitySession> activeActivitySessions;
@@ -82,7 +81,13 @@ namespace DurableTask.AzureStorage
         /// <inheritdoc/>
         public override string ToString()
         {
-            return $"AzureStorageOrchestrationService on {storageAccountName}";
+            string blobAccountName = this.azureStorageClient.BlobAccountName;
+            string queueAccountName = this.azureStorageClient.QueueAccountName;
+            string tableAccountName = this.azureStorageClient.TableAccountName;
+
+            return blobAccountName == queueAccountName && blobAccountName == tableAccountName
+                ? $"AzureStorageOrchestrationService on {blobAccountName}"
+                : $"AzureStorageOrchestrationService on {blobAccountName} for blobs, {queueAccountName} for queues, and {tableAccountName} for tables";
         }
 
         /// <summary>
@@ -102,8 +107,6 @@ namespace DurableTask.AzureStorage
             this.settings = settings;
 
             this.azureStorageClient = new AzureStorageClient(settings);
-
-            this.storageAccountName = this.azureStorageClient.StorageAccountName;
             this.stats = this.azureStorageClient.Stats;
 
             string compressedMessageBlobContainerName = $"{settings.TaskHubName.ToLowerInvariant()}-largemessages";
@@ -141,7 +144,7 @@ namespace DurableTask.AzureStorage
                 "default");
 
             this.orchestrationSessionManager = new OrchestrationSessionManager(
-                this.storageAccountName,
+                this.azureStorageClient.QueueAccountName,
                 this.settings,
                 this.stats,
                 this.trackingStore);
@@ -284,7 +287,7 @@ namespace DurableTask.AzureStorage
             catch (Exception e)
             {
                 this.settings.Logger.GeneralError(
-                    this.storageAccountName,
+                    this.azureStorageClient.QueueAccountName,
                     this.settings.TaskHubName,
                     $"Failed to create the task hub: {e}");
 
@@ -429,7 +432,7 @@ namespace DurableTask.AzureStorage
                 catch (Exception e)
                 {
                     this.settings.Logger.GeneralError(
-                        this.storageAccountName,
+                        this.azureStorageClient.QueueAccountName,
                         this.settings.TaskHubName,
                         $"Unexpected error in {nameof(ReportStatsLoop)}: {e}");
                 }
@@ -456,7 +459,7 @@ namespace DurableTask.AzureStorage
                 out int activeOrchestrationSessions);
 
             this.settings.Logger.OrchestrationServiceStats(
-                this.storageAccountName,
+                this.azureStorageClient.QueueAccountName,
                 this.settings.TaskHubName,
                 storageRequests,
                 messagesSent,
@@ -592,7 +595,7 @@ namespace DurableTask.AzureStorage
                             // orchestration that has not yet checkpointed its history. We abandon such messages
                             // so that they can be reprocessed after the history checkpoint has completed.
                             this.settings.Logger.ReceivedOutOfOrderMessage(
-                                this.storageAccountName,
+                                this.azureStorageClient.QueueAccountName,
                                 this.settings.TaskHubName,
                                 session.Instance.InstanceId,
                                 session.Instance.ExecutionId,
@@ -685,7 +688,7 @@ namespace DurableTask.AzureStorage
                         }
 
                         this.settings.Logger.DiscardingWorkItem(
-                            this.storageAccountName,
+                            this.azureStorageClient.QueueAccountName,
                             this.settings.TaskHubName,
                             session.Instance.InstanceId,
                             session.Instance.ExecutionId,
@@ -715,7 +718,7 @@ namespace DurableTask.AzureStorage
                 catch (Exception e)
                 {
                     this.settings.Logger.OrchestrationProcessingFailure(
-                        this.storageAccountName,
+                        this.azureStorageClient.QueueAccountName,
                         this.settings.TaskHubName,
                         session?.Instance.InstanceId ?? string.Empty,
                         session?.Instance.ExecutionId ?? string.Empty,
@@ -962,7 +965,7 @@ namespace DurableTask.AzureStorage
             if (!this.orchestrationSessionManager.TryGetExistingSession(workItem.InstanceId, out session))
             {
                 this.settings.Logger.AssertFailure(
-                    this.storageAccountName,
+                    this.azureStorageClient.QueueAccountName,
                     this.settings.TaskHubName,
                     $"{nameof(CompleteTaskOrchestrationWorkItemAsync)}: Session for instance {workItem.InstanceId} was not found!");
                 return;
@@ -976,7 +979,7 @@ namespace DurableTask.AzureStorage
             if (executionId == null)
             {
                 this.settings.Logger.GeneralWarning(
-                    this.storageAccountName,
+                    this.azureStorageClient.QueueAccountName,
                     this.settings.TaskHubName,
                     $"{nameof(CompleteTaskOrchestrationWorkItemAsync)}: Could not find execution id.",
                     instanceId: instanceId);
@@ -1055,7 +1058,7 @@ namespace DurableTask.AzureStorage
                     //       It's possible that history updates may have been partially committed at this point.
                     //       If so, what are the implications of this as far as DurableTask.Core are concerned?
                     this.settings.Logger.OrchestrationProcessingFailure(
-                        this.storageAccountName,
+                        this.azureStorageClient.TableAccountName,
                         this.settings.TaskHubName,
                         instanceId,
                         executionId,
@@ -1244,7 +1247,7 @@ namespace DurableTask.AzureStorage
             if (!this.orchestrationSessionManager.TryGetExistingSession(workItem.InstanceId, out session))
             {
                 this.settings.Logger.AssertFailure(
-                    this.storageAccountName,
+                    this.azureStorageClient.QueueAccountName,
                     this.settings.TaskHubName,
                     $"{nameof(RenewTaskOrchestrationWorkItemLockAsync)}: Session for instance {workItem.InstanceId} was not found!");
                 return;
@@ -1269,7 +1272,7 @@ namespace DurableTask.AzureStorage
             if (!this.orchestrationSessionManager.TryGetExistingSession(workItem.InstanceId, out session))
             {
                 this.settings.Logger.AssertFailure(
-                    this.storageAccountName,
+                    this.azureStorageClient.QueueAccountName,
                     this.settings.TaskHubName,
                     $"{nameof(AbandonTaskOrchestrationWorkItemAsync)}: Session for instance {workItem.InstanceId} was not found!");
                 return Utils.CompletedTask;
@@ -1341,7 +1344,7 @@ namespace DurableTask.AzureStorage
 
 
                 Guid traceActivityId = Guid.NewGuid();
-                var session = new ActivitySession(this.settings, this.storageAccountName, message, traceActivityId);
+                var session = new ActivitySession(this.settings, this.azureStorageClient.QueueAccountName, message, traceActivityId);
                 session.StartNewLogicalTraceScope();
 
                 // correlation 
@@ -1356,7 +1359,7 @@ namespace DurableTask.AzureStorage
                         requestTraceContext.SetParentAndStart(parentTraceContextBase);
                     });
 
-                TraceMessageReceived(this.settings, session.MessageData, this.storageAccountName);
+                TraceMessageReceived(this.settings, session.MessageData, this.azureStorageClient.QueueAccountName);
                 session.TraceProcessingMessage(message, isExtendedSession: false);
 
                 if (!this.activeActivitySessions.TryAdd(message.Id, session))
@@ -1364,7 +1367,7 @@ namespace DurableTask.AzureStorage
                     // This means we're already processing this message. This is never expected since the message
                     // should be kept invisible via background calls to RenewTaskActivityWorkItemLockAsync.
                     this.settings.Logger.AssertFailure(
-                        this.storageAccountName,
+                        this.azureStorageClient.QueueAccountName,
                         this.settings.TaskHubName,
                         $"Work item queue message with ID = {message.Id} is being processed multiple times concurrently.");
                     return null;
@@ -1391,7 +1394,7 @@ namespace DurableTask.AzureStorage
             {
                 // The context does not exist - possibly because it was already removed.
                 this.settings.Logger.AssertFailure(
-                    this.storageAccountName,
+                    this.azureStorageClient.QueueAccountName,
                     this.settings.TaskHubName,
                     $"Could not find context for work item with ID = {workItem.Id}.");
                 return;
@@ -1459,7 +1462,7 @@ namespace DurableTask.AzureStorage
             {
                 // The context does not exist - possibly because it was already removed.
                 this.settings.Logger.AssertFailure(
-                    this.storageAccountName,
+                    this.azureStorageClient.QueueAccountName,
                     this.settings.TaskHubName,
                     $"Could not find context for work item with ID = {workItem.Id}.");
                 return;

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <FileVersion>1.10.2</FileVersion>
+    <FileVersion>1.10.1</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <Version>$(FileVersion)</Version>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <FileVersion>1.10.1</FileVersion>
+    <FileVersion>1.10.2</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <Version>$(FileVersion)</Version>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -41,7 +41,7 @@ namespace DurableTask.AzureStorage.Messaging
         {
             this.azureStorageClient = azureStorageClient;
             this.messageManager = messageManager;
-            this.storageAccountName = azureStorageClient.StorageAccountName;
+            this.storageAccountName = azureStorageClient.QueueAccountName;
             this.settings = azureStorageClient.Settings;
 
 

--- a/src/DurableTask.AzureStorage/Monitoring/DisconnectedPerformanceMonitor.cs
+++ b/src/DurableTask.AzureStorage/Monitoring/DisconnectedPerformanceMonitor.cs
@@ -175,7 +175,7 @@ namespace DurableTask.AzureStorage.Monitoring
             {
                 // The queues are not yet provisioned.
                 this.settings.Logger.GeneralWarning(
-                    this.azureStorageClient.StorageAccountName,
+                    this.azureStorageClient.QueueAccountName,
                     this.settings.TaskHubName,
                     $"Task hub has not been provisioned: {e.RequestInformation.ExtendedErrorInformation?.ErrorMessage}");
                 return false;

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -42,12 +42,12 @@ namespace DurableTask.AzureStorage
         readonly DispatchQueue fetchRuntimeStateQueue;
 
         public OrchestrationSessionManager(
-            string storageAccountName,
+            string queueAccountName,
             AzureStorageOrchestrationServiceSettings settings,
             AzureStorageOrchestrationServiceStats stats,
             ITrackingStore trackingStore)
         {
-            this.storageAccountName = storageAccountName;
+            this.storageAccountName = queueAccountName;
             this.settings = settings;
             this.stats = stats;
             this.trackingStore = trackingStore;

--- a/src/DurableTask.AzureStorage/Partitioning/AppLeaseManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/AppLeaseManager.cs
@@ -60,7 +60,7 @@ namespace DurableTask.AzureStorage.Partitioning
             this.appLeaseInfoBlobName = appLeaseInfoBlobName;
             this.options = options;
 
-            this.storageAccountName = this.azureStorageClient.StorageAccountName;
+            this.storageAccountName = this.azureStorageClient.BlobAccountName;
             this.settings = this.azureStorageClient.Settings;
             this.taskHub = settings.TaskHubName;
             this.workerName = settings.WorkerId;

--- a/src/DurableTask.AzureStorage/Partitioning/BlobLeaseManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/BlobLeaseManager.cs
@@ -45,7 +45,7 @@ namespace DurableTask.AzureStorage.Partitioning
         {
             this.azureStorageClient = azureStorageClient;
             this.settings = this.azureStorageClient.Settings;
-            this.storageAccountName = this.azureStorageClient.StorageAccountName;
+            this.storageAccountName = this.azureStorageClient.BlobAccountName;
             this.taskHubName = this.settings.TaskHubName;
             this.workerName = this.settings.WorkerId;
             this.leaseContainerName = leaseContainerName;

--- a/src/DurableTask.AzureStorage/Partitioning/LeaseCollectionBalancer.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/LeaseCollectionBalancer.cs
@@ -47,7 +47,7 @@ namespace DurableTask.AzureStorage.Partitioning
         public LeaseCollectionBalancer(
             string leaseType,
             AzureStorageOrchestrationServiceSettings settings,
-            string accountName,
+            string blobAccountName,
             ILeaseManager<T> leaseManager, 
             LeaseCollectionBalancerOptions options,
             Func<string, bool> shouldAquireLeaseDelegate = null,
@@ -55,7 +55,7 @@ namespace DurableTask.AzureStorage.Partitioning
 
         {
             this.leaseType = leaseType;
-            this.accountName = accountName;
+            this.accountName = blobAccountName;
             this.taskHub = settings.TaskHubName;
             this.workerName = settings.WorkerId;
             this.leaseManager = leaseManager;

--- a/src/DurableTask.AzureStorage/Partitioning/LegacyPartitionManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/LegacyPartitionManager.cs
@@ -43,7 +43,7 @@ namespace DurableTask.AzureStorage.Partitioning
             this.leaseCollectionManager = new LeaseCollectionBalancer<BlobLease>(
                 "default",
                 settings,
-                this.azureStorageClient.StorageAccountName,
+                this.azureStorageClient.BlobAccountName,
                 leaseManager,
                 new LeaseCollectionBalancerOptions
                 {

--- a/src/DurableTask.AzureStorage/Partitioning/SafePartitionManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/SafePartitionManager.cs
@@ -50,7 +50,7 @@ namespace DurableTask.AzureStorage.Partitioning
             this.intentLeaseCollectionManager = new LeaseCollectionBalancer<BlobLease>(
                 "intent",
                 settings,
-                this.azureStorageClient.StorageAccountName,
+                this.azureStorageClient.BlobAccountName,
                 this.intentLeaseManager,
                 new LeaseCollectionBalancerOptions
                 {
@@ -68,7 +68,7 @@ namespace DurableTask.AzureStorage.Partitioning
             this.ownershipLeaseCollectionManager = new LeaseCollectionBalancer<BlobLease>(
                 "ownership",
                 this.settings,
-                this.azureStorageClient.StorageAccountName,
+                this.azureStorageClient.BlobAccountName,
                 this.ownershipLeaseManager,
                 new LeaseCollectionBalancerOptions
                 {

--- a/src/DurableTask.AzureStorage/Storage/AzureStorageClient.cs
+++ b/src/DurableTask.AzureStorage/Storage/AzureStorageClient.cs
@@ -107,13 +107,13 @@ namespace DurableTask.AzureStorage.Storage
         }
 
         public Task<T> MakeBlobStorageRequest<T>(Func<OperationContext, CancellationToken, Task<T>> storageRequest, string operationName, string? clientRequestId = null) =>
-            this.MakeStorageRequest(storageRequest, BlobAccountName, operationName, clientRequestId);
+            this.MakeStorageRequest<T>(storageRequest, BlobAccountName, operationName, clientRequestId);
 
         public Task<T> MakeQueueStorageRequest<T>(Func<OperationContext, CancellationToken, Task<T>> storageRequest, string operationName, string? clientRequestId = null) =>
-            this.MakeStorageRequest(storageRequest, QueueAccountName, operationName, clientRequestId);
+            this.MakeStorageRequest<T>(storageRequest, QueueAccountName, operationName, clientRequestId);
 
         public Task<T> MakeTableStorageRequest<T>(Func<OperationContext, CancellationToken, Task<T>> storageRequest, string operationName, string? clientRequestId = null) =>
-            this.MakeStorageRequest(storageRequest, TableAccountName, operationName, clientRequestId);
+            this.MakeStorageRequest<T>(storageRequest, TableAccountName, operationName, clientRequestId);
 
         public Task MakeBlobStorageRequest(Func<OperationContext, CancellationToken, Task> storageRequest, string operationName, string? clientRequestId = null) =>
             this.MakeStorageRequest(storageRequest, BlobAccountName, operationName, clientRequestId);
@@ -143,7 +143,7 @@ namespace DurableTask.AzureStorage.Storage
         }
 
         private Task MakeStorageRequest(Func<OperationContext, CancellationToken, Task> storageRequest, string accountName, string operationName, string? clientRequestId = null) =>
-            this.MakeStorageRequest((context, cancellationToken) => WrapFunctionWithReturnType(storageRequest, context, cancellationToken), accountName, operationName, clientRequestId);
+            this.MakeStorageRequest<object?>((context, cancellationToken) => WrapFunctionWithReturnType(storageRequest, context, cancellationToken), accountName, operationName, clientRequestId);
 
         private static async Task<object?> WrapFunctionWithReturnType(Func<OperationContext, CancellationToken, Task> storageRequest, OperationContext context, CancellationToken cancellationToken)
         {

--- a/src/DurableTask.AzureStorage/Storage/AzureStorageClient.cs
+++ b/src/DurableTask.AzureStorage/Storage/AzureStorageClient.cs
@@ -152,6 +152,6 @@ namespace DurableTask.AzureStorage.Storage
         }
 
         private static string GetAccountName(StorageCredentials credentials, AzureStorageOrchestrationServiceSettings settings, StorageUri serviceUri, string service) =>
-            credentials.AccountName ?? settings.StorageAccountDetails?.AccountName ?? serviceUri.GetAccountName(service) ?? string.Empty;
+            credentials.AccountName ?? settings.StorageAccountDetails?.AccountName ?? serviceUri.GetAccountName(service) ?? "(unknown)";
     }
 }

--- a/src/DurableTask.AzureStorage/Storage/Blob.cs
+++ b/src/DurableTask.AzureStorage/Storage/Blob.cs
@@ -50,14 +50,14 @@ namespace DurableTask.AzureStorage.Storage
 
         public async Task<bool> ExistsAsync()
         {
-            return await this.azureStorageClient.MakeStorageRequest<bool>(
+            return await this.azureStorageClient.MakeBlobStorageRequest<bool>(
                 (context, cancellationToken) => this.cloudBlockBlob.ExistsAsync(null, context, cancellationToken),
                 "Blob Exists");
         }
 
         public async Task<bool> DeleteIfExistsAsync()
         {
-            return await this.azureStorageClient.MakeStorageRequest<bool>(
+            return await this.azureStorageClient.MakeBlobStorageRequest<bool>(
                 (context, cancellationToken) => this.cloudBlockBlob.DeleteIfExistsAsync(DeleteSnapshotsOption.IncludeSnapshots, null, null, context, cancellationToken),
                 "Blob Delete");
         }
@@ -74,42 +74,42 @@ namespace DurableTask.AzureStorage.Storage
                 accessCondition = AccessCondition.GenerateLeaseCondition(leaseId);
             }
 
-            await this.azureStorageClient.MakeStorageRequest(
+            await this.azureStorageClient.MakeBlobStorageRequest(
                 (context, cancellationToken) => this.cloudBlockBlob.UploadTextAsync(content, null, accessCondition, null, context, cancellationToken),
                 "Blob UploadText");
         }
 
         public async Task UploadFromByteArrayAsync(byte[] buffer, int index, int byteCount)
         {
-            await this.azureStorageClient.MakeStorageRequest(
+            await this.azureStorageClient.MakeBlobStorageRequest(
                 (context, cancellationToken) => this.cloudBlockBlob.UploadFromByteArrayAsync(buffer, index, byteCount, null, null, context, cancellationToken),
                 "Blob UploadFromByeArray");
         }
 
         public async Task<string> DownloadTextAsync()
         {
-            return await this.azureStorageClient.MakeStorageRequest(
+            return await this.azureStorageClient.MakeBlobStorageRequest(
                 (context, cancellationToken) => this.cloudBlockBlob.DownloadTextAsync(null, null, null, context, cancellationToken),
                 "Blob DownloadText");
         }
 
         public async Task DownloadToStreamAsync(MemoryStream target)
         {
-            await this.azureStorageClient.MakeStorageRequest(
+            await this.azureStorageClient.MakeBlobStorageRequest(
                 (context, cancellationToken) => this.cloudBlockBlob.DownloadToStreamAsync(target, null, null, context, cancellationToken),
                 "Blob DownloadToStream");
         }
 
         public async Task FetchAttributesAsync()
         {
-            await this.azureStorageClient.MakeStorageRequest(
+            await this.azureStorageClient.MakeBlobStorageRequest(
                 (context, cancellationToken) => this.cloudBlockBlob.FetchAttributesAsync(null, null, context, cancellationToken),
                 "Blob FetchAttributes");
         }
 
         public async Task<string> AcquireLeaseAsync(TimeSpan leaseInterval, string leaseId)
         {
-            return await this.azureStorageClient.MakeStorageRequest<string>(
+            return await this.azureStorageClient.MakeBlobStorageRequest<string>(
                 (context, cancellationToken) => this.cloudBlockBlob.AcquireLeaseAsync(leaseInterval, leaseId, null, null, context, cancellationToken),
                 "Blob AcquireLease");
         }
@@ -117,7 +117,7 @@ namespace DurableTask.AzureStorage.Storage
 
         public async Task<string> ChangeLeaseAsync(string proposedLeaseId, string currentLeaseId)
         {
-            return await this.azureStorageClient.MakeStorageRequest<string>(
+            return await this.azureStorageClient.MakeBlobStorageRequest<string>(
                 (context, cancellationToken) => this.cloudBlockBlob.ChangeLeaseAsync(proposedLeaseId, accessCondition: AccessCondition.GenerateLeaseCondition(currentLeaseId), null, context, cancellationToken),
                 "Blob ChangeLease");
         }
@@ -125,14 +125,14 @@ namespace DurableTask.AzureStorage.Storage
         public async Task RenewLeaseAsync(string leaseId)
         {
             var requestOptions = new BlobRequestOptions { ServerTimeout = azureStorageClient.Settings.LeaseRenewInterval };
-            await this.azureStorageClient.MakeStorageRequest(
+            await this.azureStorageClient.MakeBlobStorageRequest(
                 (context, cancellationToken) => this.cloudBlockBlob.RenewLeaseAsync(AccessCondition.GenerateLeaseCondition(leaseId), requestOptions, context, cancellationToken),
                 "Blob RenewLease");
         }
 
         public async Task ReleaseLeaseAsync(string leaseId)
         {
-            await this.azureStorageClient.MakeStorageRequest(
+            await this.azureStorageClient.MakeBlobStorageRequest(
                 (context, cancellationToken) => this.cloudBlockBlob.ReleaseLeaseAsync(AccessCondition.GenerateLeaseCondition(leaseId), null, context, cancellationToken),
                 "Blob ReleaseLease");
         }

--- a/src/DurableTask.AzureStorage/Storage/BlobContainer.cs
+++ b/src/DurableTask.AzureStorage/Storage/BlobContainer.cs
@@ -45,14 +45,14 @@ namespace DurableTask.AzureStorage.Storage
 
         public async Task<bool> CreateIfNotExistsAsync()
         {
-            return await this.azureStorageClient.MakeStorageRequest<bool>(
+            return await this.azureStorageClient.MakeBlobStorageRequest<bool>(
                 (context, cancellationToken) => this.cloudBlobContainer.CreateIfNotExistsAsync(BlobContainerPublicAccessType.Off, null, context, cancellationToken),
                 "Create Container");
         }
 
         public async Task<bool> ExistsAsync()
         {
-            return await this.azureStorageClient.MakeStorageRequest<bool>(
+            return await this.azureStorageClient.MakeBlobStorageRequest<bool>(
                 (context, cancellationToken) => this.cloudBlobContainer.ExistsAsync(null, context, cancellationToken),
                 "Container Exists");
         }
@@ -65,7 +65,7 @@ namespace DurableTask.AzureStorage.Storage
                 accessCondition = new AccessCondition() { LeaseId = appLeaseId };
             }
 
-            return await this.azureStorageClient.MakeStorageRequest<bool>(
+            return await this.azureStorageClient.MakeBlobStorageRequest<bool>(
                 (context, cancellationToken) => this.cloudBlobContainer.DeleteIfExistsAsync(accessCondition, null, context, cancellationToken),
                 "Delete Container");
         }
@@ -103,7 +103,7 @@ namespace DurableTask.AzureStorage.Storage
             var blobList = new List<Blob>();
             do
             {
-                BlobResultSegment segment = await this.azureStorageClient.MakeStorageRequest(listBlobsFunction, "ListBlobs");
+                BlobResultSegment segment = await this.azureStorageClient.MakeBlobStorageRequest(listBlobsFunction, "ListBlobs");
 
                 continuationToken = segment.ContinuationToken;
 
@@ -124,14 +124,14 @@ namespace DurableTask.AzureStorage.Storage
         {
             AccessCondition accessCondition = new AccessCondition() { LeaseId = currentLeaseId };
 
-            return await this.azureStorageClient.MakeStorageRequest<string>(
+            return await this.azureStorageClient.MakeBlobStorageRequest<string>(
                 (context, cancellationToken) => this.cloudBlobContainer.ChangeLeaseAsync(proposedLeaseId, accessCondition, null, context, cancellationToken),
                 "Container ChangeLease");
         }
 
         public async Task<string> AcquireLeaseAsync(TimeSpan leaseInterval, string proposedLeaseId)
         {
-            return await this.azureStorageClient.MakeStorageRequest<string>(
+            return await this.azureStorageClient.MakeBlobStorageRequest<string>(
                 (context, cancellationToken) => this.cloudBlobContainer.AcquireLeaseAsync(leaseInterval, proposedLeaseId, null, null, context, cancellationToken),
                 "Container AcquireLease");
         }
@@ -139,7 +139,7 @@ namespace DurableTask.AzureStorage.Storage
         public async Task RenewLeaseAsync(string leaseId)
         {
             AccessCondition accessCondition = new AccessCondition() { LeaseId = leaseId };
-            await this.azureStorageClient.MakeStorageRequest(
+            await this.azureStorageClient.MakeBlobStorageRequest(
                 (context, cancellationToken) => this.cloudBlobContainer.RenewLeaseAsync(accessCondition, null, context, cancellationToken),
                 "Container RenewLease");
         }

--- a/src/DurableTask.AzureStorage/Storage/Queue.cs
+++ b/src/DurableTask.AzureStorage/Storage/Queue.cs
@@ -45,7 +45,7 @@ namespace DurableTask.AzureStorage.Storage
 
         public async Task AddMessageAsync(QueueMessage queueMessage, TimeSpan? visibilityDelay, Guid? clientRequestId = null)
         {
-            await this.azureStorageClient.MakeStorageRequest(
+            await this.azureStorageClient.MakeQueueStorageRequest(
                 (context, cancellationToken) => this.cloudQueue.AddMessageAsync(
                     queueMessage.CloudQueueMessage,
                     null /* timeToLive */,
@@ -60,7 +60,7 @@ namespace DurableTask.AzureStorage.Storage
 
         public async Task UpdateMessageAsync(QueueMessage queueMessage, TimeSpan visibilityTimeout, Guid? clientRequestId = null)
         {
-            await this.azureStorageClient.MakeStorageRequest(
+            await this.azureStorageClient.MakeQueueStorageRequest(
                 (context, cancellationToken) => this.cloudQueue.UpdateMessageAsync(
                     queueMessage.CloudQueueMessage,
                     visibilityTimeout,
@@ -75,7 +75,7 @@ namespace DurableTask.AzureStorage.Storage
 
         public async Task DeleteMessageAsync(QueueMessage queueMessage, Guid? clientRequestId = null)
         {
-            await this.azureStorageClient.MakeStorageRequest(
+            await this.azureStorageClient.MakeQueueStorageRequest(
                 (context, cancellationToken) => this.cloudQueue.DeleteMessageAsync(
                     queueMessage.CloudQueueMessage,
                     null,
@@ -86,7 +86,7 @@ namespace DurableTask.AzureStorage.Storage
 
         public async Task<QueueMessage?> GetMessageAsync(TimeSpan visibilityTimeout, CancellationToken callerCancellationToken)
         {
-            var cloudQueueMessage = await this.azureStorageClient.MakeStorageRequest<CloudQueueMessage>(
+            var cloudQueueMessage = await this.azureStorageClient.MakeQueueStorageRequest<CloudQueueMessage>(
                 async (context, timeoutCancellationToken) =>
                 {
                     using (var finalLinkedCts = CancellationTokenSource.CreateLinkedTokenSource(callerCancellationToken, timeoutCancellationToken))
@@ -111,28 +111,28 @@ namespace DurableTask.AzureStorage.Storage
 
         public async Task<bool> ExistsAsync()
         {
-            return await this.azureStorageClient.MakeStorageRequest<bool>(
+            return await this.azureStorageClient.MakeQueueStorageRequest<bool>(
                 (context, cancellationToken) => this.cloudQueue.ExistsAsync(null, context, cancellationToken),
                 "Queue Exists");
         }
 
         public async Task<bool> CreateIfNotExistsAsync()
         {
-            return await this.azureStorageClient.MakeStorageRequest<bool>(
+            return await this.azureStorageClient.MakeQueueStorageRequest<bool>(
                 (context, cancellationToken) => this.cloudQueue.CreateIfNotExistsAsync(null, context, cancellationToken),
                 "Queue Create");
         }
 
         public async Task<bool> DeleteIfExistsAsync()
         {
-            return await this.azureStorageClient.MakeStorageRequest<bool>(
+            return await this.azureStorageClient.MakeQueueStorageRequest<bool>(
                 (context, cancellationToken) => this.cloudQueue.DeleteIfExistsAsync(null, context, cancellationToken),
                 "Queue Delete");
         }
 
         public async Task<IEnumerable<QueueMessage>> GetMessagesAsync(int batchSize, TimeSpan visibilityTimeout, CancellationToken callerCancellationToken)
         {
-            var cloudQueueMessages = await this.azureStorageClient.MakeStorageRequest<IEnumerable<CloudQueueMessage>>(
+            var cloudQueueMessages = await this.azureStorageClient.MakeQueueStorageRequest<IEnumerable<CloudQueueMessage>>(
                 async (context, timeoutCancellationToken) =>
                 {
                     using (var finalLinkedCts = CancellationTokenSource.CreateLinkedTokenSource(callerCancellationToken, timeoutCancellationToken))
@@ -159,14 +159,14 @@ namespace DurableTask.AzureStorage.Storage
 
         public async Task FetchAttributesAsync()
         {
-            await this.azureStorageClient.MakeStorageRequest(
+            await this.azureStorageClient.MakeQueueStorageRequest(
                 (context, cancellationToken) => this.cloudQueue.FetchAttributesAsync(null, context, cancellationToken),
                 "Queue FetchAttributes");
         }
 
         public async Task<IEnumerable<QueueMessage>> PeekMessagesAsync(int batchSize)
         {
-            var cloudQueueMessages = await this.azureStorageClient.MakeStorageRequest<IEnumerable<CloudQueueMessage>>(
+            var cloudQueueMessages = await this.azureStorageClient.MakeQueueStorageRequest<IEnumerable<CloudQueueMessage>>(
                 (context, cancellationToken) => this.cloudQueue.PeekMessagesAsync(batchSize, null, context, cancellationToken),
                 "Queue PeekMessages");
 

--- a/src/DurableTask.AzureStorage/Storage/StorageUriExtensions.cs
+++ b/src/DurableTask.AzureStorage/Storage/StorageUriExtensions.cs
@@ -14,38 +14,59 @@
 namespace DurableTask.AzureStorage.Storage
 {
     using System;
+    using System.Collections.Generic;
+    using System.Net;
     using Microsoft.WindowsAzure.Storage;
 
     internal static class StorageUriExtensions
     {
-        public static string GetAccountName(this StorageUri storageUri)
+        // Note that much of this class is based on internal logic from the Azure Storage SDK
+        // Ports: https://github.com/Azure/azure-sdk-for-net/blob/c1c61f10b855ccdd97c790d92f26765e99fd15a8/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs#L599
+        // Account Name Parse: https://github.com/Azure/azure-sdk-for-net/blob/4162f6fa2445b2127468b9cfd080f01c9da88eba/sdk/storage/Azure.Storage.Blobs/src/BlobUriBuilder.cs#L166
+        // Utilities: https://github.com/Azure/azure-sdk-for-net/blob/4162f6fa2445b2127468b9cfd080f01c9da88eba/sdk/storage/Azure.Storage.Common/src/Shared/UriExtensions.cs#L16
+
+        private static readonly HashSet<int> SasPorts = new HashSet<int> { 10000, 10001, 10002, 10003, 10004, 10100, 10101, 10102, 10103, 10104, 11000, 11001, 11002, 11003, 11004, 11100, 11101, 11102, 11103, 11104 };
+
+        public static string GetAccountName(this StorageUri storageUri, string service)
         {
             if (storageUri == null)
                 throw new ArgumentNullException(nameof(storageUri));
 
-            Uri serviceUri = storageUri.PrimaryUri;
-            switch (serviceUri.HostNameType)
+            if (service == null)
+                throw new ArgumentNullException(nameof(service));
+
+            // Note that the primary and secondary endpoints must share the same resource
+            Uri uri = storageUri.PrimaryUri;
+
+            if (IsHostIPEndPointStyle(uri))
             {
-                case UriHostNameType.Dns:
-                    // Typically, Azure Storage Service URIs are formatted as <protocol>://<account>.<service>.<suffix>
-                    // Note that primary and secondary endpoints must share the same resource
-                    string[] segments = serviceUri.Host.Split('.');
-                    if (segments.Length >= 2 && IsStorageService(segments[1]))
-                        return segments[0];
-                    break;
-                case UriHostNameType.IPv4:
-                case UriHostNameType.IPv6:
-                    // In other scenarios, like for Azurite, the service URI looks like <protocol>://<host>:<port>/<account>
-                    return serviceUri.GetComponents(UriComponents.Path, UriFormat.Unescaped);
+                // In some scenarios, like for Azurite, the service URI looks like <protocol>://<host>:<port>/<account>
+                string path = GetPath(uri);
+                int accountEndIndex = path.IndexOf("/", StringComparison.InvariantCulture);
+                return accountEndIndex == -1 ? path : path.Substring(0, accountEndIndex);
             }
 
-            // Otherwise, simply return the entire host + path
-            return serviceUri.PathAndQuery == "/"
-                ? serviceUri.GetComponents(UriComponents.Host, UriFormat.Unescaped)
-                : serviceUri.GetComponents(UriComponents.Host | UriComponents.PathAndQuery, UriFormat.Unescaped);
+            return GetAccountNameFromDomain(uri.Host, service);
         }
 
-        private static bool IsStorageService(string segment)
-            => segment == "blob" || segment == "queue" || segment == "table" || segment == "file";
+        private static string GetPath(Uri uri) =>
+            uri.AbsolutePath[0] == '/' ? uri.AbsolutePath.Substring(1) : uri.AbsolutePath;
+
+        private static bool IsHostIPEndPointStyle(Uri uri) =>
+            (!string.IsNullOrEmpty(uri.Host) && uri.Host.IndexOf(".", StringComparison.InvariantCulture) >= 0 && IPAddress.TryParse(uri.Host, out _))
+            || SasPorts.Contains(uri.Port);
+
+        private static string GetAccountNameFromDomain(string host, string serviceSubDomain)
+        {
+            // Typically, Azure Storage Service URIs are formatted as <protocol>://<account>.<service>.<suffix>
+            int accountEndIndex = host.IndexOf(".", StringComparison.InvariantCulture);
+            if (accountEndIndex >= 0)
+            {
+                int serviceStartIndex = host.IndexOf(serviceSubDomain, accountEndIndex, StringComparison.InvariantCulture);
+                return serviceStartIndex > -1 ? host.Substring(0, accountEndIndex) : null;
+            }
+
+            return null;
+        }
     }
 }

--- a/src/DurableTask.AzureStorage/Storage/StorageUriExtensions.cs
+++ b/src/DurableTask.AzureStorage/Storage/StorageUriExtensions.cs
@@ -1,0 +1,51 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureStorage.Storage
+{
+    using System;
+    using Microsoft.WindowsAzure.Storage;
+
+    internal static class StorageUriExtensions
+    {
+        public static string GetAccountName(this StorageUri storageUri)
+        {
+            if (storageUri == null)
+                throw new ArgumentNullException(nameof(storageUri));
+
+            Uri serviceUri = storageUri.PrimaryUri;
+            switch (serviceUri.HostNameType)
+            {
+                case UriHostNameType.Dns:
+                    // Typically, Azure Storage Service URIs are formatted as <protocol>://<account>.<service>.<suffix>
+                    // Note that primary and secondary endpoints must share the same resource
+                    string[] segments = serviceUri.Host.Split('.');
+                    if (segments.Length >= 2 && IsStorageService(segments[1]))
+                        return segments[0];
+                    break;
+                case UriHostNameType.IPv4:
+                case UriHostNameType.IPv6:
+                    // In other scenarios, like for Azurite, the service URI looks like <protocol>://<host>:<port>/<account>
+                    return serviceUri.GetComponents(UriComponents.Path, UriFormat.Unescaped);
+            }
+
+            // Otherwise, simply return the entire host + path
+            return serviceUri.PathAndQuery == "/"
+                ? serviceUri.GetComponents(UriComponents.Host, UriFormat.Unescaped)
+                : serviceUri.GetComponents(UriComponents.Host | UriComponents.PathAndQuery, UriFormat.Unescaped);
+        }
+
+        private static bool IsStorageService(string segment)
+            => segment == "blob" || segment == "queue" || segment == "table" || segment == "file";
+    }
+}

--- a/src/DurableTask.AzureStorage/Storage/Table.cs
+++ b/src/DurableTask.AzureStorage/Storage/Table.cs
@@ -47,21 +47,21 @@ namespace DurableTask.AzureStorage.Storage
 
         public async Task<bool> CreateIfNotExistsAsync()
         {
-            return await this.azureStorageClient.MakeStorageRequest<bool>(
+            return await this.azureStorageClient.MakeTableStorageRequest<bool>(
                 (context, cancellationToken) => this.cloudTable.CreateIfNotExistsAsync(null, context, cancellationToken),
                 "Table Create");
         }
 
         public async Task<bool> DeleteIfExistsAsync()
         {
-            return await this.azureStorageClient.MakeStorageRequest<bool>(
+            return await this.azureStorageClient.MakeTableStorageRequest<bool>(
                 (context, cancellationToken) => this.cloudTable.DeleteIfExistsAsync(null, context, cancellationToken),
                 "Table Delete");
         }
 
         public async Task<bool> ExistsAsync()
         {
-            return await this.azureStorageClient.MakeStorageRequest<bool>(
+            return await this.azureStorageClient.MakeTableStorageRequest<bool>(
                 (context, cancellationToken) => this.cloudTable.ExistsAsync(null, context, cancellationToken),
                 "Table Exists");
         }
@@ -110,7 +110,7 @@ namespace DurableTask.AzureStorage.Storage
 
         private async Task ExecuteAsync(TableOperation operation, string operationType)
         {
-            var storageTableResult = await this.azureStorageClient.MakeStorageRequest<TableResult>(
+            var storageTableResult = await this.azureStorageClient.MakeTableStorageRequest<TableResult>(
                 (context, cancellationToken) => this.cloudTable.ExecuteAsync(operation, null, context, cancellationToken),
                 "Table Execute " + operationType);
 
@@ -169,7 +169,7 @@ namespace DurableTask.AzureStorage.Storage
             var stopwatch = new Stopwatch();
             long elapsedMilliseconds = 0;
 
-            var batchResults = await this.azureStorageClient.MakeStorageRequest(
+            var batchResults = await this.azureStorageClient.MakeTableStorageRequest(
                 (context, timeoutToken) => this.cloudTable.ExecuteBatchAsync(batchOperation, null, context, timeoutToken),
                 "Table BatchExecute " + batchType);
 
@@ -199,7 +199,7 @@ namespace DurableTask.AzureStorage.Storage
             {
                 stopwatch.Start();
 
-                var segment = await this.azureStorageClient.MakeStorageRequest(
+                var segment = await this.azureStorageClient.MakeTableStorageRequest(
                     async (context, timeoutCancellationToken) =>
                     {
                         using (var finalLinkedCts = CancellationTokenSource.CreateLinkedTokenSource(callerCancellationToken, timeoutCancellationToken))
@@ -256,7 +256,7 @@ namespace DurableTask.AzureStorage.Storage
 
             stopwatch.Start();
 
-            var segment = await this.azureStorageClient.MakeStorageRequest(
+            var segment = await this.azureStorageClient.MakeTableStorageRequest(
                 async (context, timeoutCancellationToken) =>
                 {
                     using (var finalLinkedCts = CancellationTokenSource.CreateLinkedTokenSource(callerCancellationToken, timeoutCancellationToken))

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -78,7 +78,7 @@ namespace DurableTask.AzureStorage.Tracking
             this.tableEntityConverter = new TableEntityConverter();
             this.taskHubName = settings.TaskHubName;
 
-            this.storageAccountName = this.azureStorageClient.StorageAccountName;
+            this.storageAccountName = this.azureStorageClient.TableAccountName;
 
             string historyTableName = settings.HistoryTableName;
             string instancesTableName = settings.InstanceTableName;


### PR DESCRIPTION
The Azure Storage account name is used for logging messages, but it may not be specified when Azure Storage Account Service URIs are supplied directly. However, while deriving the account name implicitly brings its own challenges, it also surfaces an additional question: what happens when the service accounts are different?

In this PR, I've made the following changes:
- Remove `StorageAccountName` from `AzureStorageClient` and replace it with `BlobAccountName`, `QueueAccountName`, and `TableAccountName`
- When the account name isn't specified explicitly, the account name is instead derived from each service URI based on the storage SDK's logic
- Use these new properties in lieu of the general `StorageAccountName` property based on which service is in use
  - For general log messages, when the diagnostics/log message refer to multiple services, we'll use `QueueAccountName`