### PR TITLE
Avoid many instances of JsonDataConverter

### DIFF
--- a/src/DurableTask.Core/ReflectionBasedTaskActivity.cs
+++ b/src/DurableTask.Core/ReflectionBasedTaskActivity.cs
@@ -26,6 +26,8 @@ namespace DurableTask.Core
     /// </summary>
     public class ReflectionBasedTaskActivity : TaskActivity
     {
+        private readonly static JsonDataConverter defaultDataConverter  = new JsonDataConverter();
+
         private DataConverter dataConverter;
 
         /// <summary>
@@ -35,7 +37,7 @@ namespace DurableTask.Core
         /// <param name="methodInfo">The Reflection.methodInfo for invoking the method on the activity object</param>
         public ReflectionBasedTaskActivity(object activityObject, MethodInfo methodInfo)
         {
-            DataConverter = new JsonDataConverter();
+            DataConverter = defaultDataConverter;
             ActivityObject = activityObject;
             MethodInfo = methodInfo;
         }

--- a/src/DurableTask.Core/TaskActivity.cs
+++ b/src/DurableTask.Core/TaskActivity.cs
@@ -54,12 +54,14 @@ namespace DurableTask.Core
     /// <typeparam name="TResult">Output type of the activity</typeparam>
     public abstract class AsyncTaskActivity<TInput, TResult> : TaskActivity
     {
+        private readonly static JsonDataConverter defaultDataConverter  = new JsonDataConverter();
+     
         /// <summary>
         /// Creates a new AsyncTaskActivity with the default DataConverter
         /// </summary>
         protected AsyncTaskActivity()
         {
-            DataConverter = new JsonDataConverter();
+            DataConverter = defaultDataConverter;
         }
 
         /// <summary>
@@ -68,7 +70,7 @@ namespace DurableTask.Core
         /// <param name="dataConverter"></param>
         protected AsyncTaskActivity(DataConverter dataConverter)
         {
-            DataConverter = dataConverter ?? new JsonDataConverter();
+            DataConverter = dataConverter ?? defaultDataConverter;
         }
 
         /// <summary>

--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -29,6 +29,8 @@ namespace DurableTask.Core
     /// </summary>
     public sealed class TaskHubClient
     {
+        private readonly static JsonDataConverter defaultDataConverter  = new JsonDataConverter();
+        
         readonly DataConverter defaultConverter;
         readonly LogHelper logHelper;
 
@@ -42,7 +44,7 @@ namespace DurableTask.Core
         /// </summary>
         /// <param name="serviceClient">Object implementing the <see cref="IOrchestrationServiceClient"/> interface </param>
         public TaskHubClient(IOrchestrationServiceClient serviceClient)
-            : this(serviceClient, new JsonDataConverter())
+            : this(serviceClient, defaultDataConverter)
         {
         }
 
@@ -65,7 +67,7 @@ namespace DurableTask.Core
         public TaskHubClient(IOrchestrationServiceClient serviceClient, DataConverter dataConverter = null, ILoggerFactory loggerFactory = null)
         {
             this.ServiceClient = serviceClient ?? throw new ArgumentNullException(nameof(serviceClient));
-            this.defaultConverter = dataConverter ?? new JsonDataConverter();
+            this.defaultConverter = dataConverter ?? defaultDataConverter;
             this.logHelper = new LogHelper(loggerFactory?.CreateLogger("DurableTask.Core"));
         }
 

--- a/src/DurableTask.Core/TaskOrchestration.cs
+++ b/src/DurableTask.Core/TaskOrchestration.cs
@@ -68,12 +68,14 @@ namespace DurableTask.Core
     /// <typeparam name="TStatus">Output Type for GetStatus calls</typeparam>
     public abstract class TaskOrchestration<TResult, TInput, TEvent, TStatus> : TaskOrchestration
     {
+        private readonly static JsonDataConverter defaultDataConverter  = new JsonDataConverter();
+        
         /// <summary>
         /// Creates a new TaskOrchestration with the default DataConverter
         /// </summary>
         protected TaskOrchestration()
         {
-            DataConverter = new JsonDataConverter();
+            DataConverter = defaultDataConverter;
         }
 
         /// <summary>

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -28,6 +28,8 @@ namespace DurableTask.Core
 
     internal class TaskOrchestrationContext : OrchestrationContext
     {
+        private readonly static JsonDataConverter defaultDataConverter  = new JsonDataConverter();
+ 
         private readonly IDictionary<int, OpenTaskInfo> openTasks;
         private readonly IDictionary<int, OrchestratorAction> orchestratorActionsMap;
         private OrchestrationCompleteOrchestratorAction continueAsNew;
@@ -51,8 +53,8 @@ namespace DurableTask.Core
             this.openTasks = new Dictionary<int, OpenTaskInfo>();
             this.orchestratorActionsMap = new SortedDictionary<int, OrchestratorAction>();
             this.idCounter = 0;
-            this.MessageDataConverter = new JsonDataConverter();
-            this.ErrorDataConverter = new JsonDataConverter();
+            this.MessageDataConverter = defaultDataConverter;
+            this.ErrorDataConverter = defaultDataConverter;
             OrchestrationInstance = orchestrationInstance;
             IsReplaying = false;
             ErrorPropagationMode = errorPropagationMode;


### PR DESCRIPTION
Since JsonDataConverter is an immutable class, there's no point creating new instances it of it every time Activity/Orchestration/Context/Client objects are created.
Users are still able to provide their own implementation as before.