### PR TITLE
Fix logging for large queue message sizes

### DIFF
--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -137,10 +137,14 @@ namespace DurableTask.AzureStorage
                 string decompressedMessage = await this.DownloadAndDecompressAsBytesAsync(envelope.CompressedBlobName);
                 envelope = Utils.DeserializeFromJson<MessageData>(serializer, decompressedMessage);
                 envelope.MessageFormat = MessageFormatFlags.StorageBlob;
+                envelope.TotalMessageSizeBytes = Encoding.UTF8.GetByteCount(decompressedMessage);
+            }
+            else
+            {
+                envelope.TotalMessageSizeBytes = Encoding.UTF8.GetByteCount(queueMessage.Message);
             }
 
             envelope.OriginalQueueMessage = queueMessage;
-            envelope.TotalMessageSizeBytes = Encoding.UTF8.GetByteCount(queueMessage.Message);
             envelope.QueueName = queueName;
             return envelope;
         }

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -119,7 +119,7 @@ namespace DurableTask.AzureStorage.Messaging
                     Utils.GetTaskEventId(taskMessage.Event),
                     sourceInstance.InstanceId,
                     sourceInstance.ExecutionId,
-                    Encoding.UTF8.GetByteCount(rawContent),
+                    data.TotalMessageSizeBytes,
                     data.QueueName /* PartitionId */,
                     taskMessage.OrchestrationInstance.InstanceId,
                     taskMessage.OrchestrationInstance.ExecutionId,


### PR DESCRIPTION
Fixes #797 

The existing traces for message sizes tracked the actual queue message sizes but didn't account for large message scenarios where the payload is offloaded to blob storage. It's really important that we log the actual payload sizes since the impact on performance is significant.
