### PR TITLE
Add Non-Generic Overload for AddTaskActivitiesFromInterface

### DIFF
--- a/src/DurableTask.Core/TaskHubWorker.cs
+++ b/src/DurableTask.Core/TaskHubWorker.cs
@@ -314,11 +314,24 @@ namespace DurableTask.Core
         /// </summary>
         /// <typeparam name="T">Interface</typeparam>
         /// <param name="activities">Object that implements this interface</param>
+        public TaskHubWorker AddTaskActivitiesFromInterface<T>(T activities)
+        {
+            return this.AddTaskActivitiesFromInterface(activities, false);
+        }
+
+        /// <summary>
+        ///     Infers and adds every method in the specified interface T on the
+        ///     passed in object as a different TaskActivity with Name set to the method name
+        ///     and version set to an empty string. Methods can then be invoked from task orchestrations
+        ///     by calling ScheduleTask(name, version) with name as the method name and string.Empty as the version.
+        /// </summary>
+        /// <typeparam name="T">Interface</typeparam>
+        /// <param name="activities">Object that implements this interface</param>
         /// <param name="useFullyQualifiedMethodNames">
         ///     If true, the method name translation from the interface contains
         ///     the interface name, if false then only the method name is used
         /// </param>
-        public TaskHubWorker AddTaskActivitiesFromInterface<T>(T activities, bool useFullyQualifiedMethodNames = false)
+        public TaskHubWorker AddTaskActivitiesFromInterface<T>(T activities, bool useFullyQualifiedMethodNames)
         {
             return this.AddTaskActivitiesFromInterface(typeof(T), activities, useFullyQualifiedMethodNames);
         }

--- a/src/DurableTask.Core/TaskHubWorker.cs
+++ b/src/DurableTask.Core/TaskHubWorker.cs
@@ -314,9 +314,13 @@ namespace DurableTask.Core
         /// </summary>
         /// <typeparam name="T">Interface</typeparam>
         /// <param name="activities">Object that implements this interface</param>
-        public TaskHubWorker AddTaskActivitiesFromInterface<T>(T activities)
+        /// <param name="useFullyQualifiedMethodNames">
+        ///     If true, the method name translation from the interface contains
+        ///     the interface name, if false then only the method name is used
+        /// </param>
+        public TaskHubWorker AddTaskActivitiesFromInterface<T>(T activities, bool useFullyQualifiedMethodNames = false)
         {
-            return this.AddTaskActivitiesFromInterface(activities, false);
+            return this.AddTaskActivitiesFromInterface(typeof(T), activities, useFullyQualifiedMethodNames);
         }
 
         /// <summary>
@@ -325,15 +329,14 @@ namespace DurableTask.Core
         ///     and version set to an empty string. Methods can then be invoked from task orchestrations
         ///     by calling ScheduleTask(name, version) with name as the method name and string.Empty as the version.
         /// </summary>
-        /// <typeparam name="T">Interface</typeparam>
-        /// <param name="activities">Object that implements this interface</param>
+        /// <param name="interface">Interface type.</param>
+        /// <param name="activities">Object that implements the <paramref name="interface"/> interface</param>
         /// <param name="useFullyQualifiedMethodNames">
         ///     If true, the method name translation from the interface contains
         ///     the interface name, if false then only the method name is used
         /// </param>
-        public TaskHubWorker AddTaskActivitiesFromInterface<T>(T activities, bool useFullyQualifiedMethodNames)
+        public TaskHubWorker AddTaskActivitiesFromInterface(Type @interface, object activities, bool useFullyQualifiedMethodNames = false)
         {
-            Type @interface = typeof(T);
             if (!@interface.IsInterface)
             {
                 throw new Exception("Contract can only be an interface.");

--- a/src/DurableTask.Core/TaskHubWorker.cs
+++ b/src/DurableTask.Core/TaskHubWorker.cs
@@ -342,6 +342,11 @@ namespace DurableTask.Core
                 throw new Exception("Contract can only be an interface.");
             }
 
+            if (!@interface.IsAssignableFrom(activities.GetType()))
+            {
+                throw new ArgumentException($"{activities.GetType().FullName} does not implement {@interface.FullName}", nameof(activities));
+            }
+
             foreach (MethodInfo methodInfo in @interface.GetMethods())
             {
                 TaskActivity taskActivity = new ReflectionBasedTaskActivity(activities, methodInfo);

--- a/test/DurableTask.ServiceBus.Tests/DispatcherTests.cs
+++ b/test/DurableTask.ServiceBus.Tests/DispatcherTests.cs
@@ -572,7 +572,7 @@ namespace DurableTask.ServiceBus.Tests
 
             await this.taskHub.AddTaskOrchestrations(typeof (AsyncDynamicGreetingsOrchestration))
                 .AddTaskActivitiesFromInterface<IGreetings>(new GreetingsManager(), true)
-                .AddTaskActivitiesFromInterface<IGreetings2>(new GreetingsManager2(), true)
+                .AddTaskActivitiesFromInterface(typeof(IGreetings2), new GreetingsManager2(), true)
                 .StartAsync();
 
             OrchestrationInstance id = await this.client.CreateOrchestrationInstanceAsync(typeof (AsyncDynamicGreetingsOrchestration),


### PR DESCRIPTION
This change does the following:

* Adds a new non-generic `AddTaskActivitiesFromInterface` overload that lets the caller pass in a type instead.