### PR TITLE
Improve logging for lease management

### DIFF
--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -625,13 +625,14 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(EventIds.StartingLeaseRenewal, Level = EventLevel.Verbose, Version = 2)]
+        [Event(EventIds.StartingLeaseRenewal, Level = EventLevel.Verbose, Version = 3)]
         public void StartingLeaseRenewal(
             string Account,
             string TaskHub,
             string WorkerName,
             string PartitionId,
             string Token,
+            string LeaseType,
             string AppName,
             string ExtensionVersion)
         {
@@ -642,11 +643,12 @@ namespace DurableTask.AzureStorage
                 WorkerName ?? string.Empty,
                 PartitionId ?? string.Empty,
                 Token ?? string.Empty,
+                LeaseType,
                 AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.LeaseRenewalResult, Level = EventLevel.Verbose, Version = 2)]
+        [Event(EventIds.LeaseRenewalResult, Level = EventLevel.Verbose, Version = 3)]
         public void LeaseRenewalResult(
             string Account,
             string TaskHub,
@@ -654,6 +656,7 @@ namespace DurableTask.AzureStorage
             string PartitionId,
             bool Success,
             string Token,
+            string LeaseType,
             string Details,
             string AppName,
             string ExtensionVersion)
@@ -666,18 +669,20 @@ namespace DurableTask.AzureStorage
                 PartitionId ?? string.Empty,
                 Success,
                 Token ?? string.Empty,
+                LeaseType,
                 Details ?? string.Empty,
                 AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.LeaseRenewalFailed, Level = EventLevel.Informational, Version = 2)]
+        [Event(EventIds.LeaseRenewalFailed, Level = EventLevel.Informational, Version = 3)]
         public void LeaseRenewalFailed(
             string Account,
             string TaskHub,
             string WorkerName,
             string PartitionId,
             string Token,
+            string LeaseType,
             string Details,
             string AppName,
             string ExtensionVersion)
@@ -689,17 +694,19 @@ namespace DurableTask.AzureStorage
                 WorkerName ?? string.Empty,
                 PartitionId ?? string.Empty,
                 Token ?? string.Empty,
+                LeaseType,
                 Details ?? string.Empty,
                 AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.LeaseAcquisitionStarted, Level = EventLevel.Informational, Version = 2)]
+        [Event(EventIds.LeaseAcquisitionStarted, Level = EventLevel.Informational, Version = 3)]
         public void LeaseAcquisitionStarted(
             string Account,
             string TaskHub,
             string WorkerName,
             string PartitionId,
+            string LeaseType,
             string AppName,
             string ExtensionVersion)
         {
@@ -709,16 +716,18 @@ namespace DurableTask.AzureStorage
                 TaskHub,
                 WorkerName ?? string.Empty,
                 PartitionId ?? string.Empty,
+                LeaseType,
                 AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.LeaseAcquisitionSucceeded, Level = EventLevel.Informational, Version = 2)]
+        [Event(EventIds.LeaseAcquisitionSucceeded, Level = EventLevel.Informational, Version = 3)]
         public void LeaseAcquisitionSucceeded(
             string Account,
             string TaskHub,
             string WorkerName,
             string PartitionId,
+            string LeaseType,
             string AppName,
             string ExtensionVersion)
         {
@@ -728,16 +737,18 @@ namespace DurableTask.AzureStorage
                 TaskHub,
                 WorkerName ?? string.Empty,
                 PartitionId ?? string.Empty,
+                LeaseType,
                 AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.LeaseAcquisitionFailed, Level = EventLevel.Informational, Version = 2)]
+        [Event(EventIds.LeaseAcquisitionFailed, Level = EventLevel.Informational, Version = 3)]
         public void LeaseAcquisitionFailed(
             string Account,
             string TaskHub,
             string WorkerName,
             string PartitionId,
+            string LeaseType,
             string AppName,
             string ExtensionVersion)
         {
@@ -747,6 +758,7 @@ namespace DurableTask.AzureStorage
                 TaskHub,
                 WorkerName ?? string.Empty,
                 PartitionId ?? string.Empty,
+                LeaseType,
                 AppName,
                 ExtensionVersion);
         }
@@ -797,12 +809,13 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(EventIds.LeaseStealingFailed, Level = EventLevel.Informational, Version = 2)]
+        [Event(EventIds.LeaseStealingFailed, Level = EventLevel.Informational, Version = 3)]
         public void LeaseStealingFailed(
             string Account,
             string TaskHub,
             string WorkerName,
             string PartitionId,
+            string LeaseType,
             string AppName,
             string ExtensionVersion)
         {
@@ -812,6 +825,7 @@ namespace DurableTask.AzureStorage
                 TaskHub,
                 WorkerName ?? string.Empty,
                 PartitionId ?? string.Empty,
+                LeaseType,
                 AppName,
                 ExtensionVersion);
         }
@@ -837,13 +851,14 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(EventIds.LeaseRemoved, Level = EventLevel.Informational, Version = 2)]
+        [Event(EventIds.LeaseRemoved, Level = EventLevel.Informational, Version = 3)]
         public void LeaseRemoved(
             string Account,
             string TaskHub,
             string WorkerName,
             string PartitionId,
             string Token,
+            string LeaseType,
             string AppName,
             string ExtensionVersion)
         {
@@ -854,17 +869,19 @@ namespace DurableTask.AzureStorage
                 WorkerName ?? string.Empty,
                 PartitionId ?? string.Empty,
                 Token ?? string.Empty,
+                LeaseType,
                 AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.LeaseRemovalFailed, Level = EventLevel.Warning, Version = 2)]
+        [Event(EventIds.LeaseRemovalFailed, Level = EventLevel.Warning, Version = 3)]
         public void LeaseRemovalFailed(
             string Account,
             string TaskHub,
             string WorkerName,
             string PartitionId,
             string Token,
+            string LeaseType,
             string AppName,
             string ExtensionVersion)
         {
@@ -875,6 +892,7 @@ namespace DurableTask.AzureStorage
                 WorkerName ?? string.Empty,
                 PartitionId ?? string.Empty,
                 Token ?? string.Empty,
+                LeaseType,
                 AppName,
                 ExtensionVersion);
         }

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -228,6 +228,11 @@ namespace DurableTask.AzureStorage
                 throw new ArgumentOutOfRangeException(nameof(settings), "The number of partitions must be a positive integer and no greater than 16.");
             }
 
+            if (string.IsNullOrEmpty(settings.TaskHubName))
+            {
+                throw new ArgumentNullException(nameof(settings), $"A {nameof(settings.TaskHubName)} value must be configured in the settings.");
+            }
+
             // TODO: More validation.
         }
 

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -97,7 +97,7 @@ namespace DurableTask.AzureStorage
         /// <summary>
         /// Gets or sets the name of the task hub. This value is used to group related storage resources.
         /// </summary>
-        public string TaskHubName { get; set; }
+        public string TaskHubName { get; set; } = "Default";
 
         /// <summary>
         /// Gets or sets the maximum number of work items that can be processed concurrently on a single node.

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <FileVersion>1.11.0</FileVersion>
+    <FileVersion>1.11.1</FileVersion>
     <AssemblyVersion>$(FileVersion)</AssemblyVersion>
     <Version>$(FileVersion)</Version>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/DurableTask.AzureStorage/Logging/LogEvents.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogEvents.cs
@@ -1503,13 +1503,15 @@ namespace DurableTask.AzureStorage.Logging
                 string taskHub,
                 string workerName,
                 string partitionId,
-                string token)
+                string token,
+                string leaseType)
             {
                 this.Account = account;
                 this.TaskHub = taskHub;
                 this.WorkerName = workerName;
                 this.PartitionId = partitionId;
                 this.Token = token;
+                this.LeaseType = leaseType;
             }
 
             [StructuredLogField]
@@ -1527,6 +1529,9 @@ namespace DurableTask.AzureStorage.Logging
             [StructuredLogField]
             public string Token { get; }
 
+            [StructuredLogField]
+            public string LeaseType { get; }
+
             public override EventId EventId => new EventId(
                 EventIds.StartingLeaseRenewal,
                 nameof(EventIds.StartingLeaseRenewal));
@@ -1534,7 +1539,7 @@ namespace DurableTask.AzureStorage.Logging
             public override LogLevel Level => LogLevel.Debug;
 
             protected override string CreateLogMessage() =>
-                $"{this.PartitionId}: Starting lease renewal with token {this.Token}";
+                $"{this.PartitionId}: Starting {this.LeaseType} lease renewal with token {this.Token}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.StartingLeaseRenewal(
                 this.Account,
@@ -1542,6 +1547,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.WorkerName,
                 this.PartitionId,
                 this.Token,
+                this.LeaseType,
                 Utils.AppName,
                 Utils.ExtensionVersion);
         }
@@ -1555,6 +1561,7 @@ namespace DurableTask.AzureStorage.Logging
                 string partitionId,
                 bool success,
                 string token,
+                string leaseType,
                 string details)
             {
                 this.Account = account;
@@ -1563,6 +1570,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.PartitionId = partitionId;
                 this.Success = success;
                 this.Token = token;
+                this.LeaseType = leaseType;
                 this.Details = details;
             }
 
@@ -1585,6 +1593,9 @@ namespace DurableTask.AzureStorage.Logging
             public string Token { get; }
 
             [StructuredLogField]
+            public string LeaseType { get; }
+
+            [StructuredLogField]
             public string Details { get; }
 
             public override EventId EventId => new EventId(
@@ -1594,7 +1605,7 @@ namespace DurableTask.AzureStorage.Logging
             public override LogLevel Level => LogLevel.Debug;
 
             protected override string CreateLogMessage() =>
-                $"{this.PartitionId}: Lease renewal with token {this.Token} {(this.Success ? "succeeded" : "failed")}";
+                $"{this.PartitionId}: {this.LeaseType} lease renewal with token {this.Token} {(this.Success ? "succeeded" : "failed")}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseRenewalResult(
                 this.Account,
@@ -1603,6 +1614,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.PartitionId,
                 this.Success,
                 this.Token,
+                this.LeaseType,
                 this.Details,
                 Utils.AppName,
                 Utils.ExtensionVersion);
@@ -1616,6 +1628,7 @@ namespace DurableTask.AzureStorage.Logging
                 string workerName,
                 string partitionId,
                 string token,
+                string leaseType,
                 string details)
             {
                 this.Account = account;
@@ -1623,6 +1636,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.WorkerName = workerName;
                 this.PartitionId = partitionId;
                 this.Token = token;
+                this.LeaseType = leaseType;
                 this.Details = details;
             }
 
@@ -1642,6 +1656,9 @@ namespace DurableTask.AzureStorage.Logging
             public string Token { get; }
 
             [StructuredLogField]
+            public string LeaseType { get; }
+
+            [StructuredLogField]
             public string Details { get; }
 
             public override EventId EventId => new EventId(
@@ -1651,7 +1668,7 @@ namespace DurableTask.AzureStorage.Logging
             public override LogLevel Level => LogLevel.Information;
 
             protected override string CreateLogMessage() =>
-                $"{this.PartitionId}: Lease renewal with token {this.Token} failed: {this.Details}";
+                $"{this.PartitionId}: {this.LeaseType} lease renewal with token {this.Token} failed: {this.Details}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseRenewalFailed(
                 this.Account,
@@ -1659,6 +1676,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.WorkerName,
                 this.PartitionId,
                 this.Token,
+                this.LeaseType,
                 this.Details,
                 Utils.AppName,
                 Utils.ExtensionVersion);
@@ -1670,12 +1688,14 @@ namespace DurableTask.AzureStorage.Logging
                 string account,
                 string taskHub,
                 string workerName,
-                string partitionId)
+                string partitionId,
+                string leaseType)
             {
                 this.Account = account;
                 this.TaskHub = taskHub;
                 this.WorkerName = workerName;
                 this.PartitionId = partitionId;
+                this.LeaseType = leaseType;
             }
 
             [StructuredLogField]
@@ -1690,19 +1710,23 @@ namespace DurableTask.AzureStorage.Logging
             [StructuredLogField]
             public string PartitionId { get; }
 
+            [StructuredLogField]
+            public string LeaseType { get; }
+
             public override EventId EventId => new EventId(
                 EventIds.LeaseAcquisitionStarted,
                 nameof(EventIds.LeaseAcquisitionStarted));
 
             public override LogLevel Level => LogLevel.Information;
 
-            protected override string CreateLogMessage() => $"{this.PartitionId}: Attempting to acquire lease";
+            protected override string CreateLogMessage() => $"{this.PartitionId}: Attempting to acquire {this.LeaseType} lease";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseAcquisitionStarted(
                 this.Account,
                 this.TaskHub,
                 this.WorkerName,
                 this.PartitionId,
+                this.LeaseType,
                 Utils.AppName,
                 Utils.ExtensionVersion);
         }
@@ -1713,12 +1737,14 @@ namespace DurableTask.AzureStorage.Logging
                 string account,
                 string taskHub,
                 string workerName,
-                string partitionId)
+                string partitionId,
+                string leaseType)
             {
                 this.Account = account;
                 this.TaskHub = taskHub;
                 this.WorkerName = workerName;
                 this.PartitionId = partitionId;
+                this.LeaseType = leaseType;
             }
 
             [StructuredLogField]
@@ -1733,19 +1759,23 @@ namespace DurableTask.AzureStorage.Logging
             [StructuredLogField]
             public string PartitionId { get; }
 
+            [StructuredLogField]
+            public string LeaseType { get; }
+
             public override EventId EventId => new EventId(
                 EventIds.LeaseAcquisitionSucceeded,
                 nameof(EventIds.LeaseAcquisitionSucceeded));
 
             public override LogLevel Level => LogLevel.Information;
 
-            protected override string CreateLogMessage() => $"{this.PartitionId}: Successfully acquired lease";
+            protected override string CreateLogMessage() => $"{this.PartitionId}: Successfully acquired {this.LeaseType} lease";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseAcquisitionSucceeded(
                 this.Account,
                 this.TaskHub,
                 this.WorkerName,
                 this.PartitionId,
+                this.LeaseType,
                 Utils.AppName,
                 Utils.ExtensionVersion);
         }
@@ -1756,12 +1786,14 @@ namespace DurableTask.AzureStorage.Logging
                 string account,
                 string taskHub,
                 string workerName,
-                string partitionId)
+                string partitionId,
+                string leaseType)
             {
                 this.Account = account;
                 this.TaskHub = taskHub;
                 this.WorkerName = workerName;
                 this.PartitionId = partitionId;
+                this.LeaseType = leaseType;
             }
 
             [StructuredLogField]
@@ -1776,19 +1808,23 @@ namespace DurableTask.AzureStorage.Logging
             [StructuredLogField]
             public string PartitionId { get; }
 
+            [StructuredLogField]
+            public string LeaseType { get; }
+
             public override EventId EventId => new EventId(
                 EventIds.LeaseAcquisitionFailed,
                 nameof(EventIds.LeaseAcquisitionFailed));
 
             public override LogLevel Level => LogLevel.Information;
 
-            protected override string CreateLogMessage() => $"{this.PartitionId}: Failed to acquire lease";
+            protected override string CreateLogMessage() => $"{this.PartitionId}: Failed to acquire {this.LeaseType} lease";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseAcquisitionFailed(
                 this.Account,
                 this.TaskHub,
                 this.WorkerName,
                 this.PartitionId,
+                this.LeaseType,
                 Utils.AppName,
                 Utils.ExtensionVersion);
         }
@@ -1836,7 +1872,7 @@ namespace DurableTask.AzureStorage.Logging
             public override LogLevel Level => LogLevel.Information;
 
             protected override string CreateLogMessage() =>
-                $"{this.PartitionId}: Attempting to steal lease '{this.LeaseType}' from {this.FromWorkerName}";
+                $"{this.PartitionId}: Attempting to steal {this.LeaseType} lease from {this.FromWorkerName}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.AttemptingToStealLease(
                 this.Account,
@@ -1863,7 +1899,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.TaskHub = taskHub;
                 this.WorkerName = workerName;
                 this.FromWorkerName = fromWorkerName;
-                this.LeaseType = LeaseType;
+                this.LeaseType = leaseType;
                 this.PartitionId = partitionId;
             }
 
@@ -1892,7 +1928,7 @@ namespace DurableTask.AzureStorage.Logging
             public override LogLevel Level => LogLevel.Information;
 
             protected override string CreateLogMessage() =>
-                $"{this.PartitionId}: Successfully stole lease '{this.LeaseType}' from {this.FromWorkerName}";
+                $"{this.PartitionId}: Successfully stole {this.LeaseType} lease from {this.FromWorkerName}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseStealingSucceeded(
                 this.Account,
@@ -1911,12 +1947,14 @@ namespace DurableTask.AzureStorage.Logging
                 string account,
                 string taskHub,
                 string workerName,
-                string partitionId)
+                string partitionId,
+                string leaseType)
             {
                 this.Account = account;
                 this.TaskHub = taskHub;
                 this.WorkerName = workerName;
                 this.PartitionId = partitionId;
+                this.LeaseType = leaseType;
             }
 
             [StructuredLogField]
@@ -1931,19 +1969,23 @@ namespace DurableTask.AzureStorage.Logging
             [StructuredLogField]
             public string PartitionId { get; }
 
+            [StructuredLogField]
+            public string LeaseType { get; }
+
             public override EventId EventId => new EventId(
                 EventIds.LeaseStealingFailed,
                 nameof(EventIds.LeaseStealingFailed));
 
             public override LogLevel Level => LogLevel.Information;
 
-            protected override string CreateLogMessage() => $"{this.PartitionId}: Failed to steal lease";
+            protected override string CreateLogMessage() => $"{this.PartitionId}: Failed to steal {this.LeaseType} lease";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseStealingFailed(
                 this.Account,
                 this.TaskHub,
                 this.WorkerName,
                 this.PartitionId,
+                this.LeaseType,
                 Utils.AppName,
                 Utils.ExtensionVersion);
         }
@@ -2004,13 +2046,15 @@ namespace DurableTask.AzureStorage.Logging
                 string taskHub,
                 string workerName,
                 string partitionId,
-                string token)
+                string token,
+                string leaseType)
             {
                 this.Account = account;
                 this.TaskHub = taskHub;
                 this.WorkerName = workerName;
                 this.PartitionId = partitionId;
                 this.Token = token;
+                this.LeaseType = leaseType;
             }
 
             [StructuredLogField]
@@ -2028,13 +2072,16 @@ namespace DurableTask.AzureStorage.Logging
             [StructuredLogField]
             public string Token { get; }
 
+            [StructuredLogField]
+            public string LeaseType { get; }
+
             public override EventId EventId => new EventId(
                 EventIds.LeaseRemoved,
                 nameof(EventIds.LeaseRemoved));
 
             public override LogLevel Level => LogLevel.Information;
 
-            protected override string CreateLogMessage() => $"{this.PartitionId}: {this.WorkerName} has released its lease";
+            protected override string CreateLogMessage() => $"{this.PartitionId}: {this.WorkerName} has released its {this.LeaseType} lease";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseRemoved(
                 this.Account,
@@ -2042,6 +2089,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.WorkerName,
                 this.PartitionId,
                 this.Token,
+                this.LeaseType,
                 Utils.AppName,
                 Utils.ExtensionVersion);
         }
@@ -2053,13 +2101,15 @@ namespace DurableTask.AzureStorage.Logging
                 string taskHub,
                 string workerName,
                 string partitionId,
-                string token)
+                string token,
+                string leaseType)
             {
                 this.Account = account;
                 this.TaskHub = taskHub;
                 this.WorkerName = workerName;
                 this.PartitionId = partitionId;
                 this.Token = token;
+                this.LeaseType = leaseType;
             }
 
             [StructuredLogField]
@@ -2077,6 +2127,9 @@ namespace DurableTask.AzureStorage.Logging
             [StructuredLogField]
             public string Token { get; }
 
+            [StructuredLogField]
+            public string LeaseType { get; }
+
             public override EventId EventId => new EventId(
                 EventIds.LeaseRemovalFailed,
                 nameof(EventIds.LeaseRemovalFailed));
@@ -2084,7 +2137,7 @@ namespace DurableTask.AzureStorage.Logging
             public override LogLevel Level => LogLevel.Warning;
 
             protected override string CreateLogMessage() =>
-                $"{this.PartitionId}: {this.WorkerName} failed to release its lease due to a conflict";
+                $"{this.PartitionId}: {this.WorkerName} failed to release its {this.LeaseType} lease due to a conflict";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.LeaseRemovalFailed(
                 this.Account,
@@ -2092,6 +2145,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.WorkerName,
                 this.PartitionId,
                 this.Token,
+                this.LeaseType,
                 Utils.AppName,
                 Utils.ExtensionVersion);
         }

--- a/src/DurableTask.AzureStorage/Logging/LogHelper.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogHelper.cs
@@ -496,14 +496,16 @@ namespace DurableTask.AzureStorage.Logging
             string taskHub,
             string workerName,
             string partitionId,
-            string token)
+            string token,
+            string leaseType)
         {
             var logEvent = new LogEvents.StartingLeaseRenewal(
                 account,
                 taskHub,
                 workerName,
                 partitionId,
-                token);
+                token,
+                leaseType);
             this.WriteStructuredLog(logEvent);
         }
 
@@ -514,6 +516,7 @@ namespace DurableTask.AzureStorage.Logging
             string partitionId,
             bool success,
             string token,
+            string leaseType,
             string details)
         {
             var logEvent = new LogEvents.LeaseRenewalResult(
@@ -523,6 +526,7 @@ namespace DurableTask.AzureStorage.Logging
                 partitionId,
                 success,
                 token,
+                leaseType,
                 details);
             this.WriteStructuredLog(logEvent);
         }
@@ -533,6 +537,7 @@ namespace DurableTask.AzureStorage.Logging
             string workerName,
             string partitionId,
             string token,
+            string leaseType,
             string details)
         {
             var logEvent = new LogEvents.LeaseRenewalFailed(
@@ -541,6 +546,7 @@ namespace DurableTask.AzureStorage.Logging
                 workerName,
                 partitionId,
                 token,
+                leaseType,
                 details);
             this.WriteStructuredLog(logEvent);
         }
@@ -549,13 +555,15 @@ namespace DurableTask.AzureStorage.Logging
             string account,
             string taskHub,
             string workerName,
-            string partitionId)
+            string partitionId,
+            string leaseType)
         {
             var logEvent = new LogEvents.LeaseAcquisitionStarted(
                 account,
                 taskHub,
                 workerName,
-                partitionId);
+                partitionId,
+                leaseType);
             this.WriteStructuredLog(logEvent);
         }
 
@@ -563,13 +571,15 @@ namespace DurableTask.AzureStorage.Logging
             string account,
             string taskHub,
             string workerName,
-            string partitionId)
+            string partitionId,
+            string leaseType)
         {
             var logEvent = new LogEvents.LeaseAcquisitionSucceeded(
                 account,
                 taskHub,
                 workerName,
-                partitionId);
+                partitionId,
+                leaseType);
             this.WriteStructuredLog(logEvent);
         }
 
@@ -577,13 +587,15 @@ namespace DurableTask.AzureStorage.Logging
             string account,
             string taskHub,
             string workerName,
-            string partitionId)
+            string partitionId,
+            string leaseType)
         {
             var logEvent = new LogEvents.LeaseAcquisitionFailed(
                 account,
                 taskHub,
                 workerName,
-                partitionId);
+                partitionId,
+                leaseType);
             this.WriteStructuredLog(logEvent);
         }
 
@@ -627,13 +639,15 @@ namespace DurableTask.AzureStorage.Logging
             string account,
             string taskHub,
             string workerName,
-            string partitionId)
+            string partitionId,
+            string leaseType)
         {
             var logEvent = new LogEvents.LeaseStealingFailed(
                 account,
                 taskHub,
                 workerName,
-                partitionId);
+                partitionId,
+                leaseType);
             this.WriteStructuredLog(logEvent);
         }
 
@@ -658,14 +672,16 @@ namespace DurableTask.AzureStorage.Logging
             string taskHub,
             string workerName,
             string partitionId,
-            string token)
+            string token,
+            string leaseType)
         {
             var logEvent = new LogEvents.LeaseRemoved(
                 account,
                 taskHub,
                 workerName,
                 partitionId,
-                token);
+                token,
+                leaseType);
             this.WriteStructuredLog(logEvent);
         }
 
@@ -674,14 +690,16 @@ namespace DurableTask.AzureStorage.Logging
             string taskHub,
             string workerName,
             string partitionId,
-            string token)
+            string token,
+            string leaseType)
         {
             var logEvent = new LogEvents.LeaseRemovalFailed(
                 account,
                 taskHub,
                 workerName,
                 partitionId,
-                token);
+                token,
+                leaseType);
             this.WriteStructuredLog(logEvent);
         }
 

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -223,7 +223,7 @@ namespace DurableTask.AzureStorage.Messaging
                 this.settings.TaskHubName,
                 this.settings.WorkerId,
                 this.Name,
-                $"{caller} is releasing lease on {this.Name} for reason: {reason}");
+                $"{caller} is releasing partition {this.Name} for reason: {reason}");
         }
 
         public virtual void Dispose()

--- a/src/DurableTask.AzureStorage/Partitioning/AppLeaseManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/AppLeaseManager.cs
@@ -25,6 +25,8 @@ namespace DurableTask.AzureStorage.Partitioning
     /// </summary>
     sealed class AppLeaseManager
     {
+        const string LeaseType = "app";
+
         readonly AzureStorageClient azureStorageClient;
         readonly IPartitionManager partitionManager;
         readonly AzureStorageOrchestrationServiceSettings settings;
@@ -168,6 +170,7 @@ namespace DurableTask.AzureStorage.Partitioning
 
             this.starterTokenSource.Cancel();
             this.starterTokenSource.Dispose();
+            this.starterTokenSource = null;
         }
 
         public async Task ForceChangeAppLeaseAsync()
@@ -300,9 +303,10 @@ namespace DurableTask.AzureStorage.Partitioning
                     this.storageAccountName,
                     this.taskHub,
                     this.workerName,
-                    this.appLeaseContainerName);
+                    this.appLeaseContainerName,
+                    LeaseType);
 
-                await appLeaseContainer.ChangeLeaseAsync(this.appLeaseId, currentLeaseId);
+                await this.appLeaseContainer.ChangeLeaseAsync(this.appLeaseId, currentLeaseId);
 
                 var appLeaseInfo = new AppLeaseInfo()
                 {
@@ -316,7 +320,8 @@ namespace DurableTask.AzureStorage.Partitioning
                     this.storageAccountName,
                     this.taskHub,
                     this.workerName,
-                    this.appLeaseContainerName);
+                    this.appLeaseContainerName,
+                    LeaseType);
 
                 // When changing the lease over to another app, the paritions will still be listened to on the first app until the AppLeaseManager
                 // renew task fails to renew the lease. To avoid potential split brain we must delay before the new lease holder can start
@@ -351,9 +356,10 @@ namespace DurableTask.AzureStorage.Partitioning
                     this.storageAccountName,
                     this.taskHub,
                     this.workerName,
-                    this.appLeaseContainerName);
+                    this.appLeaseContainerName,
+                    LeaseType);
 
-                await appLeaseContainer.AcquireLeaseAsync(this.options.LeaseInterval, this.appLeaseId);
+                await this.appLeaseContainer.AcquireLeaseAsync(this.options.LeaseInterval, this.appLeaseId);
 
                 await this.UpdateOwnerAppIdToCurrentApp();
                 leaseAcquired = true;
@@ -362,7 +368,8 @@ namespace DurableTask.AzureStorage.Partitioning
                     this.storageAccountName,
                     this.taskHub,
                     this.workerName,
-                    this.appLeaseContainerName);
+                    this.appLeaseContainerName,
+                    LeaseType);
             }
             catch (DurableTaskStorageException e)
             {
@@ -372,7 +379,8 @@ namespace DurableTask.AzureStorage.Partitioning
                     this.storageAccountName,
                     this.taskHub,
                     this.workerName,
-                    this.appLeaseContainerName);
+                    this.appLeaseContainerName,
+                    LeaseType);
 
                 this.settings.Logger.PartitionManagerWarning(
                     this.storageAccountName,
@@ -417,7 +425,7 @@ namespace DurableTask.AzureStorage.Partitioning
                         this.storageAccountName, 
                         this.taskHub, 
                         this.workerName,
-                        this.appLeaseContainerName, 
+                        this.appLeaseContainerName,
                         $"App lease renewer task failed. AppLeaseId: {this.appLeaseId} Exception: {ex}");
                 }
             }
@@ -451,9 +459,10 @@ namespace DurableTask.AzureStorage.Partitioning
                     this.taskHub,
                     this.workerName,
                     this.appLeaseContainerName,
-                    this.appLeaseId);
+                    this.appLeaseId,
+                    LeaseType);
 
-                await appLeaseContainer.RenewLeaseAsync(appLeaseId);
+                await this.appLeaseContainer.RenewLeaseAsync(appLeaseId);
 
                 renewed = true;
             }
@@ -474,6 +483,7 @@ namespace DurableTask.AzureStorage.Partitioning
                         this.workerName,
                         this.appLeaseContainerName,
                         this.appLeaseId,
+                        LeaseType,
                         ex.Message);
 
                     this.settings.Logger.PartitionManagerWarning(
@@ -498,6 +508,7 @@ namespace DurableTask.AzureStorage.Partitioning
                 this.appLeaseContainerName,
                 renewed,
                 this.appLeaseId,
+                LeaseType,
                 errorMessage);
 
             return renewed;


### PR DESCRIPTION
I was doing some manual testing of the lease management code to try and diagnose some issues we've been facing recently and found a few places where we could use some improvements. Here are the changes in this PR:

* Add "lease type" fields to all the lease management logs for easier analysis
* Fixes an `ObjectDisposedException` when restarting the task hub worker (reported by an internal DTFx user).
* A small number of minor code cleanup changes

I found some more fundamental lease management issues as well, but I'll try to tackle those in a separate PR.