### PR TITLE
Adding an option to log structured events via LoggerFactory in Service Fabric provider

### DIFF
--- a/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
+++ b/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>net461</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Microsoft.Azure.DurableTask.AzureServiceFabric</PackageId>
-    <Version>2.3.4</Version>
+    <Version>2.3.5</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
   </PropertyGroup>

--- a/src/DurableTask.AzureServiceFabric/FabricOrchestrationProviderSettings.cs
+++ b/src/DurableTask.AzureServiceFabric/FabricOrchestrationProviderSettings.cs
@@ -15,6 +15,7 @@ namespace DurableTask.AzureServiceFabric
 {
     using DurableTask.Core;
     using DurableTask.Core.Settings;
+    using Microsoft.Extensions.Logging;
 
     /// <summary>
     /// Provides settings for service fabric based custom provider implementations
@@ -50,5 +51,10 @@ namespace DurableTask.AzureServiceFabric
         ///     Settings to configure the Task Activity Dispatcher
         /// </summary>
         public TaskActivityDispatcherSettings TaskActivityDispatcherSettings { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional <see cref="ILoggerFactory"/> to use for diagnostic logging.
+        /// </summary>
+        public ILoggerFactory LoggerFactory { get; set; }
     }
 }

--- a/src/DurableTask.AzureServiceFabric/Service/TaskHubProxyListener.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/TaskHubProxyListener.cs
@@ -192,11 +192,11 @@ namespace DurableTask.AzureServiceFabric.Service
             {
                 EnsureFabricOrchestrationProviderIsInitialized();
 
-                this.worker = new TaskHubWorker(this.fabricOrchestrationProvider.OrchestrationService);
+                this.worker = new TaskHubWorker(this.fabricOrchestrationProvider.OrchestrationService, this.fabricOrchestrationProviderSettings.LoggerFactory);
 
                 if (this.registerOrchestrations2 != null)
                 {
-                    this.localClient = new TaskHubClient(this.fabricOrchestrationProvider.OrchestrationServiceClient);
+                    this.localClient = new TaskHubClient(this.fabricOrchestrationProvider.OrchestrationServiceClient, loggerFactory: this.fabricOrchestrationProviderSettings.LoggerFactory);
                     this.registerOrchestrations2(this.worker, this.localClient);
                 }
                 else

--- a/src/DurableTask.AzureServiceFabric/Tracing/ServiceFabricProviderEventSource.cs
+++ b/src/DurableTask.AzureServiceFabric/Tracing/ServiceFabricProviderEventSource.cs
@@ -130,7 +130,7 @@ namespace DurableTask.AzureServiceFabric.Tracing
 
         [Event(503,
             Keywords = Keywords.Common,
-            Level = EventLevel.Informational,
+            Level = EventLevel.Verbose,
             Message = "Current number of entries in store {0} : {1}")]
         internal void LogStoreCount(string storeName, long count)
         {


### PR DESCRIPTION
## Summary
* DurableTask.Core library supports emitting structured logs if an `ILoggerFactory` is provided during `TaskHubWorker` or `TaskHubClient` creation. This pull requests adds an option to provide the logger as part of `FabricOrchestrationProviderSettings` which is then passed into the initialization of `TaskHubWorker` or `TaskHubClient` objects.
* Updated the verbosity level for `LogStoreCount` trace. This trace is more like a counter which is emitted every minute for all reliable collections, reporting the number of objects in the collection. This can turn out to be very noisy, and drowning out other legitimate traces.
* I have not yet converted the ServiceFabric traces into structured logs. That will come in as part of a future PR