### PR TITLE
Update ServiceBus dependency to fix net6 bug

### DIFF
--- a/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
+++ b/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
@@ -6,6 +6,22 @@
     <PackageId>Microsoft.Azure.DurableTask.ServiceBus</PackageId>
   </PropertyGroup>
 
+    <!-- Version Info -->
+  <PropertyGroup>
+    <MajorVersion>2</MajorVersion>
+    <MinorVersion>7</MinorVersion>
+    <PatchVersion>0</PatchVersion>
+
+    <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
+    <FileVersion>$(VersionPrefix).0</FileVersion>
+    <!-- FileVersionRevision is expected to be set by the CI. This is useful for distinguishing between multiple builds of the same version. -->
+    <FileVersion Condition="'$(FileVersionRevision)' != ''">$(VersionPrefix).$(FileVersionRevision)</FileVersion>
+    <!-- The assembly version is only the major/minor pair, making it easier to do in-place upgrades -->
+    <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
+    <!-- This version is used as the nuget package version -->
+    <Version>$(VersionPrefix)</Version>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="ImpromptuInterface" version="6.2.2" />
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" version="1.0.0" />
@@ -21,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.2.1" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
   </ItemGroup>
 

--- a/test/DurableTask.ServiceBus.Tests/DurableTask.ServiceBus.Tests.csproj
+++ b/test/DurableTask.ServiceBus.Tests/DurableTask.ServiceBus.Tests.csproj
@@ -30,7 +30,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="EnterpriseLibrary.SemanticLogging.NetCore" Version="2.0.1406.4" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />


### PR DESCRIPTION
There is a bug in `Microsoft.Azure.ServiceBus` with net6 where all messages fail to dequeue (making it completely unusable). This PR updates our referenced package to address this issue.

- `Microsoft.Azure.ServiceBus` package changed from 4.1.3 to 4.2.1
- `Microsoft.Azure.DurableTask.ServiceBus` package version changed from 2.6.0 to 2.7.0 (minor version chosen to reflect minor version change in dependency)

resolves #815 