### PR TITLE
Added log when a decrease in partition count has been detected

### DIFF
--- a/src/DurableTask.AzureStorage/Partitioning/BlobLeaseManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/BlobLeaseManager.cs
@@ -88,6 +88,18 @@ namespace DurableTask.AzureStorage.Partitioning
 
             blobLeases.AddRange(downloadTasks.Select(t => t.Result));
 
+            if (blobLeases.Count > this.settings.PartitionCount)
+            {
+                this.settings.Logger.PartitionManagerError(
+                       this.storageAccountName,
+                       this.taskHubName,
+                       this.workerName,
+                       string.Empty,
+                       $"Partition count for the task hub is set to {this.settings.PartitionCount} while {blobLeases.Count} blobs are detected in storage." +
+                       $"This happens when partition count has been decreased without removing unused storage resources or switching to a new task hub. " +
+                       $"This will result in inefficient partition load balancing.");
+            }
+
             return blobLeases;
         }
 


### PR DESCRIPTION
When customers decrease their partition count without switching to a new task hub or removing their unused storage resources old blobs associated with partitions will cause partition load balancing to be inefficient.

This PR adds a partition error log message when this case is detected.