### PR TITLE
Added ArgumentException catch block when stealing lease

### DIFF
--- a/src/DurableTask.AzureStorage/Partitioning/LeaseCollectionBalancer.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/LeaseCollectionBalancer.cs
@@ -575,6 +575,11 @@ namespace DurableTask.AzureStorage.Partitioning
                 // Concurrency issue in stealing the lease, someone else got it before us
                 this.settings.Logger.LeaseStealingFailed(this.accountName, this.taskHub, this.workerName, lease.PartitionId);
             }
+            catch (ArgumentException)
+            {
+                // Concurrency issue in stealing the lease, someone else got it before us
+                this.settings.Logger.LeaseStealingFailed(this.accountName, this.taskHub, this.workerName, lease.PartitionId);
+            }
             catch (Exception ex)
             {
                 // Eat any exceptions during stealing


### PR DESCRIPTION
Added ArgumentException catch block when attempting to steal a lease. This can be thrown when another worker steals the lease before we get to it.

resolves #406 