### PR TITLE
Use `using` for disposable objects

### DIFF
--- a/src/DurableTask.Core/Serializing/JsonDataConverter.cs
+++ b/src/DurableTask.Core/Serializing/JsonDataConverter.cs
@@ -76,14 +76,14 @@ namespace DurableTask.Core.Serializing
             }
 
             var sb = new StringBuilder(0x100);
-            var textWriter = new StringWriter(sb, CultureInfo.InvariantCulture);
+            using (var textWriter = new StringWriter(sb, CultureInfo.InvariantCulture))
             using (var writer = new JsonTextWriter(textWriter))
             {
                 writer.Formatting = (formatted ? Formatting.Indented : Formatting.None);
                 this.serializer.Serialize(writer, value);
+            
+                return textWriter.ToString();
             }
-
-            return textWriter.ToString();
         }
 
         /// <summary>
@@ -99,9 +99,11 @@ namespace DurableTask.Core.Serializing
                 return null;
             }
 
-            var reader = new StringReader(data);
-
-            return this.serializer.Deserialize(new JsonTextReader(reader), objectType);
+            using (var reader = new StringReader(data))
+            using (var jsonTextReader = new JsonTextReader(reader))
+            {
+                return this.serializer.Deserialize(jsonTextReader, objectType);
+            }
         }
     }
 }


### PR DESCRIPTION
Use `using` when working with IDisposable objects. This allows better memory management by the GC.