### PR TITLE
Add a backend-configurable flag to disable problematic OrchestrationRuntimeState behavior

### DIFF
--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -534,7 +534,11 @@ namespace DurableTask.Core
                 } while (continuedAsNew);
             }
 
-            workItem.OrchestrationRuntimeState = originalOrchestrationRuntimeState;
+            if (workItem.RestoreOriginalRuntimeStateDuringCompletion)
+            {
+                // some backends expect the original runtime state object
+                workItem.OrchestrationRuntimeState = originalOrchestrationRuntimeState;
+            }
 
             runtimeState.Status = runtimeState.Status ?? carryOverStatus;
 
@@ -552,8 +556,11 @@ namespace DurableTask.Core
                 continuedAsNew ? null : timerMessages,
                 continuedAsNewMessage,
                 instanceState);
-
-            workItem.OrchestrationRuntimeState = runtimeState;
+            
+            if (workItem.RestoreOriginalRuntimeStateDuringCompletion)
+            {
+                workItem.OrchestrationRuntimeState = runtimeState;
+            }
 
             return isCompleted || continuedAsNew || isInterrupted;
         }

--- a/src/DurableTask.Core/TaskOrchestrationWorkItem.cs
+++ b/src/DurableTask.Core/TaskOrchestrationWorkItem.cs
@@ -58,6 +58,11 @@ namespace DurableTask.Core
         /// </summary>
         public bool IsExtendedSession = false;
 
+        /// <summary>
+        /// A flag to control whether the original runtime state should be used while completing a work item.
+        /// </summary>
+        public virtual bool RestoreOriginalRuntimeStateDuringCompletion => true;
+
         internal OrchestrationExecutionCursor Cursor;
     }
 }


### PR DESCRIPTION
Currently, the TaskOrchestrationDispatcher, when completing a work item, does a tricky thing with the `OrchestrationRuntimeState` field of the work item:

1. replaces the new runtime state with the original runtime state object 
2. calls `CompleteTaskOrchestrationWorkItemAsync`
3. assigns it the new runtime state

This is a problem with the Netherite backend since the latter may immediately resubmit the workitem to continue the orchestration, causing a race condition with number 3 that leads to state corruption.

This PR adds a flag so that backends can turn off this behavior. 

_None of the other backends are affected since the flag is on by default._
