### PR TITLE
[WIP] Update CI to utilize latest Nuget CLI

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -7,6 +7,15 @@ pool:
     - ImageOverride -equals MMS2022TLS
 
 steps:
+
+# NuGet tool installer
+# Acquires a specific version of NuGet from the internet or the tools cache and adds it to the PATH. Use this task to change the version of NuGet used in the NuGet tasks.
+# This is necessary because .NET5 has some compatibility issues with older Nuget versions (<=5.7), causing nuget pack to potentially fail
+- task: NuGetToolInstaller@1
+  inputs:
+    versionSpec: '5.8'
+    #checkLatest: false # Optional
+
 # Start by restoring all the dependencies. This needs to be its own task
 # from what I can tell. We specifically only target DurableTask.AzureStorage
 # and its direct dependencies.


### PR DESCRIPTION
Currently, our release CI is failing with this error:
```
##[warning].NET 5 has some compatibility issues with older Nuget versions(<=5.7), so if you are using an older Nuget version(and not dotnet cli) to restore, then the dotnet cli commands (e.g. dotnet build) which rely on such restored packages might fail. To mitigate such error, you can either: (1) - Use dotnet cli to restore, (2) - Use Nuget version 5.8 to restore, (3) - Use global.json using an older sdk version(<=3) to build
##[error]Error: The process 'C:\Program Files\dotnet\dotnet.exe' failed with exit code 1
##[error]An error occurred while trying to pack the files.
Info: Azure Pipelines hosted agents have been updated and now contain .Net 5.x SDK/Runtime along with the older .Net Core version which are currently lts. Unless you have locked down a SDK version for your project(s), 5.x SDK might be picked up which might have breaking behavior as compared to previous versions. You can learn more about the breaking changes here: https://docs.microsoft.com/en-us/dotnet/core/tools/ and https://docs.microsoft.com/en-us/dotnet/core/compatibility/ . To learn about more such changes and troubleshoot, refer here: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/build/dotnet-core-cli?view=azure-devops#troubleshooting
Finishing: Generate nuget packages
```

This seems to suggest that the .NET SDK version in our CI has been updated, which is breaking our usage of `nuget pack`. This change looks to update our CI Nuget installation to patch this newly introduced regression.