### PR TITLE
Add .NET 2.1 to release pipeline

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -59,6 +59,12 @@ steps:
     platform: x64
     msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
 
+- task: UseDotNet@2
+  displayName: 'Use the .NET Core 2.1 SDK (required for build signing)'
+  inputs:
+    packageType: 'sdk'
+    version: '2.1.x'
+
 # Manifest Generator Task
 - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
   displayName: 'Manifest Generator '


### PR DESCRIPTION
This ESRP signing step of the DTFx release pipeline is failing because the build images no longer include .NET Core v2.1. This PR explicitly installs that version of .NET so that the ESRP steps can run successfully.  This is the same step we use for pretty much all of our other existing release pipelines, so I'm surprised we didn't have it already for this one.