### PR TITLE
Remove redundant Microsoft.SourceLink.GitHub package references

### DIFF
--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -30,10 +30,6 @@
     <!-- The assembly version is only the major/minor pair, making it easier to do in-place upgrades -->
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
   </PropertyGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.*" PrivateAssets="All" />
-  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />

--- a/src/DurableTask.Redis/DurableTask.Redis.csproj
+++ b/src/DurableTask.Redis/DurableTask.Redis.csproj
@@ -25,10 +25,6 @@
   <ItemGroup>
     <PackageReference Include="StackExchange.Redis" Version="2.0.571" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
-  </ItemGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\DurableTask.Core\DurableTask.Core.csproj" />

--- a/src/DurableTask.SqlServer/DurableTask.SqlServer.csproj
+++ b/src/DurableTask.SqlServer/DurableTask.SqlServer.csproj
@@ -19,10 +19,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
The release pipeline recently started failing with the following error during `nuget restore`:

> D:\a\_work\1\s\src\DurableTask.AzureStorage\DurableTask.AzureStorage.csproj : error NU1504: Duplicate 'PackageReference' items found. Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior. The duplicate 'PackageReference' items are: Microsoft.SourceLink.GitHub 1.0.*, Microsoft.SourceLink.GitHub 1.0.*.

I believe this is due to the fact that both DurableTask.AzureStorage.csproj and the DurableTask.props file it imports both include this package reference. These changes were made > 3 years ago, so I think we're seeing this now because of [recent SDK updates](https://github.com/dotnet/sdk/issues/24747#issuecomment-1218481503) made by the .NET and/or nuget teams, which was probably automatically picked up by the Azure Pipelines infrastructure.