### PR TITLE
add FetchParentInstancesOnly to OrchestrationQuery

### DIFF
--- a/src/DurableTask.Core/Query/OrchestrationQuery.cs
+++ b/src/DurableTask.Core/Query/OrchestrationQuery.cs
@@ -69,5 +69,10 @@ namespace DurableTask.Core.Query
         /// Determines whether the query will include the input of the orchestration.
         /// </summary>
         public bool FetchInputsAndOutputs { get; set; } = true;
-    }
+
+        /// <summary>
+        /// Determines whether the query will retrieve only parent instances.
+        /// </summary>
+        public bool FetchParentInstancesOnly { get; set; } = false;
+	}
 }


### PR DESCRIPTION
Hello,
As mentioned in my PR for [durabletask-mssql](https://github.com/microsoft/durabletask-mssql) at this link https://github.com/microsoft/durabletask-mssql/actions/runs/2422744112 
This PR adds the property FetchParentInstancesOnly to the OrchestrationQuery class.
This property will be used in every provider (mssql, AzureStorage...) to enable filtering instances by ParentInstanceId (in order to fetch only parent instances if needed).
