### PR TITLE
Propagating Orchestration Tags to TaskActivity

### DIFF
--- a/src/DurableTask.Core/OrchestrationExecutionContext.cs
+++ b/src/DurableTask.Core/OrchestrationExecutionContext.cs
@@ -10,7 +10,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
-#nullable enable
 namespace DurableTask.Core
 {
     using System.Collections.Generic;
@@ -26,6 +25,6 @@ namespace DurableTask.Core
         /// Gets the orchestration tags
         /// </summary>
         [DataMember]
-        public IDictionary<string, string> OrchestrationTags { get; internal set; } = new Dictionary<string, string>();
+        public IReadOnlyDictionary<string, string> OrchestrationTags { get; internal set; }
     }
 }

--- a/src/DurableTask.Core/OrchestrationExecutionContext.cs
+++ b/src/DurableTask.Core/OrchestrationExecutionContext.cs
@@ -1,0 +1,31 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+#nullable enable
+namespace DurableTask.Core
+{
+    using System.Collections.Generic;
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// Context associated with the orchestration being executed.
+    /// </summary>
+    [DataContract]
+    public class OrchestrationExecutionContext
+    {
+        /// <summary>
+        /// Gets the orchestration tags
+        /// </summary>
+        [DataMember]
+        public IDictionary<string, string> OrchestrationTags { get; internal set; } = new Dictionary<string, string>();
+    }
+}

--- a/src/DurableTask.Core/TaskActivityDispatcher.cs
+++ b/src/DurableTask.Core/TaskActivityDispatcher.cs
@@ -151,13 +151,7 @@ namespace DurableTask.Core
                 dispatchContext.SetProperty(taskMessage.OrchestrationInstance);
                 dispatchContext.SetProperty(taskActivity);
                 dispatchContext.SetProperty(scheduledEvent);
-
-                if (taskMessage.OrchestrationRuntimeState != null)
-                {
-                    // Why this code? The deserialized version of runtime state doesn't have critical properties like ExecutionStartedEvent etc
-                    // setup. The only way to have that info is through recreation of event history.
-                    dispatchContext.SetProperty(new OrchestrationRuntimeState(taskMessage.OrchestrationRuntimeState.Events));
-                }
+                dispatchContext.SetProperty(taskMessage.OrchestrationExecutionContext);
 
                 // correlation
                 CorrelationTraceClient.Propagate(() =>

--- a/src/DurableTask.Core/TaskActivityDispatcher.cs
+++ b/src/DurableTask.Core/TaskActivityDispatcher.cs
@@ -152,6 +152,13 @@ namespace DurableTask.Core
                 dispatchContext.SetProperty(taskActivity);
                 dispatchContext.SetProperty(scheduledEvent);
 
+                if (taskMessage.OrchestrationRuntimeState != null)
+                {
+                    // Why this code? The deserialized version of runtime state doesn't have critical properties like ExecutionStartedEvent etc
+                    // setup. The only way to have that info is through recreation of event history.
+                    dispatchContext.SetProperty(new OrchestrationRuntimeState(taskMessage.OrchestrationRuntimeState.Events));
+                }
+
                 // correlation
                 CorrelationTraceClient.Propagate(() =>
                 {

--- a/src/DurableTask.Core/TaskActivityDispatcher.cs
+++ b/src/DurableTask.Core/TaskActivityDispatcher.cs
@@ -151,7 +151,12 @@ namespace DurableTask.Core
                 dispatchContext.SetProperty(taskMessage.OrchestrationInstance);
                 dispatchContext.SetProperty(taskActivity);
                 dispatchContext.SetProperty(scheduledEvent);
-                dispatchContext.SetProperty(taskMessage.OrchestrationExecutionContext);
+
+                // In transitionary phase (activity queued from old code, accessed in new code) context can be null.
+                if (taskMessage.OrchestrationExecutionContext != null)
+                {
+                    dispatchContext.SetProperty(taskMessage.OrchestrationExecutionContext);
+                }
 
                 // correlation
                 CorrelationTraceClient.Propagate(() =>

--- a/src/DurableTask.Core/TaskMessage.cs
+++ b/src/DurableTask.Core/TaskMessage.cs
@@ -13,6 +13,7 @@
 
 namespace DurableTask.Core
 {
+    using System.Collections.Generic;
     using System.Runtime.Serialization;
     using DurableTask.Core.History;
 
@@ -41,10 +42,10 @@ namespace DurableTask.Core
         public OrchestrationInstance OrchestrationInstance { get; set; }
 
         /// <summary>
-        /// Gets or sets the orchestration runtime state.
+        /// Gets or sets the context associated with executing orchestration.
         /// </summary>
         [DataMember]
-        public OrchestrationRuntimeState OrchestrationRuntimeState { get; set; }
+        public OrchestrationExecutionContext OrchestrationExecutionContext { get; set; }
 
         /// <summary>
         /// Implementation for <see cref="IExtensibleDataObject.ExtensionData"/>.

--- a/src/DurableTask.Core/TaskMessage.cs
+++ b/src/DurableTask.Core/TaskMessage.cs
@@ -13,7 +13,6 @@
 
 namespace DurableTask.Core
 {
-    using System.Collections.Generic;
     using System.Runtime.Serialization;
     using DurableTask.Core.History;
 

--- a/src/DurableTask.Core/TaskMessage.cs
+++ b/src/DurableTask.Core/TaskMessage.cs
@@ -41,6 +41,12 @@ namespace DurableTask.Core
         public OrchestrationInstance OrchestrationInstance { get; set; }
 
         /// <summary>
+        /// Gets or sets the orchestration runtime state.
+        /// </summary>
+        [DataMember]
+        public OrchestrationRuntimeState OrchestrationRuntimeState { get; set; }
+
+        /// <summary>
         /// Implementation for <see cref="IExtensibleDataObject.ExtensionData"/>.
         /// </summary>
         public ExtensionDataObject ExtensionData { get; set; }

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -842,6 +842,7 @@ namespace DurableTask.Core
 
             taskMessage.Event = scheduledEvent;
             taskMessage.OrchestrationInstance = runtimeState.OrchestrationInstance;
+            taskMessage.OrchestrationRuntimeState = runtimeState;
 
             if (!includeParameters)
             {

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -565,6 +565,11 @@ namespace DurableTask.Core
             return isCompleted || continuedAsNew || isInterrupted;
         }
 
+        static OrchestrationExecutionContext GetOrchestrationExecutionContext(OrchestrationRuntimeState runtimeState)
+        {
+            return new OrchestrationExecutionContext { OrchestrationTags = runtimeState.Tags ?? new Dictionary<string, string>() };
+        }
+
         async Task<OrchestrationExecutionCursor> ExecuteOrchestrationAsync(OrchestrationRuntimeState runtimeState, TaskOrchestrationWorkItem workItem)
         {
             // Get the TaskOrchestration implementation. If it's not found, it either means that the developer never
@@ -577,6 +582,7 @@ namespace DurableTask.Core
             dispatchContext.SetProperty(taskOrchestration);
             dispatchContext.SetProperty(runtimeState);
             dispatchContext.SetProperty(workItem);
+            dispatchContext.SetProperty(GetOrchestrationExecutionContext(runtimeState));
 
             TaskOrchestrationExecutor? executor = null;
 
@@ -842,7 +848,7 @@ namespace DurableTask.Core
 
             taskMessage.Event = scheduledEvent;
             taskMessage.OrchestrationInstance = runtimeState.OrchestrationInstance;
-            taskMessage.OrchestrationRuntimeState = runtimeState;
+            taskMessage.OrchestrationExecutionContext = GetOrchestrationExecutionContext(runtimeState);
 
             if (!includeParameters)
             {

--- a/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
+++ b/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
@@ -57,16 +57,19 @@ namespace DurableTask.Core.Tests
             TaskOrchestration? orchestration = null;
             OrchestrationRuntimeState? state = null;
             OrchestrationInstance? instance1 = null;
+            OrchestrationExecutionContext? executionContext1 = null;
 
             TaskActivity? activity = null;
             TaskScheduledEvent? taskScheduledEvent = null;
             OrchestrationInstance? instance2 = null;
+            OrchestrationExecutionContext? executionContext2 = null;
 
             this.worker.AddOrchestrationDispatcherMiddleware((context, next) =>
             {
                 orchestration = context.GetProperty<TaskOrchestration>();
                 state = context.GetProperty<OrchestrationRuntimeState>();
                 instance1 = context.GetProperty<OrchestrationInstance>();
+                executionContext1 = context.GetProperty<OrchestrationExecutionContext>();
 
                 return next();
             });
@@ -76,6 +79,7 @@ namespace DurableTask.Core.Tests
                 activity = context.GetProperty<TaskActivity>();
                 taskScheduledEvent = context.GetProperty<TaskScheduledEvent>();
                 instance2 = context.GetProperty<OrchestrationInstance>();
+                executionContext2 = context.GetProperty<OrchestrationExecutionContext>();
 
                 return next();
             });
@@ -88,10 +92,12 @@ namespace DurableTask.Core.Tests
             Assert.IsNotNull(orchestration);
             Assert.IsNotNull(state);
             Assert.IsNotNull(instance1);
+            Assert.IsNotNull(executionContext1);
 
             Assert.IsNotNull(activity);
             Assert.IsNotNull(taskScheduledEvent);
             Assert.IsNotNull(instance2);
+            Assert.IsNotNull(executionContext2);
 
             Assert.AreNotSame(instance1, instance2);
             Assert.AreEqual(instance1!.InstanceId, instance2!.InstanceId);
@@ -174,14 +180,14 @@ namespace DurableTask.Core.Tests
         [TestMethod]
         public async Task EnsureActivityDispatcherMiddlewareHasAccessToRuntimeState()
         {
-            OrchestrationRuntimeState? runtimeState = null;
+            OrchestrationExecutionContext? executionContext = null;
 
             for (var i = 0; i < 10; i++)
             {
                 string value = i.ToString();
                 this.worker.AddActivityDispatcherMiddleware(async (context, next) =>
                 {
-                    runtimeState = context.GetProperty<OrchestrationRuntimeState>();
+                    executionContext = context.GetProperty<OrchestrationExecutionContext>();
                     await next();
                 });
             }
@@ -201,8 +207,8 @@ namespace DurableTask.Core.Tests
 
             // Each activity gets a new context, so the output should stay the same regardless of how
             // many activities an orchestration schedules (as long as there is at least one).
-            Assert.IsNotNull(runtimeState);
-            Assert.AreEqual("Value", runtimeState?.Tags?["Test"]);
+            Assert.IsNotNull(executionContext);
+            Assert.AreEqual("Value", executionContext?.OrchestrationTags?["Test"]);
         }
 
         [DataTestMethod]


### PR DESCRIPTION
Propagating OrchestrationRuntimeState to TaskActivity dispatcher middleware. This allows Tags and other historical events to be accessible from TaskActivity dispatcher middleware