### PR TITLE
Use the SimpleBufferManager when downloading Lease blobs

### DIFF
--- a/src/DurableTask.AzureStorage/Partitioning/BlobLeaseManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/BlobLeaseManager.cs
@@ -16,8 +16,10 @@ namespace DurableTask.AzureStorage.Partitioning
     using System;
     using System.Collections.Generic;
     using System.Globalization;
+    using System.IO;
     using System.Linq;
     using System.Net;
+    using System.Text;
     using System.Threading.Tasks;
     using DurableTask.AzureStorage.Storage;
     using Newtonsoft.Json;
@@ -321,7 +323,21 @@ namespace DurableTask.AzureStorage.Partitioning
 
         async Task<BlobLease> DownloadLeaseBlob(Blob blob)
         {
-            string serializedLease = await blob.DownloadTextAsync();
+            string serializedLease = null;
+            var buffer = SimpleBufferManager.Shared.TakeBuffer(SimpleBufferManager.SmallBufferSize);
+            try
+            {
+                using (var memoryStream = new MemoryStream(buffer))
+                {
+                    await blob.DownloadToStreamAsync(memoryStream);
+                    serializedLease = Encoding.UTF8.GetString(buffer, 0, (int)memoryStream.Position);
+                }
+            }
+            finally
+            {
+                SimpleBufferManager.Shared.ReturnBuffer(buffer);
+            }
+
             BlobLease deserializedLease = JsonConvert.DeserializeObject<BlobLease>(serializedLease);
             deserializedLease.Blob = blob;
 

--- a/src/DurableTask.AzureStorage/SimpleBufferManager.cs
+++ b/src/DurableTask.AzureStorage/SimpleBufferManager.cs
@@ -26,6 +26,7 @@ namespace DurableTask.AzureStorage
     {
         internal const int MaxBufferSize = 1024 * 1024; //  1 MB
         const int DefaultBufferSize = 64 * 1024;        // 64 KB
+        public const int SmallBufferSize = 1024;        //  1 KB
 
         /// <summary>
         /// Shared singleton instance of <see cref="SimpleBufferManager"/>.


### PR DESCRIPTION
This PR changes the `BlobLeaseManager` to use the `SimpleBufferManager` when reading the lease blobs. This is done since the call to `DownloadTextAsync` results in allocation of a new `MemoryStream`, which allocates a new `byte[]`. For high performance services, such allocations have a high impact on performance and GC times.