### PR TITLE
Added Generation to ExecutionStartedEvent for Dedupe Checks

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1561,8 +1561,6 @@ namespace DurableTask.AzureStorage
                 {
                     executionStartedEvent.Generation = 1;
                 }
-
-                creationMessage.Event = executionStartedEvent;
             }
 
             ControlQueue controlQueue = await this.GetControlQueueAsync(creationMessage.OrchestrationInstance.InstanceId);

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1578,8 +1578,6 @@ namespace DurableTask.AzureStorage
                 inputStatusOverride = this.messageManager.GetBlobUrl(internalMessage.CompressedBlobName);
             }
 
-            Thread.Sleep(5000);
-
             await this.trackingStore.SetNewExecutionAsync(
                 executionStartedEvent,
                 existingInstance?.ETag,

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1551,6 +1551,20 @@ namespace DurableTask.AzureStorage
                 return;
             }
 
+            if (executionStartedEvent.Generation == null)
+            {
+                if (existingInstance != null)
+                {
+                    executionStartedEvent.Generation = existingInstance.State.Generation + 1;
+                }
+                else
+                {
+                    executionStartedEvent.Generation = 1;
+                }
+
+                creationMessage.Event = executionStartedEvent;
+            }
+
             ControlQueue controlQueue = await this.GetControlQueueAsync(creationMessage.OrchestrationInstance.InstanceId);
             MessageData internalMessage = await this.SendTaskOrchestrationMessageInternalAsync(
                 EmptySourceInstance,
@@ -1563,6 +1577,8 @@ namespace DurableTask.AzureStorage
             {
                 inputStatusOverride = this.messageManager.GetBlobUrl(internalMessage.CompressedBlobName);
             }
+
+            Thread.Sleep(5000);
 
             await this.trackingStore.SetNewExecutionAsync(
                 executionStartedEvent,

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <FileVersion>1.10.2</FileVersion>
+    <FileVersion>1.10.1</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <Version>$(FileVersion)</Version>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <FileVersion>1.10.1</FileVersion>
+    <FileVersion>1.10.2</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <Version>$(FileVersion)</Version>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/DurableTask.AzureStorage/OrchestrationInstanceStatus.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationInstanceStatus.cs
@@ -32,5 +32,6 @@ namespace DurableTask.AzureStorage
         public DateTime? CompletedTime { get; set; }
         public string RuntimeStatus { get; set; }
         public DateTime? ScheduledStartTime { get; set; }
+        public int Generation { get; set; }
     }
 }

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -235,13 +235,14 @@ namespace DurableTask.AzureStorage
             foreach (MessageData message in executionStartedMessages)
             {
                 OrchestrationInstance localInstance = message.TaskMessage.OrchestrationInstance;
+                var expectedGeneration = ((ExecutionStartedEvent)message.TaskMessage.Event).Generation;
                 if (remoteOrchestrationsById.TryGetValue(localInstance.InstanceId, out OrchestrationState remoteInstance) &&
                     (remoteInstance.OrchestrationInstance.ExecutionId == null || string.Equals(localInstance.ExecutionId, remoteInstance.OrchestrationInstance.ExecutionId, StringComparison.OrdinalIgnoreCase)))
                 {
                     // Happy path: The message matches the table status. Alternatively, if the table doesn't have an ExecutionId field (older clients, pre-v1.8.5),
                     // then we have no way of knowing if it's a duplicate. Either way, allow it to run.
                 }
-                else if (this.IsScheduledAfterInstanceUpdate(message, remoteInstance))
+                else if (expectedGeneration == remoteInstance?.Generation && this.IsScheduledAfterInstanceUpdate(message, remoteInstance))
                 {
                     // The message was scheduled after the Instances table was updated with the orchestration info.
                     // We know almost certainly that this is a redundant message and can be safely discarded because

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -490,6 +490,10 @@ namespace DurableTask.AzureStorage.Tracking
                         {
                             property.SetValue(orchestrationInstanceStatus, value.DateTime);
                         }
+                        else if (property.PropertyType == typeof(int) || property.PropertyType == typeof(int?))
+                        {
+                            property.SetValue(orchestrationInstanceStatus, value.Int32Value);
+                        }
                         else
                         {
                             property.SetValue(orchestrationInstanceStatus, value.StringValue);
@@ -525,6 +529,7 @@ namespace DurableTask.AzureStorage.Tracking
             orchestrationState.Input = orchestrationInstanceStatus.Input;
             orchestrationState.Output = orchestrationInstanceStatus.Output;
             orchestrationState.ScheduledStartTime = orchestrationInstanceStatus.ScheduledStartTime;
+            orchestrationState.Generation = orchestrationInstanceStatus.Generation;
 
             if (this.settings.FetchLargeMessageDataEnabled)
             {
@@ -765,6 +770,7 @@ namespace DurableTask.AzureStorage.Tracking
                     ["TaskHubName"] = new EntityProperty(this.settings.TaskHubName),
                     ["ScheduledStartTime"] = new EntityProperty(executionStartedEvent.ScheduledStartTime),
                     ["ExecutionId"] = new EntityProperty(executionStartedEvent.OrchestrationInstance.ExecutionId),
+                    ["Generation"] = new EntityProperty(executionStartedEvent.Generation),
                 }
             };
 

--- a/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
@@ -115,7 +115,8 @@ namespace DurableTask.AzureStorage.Tracking
                 CreatedTime = executionStartedEvent.Timestamp,
                 LastUpdatedTime = DateTime.UtcNow,
                 CompletedTime = Core.Common.DateTimeUtils.MinDateTime,
-                ScheduledStartTime = executionStartedEvent.ScheduledStartTime
+                ScheduledStartTime = executionStartedEvent.ScheduledStartTime,
+                Generation = executionStartedEvent.Generation
             };
 
             var orchestrationStateEntity = new OrchestrationStateInstanceEntity()

--- a/src/DurableTask.Core/History/ExecutionStartedEvent.cs
+++ b/src/DurableTask.Core/History/ExecutionStartedEvent.cs
@@ -92,5 +92,11 @@ namespace DurableTask.Core.History
         /// </summary>
         [DataMember]
         public DateTime? ScheduledStartTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the generation of the orchestration
+        /// </summary>
+        [DataMember]
+        public int? Generation { get; set; }
     }
 }

--- a/src/DurableTask.Core/OrchestrationState.cs
+++ b/src/DurableTask.Core/OrchestrationState.cs
@@ -108,7 +108,7 @@ namespace DurableTask.Core
         public string Version;
 
         /// <summary>
-        /// The orchestration gneration. Reused instanceIds will increment this value.
+        /// The orchestration generation. Reused instanceIds will increment this value.
         /// </summary>
         [DataMember]
         public int? Generation;

--- a/src/DurableTask.Core/OrchestrationState.cs
+++ b/src/DurableTask.Core/OrchestrationState.cs
@@ -108,6 +108,12 @@ namespace DurableTask.Core
         public string Version;
 
         /// <summary>
+        /// The orchestration gneration. Reused instanceIds will increment this value.
+        /// </summary>
+        [DataMember]
+        public int Generation;
+
+        /// <summary>
         /// Gets or sets date to start the orchestration
         /// </summary>
         [DataMember]

--- a/src/DurableTask.Core/OrchestrationState.cs
+++ b/src/DurableTask.Core/OrchestrationState.cs
@@ -111,7 +111,7 @@ namespace DurableTask.Core
         /// The orchestration gneration. Reused instanceIds will increment this value.
         /// </summary>
         [DataMember]
-        public int Generation;
+        public int? Generation;
 
         /// <summary>
         /// Gets or sets date to start the orchestration


### PR DESCRIPTION
This PR addresses issues when running dedupe orchestration started checks when reusing instanceIds. Currently if the instances table hasn't been updated by the time the dedupe checks run, the execution stated event can be discarded if the instanceId was reused. This is because the remoteInstance will be the previous instance execution, instead of the current instance execution. This PR addresses this issue by adding the column Generation to the Instances table, which represents the sequence number of each instance to ensure the correct execution is being represented in remoteInstance.