### PR TITLE
Additional Azure Storage lease management fixes

### DIFF
--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -214,16 +214,19 @@ namespace DurableTask.AzureStorage.Messaging
 
         public void Release(CloseReason? reason, string caller)
         {
-            this.releaseTokenSource.Cancel();
+            if (!this.IsReleased)
+            {
+                this.releaseTokenSource.Cancel();
 
-            this.IsReleased = true;
+                this.IsReleased = true;
 
-            this.settings.Logger.PartitionManagerInfo(
-                this.storageAccountName,
-                this.settings.TaskHubName,
-                this.settings.WorkerId,
-                this.Name,
-                $"{caller} is releasing partition {this.Name} for reason: {reason}");
+                this.settings.Logger.PartitionManagerInfo(
+                    this.storageAccountName,
+                    this.settings.TaskHubName,
+                    this.settings.WorkerId,
+                    this.Name,
+                    $"{caller} is releasing partition {this.Name} for reason: {reason}");
+            }
         }
 
         public virtual void Dispose()

--- a/src/DurableTask.AzureStorage/Partitioning/LeaseCollectionBalancer.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/LeaseCollectionBalancer.cs
@@ -340,7 +340,7 @@ namespace DurableTask.AzureStorage.Partitioning
                         this.accountName,
                         this.taskHub,
                         this.workerName,
-                        string.Empty /* partitionId */,
+                        lease.PartitionId,
                         $"Skipping {this.leaseType} lease aquiring for {lease.PartitionId}");
                     continue;
                 }


### PR DESCRIPTION
This is a continuation of my other PR, _Improve logging for lease management #723_, that fixes a couple issues I discovered while doing some manual testing of the startup/shutdown sequence.

* **Remove misleading "lease lost" log message during shutdown**: This is likely an artifact from when we originally designed the "safe" partition balancer. Basically, whenever we shutdown either the intent lease or the ownership lease, we also attempt to "release" the control queue. However, since both lease managers try to release the same control queue, we were logging redundant and misleading messages about releasing something that was already released.

* **Make lease release serial instead of parallel for better determinism**: Debugging the behavior of lease removal was difficult because we release leases in parallel. As I mentioned in the above point, this results in us manipulating shared data in a way that seems unintended and thus ripe for accidental race conditions. There's no strict reason to have this logic be parallelized, so I went ahead and made it serial.

* **Cleanup subscriptions during shutdown**: I noticed an issue where we were failing to clean up lease manager subscriptions. This resulted in duplicate lease/partition management behavior after a partition is shut down and later restarted. It was easy to spot because of the warning, `"Attempted to add a control queue {controlQueue.Name} multiple times!"`, which now goes away after this fix. I do wonder if there are some mysterious bugs that could be linked to this "subscription leak".