### PR TITLE
Fix wrong blob URL on orchestration inputs

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1586,22 +1586,15 @@ namespace DurableTask.AzureStorage
             }
 
             ControlQueue controlQueue = await this.GetControlQueueAsync(creationMessage.OrchestrationInstance.InstanceId);
-            MessageData internalMessage = await this.SendTaskOrchestrationMessageInternalAsync(
+            await this.SendTaskOrchestrationMessageInternalAsync(
                 EmptySourceInstance,
                 controlQueue,
                 creationMessage);
 
-            // CompressedBlobName either has a blob path for large messages or is null.
-            string inputStatusOverride = null;
-            if (internalMessage.CompressedBlobName != null)
-            {
-                inputStatusOverride = this.messageManager.GetBlobUrl(internalMessage.CompressedBlobName);
-            }
-
             await this.trackingStore.SetNewExecutionAsync(
                 executionStartedEvent,
                 existingInstance?.ETag,
-                inputStatusOverride);
+                inputStatusOverride: null);
         }
 
         /// <summary>

--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -130,14 +130,7 @@ namespace DurableTask.AzureStorage
 
         internal static bool TryGetLargeMessageReference(string messagePayload, out Uri blobUrl)
         {
-            if (Uri.IsWellFormedUriString(messagePayload, UriKind.Absolute))
-            {
-                blobUrl = new Uri(messagePayload);
-                return true;
-            }
-
-            blobUrl = null;
-            return false;
+            return Uri.TryCreate(messagePayload, UriKind.Absolute, out blobUrl);
         }
 
         public async Task<MessageData> DeserializeQueueMessageAsync(QueueMessage queueMessage, string queueName)

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -537,6 +537,8 @@ namespace DurableTask.AzureStorage.Tracking
                 if (MessageManager.TryGetLargeMessageReference(orchestrationState.Input, out Uri blobUrl))
                 {
                     string json = await this.messageManager.DownloadAndDecompressAsBytesAsync(blobUrl);
+
+                    // Depending on which blob this is, we interpret it differently.
                     if (blobUrl.AbsolutePath.EndsWith("ExecutionStarted.json.gz"))
                     {
                         // The downloaded content is an ExecutedStarted message payload that

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -534,7 +534,34 @@ namespace DurableTask.AzureStorage.Tracking
 
             if (this.settings.FetchLargeMessageDataEnabled)
             {
-                orchestrationState.Input = await this.messageManager.FetchLargeMessageIfNecessary(orchestrationState.Input);
+                if (MessageManager.TryGetLargeMessageReference(orchestrationState.Input, out Uri blobUrl))
+                {
+                    string json = await this.messageManager.DownloadAndDecompressAsBytesAsync(blobUrl);
+                    if (blobUrl.AbsolutePath.EndsWith("ExecutionStarted.json.gz"))
+                    {
+                        // The downloaded content is an ExecutedStarted message payload that
+                        // was created when the orchestration was started.
+                        MessageData msg = this.messageManager.DeserializeMessageData(json);
+                        if (msg?.TaskMessage?.Event is ExecutionStartedEvent startEvent)
+                        {
+                            orchestrationState.Input = startEvent.Input;
+                        }
+                        else
+                        {
+                            this.settings.Logger.GeneralWarning(
+                                this.storageAccountName,
+                                this.taskHubName,
+                                $"Orchestration input blob URL '{blobUrl}' contained unrecognized data.",
+                                instanceId);
+                        }
+                    }
+                    else
+                    {
+                        // The downloaded content is the raw input JSON
+                        orchestrationState.Input = json;
+                    }
+                }
+
                 orchestrationState.Output = await this.messageManager.FetchLargeMessageIfNecessary(orchestrationState.Output);
             }
 
@@ -790,7 +817,7 @@ namespace DurableTask.AzureStorage.Tracking
         public override async Task<bool> SetNewExecutionAsync(
             ExecutionStartedEvent executionStartedEvent,
             string eTag,
-            string inputStatusOverride)
+            string inputPayloadOverride)
         {
             string sanitizedInstanceId = KeySanitation.EscapePartitionKey(executionStartedEvent.OrchestrationInstance.InstanceId);
             DynamicTableEntity entity = new DynamicTableEntity(sanitizedInstanceId, "")
@@ -798,7 +825,7 @@ namespace DurableTask.AzureStorage.Tracking
                 ETag = eTag,
                 Properties =
                 {
-                    ["Input"] = new EntityProperty(inputStatusOverride ?? executionStartedEvent.Input),
+                    ["Input"] = new EntityProperty(inputPayloadOverride ?? executionStartedEvent.Input),
                     ["CreatedTime"] = new EntityProperty(executionStartedEvent.Timestamp),
                     ["Name"] = new EntityProperty(executionStartedEvent.Name),
                     ["Version"] = new EntityProperty(executionStartedEvent.Version),

--- a/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
@@ -143,9 +143,9 @@ namespace DurableTask.AzureStorage.Tracking
         /// </summary>
         /// <param name="executionStartedEvent">The Execution Started Event being queued</param>
         /// <param name="eTag">The eTag value to use for optimistic concurrency or <c>null</c> to overwrite any existing execution status.</param>
-        /// <param name="inputStatusOverride">An override value to use for the Input column. If not specified, uses <see cref="ExecutionStartedEvent.Input"/>.</param>
+        /// <param name="inputPayloadOverride">An override value to use for the Input column. If not specified, uses <see cref="ExecutionStartedEvent.Input"/>.</param>
         /// <returns>Returns <c>true</c> if the record was created successfully; <c>false</c> otherwise.</returns>
-        Task<bool> SetNewExecutionAsync(ExecutionStartedEvent executionStartedEvent, string eTag, string inputStatusOverride);
+        Task<bool> SetNewExecutionAsync(ExecutionStartedEvent executionStartedEvent, string eTag, string inputPayloadOverride);
 
         /// <summary>
         /// Used to update a state in the tracking store to pending whenever a rewind is initiated from the client

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -558,7 +558,7 @@ namespace DurableTask.AzureStorage.Tests
             CloudBlobContainer cloudBlobContainer = cloudBlobClient.GetContainerReference(containerName);
             await cloudBlobContainer.CreateIfNotExistsAsync();
             CloudBlobDirectory instanceDirectory = cloudBlobContainer.GetDirectoryReference(directoryName);
-            int blobCount = 0;
+            var blobs = new List<IListBlobItem>();
             BlobContinuationToken blobContinuationToken = null;
             do
             {
@@ -572,13 +572,18 @@ namespace DurableTask.AzureStorage.Tests
                             options: null,
                             operationContext: context,
                             cancellationToken: timeoutToken);
-                }); ;
+                });
                 
                 blobContinuationToken = results.ContinuationToken;
-                blobCount += results.Results.Count();
+                blobs.AddRange(results.Results);
             } while (blobContinuationToken != null);
 
-            return blobCount;
+            Trace.TraceInformation(
+                "Found {0} blobs: {1}{2}",
+                blobs.Count,
+                Environment.NewLine,
+                string.Join(Environment.NewLine, blobs.Select(b => b.Uri)));
+            return blobs.Count;
         }
 
 

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -1517,6 +1517,7 @@ namespace DurableTask.AzureStorage.Tests
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
                 Assert.AreEqual(message, JToken.Parse(status?.Output));
+                Assert.AreEqual(message, JToken.Parse(status.Input));
 
                 await host.StopAsync();
             }
@@ -1585,6 +1586,10 @@ namespace DurableTask.AzureStorage.Tests
                     client.InstanceId,
                     status?.Output,
                     Encoding.UTF8.GetByteCount(message));
+
+                Assert.IsTrue(status.Output.EndsWith("-Result.json.gz"));
+                Assert.IsTrue(status.Input.EndsWith("-Input.json.gz"));
+
                 await host.StopAsync();
             }
         }


### PR DESCRIPTION
An internal partner team noticed an issue where the Instances table gets populated with a wrong blob URL when an orchestration is started with a large input (one that doesn't fit into table storage). Specifically, the `Input` column/property was getting populated with the blob URL of the queue message instead of with a blob URL for the orchestration's input.  This was causing orchestration status queries to return the wrong input data.

Upon investigation, it looks like this issue has existed for a while but just went undetected. I was able to observe the problem by updating some existing unit tests to validate the reported orchestration input when large inputs are used.

~~The fix was to remove some code that was causing us to populate the `Input` column/property incorrectly.~~

EDIT: The originally submitted fix ended up creating a new blob, resulting in further duplication of large payloads. I decided this would not be a good fix as it would increase the performance penalty associated with large messages. I've submitted an updated fix which instead examines the previous payload and parses out the input contained within it. This allows us to keep the same number of blobs, ensuring there's no performance regression. The previous fix would only have worked for new orchestrations, but this new fix works for both old and new orchestrations.