### PR TITLE
Make batch instance purging more efficient

### DIFF
--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
     <MinorVersion>12</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     
     <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
     <FileVersion>$(Version).0</FileVersion>

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -623,55 +623,87 @@ namespace DurableTask.AzureStorage.Tracking
             return orchestrationStates;
         }
 
-        async Task<PurgeHistoryResult> DeleteHistoryAsync(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus)
+        async Task<PurgeHistoryResult> DeleteHistoryAsync(
+            DateTime createdTimeFrom,
+            DateTime? createdTimeTo,
+            IEnumerable<OrchestrationStatus> runtimeStatus)
         {
-            TableQuery<OrchestrationInstanceStatus> query = OrchestrationInstanceStatusQueryCondition.Parse(createdTimeFrom, createdTimeTo, runtimeStatus)
-                .ToTableQuery<OrchestrationInstanceStatus>();
+            TableQuery<OrchestrationInstanceStatus> query = OrchestrationInstanceStatusQueryCondition.Parse(
+                createdTimeFrom,
+                createdTimeTo,
+                runtimeStatus).ToTableQuery<OrchestrationInstanceStatus>();
+
+            // Limit to batches of 100 to avoid excessive memory usage and table storage scanning
+            query.TakeCount = 2;
 
             int storageRequests = 0;
+            int instancesDeleted = 0;
             int rowsDeleted = 0;
 
-            var tableEntitiesResponseInfo = await this.InstancesTable.ExecuteQueryAsync(query);
-            var results = tableEntitiesResponseInfo.ReturnedEntities;
-
-                foreach (OrchestrationInstanceStatus orchestrationInstanceStatus in results)
+            while (true)
+            {
+                TableEntitiesResponseInfo<OrchestrationInstanceStatus> tableEntitiesResponseInfo = 
+                    await this.InstancesTable.ExecuteQueryAsync(query);
+                IList<OrchestrationInstanceStatus> results = tableEntitiesResponseInfo.ReturnedEntities;
+                if (results.Count == 0)
                 {
-                    var statisticsFromDeletion = await this.DeleteAllDataForOrchestrationInstance(orchestrationInstanceStatus);
-                    storageRequests += statisticsFromDeletion.StorageRequests;
-                    rowsDeleted += statisticsFromDeletion.RowsDeleted;
+                    break;
                 }
 
-            return new PurgeHistoryResult(storageRequests, results.Count, rowsDeleted);
+                // Delete instances in parallel
+                await results.ParallelForEachAsync(
+                    this.settings.MaxStorageOperationConcurrency,
+                    async instance =>
+                    {
+                        PurgeHistoryResult statisticsFromDeletion = await this.DeleteAllDataForOrchestrationInstance(instance);
+                        Interlocked.Add(ref instancesDeleted, statisticsFromDeletion.InstancesDeleted);
+                        Interlocked.Add(ref storageRequests, statisticsFromDeletion.RowsDeleted);
+                        Interlocked.Add(ref rowsDeleted, statisticsFromDeletion.RowsDeleted);
+                    });
+            }
+
+            return new PurgeHistoryResult(storageRequests, instancesDeleted, rowsDeleted);
         }
 
         async Task<PurgeHistoryResult> DeleteAllDataForOrchestrationInstance(OrchestrationInstanceStatus orchestrationInstanceStatus)
         {
             int storageRequests = 0;
             int rowsDeleted = 0;
+
+            string sanitizedInstanceId = KeySanitation.UnescapePartitionKey(orchestrationInstanceStatus.PartitionKey);
+
             var historyEntitiesResponseInfo = await this.GetHistoryEntitiesResponseInfoAsync(
-                KeySanitation.UnescapePartitionKey(orchestrationInstanceStatus.PartitionKey),
-                null,
-                new []
-                {
-                    RowKeyProperty
-                });
+                instanceId: sanitizedInstanceId,
+                expectedExecutionId: null,
+                projectionColumns: new[] { RowKeyProperty });
             storageRequests += historyEntitiesResponseInfo.RequestCount;
 
-            var historyEntities = historyEntitiesResponseInfo.ReturnedEntities;
+            IList<DynamicTableEntity> historyEntities = historyEntitiesResponseInfo.ReturnedEntities;
 
-            await this.messageManager.DeleteLargeMessageBlobs(orchestrationInstanceStatus.PartitionKey);
+            var tasks = new List<Task>();
+            tasks.Add(Task.Run(async () =>
+            {
+                int storageOperations = await this.messageManager.DeleteLargeMessageBlobs(sanitizedInstanceId);
+                Interlocked.Add(ref storageRequests, storageOperations);
+            }));
 
-            var deletedEntitiesResponseInfo = await this.HistoryTable.DeleteBatchAsync(historyEntities);
-            rowsDeleted += deletedEntitiesResponseInfo.TableResults.Count;
-            storageRequests += deletedEntitiesResponseInfo.RequestCount;
+            tasks.Add(Task.Run(async () =>
+            {
+                var deletedEntitiesResponseInfo = await this.HistoryTable.DeleteBatchAsync(historyEntities);
+                Interlocked.Add(ref rowsDeleted, deletedEntitiesResponseInfo.TableResults.Count);
+                Interlocked.Add(ref storageRequests, deletedEntitiesResponseInfo.RequestCount);
+            }));
 
-            await this.InstancesTable.DeleteAsync(new DynamicTableEntity
-                    {
-                        PartitionKey = orchestrationInstanceStatus.PartitionKey,
-                        RowKey = string.Empty,
-                        ETag = "*"
-                    });
+            tasks.Add(this.InstancesTable.DeleteAsync(new DynamicTableEntity
+            {
+                PartitionKey = orchestrationInstanceStatus.PartitionKey,
+                RowKey = string.Empty,
+                ETag = "*"
+            }));
 
+            await Task.WhenAll(tasks);
+
+            // This is for the instances table deletion
             storageRequests++;
 
             return new PurgeHistoryResult(storageRequests, 1, rowsDeleted);

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -628,13 +628,17 @@ namespace DurableTask.AzureStorage.Tracking
             DateTime? createdTimeTo,
             IEnumerable<OrchestrationStatus> runtimeStatus)
         {
-            TableQuery<OrchestrationInstanceStatus> query = OrchestrationInstanceStatusQueryCondition.Parse(
+            var filter = OrchestrationInstanceStatusQueryCondition.Parse(
                 createdTimeFrom,
                 createdTimeTo,
-                runtimeStatus).ToTableQuery<OrchestrationInstanceStatus>();
+                runtimeStatus);
+            filter.FetchInput = false;
+            filter.FetchOutput = false;
+
+            TableQuery<OrchestrationInstanceStatus> query = filter.ToTableQuery<OrchestrationInstanceStatus>();
 
             // Limit to batches of 100 to avoid excessive memory usage and table storage scanning
-            query.TakeCount = 2;
+            query.TakeCount = 100;
 
             int storageRequests = 0;
             int instancesDeleted = 0;

--- a/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
+++ b/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
@@ -24,10 +24,9 @@ namespace DurableTask.AzureStorage.Tracking
     /// </summary>
     public class OrchestrationInstanceStatusQueryCondition
     {
-        private static readonly List<string> ColumnsWithoutInput = typeof(OrchestrationInstanceStatus).GetProperties()
-            .Where(prop => !prop.Name.Equals(nameof(OrchestrationInstanceStatus.Input)))
+        static readonly string[] ColumnNames = typeof(OrchestrationInstanceStatus).GetProperties()
             .Select(prop => prop.Name)
-            .ToList();
+            .ToArray();
 
         /// <summary>
         /// RuntimeStatus
@@ -65,6 +64,11 @@ namespace DurableTask.AzureStorage.Tracking
         public bool FetchInput { get; set; } = true;
 
         /// <summary>
+        /// If true, the output will be returned with the results. The default value is true.
+        /// </summary>
+        public bool FetchOutput { get; set; } = true;
+
+        /// <summary>
         /// Get the TableQuery object
         /// </summary>
         /// <typeparam name="T"></typeparam>
@@ -80,9 +84,20 @@ namespace DurableTask.AzureStorage.Tracking
                 this.InstanceIdPrefix == null &&
                 this.InstanceId == null))
             {
-                if (!this.FetchInput)
+                if (!this.FetchInput || !this.FetchOutput)
                 {
-                    query.Select(ColumnsWithoutInput);
+                    var columns = new HashSet<string>(ColumnNames);
+                    if (!this.FetchInput)
+                    {
+                        columns.Remove(nameof(OrchestrationInstanceStatus.Input));
+                    }
+
+                    if (!this.FetchOutput)
+                    {
+                        columns.Remove(nameof(OrchestrationInstanceStatus.Output));
+                    }
+
+                    query.Select(columns.ToList());
                 }
 
                 string conditions = this.GetConditions();
@@ -168,13 +183,18 @@ namespace DurableTask.AzureStorage.Tracking
         /// <param name="createdTimeTo">CreatedTimeTo</param>
         /// <param name="runtimeStatus">RuntimeStatus</param>
         /// <returns></returns>
-        public static OrchestrationInstanceStatusQueryCondition Parse(DateTime createdTimeFrom, DateTime? createdTimeTo, IEnumerable<OrchestrationStatus> runtimeStatus)
+        public static OrchestrationInstanceStatusQueryCondition Parse(
+            DateTime createdTimeFrom,
+            DateTime? createdTimeTo,
+            IEnumerable<OrchestrationStatus> runtimeStatus)
         {
             var condition = new OrchestrationInstanceStatusQueryCondition
             {
                 CreatedTimeFrom = createdTimeFrom,
                 CreatedTimeTo = createdTimeTo ?? default(DateTime),
-                RuntimeStatus = runtimeStatus
+                RuntimeStatus = runtimeStatus,
+                FetchInput = false,
+                FetchOutput = false,
             };
             return condition;
         }

--- a/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
+++ b/src/DurableTask.AzureStorage/Tracking/OrchestrationInstanceStatusQueryCondition.cs
@@ -193,8 +193,6 @@ namespace DurableTask.AzureStorage.Tracking
                 CreatedTimeFrom = createdTimeFrom,
                 CreatedTimeTo = createdTimeTo ?? default(DateTime),
                 RuntimeStatus = runtimeStatus,
-                FetchInput = false,
-                FetchOutput = false,
             };
             return condition;
         }


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-functions-durable-extension/issues/2211 (though perhaps not perfectly).

This PR makes batch purging more efficient in the following ways:

1. Scan the Instances table in multiple batches rather than scanning the whole thing in one go. This will result in decreased memory usage and prevent purge operations from making zero progress in timeout scenarios.
1. Remove outputs from the result of the initial scan to reduce network bandwidth and memory usage
1. Execute purge commands in parallel rather than serially, reducing the total amount of time expected to purge the history.

I added a small amount of code cleanup as well as made some fixes related to storage operation counting that I found while working through this code.
