### PR TITLE
Disable flaky test: MessageLegacyCompressToAlwaysCompressTest

### DIFF
--- a/test/DurableTask.ServiceBus.Tests/DispatcherTests.cs
+++ b/test/DurableTask.ServiceBus.Tests/DispatcherTests.cs
@@ -148,7 +148,8 @@ namespace DurableTask.ServiceBus.Tests
             Assert.AreEqual(OrchestrationStatus.Completed, state.OrchestrationStatus);
         }
 
-        [TestMethod]
+        // TODO: Identify why this test is failing and re-enable it: https://github.com/Azure/durabletask/issues/813
+        ////[TestMethod]
         public async Task MessageLegacyCompressToAlwaysCompressTest()
         {
             await this.taskHubLegacyCompression.AddTaskOrchestrations(typeof (MessageCompressionCompatTest))


### PR DESCRIPTION
This test is failing consistently in the CI and has been known to be flaky for a while. It's not clear what it does or why it's failing. The Service Bus project also doesn't have any dedicated maintainers, so disabling this test for now to unblock the CI for accepting other PRs.