### PR TITLE
Add SBOM to DT.Core, DT.ServiceBus, and DT.Emulator Release NuGet packages

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -143,6 +143,7 @@ steps:
 
 # Packaging needs to be a separate step from build.
 # This will automatically pick up the signed DLLs.
+
 - task: DotNetCoreCLI@2
   displayName: Generate nuget packages
   inputs:
@@ -151,10 +152,28 @@ steps:
     configuration: Release
     nobuild: true
     packDirectory: $(build.artifactStagingDirectory)
-    packagesToPack: |
-      src/DurableTask.AzureStorage/DurableTask.AzureStorage.sln
-      src/DurableTask.Emulator/DurableTask.Emulator.csproj
-      src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
+    packagesToPack: 'src/DurableTask.AzureStorage/DurableTask.AzureStorage.sln'
+
+
+- task: DotNetCoreCLI@2
+  displayName: Generate nuget packages
+  inputs:
+    command: pack
+    verbosityPack: Minimal
+    configuration: Release
+    nobuild: true
+    packDirectory: $(build.artifactStagingDirectory)
+    packagesToPack: 'src/DurableTask.Emulator/DurableTask.Emulator.csproj'
+
+- task: DotNetCoreCLI@2
+  displayName: Generate nuget packages
+  inputs:
+    command: pack
+    verbosityPack: Minimal
+    configuration: Release
+    nobuild: true
+    packDirectory: $(build.artifactStagingDirectory)
+    packagesToPack: 'src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj'
 
 # Digitally sign all the nuget packages with the Microsoft certificate.
 # This appears to be an in-place signing job, which is convenient.

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -49,6 +49,24 @@ steps:
     msbuildArgs: /p:GITHUB_RUN_NUMBER=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
 
 - task: DotNetCoreCLI@2
+  displayName: 'dotnet publish (Core net461)'
+  inputs:
+    command: 'publish'
+    publishWebProjects: false
+    projects: 'src\DurableTask.Core\DurableTask.Core.csproj' 
+    arguments: "-c Release -f net461"
+    zipAfterPublish: false
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet publish (Core netstandard2.0)'
+  inputs:
+    command: 'publish'
+    publishWebProjects: false
+    projects: 'src\DurableTask.Core\DurableTask.Core.csproj' 
+    arguments: "-c Release -f netstandard2.0"
+    zipAfterPublish: false
+
+- task: DotNetCoreCLI@2
   displayName: 'dotnet publish (AzureStorage net461)'
   inputs:
     command: 'publish'

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -15,11 +15,14 @@ steps:
   inputs:
     command: restore
     verbosityRestore: Minimal
-    projects: 'src/DurableTask.AzureStorage/DurableTask.AzureStorage.sln'
+    projects: |
+      src/DurableTask.AzureStorage/DurableTask.AzureStorage.sln
+      src/DurableTask.Emulator/DurableTask.Emulator.csproj
+      src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
 
 # Build the filtered solution in release mode, specifying the continuous integration flag.
 - task: VSBuild@1
-  displayName: 'Build'
+  displayName: 'Build (AzureStorage)'
   inputs:
     solution: 'src/DurableTask.AzureStorage/DurableTask.AzureStorage.sln'
     vsVersion: '16.0'
@@ -27,8 +30,26 @@ steps:
     configuration: Release
     msbuildArgs: /p:GITHUB_RUN_NUMBER=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
 
+- task: VSBuild@1
+  displayName: 'Build (Emulator)'
+  inputs:
+    solution: 'src/DurableTask.Emulator/DurableTask.Emulator.csproj'
+    vsVersion: '16.0'
+    logFileVerbosity: minimal
+    configuration: Release
+    msbuildArgs: /p:GITHUB_RUN_NUMBER=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
+
+- task: VSBuild@1
+  displayName: 'Build (ServiceBus)'
+  inputs:
+    solution: 'src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj'
+    vsVersion: '16.0'
+    logFileVerbosity: minimal
+    configuration: Release
+    msbuildArgs: /p:GITHUB_RUN_NUMBER=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
+
 - task: DotNetCoreCLI@2
-  displayName: 'dotnet publish'
+  displayName: 'dotnet publish (AzureStorage net461)'
   inputs:
     command: 'publish'
     publishWebProjects: false
@@ -37,11 +58,47 @@ steps:
     zipAfterPublish: false
 
 - task: DotNetCoreCLI@2
-  displayName: 'dotnet publish'
+  displayName: 'dotnet publish (AzureStorage netstandard2.0)'
   inputs:
     command: 'publish'
     publishWebProjects: false
     projects: 'src\DurableTask.AzureStorage\DurableTask.AzureStorage.csproj' 
+    arguments: "-c Release -f netstandard2.0"
+    zipAfterPublish: false
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet publish (Emulator net461)'
+  inputs:
+    command: 'publish'
+    publishWebProjects: false
+    projects: 'src\DurableTask.Emulator\DurableTask.Emulator.csproj' 
+    arguments: "-c Release -f net461"
+    zipAfterPublish: false
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet publish (Emulator netstandard2.0)'
+  inputs:
+    command: 'publish'
+    publishWebProjects: false
+    projects: 'src\DurableTask.Emulator\DurableTask.Emulator.csproj' 
+    arguments: "-c Release -f netstandard2.0"
+    zipAfterPublish: false
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet publish (ServiceBus net461)'
+  inputs:
+    command: 'publish'
+    publishWebProjects: false
+    projects: 'src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj' 
+    arguments: "-c Release -f net461"
+    zipAfterPublish: false
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet publish (ServiceBus netstandard2.0)'
+  inputs:
+    command: 'publish'
+    publishWebProjects: false
+    projects: 'src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj' 
     arguments: "-c Release -f netstandard2.0"
     zipAfterPublish: false
 
@@ -94,7 +151,10 @@ steps:
     configuration: Release
     nobuild: true
     packDirectory: $(build.artifactStagingDirectory)
-    packagesToPack: 'src/DurableTask.AzureStorage/DurableTask.AzureStorage.sln'
+    packagesToPack: |
+      src/DurableTask.AzureStorage/DurableTask.AzureStorage.sln
+      src/DurableTask.Emulator/DurableTask.Emulator.csproj
+      src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
 
 # Digitally sign all the nuget packages with the Microsoft certificate.
 # This appears to be an in-place signing job, which is convenient.

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -14,6 +14,9 @@
     <AssemblyVersion>2.7.0</AssemblyVersion>
     <FileVersion>2.7.0</FileVersion>
     <Version>2.7.0</Version>
+  </PropertyGroup>
+   
+   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
@@ -34,5 +37,10 @@
     <PackageReference Include="System.Reactive.Core" Version="4.4.1" />
     <PackageReference Include="System.Reactive.Compatibility" Version="4.4.1" />
   </ItemGroup>
+   
+   <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <NuspecFile>DurableTask.Core.nuspec</NuspecFile>
+    <NuspecProperties>configuration=$(Configuration);targetFramework=$(TargetFramework);version=$(Version)</NuspecProperties>
+  </PropertyGroup>
   
 </Project>

--- a/src/DurableTask.Core/DurableTask.Core.nuspec
+++ b/src/DurableTask.Core/DurableTask.Core.nuspec
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (c) Microsoft. All rights reserved.
+Licensed under the MIT license. See LICENSE file in the project root for full license information.
+-->
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>DurableTask.Core</id>
+    <!-- Needed to specify the version here for the nuspec to be valid -->
+    <version>$version$</version>
+    <title>Durable Task Framework</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/Azure/azure-functions-durable-extension</projectUrl>
+    <description>This package provides a C# based durable task framework for writing long running applications.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <dependencies>
+      <group targetFramework=".NETFramework4.6.1" />
+      <group targetFramework=".NETStandard2.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src=".\bin\$configuration$\net461\publish\**" target="lib/net461"/>
+    <file src=".\bin\$configuration$\netstandard2.0\publish\**" target="lib/netstandard2.0"/>
+    <file src="..\..\_manifest\**" target="content/SBOM"/>
+  </files>
+</package>

--- a/src/DurableTask.Core/DurableTask.Core.nuspec
+++ b/src/DurableTask.Core/DurableTask.Core.nuspec
@@ -13,7 +13,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
-    <projectUrl>https://github.com/Azure/azure-functions-durable-extension</projectUrl>
+    <projectUrl>https://github.com/Azure/durabletask</projectUrl>
     <description>This package provides a C# based durable task framework for writing long running applications.</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>

--- a/src/DurableTask.Emulator/DurableTask.Emulator.csproj
+++ b/src/DurableTask.Emulator/DurableTask.Emulator.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
    
    <PropertyGroup Condition="'$(Configuration)'=='Release'">
-    <NuspecFile>DurableTask.AzureStorage.nuspec</NuspecFile>
+    <NuspecFile>DurableTask.Emulator.nuspec</NuspecFile>
     <NuspecProperties>configuration=$(Configuration);targetFramework=$(TargetFramework);version=$(Version)</NuspecProperties>
   </PropertyGroup>
 

--- a/src/DurableTask.Emulator/DurableTask.Emulator.csproj
+++ b/src/DurableTask.Emulator/DurableTask.Emulator.csproj
@@ -19,5 +19,10 @@
   <ItemGroup>
     <ProjectReference Include="..\DurableTask.Core\DurableTask.Core.csproj" />
   </ItemGroup>
+   
+   <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <NuspecFile>DurableTask.AzureStorage.nuspec</NuspecFile>
+    <NuspecProperties>configuration=$(Configuration);targetFramework=$(TargetFramework);version=$(Version)</NuspecProperties>
+  </PropertyGroup>
 
 </Project>

--- a/src/DurableTask.Emulator/DurableTask.Emulator.nuspec
+++ b/src/DurableTask.Emulator/DurableTask.Emulator.nuspec
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (c) Microsoft. All rights reserved.
+Licensed under the MIT license. See LICENSE file in the project root for full license information.
+-->
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>DurableTask.Emulator</id>
+    <!-- Needed to specify the version here for the nuspec to be valid -->
+    <version>$version$</version>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/Azure/durabletask</projectUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <dependencies>
+      <group targetFramework=".NETFramework4.6.1" />
+      <group targetFramework=".NETStandard2.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src=".\bin\$configuration$\net461\publish\**" target="lib/net461"/>
+    <file src=".\bin\$configuration$\netstandard2.0\publish\**" target="lib/netstandard2.0"/>
+    <file src="..\..\_manifest\**" target="content/SBOM"/>
+  </files>
+</package>

--- a/src/DurableTask.Emulator/DurableTask.Emulator.nuspec
+++ b/src/DurableTask.Emulator/DurableTask.Emulator.nuspec
@@ -8,11 +8,13 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     <id>DurableTask.Emulator</id>
     <!-- Needed to specify the version here for the nuspec to be valid -->
     <version>$version$</version>
+    <title>Emulator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/Azure/durabletask</projectUrl>
+    <description>An in-memory store intended for testing purposes only</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
       <group targetFramework=".NETFramework4.6.1" />

--- a/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
+++ b/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
@@ -28,4 +28,9 @@
   <ItemGroup>
     <ProjectReference Include="..\DurableTask.Core\DurableTask.Core.csproj" />
   </ItemGroup>
+   
+   <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <NuspecFile>DurableTask.ServiceBus.nuspec</NuspecFile>
+    <NuspecProperties>configuration=$(Configuration);targetFramework=$(TargetFramework);version=$(Version)</NuspecProperties>
+  </PropertyGroup>
 </Project>

--- a/src/DurableTask.ServiceBus/DurableTask.ServiceBus.nuspec
+++ b/src/DurableTask.ServiceBus/DurableTask.ServiceBus.nuspec
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (c) Microsoft. All rights reserved.
+Licensed under the MIT license. See LICENSE file in the project root for full license information.
+-->
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>DurableTask.ServiceBus</id>
+    <!-- Needed to specify the version here for the nuspec to be valid -->
+    <version>$version$</version>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/Azure/durabletask</projectUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <dependencies>
+      <group targetFramework=".NETFramework4.6.1" />
+      <group targetFramework=".NETStandard2.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src=".\bin\$configuration$\net461\publish\**" target="lib/net461"/>
+    <file src=".\bin\$configuration$\netstandard2.0\publish\**" target="lib/netstandard2.0"/>
+    <file src="..\..\_manifest\**" target="content/SBOM"/>
+  </files>
+</package>

--- a/src/DurableTask.ServiceBus/DurableTask.ServiceBus.nuspec
+++ b/src/DurableTask.ServiceBus/DurableTask.ServiceBus.nuspec
@@ -8,11 +8,13 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     <id>DurableTask.ServiceBus</id>
     <!-- Needed to specify the version here for the nuspec to be valid -->
     <version>$version$</version>
+    <title>ServiceBus provider extension for the Durable Task Framework.</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/Azure/durabletask</projectUrl>
+    <description>Orchestration message and runtime state is stored in Service Bus queues while tracking state is stored in Azure Storage.</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
       <group targetFramework=".NETFramework4.6.1" />


### PR DESCRIPTION
This PR adds an SBOM manifest to the DurableTask.Core, DurableTask.ServiceBus, and DurableTask.Emulator Release NuGet packages. It adds a dotnet publish step for each project in the release pipeline. Each project also includes a .nuspec file now that specifies the additional files that need to get added to the NuGet package during dotnet pack.