### PR TITLE
Update license in .nuspec files

### DIFF
--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.nuspec
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.nuspec
@@ -21,7 +21,7 @@ limitations under the License.
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-	<license type="expression">Apache-2.0</license>
+    <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/Azure/azure-functions-durable-extension</projectUrl>
     <description>AAzure Task Durable Orchestration Workflow Activity Reliable AzureStorage</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.nuspec
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.nuspec
@@ -1,7 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Copyright (c) Microsoft. All rights reserved.
-Licensed under the MIT license. See LICENSE file in the project root for full license information.
+Copyright Microsoft Corporation
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 -->
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
@@ -12,7 +21,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <license type="expression">MIT</license>
+	<license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/Azure/azure-functions-durable-extension</projectUrl>
     <description>AAzure Task Durable Orchestration Workflow Activity Reliable AzureStorage</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/src/DurableTask.Core/DurableTask.Core.nuspec
+++ b/src/DurableTask.Core/DurableTask.Core.nuspec
@@ -21,7 +21,7 @@ limitations under the License.
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-	<license type="expression">Apache-2.0</license>
+    <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/Azure/durabletask</projectUrl>
     <description>This package provides a C# based durable task framework for writing long running applications.</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/src/DurableTask.Core/DurableTask.Core.nuspec
+++ b/src/DurableTask.Core/DurableTask.Core.nuspec
@@ -1,7 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Copyright (c) Microsoft. All rights reserved.
-Licensed under the MIT license. See LICENSE file in the project root for full license information.
+Copyright Microsoft Corporation
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 -->
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
@@ -12,7 +21,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <license type="expression">MIT</license>
+	<license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/Azure/durabletask</projectUrl>
     <description>This package provides a C# based durable task framework for writing long running applications.</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/src/DurableTask.Emulator/DurableTask.Emulator.nuspec
+++ b/src/DurableTask.Emulator/DurableTask.Emulator.nuspec
@@ -1,7 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Copyright (c) Microsoft. All rights reserved.
-Licensed under the MIT license. See LICENSE file in the project root for full license information.
+Copyright Microsoft Corporation
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 -->
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
@@ -12,7 +21,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <license type="expression">MIT</license>
+	<license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/Azure/durabletask</projectUrl>
     <description>An in-memory store intended for testing purposes only</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/src/DurableTask.Emulator/DurableTask.Emulator.nuspec
+++ b/src/DurableTask.Emulator/DurableTask.Emulator.nuspec
@@ -21,7 +21,7 @@ limitations under the License.
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-	<license type="expression">Apache-2.0</license>
+    <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/Azure/durabletask</projectUrl>
     <description>An in-memory store intended for testing purposes only</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/src/DurableTask.ServiceBus/DurableTask.ServiceBus.nuspec
+++ b/src/DurableTask.ServiceBus/DurableTask.ServiceBus.nuspec
@@ -21,7 +21,7 @@ limitations under the License.
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-	<license type="expression">Apache-2.0</license>
+    <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/Azure/durabletask</projectUrl>
     <description>Orchestration message and runtime state is stored in Service Bus queues while tracking state is stored in Azure Storage.</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/src/DurableTask.ServiceBus/DurableTask.ServiceBus.nuspec
+++ b/src/DurableTask.ServiceBus/DurableTask.ServiceBus.nuspec
@@ -1,7 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Copyright (c) Microsoft. All rights reserved.
-Licensed under the MIT license. See LICENSE file in the project root for full license information.
+Copyright Microsoft Corporation
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 -->
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
@@ -12,7 +21,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <license type="expression">MIT</license>
+	<license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/Azure/durabletask</projectUrl>
     <description>Orchestration message and runtime state is stored in Service Bus queues while tracking state is stored in Azure Storage.</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>


### PR DESCRIPTION
This PR fixes the license in the .nuspec files from MIT to Apache 2.0.