### PR TITLE
DT.AzureStorage: Background renewal for pending orchestrator messages

### DIFF
--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -91,7 +91,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(EventIds.ReceivedMessage, Level = EventLevel.Informational, Opcode = EventOpcode.Receive, Task = Tasks.Dequeue, Version = 6)]
+        [Event(EventIds.ReceivedMessage, Level = EventLevel.Informational, Opcode = EventOpcode.Receive, Task = Tasks.Dequeue, Version = 7)]
         public void ReceivedMessage(
             Guid relatedActivityId,
             string Account,
@@ -107,6 +107,7 @@ namespace DurableTask.AzureStorage
             long SizeInBytes,
             string PartitionId,
             long SequenceNumber,
+            string PopReceipt,
             int Episode,
             string AppName,
             string ExtensionVersion)
@@ -127,12 +128,13 @@ namespace DurableTask.AzureStorage
                 SizeInBytes,
                 PartitionId,
                 SequenceNumber,
+                PopReceipt ?? string.Empty,
                 Episode,
                 AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.DeletingMessage, Level = EventLevel.Informational, Version = 5)]
+        [Event(EventIds.DeletingMessage, Level = EventLevel.Informational, Version = 6)]
         public void DeletingMessage(
             string Account,
             string TaskHub,
@@ -143,6 +145,7 @@ namespace DurableTask.AzureStorage
             string ExecutionId,
             string PartitionId,
             long SequenceNumber,
+            string PopReceipt,
             string AppName,
             string ExtensionVersion)
         {
@@ -157,11 +160,12 @@ namespace DurableTask.AzureStorage
                 ExecutionId ?? string.Empty,
                 PartitionId,
                 SequenceNumber,
+                PopReceipt ?? string.Empty,
                 AppName,
                 ExtensionVersion);
         }
 
-        [Event(EventIds.AbandoningMessage, Level = EventLevel.Warning, Version = 6)]
+        [Event(EventIds.AbandoningMessage, Level = EventLevel.Warning, Version = 7)]
         public void AbandoningMessage(
             string Account,
             string TaskHub,
@@ -172,6 +176,7 @@ namespace DurableTask.AzureStorage
             string ExecutionId,
             string PartitionId,
             long SequenceNumber,
+            string PopReceipt,
             int VisibilityTimeoutSeconds,
             string AppName,
             string ExtensionVersion)
@@ -187,6 +192,7 @@ namespace DurableTask.AzureStorage
                 ExecutionId ?? string.Empty,
                 PartitionId,
                 SequenceNumber,
+                PopReceipt ?? string.Empty,
                 VisibilityTimeoutSeconds,
                 AppName,
                 ExtensionVersion);
@@ -203,7 +209,7 @@ namespace DurableTask.AzureStorage
             this.WriteEvent(EventIds.AssertFailure, Account, TaskHub, Details, AppName, ExtensionVersion);
         }
 
-        [Event(EventIds.MessageGone, Level = EventLevel.Warning, Version = 4)]
+        [Event(EventIds.MessageGone, Level = EventLevel.Warning, Version = 5)]
         public void MessageGone(
             string Account,
             string TaskHub,
@@ -214,6 +220,7 @@ namespace DurableTask.AzureStorage
             string ExecutionId,
             string PartitionId,
             string Details,
+            string PopReceipt,
             string AppName,
             string ExtensionVersion)
         {
@@ -228,6 +235,7 @@ namespace DurableTask.AzureStorage
                 ExecutionId ?? string.Empty,
                 PartitionId,
                 Details,
+                PopReceipt ?? string.Empty,
                 AppName,
                 ExtensionVersion);
         }
@@ -238,7 +246,7 @@ namespace DurableTask.AzureStorage
             this.WriteEvent(EventIds.GeneralError, Account, TaskHub, Details, AppName, ExtensionVersion);
         }
 
-        [Event(EventIds.DuplicateMessageDetected, Level = EventLevel.Warning, Version = 3)]
+        [Event(EventIds.DuplicateMessageDetected, Level = EventLevel.Warning, Version = 4)]
         public void DuplicateMessageDetected(
             string Account,
             string TaskHub,
@@ -249,6 +257,7 @@ namespace DurableTask.AzureStorage
             string ExecutionId,
             string PartitionId,
             int DequeueCount,
+            string PopReceipt,
             string AppName,
             string ExtensionVersion)
         {
@@ -263,6 +272,7 @@ namespace DurableTask.AzureStorage
                 ExecutionId ?? string.Empty,
                 PartitionId,
                 DequeueCount,
+                PopReceipt ?? string.Empty,
                 AppName,
                 ExtensionVersion);
         }
@@ -397,7 +407,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(EventIds.RenewingMessage, Level = EventLevel.Informational, Version = 3)]
+        [Event(EventIds.RenewingMessage, Level = EventLevel.Informational, Version = 4)]
         public void RenewingMessage(
             string Account,
             string TaskHub,
@@ -407,6 +417,7 @@ namespace DurableTask.AzureStorage
             string EventType,
             int TaskEventId,
             string MessageId,
+            string PopReceipt,
             int VisibilityTimeoutSeconds,
             string AppName,
             string ExtensionVersion)
@@ -421,6 +432,7 @@ namespace DurableTask.AzureStorage
                 EventType,
                 TaskEventId,
                 MessageId,
+                PopReceipt ?? string.Empty,
                 VisibilityTimeoutSeconds,
                 AppName,
                 ExtensionVersion);

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -907,6 +907,7 @@ namespace DurableTask.AzureStorage
                 data.TotalMessageSizeBytes,
                 data.QueueName /* PartitionId */,
                 data.SequenceNumber,
+                queueMessage.PopReceipt,
                 data.Episode.GetValueOrDefault(-1));
         }
 

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
     <MinorVersion>13</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     
     <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)</Version>
     <FileVersion>$(Version).0</FileVersion>

--- a/src/DurableTask.AzureStorage/Logging/LogEvents.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogEvents.cs
@@ -138,6 +138,7 @@ namespace DurableTask.AzureStorage.Logging
                 long sizeInBytes,
                 string partitionId,
                 long sequenceNumber,
+                string popReceipt,
                 int episode)
             {
                 this.RelatedActivityId = relatedActivityId;
@@ -154,6 +155,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.SizeInBytes = sizeInBytes;
                 this.PartitionId = partitionId;
                 this.SequenceNumber = sequenceNumber;
+                this.PopReceipt = popReceipt;
                 this.Episode = episode;
             }
 
@@ -199,6 +201,9 @@ namespace DurableTask.AzureStorage.Logging
             public long SequenceNumber { get; }
 
             [StructuredLogField]
+            public string PopReceipt { get; }
+
+            [StructuredLogField]
             public int Episode { get; }
 
             public override EventId EventId => new EventId(
@@ -229,6 +234,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.SizeInBytes,
                 this.PartitionId,
                 this.SequenceNumber,
+                this.PopReceipt,
                 this.Episode,
                 Utils.AppName,
                 Utils.ExtensionVersion);
@@ -245,7 +251,8 @@ namespace DurableTask.AzureStorage.Logging
                 string instanceId,
                 string executionId,
                 string partitionId,
-                long sequenceNumber)
+                long sequenceNumber,
+                string popReceipt)
             {
                 this.Account = account;
                 this.TaskHub = taskHub;
@@ -256,6 +263,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.ExecutionId = executionId;
                 this.PartitionId = partitionId;
                 this.SequenceNumber = sequenceNumber;
+                this.PopReceipt = popReceipt;
             }
 
             [StructuredLogField]
@@ -285,6 +293,9 @@ namespace DurableTask.AzureStorage.Logging
             [StructuredLogField]
             public long SequenceNumber { get; }
 
+            [StructuredLogField]
+            public string PopReceipt { get; }
+
             public override EventId EventId => new EventId(
                 EventIds.DeletingMessage,
                 nameof(EventIds.DeletingMessage));
@@ -307,6 +318,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.ExecutionId,
                 this.PartitionId,
                 this.SequenceNumber,
+                this.PopReceipt,
                 Utils.AppName,
                 Utils.ExtensionVersion);
         }
@@ -323,6 +335,7 @@ namespace DurableTask.AzureStorage.Logging
                 string executionId,
                 string partitionId,
                 long sequenceNumber,
+                string popReceipt,
                 int visibilityTimeoutSeconds)
             {
                 this.Account = account;
@@ -334,6 +347,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.ExecutionId = executionId;
                 this.PartitionId = partitionId;
                 this.SequenceNumber = sequenceNumber;
+                this.PopReceipt = popReceipt;
                 this.VisibilityTimeoutSeconds = visibilityTimeoutSeconds;
             }
 
@@ -365,6 +379,9 @@ namespace DurableTask.AzureStorage.Logging
             public long SequenceNumber { get; }
 
             [StructuredLogField]
+            public string PopReceipt { get; }
+
+            [StructuredLogField]
             public int VisibilityTimeoutSeconds { get; }
 
             public override EventId EventId => new EventId(
@@ -390,6 +407,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.ExecutionId,
                 this.PartitionId,
                 this.SequenceNumber,
+                this.PopReceipt,
                 this.VisibilityTimeoutSeconds,
                 Utils.AppName,
                 Utils.ExtensionVersion);
@@ -443,7 +461,8 @@ namespace DurableTask.AzureStorage.Logging
                 string partitionId,
                 string eventType,
                 int taskEventId,
-                string details)
+                string details,
+                string popReceipt)
             {
                 this.Account = account;
                 this.TaskHub = taskHub;
@@ -454,6 +473,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.ExecutionId = executionId;
                 this.PartitionId = partitionId;
                 this.Details = details;
+                this.PopReceipt = popReceipt;
             }
 
             [StructuredLogField]
@@ -483,6 +503,9 @@ namespace DurableTask.AzureStorage.Logging
             [StructuredLogField]
             public string Details { get; }
 
+            [StructuredLogField]
+            public string PopReceipt { get; }
+
             public override EventId EventId => new EventId(
                 EventIds.MessageGone,
                 nameof(EventIds.MessageGone));
@@ -505,6 +528,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.ExecutionId,
                 this.PartitionId,
                 this.Details,
+                this.PopReceipt,
                 Utils.AppName,
                 Utils.ExtensionVersion);
         }
@@ -557,7 +581,8 @@ namespace DurableTask.AzureStorage.Logging
                 string instanceId,
                 string executionId,
                 string partitionId,
-                int dequeueCount)
+                int dequeueCount,
+                string popReceipt)
             {
                 this.Account = account;
                 this.TaskHub = taskHub;
@@ -568,6 +593,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.ExecutionId = executionId;
                 this.PartitionId = partitionId;
                 this.DequeueCount = dequeueCount;
+                this.PopReceipt = popReceipt;
             }
 
             [StructuredLogField]
@@ -597,6 +623,9 @@ namespace DurableTask.AzureStorage.Logging
             [StructuredLogField]
             public int DequeueCount { get; }
 
+            [StructuredLogField]
+            public string PopReceipt { get; }
+
             public override EventId EventId => new EventId(
                 EventIds.DuplicateMessageDetected,
                 nameof(EventIds.DuplicateMessageDetected));
@@ -621,6 +650,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.ExecutionId,
                 this.PartitionId,
                 this.DequeueCount,
+                this.PopReceipt,
                 Utils.AppName,
                 Utils.ExtensionVersion);
         }
@@ -980,6 +1010,7 @@ namespace DurableTask.AzureStorage.Logging
                 string eventType,
                 int taskEventId,
                 string messageId,
+                string popReceipt,
                 int visibilityTimeoutSeconds)
             {
                 this.Account = account;
@@ -990,6 +1021,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.EventType = eventType;
                 this.TaskEventId = taskEventId;
                 this.MessageId = messageId;
+                this.PopReceipt = popReceipt;
                 this.VisibilityTimeoutSeconds = visibilityTimeoutSeconds;
             }
 
@@ -1018,6 +1050,9 @@ namespace DurableTask.AzureStorage.Logging
             public string MessageId { get; }
 
             [StructuredLogField]
+            public string PopReceipt { get; }
+
+            [StructuredLogField]
             public int VisibilityTimeoutSeconds { get; }
 
             public override EventId EventId => new EventId(
@@ -1042,6 +1077,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.EventType,
                 this.TaskEventId,
                 this.MessageId,
+                this.PopReceipt,
                 this.VisibilityTimeoutSeconds,
                 Utils.AppName,
                 Utils.ExtensionVersion);

--- a/src/DurableTask.AzureStorage/Logging/LogHelper.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogHelper.cs
@@ -74,6 +74,7 @@ namespace DurableTask.AzureStorage.Logging
             long sizeInBytes,
             string partitionId,
             long sequenceNumber,
+            string popReceipt,
             int episode)
         {
             var logEvent = new LogEvents.ReceivedMessage(
@@ -91,6 +92,7 @@ namespace DurableTask.AzureStorage.Logging
                 sizeInBytes,
                 partitionId,
                 sequenceNumber,
+                popReceipt,
                 episode);
             this.WriteStructuredLog(logEvent);
         }
@@ -104,7 +106,8 @@ namespace DurableTask.AzureStorage.Logging
             string instanceId,
             string executionId,
             string partitionId,
-            long sequenceNumber)
+            long sequenceNumber,
+            string popReceipt)
         {
             var logEvent = new LogEvents.DeletingMessage(
                 account,
@@ -115,7 +118,8 @@ namespace DurableTask.AzureStorage.Logging
                 instanceId,
                 executionId,
                 partitionId,
-                sequenceNumber);
+                sequenceNumber,
+                popReceipt);
             this.WriteStructuredLog(logEvent);
         }
 
@@ -129,6 +133,7 @@ namespace DurableTask.AzureStorage.Logging
             string executionId,
             string partitionId,
             long sequenceNumber,
+            string popReceipt,
             int visibilityTimeoutSeconds)
         {
             var logEvent = new LogEvents.AbandoningMessage(
@@ -141,6 +146,7 @@ namespace DurableTask.AzureStorage.Logging
                 executionId,
                 partitionId,
                 sequenceNumber,
+                popReceipt,
                 visibilityTimeoutSeconds);
             this.WriteStructuredLog(logEvent);
         }
@@ -166,7 +172,8 @@ namespace DurableTask.AzureStorage.Logging
             string partitionId,
             string eventType,
             int taskEventId,
-            string details)
+            string details,
+            string popReceipt)
         {
             var logEvent = new LogEvents.MessageGone(
                 account,
@@ -177,7 +184,8 @@ namespace DurableTask.AzureStorage.Logging
                 partitionId,
                 eventType,
                 taskEventId,
-                details);
+                details,
+                popReceipt);
             this.WriteStructuredLog(logEvent);
         }
 
@@ -202,7 +210,8 @@ namespace DurableTask.AzureStorage.Logging
             string instanceId,
             string executionId,
             string partitionId,
-            int dequeueCount)
+            int dequeueCount,
+            string popReceipt)
         {
             var logEvent = new LogEvents.DuplicateMessageDetected(
                 account,
@@ -213,7 +222,8 @@ namespace DurableTask.AzureStorage.Logging
                 instanceId,
                 executionId,
                 partitionId,
-                dequeueCount);
+                dequeueCount,
+                popReceipt);
             this.WriteStructuredLog(logEvent);
         }
 
@@ -336,6 +346,7 @@ namespace DurableTask.AzureStorage.Logging
             string eventType,
             int taskEventId,
             string messageId,
+            string popReceipt,
             int visibilityTimeoutSeconds)
         {
             var logEvent = new LogEvents.RenewingMessage(
@@ -347,6 +358,7 @@ namespace DurableTask.AzureStorage.Logging
                 eventType,
                 taskEventId,
                 messageId,
+                popReceipt,
                 visibilityTimeoutSeconds);
             this.WriteStructuredLog(logEvent);
         }

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -143,7 +143,8 @@ namespace DurableTask.AzureStorage.Messaging
                                     messageData.TaskMessage.OrchestrationInstance.InstanceId,
                                     messageData.TaskMessage.OrchestrationInstance.ExecutionId,
                                     this.Name,
-                                    queueMessage.DequeueCount);
+                                    queueMessage.DequeueCount,
+                                    queueMessage.PopReceipt);
                             }
 
                             batchMessages.Add(messageData);

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -298,7 +298,7 @@ namespace DurableTask.AzureStorage.Messaging
             }
         }
 
-        public async Task RenewMessageAsync(MessageData message, SessionBase session)
+        public async Task RenewMessageAsync(MessageData message, SessionBase? session)
         {
             QueueMessage queueMessage = message.OriginalQueueMessage;
             TaskMessage taskMessage = message.TaskMessage;
@@ -398,7 +398,7 @@ namespace DurableTask.AzureStorage.Messaging
         {
             if (this.IsMessageGoneException(e))
             {
-                // Message may have been processed and deleted already.
+                // Message may have been processed and deleted already -OR- we lost track of its pop receipt
                 this.settings.Logger.MessageGone(
                     this.storageAccountName,
                     this.settings.TaskHubName,

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -271,6 +271,7 @@ namespace DurableTask.AzureStorage.Messaging
                 executionId,
                 this.storageQueue.Name,
                 sequenceNumber,
+                queueMessage.PopReceipt,
                 numSecondsToWait);
 
             try
@@ -292,7 +293,8 @@ namespace DurableTask.AzureStorage.Messaging
                     executionId,
                     eventType,
                     taskEventId,
-                    details: $"Caller: {nameof(AbandonMessageAsync)}");
+                    details: $"Caller: {nameof(AbandonMessageAsync)}",
+                    queueMessage.PopReceipt);
             }
         }
 
@@ -311,6 +313,7 @@ namespace DurableTask.AzureStorage.Messaging
                 message.TaskMessage.Event.EventType.ToString(),
                 Utils.GetTaskEventId(message.TaskMessage.Event),
                 queueMessage.Id,
+                queueMessage.PopReceipt,
                 (int)this.MessageVisibilityTimeout.TotalSeconds);
 
             try
@@ -341,7 +344,8 @@ namespace DurableTask.AzureStorage.Messaging
                 taskMessage.OrchestrationInstance.InstanceId,
                 taskMessage.OrchestrationInstance.ExecutionId,
                 this.storageQueue.Name,
-                message.SequenceNumber);
+                message.SequenceNumber,
+                queueMessage.PopReceipt);
 
             bool haveRetried = false;
             while (true)
@@ -379,7 +383,7 @@ namespace DurableTask.AzureStorage.Messaging
             string eventType = message.TaskMessage.Event.EventType.ToString() ?? string.Empty;
             int taskEventId = Utils.GetTaskEventId(message.TaskMessage.Event);
 
-            this.HandleMessagingExceptions(e, messageId, instanceId, executionId, eventType, taskEventId, details);
+            this.HandleMessagingExceptions(e, messageId, instanceId, executionId, eventType, taskEventId, details, message.OriginalQueueMessage.PopReceipt);
         }
 
         void HandleMessagingExceptions(
@@ -389,7 +393,8 @@ namespace DurableTask.AzureStorage.Messaging
             string executionId,
             string eventType,
             int taskEventId,
-            string details)
+            string details,
+            string popReceipt)
         {
             if (this.IsMessageGoneException(e))
             {
@@ -403,7 +408,8 @@ namespace DurableTask.AzureStorage.Messaging
                     this.storageQueue.Name,
                     eventType,
                     taskEventId,
-                    details);
+                    details,
+                    popReceipt);
             }
             else
             {

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -294,7 +294,8 @@ namespace DurableTask.AzureStorage
                         msg.TaskMessage.OrchestrationInstance.InstanceId,
                         msg.TaskMessage.OrchestrationInstance.ExecutionId,
                         controlQueue.Name,
-                        msg.OriginalQueueMessage.DequeueCount);
+                        msg.OriginalQueueMessage.DequeueCount,
+                        msg.OriginalQueueMessage.PopReceipt);
 
                     return controlQueue.DeleteMessageAsync(msg, session: null);
                 }));

--- a/src/DurableTask.AzureStorage/Storage/QueueMessage.cs
+++ b/src/DurableTask.AzureStorage/Storage/QueueMessage.cs
@@ -43,5 +43,7 @@ namespace DurableTask.AzureStorage.Storage
         public DateTimeOffset? InsertionTime => this.CloudQueueMessage.InsertionTime;
 
         public DateTimeOffset? NextVisibleTime => this.CloudQueueMessage.NextVisibleTime;
+
+        public string PopReceipt => this.CloudQueueMessage.PopReceipt;
     }
 }


### PR DESCRIPTION
This PR resolves an issue where a backlog of pending orchestration messages can result in a negative feedback loop where backlogged orchestrations get stuck in duplicate execution loops and can't make forward progress. The problem seems to occur when prefetched messages have been held longer than their visibility timeout (default 5 minutes). This causes us to receive the message again (with a duplicate message warning) and causes our existing in-memory copy of the message to be invalidated, resulting in MessageGone warnings when we finally process and try to delete the message.

The fix is to create a background loop that renews prefetched orchestration messages that are stuck in the pending buffer for long periods of time. This ensures that we don't lose our lock on the message, also ensuring that we can eventually process it successfully.

I tested it using a test that looks like the following (not included in the PR since it's long-running):

```csharp
[TestMethod]
public async Task ManyStuckOrchestrations()
{
    using TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(
        enableExtendedSessions: false,
        modifySettingsAction: settings =>
        {
            settings.MaxConcurrentTaskOrchestrationWorkItems = 10;
            settings.ControlQueueVisibilityTimeout = TimeSpan.FromMinutes(2);
        });
    await host.StartAsync();

    // Needs to be larger than the max orchestration concurrency
    const int InstanceCount = 100;

    List<TestInstance<int>> instances = await host.StartInlineOrchestrations<string, int>(
        InstanceCount,
        i => $"SleepyOrchestration{i}",
        i => i,
        orchestrationName: "SayHelloOrchestration",
        version: string.Empty,
        implementation: (OrchestrationContext ctx, int input) =>
        {
            Thread.Sleep(TimeSpan.FromMinutes(1));
            return Task.FromResult($"Hello, {input}!");
        });

    // All returned objects point to the same orchestration instance
    OrchestrationState[] finalStates = await Task.WhenAll(instances.Select(
        i => i.WaitForCompletion(timeout: TimeSpan.FromMinutes(30), expectedOutputRegex: @"Hello, \w+!")));
}
```

There is an active ICM tracking a problem related to this, and I plan on sharing this fix with the customer.