### PR TITLE
Increment version of DT.AzureStorage to v1.13.2

### DIFF
--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
     <MinorVersion>13</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <PatchVersion>2</PatchVersion>
 
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <FileVersion>$(VersionPrefix).0</FileVersion>

--- a/test/DurableTask.AzureStorage.Tests/OrchestrationInstanceStatusQueryConditionTest.cs
+++ b/test/DurableTask.AzureStorage.Tests/OrchestrationInstanceStatusQueryConditionTest.cs
@@ -181,6 +181,18 @@ namespace DurableTask.AzureStorage.Tests
         }
 
         [TestMethod]
+        public void OrchestrationInstanceQuery_InstanceId()
+        {
+            var condition = new OrchestrationInstanceStatusQueryCondition
+            {
+                InstanceId = "abc123",
+            };
+
+            string result = condition.ToTableQuery<OrchestrationInstanceStatus>().FilterString;
+            Assert.AreEqual("PartitionKey eq 'abc123'", result);
+        }
+
+        [TestMethod]
         public void OrchestrationInstanceQuery_EmptyInstanceId()
         {
             var condition = new OrchestrationInstanceStatusQueryCondition


### PR DESCRIPTION
This is in preparation for a bug-fix release of DurableTask.AzureStorage.

I also slipped in a new unit test that had been on my local machine but never contributed as a PR (it seemed too insignificant to create a separate PR just for that, hence the bundling).