### PR TITLE
Fail when orchestrator does not complete despite having no "open" tasks

### DIFF
--- a/src/DurableTask.Core/TaskOrchestrationExecutor.cs
+++ b/src/DurableTask.Core/TaskOrchestrationExecutor.cs
@@ -151,9 +151,13 @@ namespace DurableTask.Core
                                 this.context.CompleteOrchestration(this.result.Result);
                             }
                         }
-
-                        // TODO: It is an error if result is not completed when all OpenTasks are done.
-                        // Throw an exception in that case.
+                        else
+                        {
+                            // It is an error if result is not completed when all OpenTasks are done.
+                            // Throw an exception in that case.
+                            var exception = new Exception("Possible constraint violation: No 'open' tasks remain but the orchestrator is incomplete. Please verify that only DurableTask APIs are awaited.");
+                            this.context.FailOrchestration(exception);
+                        }
                     }
                 }
                 catch (NonDeterministicOrchestrationException exception)


### PR DESCRIPTION
Possibly related to: https://github.com/Azure/azure-functions-durable-extension/issues/2133, https://github.com/Azure/azure-functions-durable-extension/issues/2135

Recently, we've received a few Durable Functions reports of orchestrators getting mysteriously "stuck" despite completing all their scheduled Tasks. The telemetry generated by these incidents match those of an "illegal await" at the end of the user code execution: when an orchestrator awaits a non-DurableTask API before returning.

At this time, we have not found a root cause for these incidents, but we can still improve our core logic to transition the orchestrator to a `Failed` state when we detect an orchestrator will get stuck. This PR adds logic to do just that.

I did not add a test as I'm not familiar enough with this part of the stack to know exactly how to test with ease *and* because this is a small edge-case change. I'm happy to add one if we think this small change warrants it, but I'll need pointers.

