### PR TITLE
Adding OpenTelemetry tests

### DIFF
--- a/DurableTask.sln
+++ b/DurableTask.sln
@@ -65,6 +65,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DurableTask.SqlServer.Tests
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Correlation.Samples", "samples\Correlation.Samples\Correlation.Samples.csproj", "{5F88FF6A-E908-4341-89D6-FA530793077A}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetrySample", "samples\DistributedTraceSample\OpenTelemetrySample.csproj", "{7246B006-6676-4F71-9291-038A9A481608}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -249,6 +251,14 @@ Global
 		{5F88FF6A-E908-4341-89D6-FA530793077A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5F88FF6A-E908-4341-89D6-FA530793077A}.Release|x64.ActiveCfg = Release|Any CPU
 		{5F88FF6A-E908-4341-89D6-FA530793077A}.Release|x64.Build.0 = Release|Any CPU
+		{7246B006-6676-4F71-9291-038A9A481608}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7246B006-6676-4F71-9291-038A9A481608}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7246B006-6676-4F71-9291-038A9A481608}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7246B006-6676-4F71-9291-038A9A481608}.Debug|x64.Build.0 = Debug|Any CPU
+		{7246B006-6676-4F71-9291-038A9A481608}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7246B006-6676-4F71-9291-038A9A481608}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7246B006-6676-4F71-9291-038A9A481608}.Release|x64.ActiveCfg = Release|Any CPU
+		{7246B006-6676-4F71-9291-038A9A481608}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -277,9 +287,10 @@ Global
 		{C9F84589-3F2B-4D58-A995-BC169D16217F} = {DBCD161C-D409-48E5-924E-9B7FA1C36B84}
 		{B835BFA6-D9BB-47C4-8594-38EAE0157BBA} = {95C69A06-7F62-4652-A480-207B614C2869}
 		{5F88FF6A-E908-4341-89D6-FA530793077A} = {AF4E71A6-B16E-4488-B22D-2761101A601A}
+		{7246B006-6676-4F71-9291-038A9A481608} = {AF4E71A6-B16E-4488-B22D-2761101A601A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {2D63A120-9394-48D9-8CA9-1184364FB854}
 		EnterpriseLibraryConfigurationToolBinariesPath = packages\TransientFaultHandling.Core.5.1.1209.1\lib\NET4
+		SolutionGuid = {2D63A120-9394-48D9-8CA9-1184364FB854}
 	EndGlobalSection
 EndGlobal

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -34,7 +34,7 @@ namespace DurableTask.AzureStorage.Tests
     using Microsoft.WindowsAzure.Storage.Table;
     using Moq;
     using Newtonsoft.Json.Linq;
-#if NETCOREAPP3_1
+#if !NET461
     using OpenTelemetry;
     using OpenTelemetry.Trace;
 #endif
@@ -2083,7 +2083,7 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
-#if NETCOREAPP3_1
+#if !NET461
         /// <summary>
         /// End-to-end test which validates a simple orchestrator function that calls an activity function
         /// and checks the OpenTelemetry trace information
@@ -2111,15 +2111,37 @@ namespace DurableTask.AzureStorage.Tests
                 }
             }
 
-            // Explanation about indexes:
+            // (1) Explanation about indexes:
             // The orchestration Activity's start at Invocation[1] and each action logs
             // two activities - (Processor.OnStart(Activity) and Processor.OnEnd(Activity)
             // so we start looking at invocations from index 2 and look at every other one from there
 
-            // Additional invocations:
+            // (2) Additional invocations:
             // processor.Invocations[0] - processor.SetParentProvider(TracerProviderSdk)
             // processor.Invocations[9] - processor.OnShutdown()
             // processor.Invocations[10] - processor.Dispose(true)
+
+            // (3) Expected console output:
+
+            // Activity.DisplayName: OpenTelemetrySample.Program+HelloFanOut
+            // dt.type: client
+
+            // Activity.DisplayName: OpenTelemetrySample.Program+HelloFanOut
+            // dt.type: orchestrator
+            // dt.runtimestatus: Running
+
+            // Activity.DisplayName: OpenTelemetrySample.Program+SayHello (#0)
+            // dt.type: activity
+
+            // Activity.DisplayName: OpenTelemetrySample.Program+SayHello (#1)
+            // dt.type: activity
+
+            // Activity.DisplayName: OpenTelemetrySample.Program+SayHello (#2)
+            // dt.type: activity
+
+            // Activity.DisplayName: OpenTelemetrySample.Program+HelloFanOut
+            // dt.type: orchestrator
+            // dt.runtimestatus: Completed
 
             Activity activity2 = (Activity)processor.Invocations[2].Arguments[0];
             Activity activity4 = (Activity)processor.Invocations[4].Arguments[0];
@@ -2148,6 +2170,194 @@ namespace DurableTask.AzureStorage.Tests
             // Checking span ID correlation between parent and child
             Assert.AreEqual(activity2.SpanId, activity4.ParentSpanId);
             Assert.AreEqual(activity4.SpanId, activity6.ParentSpanId);
+            Assert.AreEqual(activity2.SpanId, activity8.ParentSpanId);
+
+            // Checking trace ID values
+            Assert.AreEqual(activity2.TraceId.ToString(), activity4.TraceId.ToString(), activity6.TraceId.ToString(), activity8.TraceId.ToString());
+        }
+
+        /// <summary>
+        /// End-to-end test which validates a simple orchestrator function that waits for an external event
+        /// raised through the RaiseEvent API and checks the OpenTelemetry trace information
+        /// </summary>
+        [DataTestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async Task OpenTelemetry_ExternalEvent_RaiseEvent(bool enableExtendedSessions)
+        {
+            var processor = new Mock<BaseProcessor<Activity>>();
+
+            using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(enableExtendedSessions))
+            {
+                using (Sdk.CreateTracerProviderBuilder()
+                .AddSource("DurableTask")
+                .AddProcessor(processor.Object)
+                .Build())
+                {
+                    await host.StartAsync();
+
+                    var timeout = TimeSpan.FromSeconds(10);
+                    var client = await host.StartOrchestrationAsync(typeof(Orchestrations.Approval), timeout);
+
+                    // Need to wait for the instance to start before sending events to it.
+                    // TODO: This requirement may not be ideal and should be revisited.
+                    await client.WaitForStartupAsync(TimeSpan.FromSeconds(10));
+                    await client.RaiseEventAsync("approval", eventData: true);
+                    await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+
+                    await host.StopAsync();
+                }
+            }
+
+            // (1) Explanation about indexes:
+            // The orchestration Activity's start at Invocation[1] and each action logs
+            // two activities - (Processor.OnStart(Activity) and Processor.OnEnd(Activity)
+            // so we start looking at invocations from index 2 and look at every other one from there
+
+            // (2) Additional invocations:
+            // processor.Invocations[0] - processor.SetParentProvider(TracerProviderSdk)
+            // processor.Invocations[11] - processor.OnShutdown()
+            // processor.Invocations[12] - processor.Dispose(true)
+
+            // (3) Expected console output:
+            //
+            // Activity.DisplayName: "DurableTask.AzureStorage.Tests.AzureStorageScenarioTests+Orchestrations+Approval"
+            // dt.type: client
+
+            // Activity.DisplayName: "DurableTask.AzureStorage.Tests.AzureStorageScenarioTests+Orchestrations+Approval"
+            // dt.type: orchestrator
+            // dt.runtimestatus: Running
+
+            // Activity.DisplayName: approval
+            // dt.type: externalevent
+
+            // Activity.DisplayName: "DurableTask.AzureStorage.Tests.AzureStorageScenarioTests+Orchestrations+Approval"
+            // dt.type: orchestrator
+            // dt.runtimestatus: Running
+
+            // Activity.DisplayName: "DurableTask.AzureStorage.Tests.AzureStorageScenarioTests+Orchestrations+Approval"
+            // dt.type: orchestrator
+            // dt.runtimestatus: Completed
+
+            Activity activity2 = (Activity)processor.Invocations[2].Arguments[0];
+            Activity activity4 = (Activity)processor.Invocations[4].Arguments[0];
+            Activity activity6 = (Activity)processor.Invocations[6].Arguments[0];
+            Activity activity8 = (Activity)processor.Invocations[8].Arguments[0];
+            Activity activity10 = (Activity)processor.Invocations[10].Arguments[0];
+
+            // Checking total number activities
+            Assert.AreEqual(13, processor.Invocations.Count);
+
+            // Checking tag values
+            string activity2TypeValue = activity2.Tags.First(k => (k.Key).Equals("dt.type")).Value;
+            string activity4TypeValue = activity4.Tags.First(k => (k.Key).Equals("dt.type")).Value;
+            string activity6TypeValue = activity6.Tags.First(k => (k.Key).Equals("dt.type")).Value;
+            string activity8TypeValue = activity8.Tags.First(k => (k.Key).Equals("dt.type")).Value;
+            string activity10TypeValue = activity10.Tags.First(k => (k.Key).Equals("dt.type")).Value;
+
+            string activity4RuntimeStatusValue = activity4.Tags.First(k => (k.Key).Equals("dt.runtimestatus")).Value;
+            string activity8RuntimeStatusValue = activity8.Tags.First(k => (k.Key).Equals("dt.runtimestatus")).Value;
+            string activity10RuntimeStatusValue = activity10.Tags.First(k => (k.Key).Equals("dt.runtimestatus")).Value;
+
+            Assert.AreEqual("client", activity2TypeValue);
+            Assert.AreEqual("orchestrator", activity4TypeValue);
+            Assert.AreEqual("Running", activity4RuntimeStatusValue);
+            Assert.AreEqual("externalevent", activity6TypeValue);
+            Assert.AreEqual("orchestrator", activity8TypeValue);
+            Assert.AreEqual("Running", activity8RuntimeStatusValue);
+            Assert.AreEqual("orchestrator", activity10TypeValue);
+            Assert.AreEqual("Completed", activity10RuntimeStatusValue);
+
+            // Checking span ID correlation between parent and child
+            Assert.AreEqual(activity2.SpanId, activity4.ParentSpanId);
+            Assert.AreEqual(activity2.SpanId, activity8.ParentSpanId);
+            Assert.AreEqual(activity2.SpanId, activity10.ParentSpanId);
+
+            // Checking trace ID values
+            Assert.AreEqual(activity2.TraceId.ToString(), activity4.TraceId.ToString(), activity8.TraceId.ToString());
+        }
+
+        /// <summary>
+        /// End-to-end test which validates a simple orchestrator function that waits for an external event
+        /// raised by calling SendEvent and checks the OpenTelemetry trace information
+        /// </summary>
+        [DataTestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async Task OpenTelemetry_ExternalEvent_SendEvent(bool enableExtendedSessions)
+        {
+            var processor = new Mock<BaseProcessor<Activity>>();
+
+            using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(enableExtendedSessions))
+            {
+                using (Sdk.CreateTracerProviderBuilder()
+                .AddSource("DurableTask")
+                .AddProcessor(processor.Object)
+                .Build())
+                {
+                    await host.StartAsync();
+
+                    host.AddAutoStartOrchestrator(typeof(Orchestrations.AutoStartOrchestration.Responder));
+
+                    var client = await host.StartOrchestrationAsync(typeof(Orchestrations.AutoStartOrchestration), "");
+                    var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+
+                    await host.StopAsync();
+                }
+            }
+
+            // (1) Explanation about indexes:
+            // The orchestration Activity's start at Invocation[1] and each action logs
+            // two activities - (Processor.OnStart(Activity) and Processor.OnEnd(Activity)
+            // so we start looking at invocations from index 2 and look at every other one from there
+
+            // (2) Additional invocations:
+            // processor.Invocations[0] - processor.SetParentProvider(TracerProviderSdk)
+            // processor.Invocations[9] - processor.OnShutdown()
+            // processor.Invocations[10] - processor.Dispose(true)
+
+            // (3) Expected console output:
+            //
+            // Activity.DisplayName: DurableTask.AzureStorage.Tests.AzureStorageScenarioTests+Orchestrations+AutoStartOrchestration
+            // dt.type: client
+
+            // Activity.DisplayName: conversation
+            // dt.type: externalevent
+
+            // Activity.DisplayName: DurableTask.AzureStorage.Tests.AzureStorageScenarioTests+Orchestrations+AutoStartOrchestration
+            // dt.type: orchestrator
+            // dt.runtimestatus: Running
+
+            // Activity.DisplayName: DurableTask.AzureStorage.Tests.AzureStorageScenarioTests+Orchestrations+AutoStartOrchestration
+            // dt.type: orchestrator
+            // dt.runtimestatus: Completed
+
+            Activity activity2 = (Activity)processor.Invocations[2].Arguments[0];
+            Activity activity4 = (Activity)processor.Invocations[4].Arguments[0];
+            Activity activity6 = (Activity)processor.Invocations[6].Arguments[0];
+            Activity activity8 = (Activity)processor.Invocations[8].Arguments[0];
+
+            // Checking total number activities
+            Assert.AreEqual(11, processor.Invocations.Count);
+
+            // Checking tag values
+            string activity2TypeValue = activity2.Tags.First(k => (k.Key).Equals("dt.type")).Value;
+            string activity4TypeValue = activity4.Tags.First(k => (k.Key).Equals("dt.type")).Value;
+            string activity6TypeValue = activity6.Tags.First(k => (k.Key).Equals("dt.type")).Value;
+            string activity8TypeValue = activity8.Tags.First(k => (k.Key).Equals("dt.type")).Value;
+
+            string activity6RuntimeStatusValue = activity6.Tags.First(k => (k.Key).Equals("dt.runtimestatus")).Value;
+            string activity8RuntimeStatusValue = activity8.Tags.First(k => (k.Key).Equals("dt.runtimestatus")).Value;
+
+            Assert.AreEqual("client", activity2TypeValue);
+            Assert.AreEqual("externalevent", activity4TypeValue);
+            Assert.AreEqual("orchestrator", activity6TypeValue);
+            Assert.AreEqual("Running", activity6RuntimeStatusValue);
+            Assert.AreEqual("orchestrator", activity8TypeValue);
+            Assert.AreEqual("Completed", activity8RuntimeStatusValue);
+
+            // Checking span ID correlation between parent and child
+            Assert.AreEqual(activity2.SpanId, activity6.ParentSpanId);
             Assert.AreEqual(activity2.SpanId, activity8.ParentSpanId);
 
             // Checking trace ID values

--- a/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
+++ b/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.6" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="WindowsAzure.Storage" version="9.3.3" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.0.0-beta.3" />
   </ItemGroup>
 
   <!-- Common package dependencies -->


### PR DESCRIPTION
This PR includes end to end tests that check traces after running orchestrations. The tests include an orchestration that calls an activity and also includes orchestrations that handle external events.