### PR TITLE
Generic extensions to create orchestrations in a strongly-typed manner

### DIFF
--- a/src/DurableTask.Core/Extensions/OrchestrationContextExtensions.cs
+++ b/src/DurableTask.Core/Extensions/OrchestrationContextExtensions.cs
@@ -1,0 +1,29 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ---------------------------------------------------------------
+
+namespace DurableTask.Core
+{
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Generic extensions to create orchestration activities type-safely.
+    /// </summary>
+    public static class OrchestrationContextExtensions
+    {
+        /// <summary>
+        /// Schedule a TaskActivity by type.
+        /// </summary>
+        /// <typeparam name="TActivity">Type that devices from TaskActivity class</typeparam>
+        /// <typeparam name="TResult">Return Type of the TaskActivity.Execute method</typeparam>
+        /// <typeparam name="TInput">Parameter type of TaskActivity</typeparam>
+        /// <param name="orchestrationContext"></param>
+        /// <param name="parameters">Parameters for the TaskActivity.Execute method</param>
+        /// <returns>Task that represents the execution of the specified TaskActivity</returns>
+        public static Task<TResult> ScheduleTask<TActivity, TInput, TResult>(this OrchestrationContext orchestrationContext, TInput parameters)
+            where TActivity: TaskActivity<TInput, TResult>
+        {
+            return orchestrationContext.ScheduleTask<TResult>(typeof(TActivity), parameters);
+        }
+    }
+}

--- a/src/DurableTask.Core/Extensions/TaskHubClientExtensions.cs
+++ b/src/DurableTask.Core/Extensions/TaskHubClientExtensions.cs
@@ -1,0 +1,78 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ---------------------------------------------------------------
+
+namespace DurableTask.Core
+{
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Generic extensions to create orchestrations type-safely.
+    /// </summary>
+    public static class TaskHubClientExtensions
+    {
+        /// <summary>
+        /// Create a new orchestration of the specified type with an automatically generated instance id
+        /// </summary>
+        /// <typeparam name="TOrchestration">Type that derives from TaskOrchestration{string, string}</typeparam>
+        /// <param name="taskHubClient"></param>
+        /// <param name="input">Input parameter to the specified TaskOrchestration</param>
+        /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
+        public static Task<OrchestrationInstance> CreateOrchestrationInstanceAsync<TOrchestration>(this TaskHubClient taskHubClient, string input)
+            where TOrchestration : TaskOrchestration<string, string>
+        {
+            return taskHubClient.CreateOrchestrationInstanceAsync(typeof(TOrchestration), input);
+        }
+
+        /// <summary>
+        /// Create a new orchestration of the specified type with an automatically generated instance id
+        /// </summary>
+        /// <typeparam name="TOrchestration">Type that derives from TaskOrchestration</typeparam>
+        /// <typeparam name="TInput">TaskOrchestration parameter type</typeparam>
+        /// <typeparam name="TResult">TaskOrchestration result type</typeparam>
+        /// <param name="taskHubClient"></param>
+        /// <param name="input">Input parameter to the specified TaskOrchestration</param>
+        /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
+        public static Task<OrchestrationInstance> CreateOrchestrationInstanceAsync<TOrchestration, TInput, TResult>(this TaskHubClient taskHubClient, TInput input)
+            where TOrchestration : TaskOrchestration<TInput, TResult>
+        {
+            return taskHubClient.CreateOrchestrationInstanceAsync(typeof(TOrchestration), input);
+        }
+
+        /// <summary>
+        /// Create a new orchestration of the specified type with the specified instance id
+        /// </summary>
+        /// <typeparam name="TOrchestration">Type that derives from TaskOrchestration</typeparam>
+        /// <typeparam name="TInput">TaskOrchestration parameter type</typeparam>
+        /// <typeparam name="TResult">TaskOrchestration result type</typeparam>
+        /// <param name="taskHubClient"></param>
+        /// <param name="instanceId">Instance id for the orchestration to be created, must be unique across the Task Hub</param>
+        /// <param name="input">Input parameter to the specified TaskOrchestration</param>
+        /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
+        public static Task<OrchestrationInstance> CreateOrchestrationInstanceAsync<TOrchestration, TInput, TResult>(this TaskHubClient taskHubClient, string instanceId, TInput input)
+            where TOrchestration : TaskOrchestration<TInput, TResult>
+        {
+            return taskHubClient.CreateOrchestrationInstanceAsync(typeof(TOrchestration), instanceId, input);
+        }
+
+        /// <summary>
+        /// Create a new orchestration of the specified type with the specified instance id
+        /// </summary>
+        /// <typeparam name="TOrchestration">Type that derives from TaskOrchestration</typeparam>
+        /// <typeparam name="TInput">TaskOrchestration parameter type</typeparam>
+        /// <typeparam name="TResult">TaskOrchestration result type</typeparam>
+        /// <param name="taskHubClient"></param>
+        /// <param name="instanceId">Instance id for the orchestration to be created, must be unique across the Task Hub</param>
+        /// <param name="input">Input parameter to the specified TaskOrchestration</param>
+        /// <param name="dedupeStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
+        /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
+        public static Task<OrchestrationInstance> CreateOrchestrationInstanceAsync<TOrchestration, TInput, TResult>(this TaskHubClient taskHubClient,
+            string instanceId,
+            TInput input,
+            OrchestrationStatus[] dedupeStatuses)
+            where TOrchestration : TaskOrchestration<TInput, TResult>
+        {
+            return taskHubClient.CreateOrchestrationInstanceAsync(typeof(TOrchestration), instanceId, input, dedupeStatuses);
+        }
+    }
+}


### PR DESCRIPTION
Adding some extensions to allow creation of Orchestrations/Activities in a type-safe manner.
Basically, a bit of modernizing API without breaking the backwards compatibility + checking in compile time that the parameter passed matches the orchestration/activity contracts.
Samples below based on Tests in project.
Before #1
`OrchestrationInstance id = await this.client.CreateOrchestrationInstanceAsync(typeof(AsyncGreetingsOrchestration), null);`
After #1
`OrchestrationInstance id = await this.client.CreateOrchestrationInstanceAsync<AsyncGreetingsOrchestration>(null);`
Before #2 (OK)
`OrchestrationInstance id = await this.client.CreateOrchestrationInstanceAsync(typeof (TypeMissingOrchestration), "test");`
Before #2 (Fails in Runtime)
`OrchestrationInstance id = await this.client.CreateOrchestrationInstanceAsync(typeof (TypeMissingOrchestration), 1);`
After #2 (Fails to Compile)
`OrchestrationInstance id = await this.client.CreateOrchestrationInstanceAsync<TypeMissingOrchestration>(1);`