### PR TITLE
DT.AzureStorage: Fixed exception when orchestration tags are too large

### DIFF
--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
     <MinorVersion>13</MinorVersion>
-    <PatchVersion>2</PatchVersion>
+    <PatchVersion>3</PatchVersion>
 
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <FileVersion>$(VersionPrefix).0</FileVersion>

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -57,6 +57,7 @@ namespace DurableTask.AzureStorage.Tracking
             "Details",
             "Correlation",
             "FailureDetails",
+            "Tags",
         };
 
         readonly string storageAccountName;


### PR DESCRIPTION
If an orchestration is started with tag data that exceeds the maximum allowed size for table storage columns when using the DurableTask.AzureStorage backend, the orchestration will cause the following exception (possibly repeatedly):

```
DurableTask.AzureStorage.Storage.DurableTaskStorageException: Element 1 in the batch returned an unexpected response code.
 ---> Microsoft.WindowsAzure.Storage.StorageException: Element 1 in the batch returned an unexpected response code.
   at Microsoft.WindowsAzure.Storage.Core.Executor.Executor.ExecuteAsyncInternal[T](RESTCommand`1 cmd, IRetryPolicy policy, OperationContext operationContext, CancellationToken token)
   at DurableTask.AzureStorage.TimeoutHandler.ExecuteWithTimeout[T](String operationName, String account, AzureStorageOrchestrationServiceSettings settings, Func`3 operation, AzureStorageOrchestrationServiceStats stats, String clientRequestId) in /_/src/DurableTask.AzureStorage/TimeoutHandler.cs:line 136
   at DurableTask.AzureStorage.Storage.AzureStorageClient.MakeStorageRequest[T](Func`3 storageRequest, String accountName, String operationName, String clientRequestId, Boolean force) in /_/src/DurableTask.AzureStorage/Storage/AzureStorageClient.cs:line 149
Request Information
RequestID:32d7747d-b002-000a-0929-0c3b5a000000
RequestDate:Fri, 09 Dec 2022 23:56:37 GMT
StatusMessage:1:The property value exceeds the maximum allowed size (64KB). If the property value is a string, it is UTF-16 encoded and the maximum number of characters should be 32K or less.
ErrorCode:
ErrorMessage:1:The property value exceeds the maximum allowed size (64KB). If the property value is a string, it is UTF-16 encoded and the maximum number of characters should be 32K or less.
RequestId:32d7747d-b002-000a-0929-0c3b5a000000
Time:2022-12-09T23:56:38.3192478Z
```

This PR fixes this by adding `"Tags"` to the list of variable-length properties.

NOTE: There is no impact to Durable Functions customers as Durable Functions doesn't support the Tags feature (and this also explains why this bug has existed for so long - the scenario was simply never considered when this backend was first written).

FYI @RamjotSingh 

Related: https://github.com/Azure/durabletask/issues/840