### PR TITLE
Enable redacting user-code exception messages

### DIFF
--- a/src/DurableTask.Core/Common/Utils.cs
+++ b/src/DurableTask.Core/Common/Utils.cs
@@ -10,13 +10,12 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
-
+#nullable enable
 namespace DurableTask.Core.Common
 {
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Dynamic;
     using System.IO;
     using System.IO.Compression;
     using System.Linq;
@@ -74,6 +73,31 @@ namespace DurableTask.Core.Common
             Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME") ??
             Environment.GetEnvironmentVariable("DTFX_APP_NAME") ??
             string.Empty;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to redact user code exceptions from log output.
+        /// </summary>
+        /// <remarks>
+        /// This value defaults to <c>true</c> if the WEBSITE_SITE_NAME is set to a non-empty value, which is always
+        /// the case in hosted Azure environments where log telemetry is automatically captured. This value can be also
+        /// be set explicitly by assigning the DTFX_REDACT_USER_CODE_EXCEPTIONS environment variable to "1" or "true".
+        /// </remarks>
+        public static bool RedactUserCodeExceptions { get; set; } = GetRedactUserCodeExceptionsDefaultValue();
+
+        static bool GetRedactUserCodeExceptionsDefaultValue()
+        {
+            string? configuredValue = Environment.GetEnvironmentVariable("DTFX_REDACT_USER_CODE_EXCEPTIONS")?.Trim();
+            if (configuredValue != null)
+            {
+                return configuredValue == "1" || configuredValue.Equals("true", StringComparison.OrdinalIgnoreCase);
+            }
+            else
+            {
+                // Fallback case when DTFX_REDACT_USER_CODE_EXCEPTIONS is not defined is to automatically redact
+                // any time we appear to be in a hosted Azure environment.
+                return Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME") != null;
+            }
+        }
 
         /// <summary>
         /// NoOp utility method
@@ -139,7 +163,7 @@ namespace DurableTask.Core.Common
 
             if (compress)
             {
-                Stream compressedStream = GetCompressedStream(resultStream);
+                Stream compressedStream = GetCompressedStream(resultStream)!;
                 resultStream.Dispose();
                 resultStream = compressedStream;
             }
@@ -212,7 +236,7 @@ namespace DurableTask.Core.Common
         /// </summary>
         /// <param name="input"></param>
         /// <returns></returns>
-        public static Stream GetCompressedStream(Stream input)
+        public static Stream? GetCompressedStream(Stream input)
         {
             if (input == null)
             {
@@ -236,7 +260,7 @@ namespace DurableTask.Core.Common
         /// </summary>
         /// <param name="input"></param>
         /// <returns></returns>
-        public static async Task<Stream> GetDecompressedStreamAsync(Stream input)
+        public static async Task<Stream?> GetDecompressedStreamAsync(Stream input)
         {
             if (input == null)
             {
@@ -294,7 +318,7 @@ namespace DurableTask.Core.Common
             }
 
             int retryCount = numberOfAttempts;
-            ExceptionDispatchInfo lastException = null;
+            ExceptionDispatchInfo? lastException = null;
             while (retryCount-- > 0)
             {
                 try
@@ -322,7 +346,7 @@ namespace DurableTask.Core.Common
         /// <summary>
         /// Executes the supplied action until successful or the supplied number of attempts is reached
         /// </summary>
-        public static async Task<T> ExecuteWithRetries<T>(Func<Task<T>> retryAction, string sessionId, string operation,
+        public static async Task<T?> ExecuteWithRetries<T>(Func<Task<T>> retryAction, string sessionId, string operation,
             int numberOfAttempts, int delayInAttemptsSecs)
         {
             if (numberOfAttempts == 0)
@@ -332,7 +356,7 @@ namespace DurableTask.Core.Common
             }
 
             int retryCount = numberOfAttempts;
-            ExceptionDispatchInfo lastException = null;
+            ExceptionDispatchInfo? lastException = null;
             while (retryCount-- > 0)
             {
                 try
@@ -394,14 +418,14 @@ namespace DurableTask.Core.Common
         /// <summary>
         /// Retrieves the exception from a previously serialized exception
         /// </summary>
-        public static Exception RetrieveCause(string details, DataConverter converter)
+        public static Exception? RetrieveCause(string details, DataConverter converter)
         {
             if (converter == null)
             {
                 throw new ArgumentNullException(nameof(converter));
             }
 
-            Exception cause = null;
+            Exception? cause = null;
             try
             {
                 if (!string.IsNullOrWhiteSpace(details))
@@ -600,9 +624,9 @@ namespace DurableTask.Core.Common
 
         internal sealed class TypeMetadata
         {
-            public string AssemblyName { get; set; }
+            public string? AssemblyName { get; set; }
 
-            public string FullyQualifiedTypeName { get; set; }
+            public string? FullyQualifiedTypeName { get; set; }
         }
     }
 }

--- a/src/DurableTask.Core/Logging/LogEvents.cs
+++ b/src/DurableTask.Core/Logging/LogEvents.cs
@@ -1279,13 +1279,13 @@ namespace DurableTask.Core.Logging
                 OrchestrationInstance instance,
                 string name,
                 TaskFailedEvent taskEvent,
-                Exception exception)
+                string exceptionDetails)
             {
                 this.InstanceId = instance.InstanceId;
                 this.ExecutionId = instance.ExecutionId;
                 this.Name = name;
                 this.TaskEventId = taskEvent.EventId;
-                this.Details = exception.ToString();
+                this.Details = exceptionDetails;
             }
 
             [StructuredLogField]

--- a/src/DurableTask.Core/Logging/LogEvents.cs
+++ b/src/DurableTask.Core/Logging/LogEvents.cs
@@ -1275,17 +1275,20 @@ namespace DurableTask.Core.Logging
 
         internal class TaskActivityFailure : StructuredLogEvent, IEventSourceEvent
         {
+            readonly Exception exception;
+
             public TaskActivityFailure(
                 OrchestrationInstance instance,
                 string name,
                 TaskFailedEvent taskEvent,
-                string exceptionDetails)
+                Exception exception)
             {
                 this.InstanceId = instance.InstanceId;
                 this.ExecutionId = instance.ExecutionId;
                 this.Name = name;
                 this.TaskEventId = taskEvent.EventId;
-                this.Details = exceptionDetails;
+                this.Details = exception.ToString();
+                this.exception = exception;
             }
 
             [StructuredLogField]
@@ -1318,7 +1321,7 @@ namespace DurableTask.Core.Logging
                     this.ExecutionId,
                     this.Name,
                     this.TaskEventId,
-                    this.Details,
+                    Utils.RedactUserCodeExceptions ? LogHelper.GetRedactedExceptionDetails(this.exception) : this.Details, // We have to be extra guarded about logging user exceptions to EventSource (ETW)
                     Utils.AppName,
                     Utils.PackageVersion);
         }

--- a/src/DurableTask.Core/TaskActivityDispatcher.cs
+++ b/src/DurableTask.Core/TaskActivityDispatcher.cs
@@ -102,7 +102,7 @@ namespace DurableTask.Core
             Activity? diagnosticActivity = null;
             try
             {
-                if (string.IsNullOrWhiteSpace(orchestrationInstance?.InstanceId))
+                if (orchestrationInstance == null || string.IsNullOrWhiteSpace(orchestrationInstance.InstanceId))
                 {
                     this.logHelper.TaskActivityDispatcherError(
                         workItem,
@@ -242,7 +242,7 @@ namespace DurableTask.Core
             catch (SessionAbortedException e)
             {
                 // The activity aborted its execution
-                this.logHelper.TaskActivityAborted(orchestrationInstance, scheduledEvent, e.Message);
+                this.logHelper.TaskActivityAborted(orchestrationInstance, scheduledEvent!, e.Message);
                 TraceHelper.TraceInstance(TraceEventType.Warning, "TaskActivityDispatcher-ExecutionAborted", orchestrationInstance, "{0}: {1}", scheduledEvent?.Name, e.Message);
                 await this.orchestrationService.AbandonTaskActivityWorkItemAsync(workItem);
             }

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -323,7 +323,7 @@ namespace DurableTask.Core
                     continuedAsNew = false;
                     continuedAsNewMessage = null;
 
-                    this.logHelper.OrchestrationExecuting(runtimeState.OrchestrationInstance, runtimeState.Name);
+                    this.logHelper.OrchestrationExecuting(runtimeState.OrchestrationInstance!, runtimeState.Name);
                     TraceHelper.TraceInstance(
                         TraceEventType.Verbose,
                         "TaskOrchestrationDispatcher-ExecuteUserOrchestration-Begin",
@@ -343,7 +343,7 @@ namespace DurableTask.Core
                     IReadOnlyList<OrchestratorAction> decisions = workItem.Cursor.LatestDecisions.ToList();
 
                     this.logHelper.OrchestrationExecuted(
-                        runtimeState.OrchestrationInstance,
+                        runtimeState.OrchestrationInstance!,
                         runtimeState.Name,
                         decisions);
                     TraceHelper.TraceInstance(
@@ -846,7 +846,7 @@ namespace DurableTask.Core
             }
 
             this.logHelper.SchedulingActivity(
-                runtimeState.OrchestrationInstance,
+                runtimeState.OrchestrationInstance!,
                 scheduledEvent);
 
             runtimeState.AddEvent(scheduledEvent);
@@ -874,7 +874,7 @@ namespace DurableTask.Core
             };
 
             this.logHelper.CreatingTimer(
-                runtimeState.OrchestrationInstance,
+                runtimeState.OrchestrationInstance!,
                 timerCreatedEvent,
                 isInternal);
 
@@ -943,7 +943,7 @@ namespace DurableTask.Core
             
             runtimeState.AddEvent(historyEvent);
 
-            this.logHelper.RaisingEvent(runtimeState.OrchestrationInstance, historyEvent);
+            this.logHelper.RaisingEvent(runtimeState.OrchestrationInstance!, historyEvent);
 
             return new TaskMessage
             {

--- a/src/DurableTask.Core/TaskOrchestrationExecutor.cs
+++ b/src/DurableTask.Core/TaskOrchestrationExecutor.cs
@@ -139,7 +139,7 @@ namespace DurableTask.Core
                                 Exception? exception = this.result.Exception?.InnerExceptions.FirstOrDefault();
                                 Debug.Assert(exception != null);
 
-                                if (Utils.IsExecutionAborting(exception))
+                                if (Utils.IsExecutionAborting(exception!))
                                 {
                                     // Let this exception propagate out to be handled by the dispatcher
                                     ExceptionDispatchInfo.Capture(exception).Throw();


### PR DESCRIPTION
### Context
DTFx code is often hosted in Azure App Service and Azure Functions. When running on these platforms, certain framework traces are captured into an internal log capturing service. One of the things logged by DTFx is exception messages for activity failures. These exception messages are often generated by user code, which may contain sensitive information (PII, secrets, etc.). 

### Change
As a safety mechanism, this PR will redact exception messages that come from activity failures. This redaction is enabled by default when hosted in an Azure App Service environment, which we infer by checking for the `WEBSITE_SITE_NAME` environment variable. This policy of redaction can be overridden by setting a `DTFX_REDACT_USER_CODE_EXCEPTIONS` environment variable to `1` or `true`.

This PR also adds additional `#nullable enable` compiler directives, which is something we routinely do as we touch the code to help make it safe from unexpected null-ref exceptions.

### Testing
I tested the exception redaction logic using the following LINQPad script:

```csharp
try
{
	Foo();
}
catch (Exception e)
{
	Console.WriteLine(GetSafeExceptionDetails(e, false));
	Console.WriteLine();
	Console.WriteLine(GetSafeExceptionDetails(e, true));
}

static string GetSafeExceptionDetails(Exception exception, bool redact)
{
	if (redact)
	{
		// Redact the exception message since its possible to contain sensitive information (PII, secrets, etc.)
		// Exception.ToString() code: https://referencesource.microsoft.com/#mscorlib/system/exception.cs,e2e19f4ed8da81aa
		var sb = new StringBuilder(capacity: 1024);
		sb.Append(exception.GetType().FullName).Append(": ").Append("[Redacted]");
		if (exception.InnerException != null)
		{
			// Recursive
			sb.AppendLine().Append(" ---> ").AppendLine(GetSafeExceptionDetails(exception.InnerException, redact));
			sb.Append("   --- End of inner exception stack trace ---");
		}

		sb.AppendLine().Append(exception.StackTrace);
		return sb.ToString();
	}
	else
	{
		return exception.ToString();
	}
}

static void Foo()
{
	try
	{
		Bar();
	}
	catch (Exception e)
	{
		throw new ApplicationException("Oh no!", e);
	}
}

static void Bar()
{
	try
	{
		Baz();
	}
	catch (Exception e)
	{
		throw new Exception("Umm...", e);
	}
}

static void Baz()
{
	throw new InvalidOperationException("Kah-BOOOOM!!!");
}
```

The results when redaction IS NOT enabled:
```
System.ApplicationException: Oh no!
 ---> System.Exception: Umm...
 ---> System.InvalidOperationException: Kah-BOOOOM!!!
   at UserQuery.<Main>g__Baz|4_3() in C:\Users\cgillum\AppData\Local\Temp\LINQPad7\_wrmpjfpn\otarjw\LINQPadQuery:line 63
   at UserQuery.<Main>g__Bar|4_2() in C:\Users\cgillum\AppData\Local\Temp\LINQPad7\_wrmpjfpn\otarjw\LINQPadQuery:line 53
   --- End of inner exception stack trace ---
   at UserQuery.<Main>g__Bar|4_2() in C:\Users\cgillum\AppData\Local\Temp\LINQPad7\_wrmpjfpn\otarjw\LINQPadQuery:line 57
   at UserQuery.<Main>g__Foo|4_1() in C:\Users\cgillum\AppData\Local\Temp\LINQPad7\_wrmpjfpn\otarjw\LINQPadQuery:line 41
   --- End of inner exception stack trace ---
   at UserQuery.<Main>g__Foo|4_1() in C:\Users\cgillum\AppData\Local\Temp\LINQPad7\_wrmpjfpn\otarjw\LINQPadQuery:line 45
   at UserQuery.Main() in C:\Users\cgillum\AppData\Local\Temp\LINQPad7\_wrmpjfpn\otarjw\LINQPadQuery:line 4
```

This is what would be seen if redaction IS enabled:
```
System.ApplicationException: [Redacted]
 ---> System.Exception: [Redacted]
 ---> System.InvalidOperationException: [Redacted]
   at UserQuery.<Main>g__Baz|4_3() in C:\Users\cgillum\AppData\Local\Temp\LINQPad7\_wrmpjfpn\otarjw\LINQPadQuery:line 63
   at UserQuery.<Main>g__Bar|4_2() in C:\Users\cgillum\AppData\Local\Temp\LINQPad7\_wrmpjfpn\otarjw\LINQPadQuery:line 53
   --- End of inner exception stack trace ---
   at UserQuery.<Main>g__Bar|4_2() in C:\Users\cgillum\AppData\Local\Temp\LINQPad7\_wrmpjfpn\otarjw\LINQPadQuery:line 57
   at UserQuery.<Main>g__Foo|4_1() in C:\Users\cgillum\AppData\Local\Temp\LINQPad7\_wrmpjfpn\otarjw\LINQPadQuery:line 41
   --- End of inner exception stack trace ---
   at UserQuery.<Main>g__Foo|4_1() in C:\Users\cgillum\AppData\Local\Temp\LINQPad7\_wrmpjfpn\otarjw\LINQPadQuery:line 45
   at UserQuery.Main() in C:\Users\cgillum\AppData\Local\Temp\LINQPad7\_wrmpjfpn\otarjw\LINQPadQuery:line 4
```