### PR TITLE
Add SBOM to DurableTask.AzureStorage Release NuGet package

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -27,6 +27,30 @@ steps:
     configuration: Release
     msbuildArgs: /p:GITHUB_RUN_NUMBER=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
 
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet publish'
+  inputs:
+    command: 'publish'
+    publishWebProjects: false
+    projects: 'src\DurableTask.AzureStorage\DurableTask.AzureStorage.csproj' 
+    arguments: "-c Release -f net461"
+    zipAfterPublish: false
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet publish'
+  inputs:
+    command: 'publish'
+    publishWebProjects: false
+    projects: 'src\DurableTask.AzureStorage\DurableTask.AzureStorage.csproj' 
+    arguments: "-c Release -f netstandard2.0"
+    zipAfterPublish: false
+
+# Manifest Generator Task
+- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+  displayName: 'Manifest Generator '
+  inputs:
+    BuildDropPath: '$(System.DefaultWorkingDirectory)'
+
 # Authenticode sign all the DLLs with the Microsoft certificate.
 # This appears to be an in-place signing job, which is convenient.
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -123,12 +123,6 @@ steps:
         }
      ]
 
-- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-  displayName: 'SBOM Generation Task'
-  inputs:
-    BuildDropPath: '$(build.artifactStagingDirectory)'
-    Verbosity: 'Information'
-
 # Make the nuget packages available for download in the ADO portal UI
 - publish: $(build.artifactStagingDirectory)
   displayName: 'Publish nuget packages to Artifacts'

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -41,4 +41,9 @@
   <ItemGroup>
     <ProjectReference Include="..\DurableTask.Core\DurableTask.Core.csproj" />
   </ItemGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <NuspecFile>DurableTask.AzureStorage.nuspec</NuspecFile>
+    <NuspecProperties>configuration=$(Configuration);targetFramework=$(TargetFramework);version=$(Version)</NuspecProperties>
+  </PropertyGroup>
 </Project>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.nuspec
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.nuspec
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (c) Microsoft. All rights reserved.
+Licensed under the MIT license. See LICENSE file in the project root for full license information.
+-->
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>DurableTask.AzureStorage</id>
+    <!-- Needed to specify the version here for the nuspec to be valid -->
+    <version>$version$</version>
+    <title>Azure Storage provider extension for the Durable Task Framework.</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/Azure/azure-functions-durable-extension</projectUrl>
+    <description>AAzure Task Durable Orchestration Workflow Activity Reliable AzureStorage</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <dependencies>
+      <group targetFramework=".NETFramework4.6.1" />
+      <group targetFramework=".NETStandard2.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src=".\bin\$configuration$\net461\publish\**" target="lib/net461"/>
+    <file src=".\bin\$configuration$\netstandard2.0\publish\**" target="lib/netstandard2.0"/>
+    <file src="..\..\_manifest\**" target="content/SBOM"/>
+  </files>
+</package>


### PR DESCRIPTION
This PR adds the SBOM manifest to the DurableTask.AzureStorage Release NuGet package. It adds a dotnet publish step and moves the manifest generator step to come before the dotnet pack step. It also adds a .nuspec file that specifies the additional files that need to get added to the NuGet package during dotnet pack.