### PR TITLE
Make Storage timeouts handling configurable

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -235,15 +235,10 @@ namespace DurableTask.AzureStorage
         public Func<string, Task<bool>> OnImminentFailFast { get; set; } = (message) => Task.FromResult(true);
 
         /// <summary>
-        /// The number of times we allow the timeout to be hit before recycling the app. We set this
-        /// to a fixed value to prevent building up an infinite number of deadlocked tasks and leak resources.
-        /// </summary>
-        public int MaxNumberOfTimeoutsBeforeRecycle { get; set; } = 5;
-
-        /// <summary>
         /// Gets or sets the  number of times we allow the timeout to be hit before recycling the app. We set this
         /// to a fixed value to prevent building up an infinite number of deadlocked tasks and leak resources.
         /// </summary>
+        public int MaxNumberOfTimeoutsBeforeRecycle { get; set; } = 5;
 
         /// <summary>
         /// Gets or sets the number of seconds before a request to Azure Storage is considered as timed out.

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -235,6 +235,27 @@ namespace DurableTask.AzureStorage
         public Func<string, Task<bool>> OnImminentFailFast { get; set; } = (message) => Task.FromResult(true);
 
         /// <summary>
+        /// The number of times we allow the timeout to be hit before recycling the app. We set this
+        /// to a fixed value to prevent building up an infinite number of deadlocked tasks and leak resources.
+        /// </summary>
+        public int MaxNumberOfTimeoutsBeforeRecycle { get; set; } = 5;
+
+        /// <summary>
+        /// Gets or sets the  number of times we allow the timeout to be hit before recycling the app. We set this
+        /// to a fixed value to prevent building up an infinite number of deadlocked tasks and leak resources.
+        /// </summary>
+
+        /// <summary>
+        /// Gets or sets the number of seconds before a request to Azure Storage is considered as timed out.
+        /// </summary>
+        public TimeSpan StorageRequestsTimeout { get; set; } = TimeSpan.FromMinutes(2);
+
+        /// <summary>
+        /// Gets or sets the window duration (in seconds) in which we count the number of timed out request before recycling the app.
+        /// </summary>
+        public TimeSpan StorageRequestsTimeoutCooldown { get; set; } = TimeSpan.FromMinutes(5);
+
+        /// <summary>
         /// Returns bool indicating is the TrackingStoreStorageAccount has been set.
         /// </summary>
         public bool HasTrackingStoreStorageAccount => this.TrackingStoreStorageAccountDetails != null;

--- a/src/DurableTask.AzureStorage/TimeoutHandler.cs
+++ b/src/DurableTask.AzureStorage/TimeoutHandler.cs
@@ -24,13 +24,6 @@ namespace DurableTask.AzureStorage
     // The TimeoutHandler class is based off of the similar Azure Functions fix seen here: https://github.com/Azure/azure-webjobs-sdk/pull/2291
     internal static class TimeoutHandler
     {
-        // The number of times we allow the timeout to be hit before recycling the app. We set this
-        // to a fixed value to prevent building up an infinite number of deadlocked tasks and leak resources.
-        private const int MaxNumberOfTimeoutsBeforeRecycle = 5;
-
-        private static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(2);
-        private static readonly TimeSpan DefaultTimeoutCooldown = TimeSpan.FromMinutes(5);
-
         private static int NumTimeoutsHit = 0;
 
         private static DateTime LastTimeoutHit = DateTime.MinValue;
@@ -59,7 +52,7 @@ namespace DurableTask.AzureStorage
             {
                 using (var cts = new CancellationTokenSource())
                 {
-                    Task timeoutTask = Task.Delay(DefaultTimeout, cts.Token);
+                    Task timeoutTask = Task.Delay(settings.StorageRequestsTimeout, cts.Token);
                     Task<T> operationTask = operation(context, cts.Token);
 
                     if (stats != null)
@@ -73,7 +66,7 @@ namespace DurableTask.AzureStorage
                         // If more less than DefaultTimeoutCooldown passed, increase timeouts count
                         // otherwise, reset the count to 1, since this is the first timeout we receive
                         // after a long (enough) while
-                        if (LastTimeoutHit + DefaultTimeoutCooldown > DateTime.UtcNow)
+                        if (LastTimeoutHit + settings.StorageRequestsTimeoutCooldown > DateTime.UtcNow)
                         {
                             NumTimeoutsHit++;
                         }
@@ -85,9 +78,9 @@ namespace DurableTask.AzureStorage
                         LastTimeoutHit = DateTime.UtcNow;
 
                         string taskHubName = settings?.TaskHubName;
-                        if (NumTimeoutsHit < MaxNumberOfTimeoutsBeforeRecycle)
+                        if (NumTimeoutsHit < settings.MaxNumberOfTimeoutsBeforeRecycle)
                         {
-                            string message = $"The operation '{operationName}' with id '{context.ClientRequestID}' did not complete in '{DefaultTimeout}'. Hit {NumTimeoutsHit} out of {MaxNumberOfTimeoutsBeforeRecycle} allowed timeouts. Retrying the operation.";
+                            string message = $"The operation '{operationName}' with id '{context.ClientRequestID}' did not complete in '{settings.StorageRequestsTimeout}'. Hit {NumTimeoutsHit} out of {settings.MaxNumberOfTimeoutsBeforeRecycle} allowed timeouts. Retrying the operation.";
                             settings.Logger.GeneralWarning(account ?? "", taskHubName ?? "", message);
 
                             cts.Cancel();
@@ -95,7 +88,7 @@ namespace DurableTask.AzureStorage
                         }
                         else
                         {
-                            string message = $"The operation '{operationName}' with id '{context.ClientRequestID}' did not complete in '{DefaultTimeout}'. Hit maximum number ({MaxNumberOfTimeoutsBeforeRecycle}) of timeouts. Terminating the process to mitigate potential deadlock.";
+                            string message = $"The operation '{operationName}' with id '{context.ClientRequestID}' did not complete in '{settings.StorageRequestsTimeout}'. Hit maximum number ({settings.MaxNumberOfTimeoutsBeforeRecycle}) of timeouts. Terminating the process to mitigate potential deadlock.";
                             settings.Logger.GeneralError(account ?? "", taskHubName ?? "", message);
 
                             // Delay to ensure the ETW event gets written


### PR DESCRIPTION
This PR allows users to configure the various settings of Timeout handling:

* MaxNumberOfTimeoutsBeforeRecycle
* StorageRequestsTimeout
* StorageRequestsTimeoutCooldown

This allows having more permissive handling in noise scenarios (e.g. when the Storage Account is shared with other scenarios), or unstable scenarios (e.g. when the Storage Account experiences longer delays).