### PR TITLE
Support Add Task Activities from Abstract or Non-Sealed Class

### DIFF
--- a/src/DurableTask.Core/OrchestrationContext.cs
+++ b/src/DurableTask.Core/OrchestrationContext.cs
@@ -88,12 +88,18 @@ namespace DurableTask.Core
         /// <returns></returns>
         public virtual T CreateClient<T>(bool useFullyQualifiedMethodNames) where T : class
         {
-            if (!typeof(T).IsInterface)
+            IInterceptor scheduleProxy = new ScheduleProxy(this, useFullyQualifiedMethodNames);
+
+            if (typeof(T).IsClass)
             {
-                throw new InvalidOperationException("Pass in an interface.");
+                if (typeof(T).IsSealed)
+                {
+                    throw new InvalidOperationException("Class cannot be sealed.");
+                }
+
+                return ProxyGenerator.CreateClassProxy<T>(scheduleProxy);
             }
 
-            IInterceptor scheduleProxy = new ScheduleProxy(this, useFullyQualifiedMethodNames);
             return ProxyGenerator.CreateInterfaceProxyWithoutTarget<T>(scheduleProxy);
         }
 
@@ -132,13 +138,18 @@ namespace DurableTask.Core
         /// <returns>Dynamic proxy that can be used to schedule the remote tasks</returns>
         public virtual T CreateRetryableClient<T>(RetryOptions retryOptions, bool useFullyQualifiedMethodNames) where T : class
         {
-            if (!typeof(T).IsInterface)
-            {
-                throw new InvalidOperationException("Pass in an interface.");
-            }
-
             IInterceptor scheduleProxy = new ScheduleProxy(this, useFullyQualifiedMethodNames);
             IInterceptor retryProxy = new RetryProxy(this, retryOptions);
+
+            if (typeof(T).IsClass)
+            {
+                if (typeof(T).IsSealed)
+                {
+                    throw new InvalidOperationException($"Class cannot be sealed.");
+                }
+
+                return ProxyGenerator.CreateClassProxyWithTarget(target: ProxyGenerator.CreateClassProxy<T>(scheduleProxy), retryProxy);
+            }
 
             T scheduleInstance = ProxyGenerator.CreateInterfaceProxyWithoutTarget<T>(scheduleProxy);
             return ProxyGenerator.CreateInterfaceProxyWithTarget(scheduleInstance, retryProxy);

--- a/src/DurableTask.Core/OrchestrationContext.cs
+++ b/src/DurableTask.Core/OrchestrationContext.cs
@@ -88,6 +88,11 @@ namespace DurableTask.Core
         /// <returns></returns>
         public virtual T CreateClient<T>(bool useFullyQualifiedMethodNames) where T : class
         {
+            if (!typeof(T).IsInterface && !typeof(T).IsClass)
+            {
+                throw new InvalidOperationException($"{nameof(T)} must be an interface or class.");
+            }
+
             IInterceptor scheduleProxy = new ScheduleProxy(this, useFullyQualifiedMethodNames);
 
             if (typeof(T).IsClass)
@@ -138,6 +143,11 @@ namespace DurableTask.Core
         /// <returns>Dynamic proxy that can be used to schedule the remote tasks</returns>
         public virtual T CreateRetryableClient<T>(RetryOptions retryOptions, bool useFullyQualifiedMethodNames) where T : class
         {
+            if (!typeof(T).IsInterface && !typeof(T).IsClass)
+            {
+                throw new InvalidOperationException($"{nameof(T)} must be an interface or class.");
+            }
+
             IInterceptor scheduleProxy = new ScheduleProxy(this, useFullyQualifiedMethodNames);
             IInterceptor retryProxy = new RetryProxy(this, retryOptions);
 

--- a/src/DurableTask.Core/OrchestrationContext.cs
+++ b/src/DurableTask.Core/OrchestrationContext.cs
@@ -88,7 +88,7 @@ namespace DurableTask.Core
         /// <returns></returns>
         public virtual T CreateClient<T>(bool useFullyQualifiedMethodNames) where T : class
         {
-            if (!typeof(T).IsInterface && !typeof(T).IsClass)
+            if (!typeof(T).IsInterface || !typeof(T).IsClass)
             {
                 throw new InvalidOperationException($"{nameof(T)} must be an interface or class.");
             }
@@ -143,7 +143,7 @@ namespace DurableTask.Core
         /// <returns>Dynamic proxy that can be used to schedule the remote tasks</returns>
         public virtual T CreateRetryableClient<T>(RetryOptions retryOptions, bool useFullyQualifiedMethodNames) where T : class
         {
-            if (!typeof(T).IsInterface && !typeof(T).IsClass)
+            if (!typeof(T).IsInterface || !typeof(T).IsClass)
             {
                 throw new InvalidOperationException($"{nameof(T)} must be an interface or class.");
             }

--- a/src/DurableTask.Core/OrchestrationContext.cs
+++ b/src/DurableTask.Core/OrchestrationContext.cs
@@ -88,7 +88,7 @@ namespace DurableTask.Core
         /// <returns></returns>
         public virtual T CreateClient<T>(bool useFullyQualifiedMethodNames) where T : class
         {
-            if (!typeof(T).IsInterface || !typeof(T).IsClass)
+            if (!typeof(T).IsInterface && !typeof(T).IsClass)
             {
                 throw new InvalidOperationException($"{nameof(T)} must be an interface or class.");
             }
@@ -143,7 +143,7 @@ namespace DurableTask.Core
         /// <returns>Dynamic proxy that can be used to schedule the remote tasks</returns>
         public virtual T CreateRetryableClient<T>(RetryOptions retryOptions, bool useFullyQualifiedMethodNames) where T : class
         {
-            if (!typeof(T).IsInterface || !typeof(T).IsClass)
+            if (!typeof(T).IsInterface && !typeof(T).IsClass)
             {
                 throw new InvalidOperationException($"{nameof(T)} must be an interface or class.");
             }


### PR DESCRIPTION
This change extends `TaskHubWorker.AddTaskActivitiesFromInterface` by supporting adding activities from `abstract` or non-sealed classes.