### PR TITLE
Keep orchestrator actions sorted, to avoid out-of-order events in OrchestrationRuntimeState

### DIFF
--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -46,7 +46,7 @@ namespace DurableTask.Core
             Utils.UnusedParameter(taskScheduler);
 
             this.openTasks = new Dictionary<int, OpenTaskInfo>();
-            this.orchestratorActionsMap = new Dictionary<int, OrchestratorAction>();
+            this.orchestratorActionsMap = new SortedDictionary<int, OrchestratorAction>();
             this.idCounter = 0;
             this.MessageDataConverter = new JsonDataConverter();
             this.ErrorDataConverter = new JsonDataConverter();


### PR DESCRIPTION
When debugging a failing test in Connor's integration tests azure/azure-functions-durable-extension#1979 today I noticed an oddity: on completed OrchestrationWorkItems, any events sent by the orchestration appeared in reverse order in the runtime state. I tracked this down to TaskOrchestrationDispatcher, which returns the orchestrator actions as follows:

```csharp
public IEnumerable<OrchestratorAction> OrchestratorActions => this.orchestratorActionsMap.Values;
```
but this is actually nondeterministic (and happened to be in reverse order for me) because the map is just a plain dictionary:
```csharp
this.orchestratorActionsMap = new Dictionary<int, OrchestratorAction>();
```

I am a bit surprised that this has not been noticed before and has not caused more issues. The particular test that detected this was an entity test, which was immune to this problem while I used the AzureStorage backend (thanks to the MessageSorter) but as soon as I used Netherite the problem became apparent.

The fix is trivial, use a `SortedDictionary` instead.