### PR TITLE
Fixes for new partition management

### DIFF
--- a/src/DurableTask.AzureStorage/Partitioning/LeaseCollectionBalancer.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/LeaseCollectionBalancer.cs
@@ -171,115 +171,102 @@ namespace DurableTask.AzureStorage.Partitioning
             }
         }
 
-        Task LeaseRenewer()
+        async Task LeaseRenewer()
         {
-            // use a dedicated thread to make the lease renewal less susceptible to thread pool starvation
-            var taskCompletionSource = new TaskCompletionSource<bool>();
-            var leaseRenewalThread = new Thread(LeaseRenewalLoop);
-            leaseRenewalThread.Name = "LeaseRenewalThread";
-            leaseRenewalThread.Start();
-            return taskCompletionSource.Task;
+            this.settings.Logger.PartitionManagerInfo(
+                this.accountName,
+                this.taskHub,
+                this.workerName,
+                string.Empty /* partitionId */,
+                $"Starting background renewal of {this.leaseType} leases with interval: {this.options.RenewInterval}.");
 
-            void LeaseRenewalLoop()
+            while (this.isStarted == 1 || !shutdownComplete)
             {
-                this.settings.Logger.PartitionManagerInfo(
-                    this.accountName,
-                    this.taskHub,
-                    this.workerName,
-                    string.Empty /* partitionId */,
-                    $"Starting background renewal of {this.leaseType} leases with interval: {this.options.RenewInterval}.");
-
-                var stopwatch = new Stopwatch();
-                var leaseTasks = new List<Task>();
-
-                while (this.isStarted == 1 || !this.shutdownComplete)
+                try
                 {
-                    try
+                    var nonRenewedLeases = new ConcurrentBag<T>();
+                    var renewTasks = new List<Task>();
+
+                    // Renew leases for all currently owned partitions in parallel
+                    foreach (T lease in this.currentlyOwnedShards.Values)
                     {
-                        this.settings.Logger.PartitionManagerInfo(
-                           this.accountName,
-                           this.taskHub,
-                           this.workerName,
-                           string.Empty /* partitionId */,
-                           $"Starting next round of {this.leaseType} lease renewals after {stopwatch.Elapsed}.");
-
-                        stopwatch.Restart();
-
-                        foreach (T lease in this.currentlyOwnedShards.Values.ToList())
+                        if (this.shouldRenewLeaseDelegate(lease.PartitionId))
                         {
-                            leaseTasks.Add(RenewOwnedLease(lease));
-                        }
-                        foreach (T shutdownLease in this.keepRenewingDuringClose.Values.ToList())
-                        {
-                            leaseTasks.Add(RenewShutdownLease(shutdownLease));
-                        }
-
-                        Task.WhenAll(leaseTasks).Wait();
-                        leaseTasks.Clear();
-
-                        var delayBy = this.options.RenewInterval - stopwatch.Elapsed;
-                        if (delayBy > TimeSpan.Zero)
-                        {
-                            this.leaseRenewerCancellationTokenSource.Token.WaitHandle.WaitOne(delayBy);
-                        }
-
-                        async Task RenewOwnedLease(T lease)
-                        {
-                            if (this.shouldRenewLeaseDelegate(lease.PartitionId))
+                            renewTasks.Add(this.RenewLeaseAsync(lease).ContinueWith(renewResult =>
                             {
-                                if (!await this.RenewLeaseAsync(lease))
+                                if (!renewResult.Result)
                                 {
-                                    await this.RemoveLeaseAsync(lease, false);
+                                    // Keep track of all failed attempts to renew so we can trigger shutdown for these partitions
+                                    nonRenewedLeases.Add(lease);
                                 }
-                            }
-                            else
-                            {
-                                await this.RemoveLeaseAsync(lease, true);
-                            }
-                        }
-
-                        async Task RenewShutdownLease(T lease)
+                            }));
+                        } 
+                        else 
                         {
-                            if (this.shouldRenewLeaseDelegate(lease.PartitionId))
-                            {
-                                if (!await this.RenewLeaseAsync(lease))
-                                {
-                                    this.keepRenewingDuringClose.TryRemove(lease.PartitionId, out var _);
-                                }
-                            }
+                            nonRenewedLeases.Add(lease);
                         }
                     }
-                    catch (OperationCanceledException)
+
+                    // Renew leases for all partitions currently in shutdown 
+                    var failedToRenewShutdownLeases = new List<T>();
+                    foreach (T shutdownLease in this.keepRenewingDuringClose.Values)
                     {
-                        this.settings.Logger.PartitionManagerInfo(
-                            this.accountName,
-                            this.taskHub,
-                            this.workerName,
-                            string.Empty /* partitionId */,
-                            $"Background renewal task for {this.leaseType} leases was canceled.");
+                        if (this.shouldRenewLeaseDelegate(shutdownLease.PartitionId))
+                        {
+                            renewTasks.Add(this.RenewLeaseAsync(shutdownLease).ContinueWith(renewResult =>
+                            {
+                                if (!renewResult.Result)
+                                {
+                                    // Keep track of all failed attempts to renew shutdown leases so we can remove them from further renew attempts
+                                    failedToRenewShutdownLeases.Add(shutdownLease);
+                                }
+                            }));
+                        }
                     }
-                    catch (Exception ex)
+
+                    // Wait for all renews to complete
+                    await Task.WhenAll(renewTasks.ToArray());
+
+                    // Trigger shutdown of all partitions we did not successfully renew leases for
+                    await nonRenewedLeases.ParallelForEachAsync(lease => this.RemoveLeaseAsync(lease, false));
+
+                    // Now remove all failed renewals of shutdown leases from further renewals
+                    foreach (T failedToRenewShutdownLease in failedToRenewShutdownLeases)
                     {
-                        this.settings.Logger.PartitionManagerError(
-                            this.accountName,
-                            this.taskHub,
-                            this.workerName,
-                            string.Empty,
-                            $"Failed during {this.leaseType} lease renewal: {ex.ToString()}");
+                        T removedLease = null;
+                        this.keepRenewingDuringClose.TryRemove(failedToRenewShutdownLease.PartitionId, out removedLease);
                     }
+
+                    await Task.Delay(this.options.RenewInterval, this.leaseRenewerCancellationTokenSource.Token);
                 }
-
-                this.currentlyOwnedShards.Clear();
-                this.keepRenewingDuringClose.Clear();
-                this.settings.Logger.PartitionManagerInfo(
-                    this.accountName,
-                    this.taskHub,
-                    this.workerName,
-                    string.Empty /* partitionId */,
-                    $"Background renewer task for {this.leaseType} leases completed.");
-
-                taskCompletionSource.SetResult(true);
+                catch (OperationCanceledException)
+                {
+                    this.settings.Logger.PartitionManagerInfo(
+                        this.accountName,
+                        this.taskHub,
+                        this.workerName,
+                        string.Empty /* partitionId */,
+                        $"Background renewal task for {this.leaseType} leases was canceled.");
+                }
+                catch (Exception ex)
+                {
+                    this.settings.Logger.PartitionManagerError(
+                        this.accountName,
+                        this.taskHub,
+                        this.workerName,
+                        string.Empty,
+                        $"Failed during {this.leaseType} lease renewal: {ex.ToString()}");
+                }
             }
+
+            this.currentlyOwnedShards.Clear();
+            this.keepRenewingDuringClose.Clear();
+            this.settings.Logger.PartitionManagerInfo(
+                this.accountName,
+                this.taskHub,
+                this.workerName,
+                string.Empty /* partitionId */,
+                $"Background renewer task for {this.leaseType} leases completed.");
         }
 
         async Task LeaseTakerAsync()

--- a/src/DurableTask.AzureStorage/Partitioning/LeaseCollectionBalancer.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/LeaseCollectionBalancer.cs
@@ -383,7 +383,10 @@ namespace DurableTask.AzureStorage.Partitioning
                 }
 
                 int myCount = workerToShardCount[this.workerName];
-                int moreShardsNeeded = target - myCount;
+
+                // if we are stealing intent leases, we are trying to take as many as required to reach balance
+                // if we are aquiring owner leases, we want to acquire all of the expired leases
+                int moreShardsNeeded = this.options.ShouldStealLeases ? target - myCount : expiredLeases.Count;
 
                 if (moreShardsNeeded > 0)
                 {

--- a/src/DurableTask.AzureStorage/Storage/AzureStorageClient.cs
+++ b/src/DurableTask.AzureStorage/Storage/AzureStorageClient.cs
@@ -115,8 +115,8 @@ namespace DurableTask.AzureStorage.Storage
         public Task<T> MakeTableStorageRequest<T>(Func<OperationContext, CancellationToken, Task<T>> storageRequest, string operationName, string? clientRequestId = null) =>
             this.MakeStorageRequest<T>(storageRequest, TableAccountName, operationName, clientRequestId);
 
-        public Task MakeBlobStorageRequest(Func<OperationContext, CancellationToken, Task> storageRequest, string operationName, string? clientRequestId = null, bool throttle = true) =>
-            this.MakeStorageRequest(storageRequest, BlobAccountName, operationName, clientRequestId, throttle);
+        public Task MakeBlobStorageRequest(Func<OperationContext, CancellationToken, Task> storageRequest, string operationName, string? clientRequestId = null, bool force = false) =>
+            this.MakeStorageRequest(storageRequest, BlobAccountName, operationName, clientRequestId, force);
 
         public Task MakeQueueStorageRequest(Func<OperationContext, CancellationToken, Task> storageRequest, string operationName, string? clientRequestId = null) =>
             this.MakeStorageRequest(storageRequest, QueueAccountName, operationName, clientRequestId);
@@ -124,9 +124,9 @@ namespace DurableTask.AzureStorage.Storage
         public Task MakeTableStorageRequest(Func<OperationContext, CancellationToken, Task> storageRequest, string operationName, string? clientRequestId = null) =>
             this.MakeStorageRequest(storageRequest, TableAccountName, operationName, clientRequestId);
 
-        private async Task<T> MakeStorageRequest<T>(Func<OperationContext, CancellationToken, Task<T>> storageRequest, string accountName, string operationName, string? clientRequestId = null, bool throttle = true)
+        private async Task<T> MakeStorageRequest<T>(Func<OperationContext, CancellationToken, Task<T>> storageRequest, string accountName, string operationName, string? clientRequestId = null, bool force = false)
         {
-            if (throttle)
+            if (!force)
             {
                 await requestThrottleSemaphore.WaitAsync();
             }
@@ -141,7 +141,7 @@ namespace DurableTask.AzureStorage.Storage
             }
             finally
             {
-                if (throttle)
+                if (!force)
                 {
                     requestThrottleSemaphore.Release();
                 }

--- a/src/DurableTask.AzureStorage/Storage/AzureStorageClient.cs
+++ b/src/DurableTask.AzureStorage/Storage/AzureStorageClient.cs
@@ -148,8 +148,8 @@ namespace DurableTask.AzureStorage.Storage
             }
         }
 
-        private Task MakeStorageRequest(Func<OperationContext, CancellationToken, Task> storageRequest, string accountName, string operationName, string? clientRequestId = null, bool throttle = true) =>
-            this.MakeStorageRequest<object?>((context, cancellationToken) => WrapFunctionWithReturnType(storageRequest, context, cancellationToken), accountName, operationName, clientRequestId, throttle);
+        private Task MakeStorageRequest(Func<OperationContext, CancellationToken, Task> storageRequest, string accountName, string operationName, string? clientRequestId = null, bool force = false) =>
+            this.MakeStorageRequest<object?>((context, cancellationToken) => WrapFunctionWithReturnType(storageRequest, context, cancellationToken), accountName, operationName, clientRequestId, force);
 
         private static async Task<object?> WrapFunctionWithReturnType(Func<OperationContext, CancellationToken, Task> storageRequest, OperationContext context, CancellationToken cancellationToken)
         {

--- a/src/DurableTask.AzureStorage/Storage/Blob.cs
+++ b/src/DurableTask.AzureStorage/Storage/Blob.cs
@@ -127,7 +127,8 @@ namespace DurableTask.AzureStorage.Storage
             var requestOptions = new BlobRequestOptions { ServerTimeout = azureStorageClient.Settings.LeaseRenewInterval };
             await this.azureStorageClient.MakeBlobStorageRequest(
                 (context, cancellationToken) => this.cloudBlockBlob.RenewLeaseAsync(AccessCondition.GenerateLeaseCondition(leaseId), requestOptions, context, cancellationToken),
-                "Blob RenewLease");
+                "Blob RenewLease",
+                throttle: false); // lease renewals should not be throttled
         }
 
         public async Task ReleaseLeaseAsync(string leaseId)

--- a/src/DurableTask.AzureStorage/Storage/Blob.cs
+++ b/src/DurableTask.AzureStorage/Storage/Blob.cs
@@ -128,7 +128,7 @@ namespace DurableTask.AzureStorage.Storage
             await this.azureStorageClient.MakeBlobStorageRequest(
                 (context, cancellationToken) => this.cloudBlockBlob.RenewLeaseAsync(AccessCondition.GenerateLeaseCondition(leaseId), requestOptions, context, cancellationToken),
                 "Blob RenewLease",
-                throttle: false); // lease renewals should not be throttled
+                force: true); // lease renewals should not be throttled
         }
 
         public async Task ReleaseLeaseAsync(string leaseId)


### PR DESCRIPTION
This fixes a bug in the partition management logic for ownership leases: all available ownership leases (for partitions that are expired and for which intent leases are owned) must be acquired, regardless of how many nodes there are and how many partitions have been already acquired. The balancing is already taken care of by the intent leases.

Also, this PR adds an exclusion so lease renewals are not subjected to request throttling; because request throttling on lease renewals can be counterproductive in heavily loaded situations.
