### PR TITLE
Added Orchestration Memory Manager

### DIFF
--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -1071,6 +1071,28 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
+        internal void ThrottlingOrchestrationHistory(
+            string Account, 
+            string TaskHub, 
+            string InstanceId, 
+            string ExecutionId, 
+            long SizeInBytes,
+            string Details, 
+            string AppName, 
+            string ExtensionVersion)
+        {
+            this.WriteEvent(
+                EventIds.ThrottlingOrchestrationHistory,
+                Account,
+                TaskHub,
+                InstanceId,
+                ExecutionId ?? string.Empty,
+                SizeInBytes,
+                Details,
+                AppName,
+                ExtensionVersion);
+        }
+
         // Specifying tasks is necessary when using WriteEventWithRelatedActivityId
         // or else the "TaskName" property written to ETW is the name of the opcode instead
         // of the name of the trace method.

--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -1083,12 +1083,12 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
+        [Event(EventIds.ThrottlingOrchestrationHistory, Level = EventLevel.Informational, Version = 1)]
         internal void ThrottlingOrchestrationHistory(
             string Account, 
             string TaskHub, 
             string InstanceId, 
             string ExecutionId, 
-            long SizeInBytes,
             string Details, 
             string AppName, 
             string ExtensionVersion)
@@ -1097,9 +1097,8 @@ namespace DurableTask.AzureStorage
                 EventIds.ThrottlingOrchestrationHistory,
                 Account,
                 TaskHub,
-                InstanceId,
+                InstanceId ?? string.Empty,
                 ExecutionId ?? string.Empty,
-                SizeInBytes,
                 Details,
                 AppName,
                 ExtensionVersion);

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -251,6 +251,11 @@ namespace DurableTask.AzureStorage
         public TimeSpan StorageRequestsTimeoutCooldown { get; set; } = TimeSpan.FromMinutes(5);
 
         /// <summary>
+        /// Gets or sets the memory limit in bytes.
+        /// </summary>
+        public long MemoryLimitBytes { get; set; } = (long)(1.5 * 1024 * 1024 * 1024);
+
+        /// <summary>
         /// Returns bool indicating is the TrackingStoreStorageAccount has been set.
         /// </summary>
         public bool HasTrackingStoreStorageAccount => this.TrackingStoreStorageAccountDetails != null;

--- a/src/DurableTask.AzureStorage/Logging/EventIds.cs
+++ b/src/DurableTask.AzureStorage/Logging/EventIds.cs
@@ -55,5 +55,6 @@ namespace DurableTask.AzureStorage.Logging
         public const int DiscardingWorkItem = 139;
         public const int ProcessingMessage = 140;
         public const int PurgeInstanceHistory = 141;
+        public const int ThrottlingOrchestrationHistory = 142;
     }
 }

--- a/src/DurableTask.AzureStorage/Logging/LogEvents.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogEvents.cs
@@ -2654,61 +2654,55 @@ namespace DurableTask.AzureStorage.Logging
                 Utils.AppName,
                 Utils.ExtensionVersion);
         }
-    }
 
-    internal class ThrottlingOrchestrationHistory : StructuredLogEvent, IEventSourceEvent
-    {
-        public ThrottlingOrchestrationHistory(
-            string account,
-            string taskHub,
-            string instanceId,
-            string executionId,
-            long sizeInBytes,
-            string details)
+        internal class ThrottlingOrchestrationHistory : StructuredLogEvent, IEventSourceEvent
         {
-            this.Account = account;
-            this.TaskHub = taskHub;
-            this.InstanceId = instanceId;
-            this.ExecutionId = executionId;
-            this.SizeInBytes = sizeInBytes;
-            this.Details = details;
+            public ThrottlingOrchestrationHistory(
+                string account,
+                string taskHub,
+                string instanceId,
+                string executionId,
+                string details)
+            {
+                this.Account = account;
+                this.TaskHub = taskHub;
+                this.InstanceId = instanceId;
+                this.ExecutionId = executionId;
+                this.Details = details;
+            }
+
+            [StructuredLogField]
+            public string Account { get; }
+
+            [StructuredLogField]
+            public string TaskHub { get; }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.ThrottlingOrchestrationHistory,
+                nameof(EventIds.ThrottlingOrchestrationHistory));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            protected override string CreateLogMessage() =>
+                $"Throttling orchestration history load for instance {this.InstanceId}: {this.Details})";
+
+            void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.ThrottlingOrchestrationHistory(
+                this.Account,
+                this.TaskHub,
+                this.InstanceId,
+                this.ExecutionId,
+                this.Details,
+                Utils.AppName,
+                Utils.ExtensionVersion);
         }
-
-        [StructuredLogField]
-        public string Account { get; }
-
-        [StructuredLogField]
-        public string TaskHub { get; }
-
-        [StructuredLogField]
-        public string InstanceId { get; }
-
-        [StructuredLogField]
-        public string ExecutionId { get; }
-
-        [StructuredLogField]
-        public long SizeInBytes { get; }
-
-        [StructuredLogField]
-        public string Details { get; }
-
-        public override EventId EventId => new EventId(
-            EventIds.ThrottlingOrchestrationHistory,
-            nameof(EventIds.ThrottlingOrchestrationHistory));
-
-        public override LogLevel Level => LogLevel.Information;
-
-        protected override string CreateLogMessage() =>
-            $"Throttling orchestration history load for instance {this.InstanceId}: {this.Details})";
-
-        void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.ThrottlingOrchestrationHistory(
-            this.Account,
-            this.TaskHub,
-            this.InstanceId,
-            this.ExecutionId,
-            this.SizeInBytes,
-            this.Details,
-            Utils.AppName,
-            Utils.ExtensionVersion);
     }
 }

--- a/src/DurableTask.AzureStorage/Logging/LogEvents.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogEvents.cs
@@ -2619,4 +2619,60 @@ namespace DurableTask.AzureStorage.Logging
                 Utils.ExtensionVersion);
         }
     }
+
+    internal class ThrottlingOrchestrationHistory : StructuredLogEvent, IEventSourceEvent
+    {
+        public ThrottlingOrchestrationHistory(
+            string account,
+            string taskHub,
+            string instanceId,
+            string executionId,
+            long sizeInBytes,
+            string details)
+        {
+            this.Account = account;
+            this.TaskHub = taskHub;
+            this.InstanceId = instanceId;
+            this.ExecutionId = executionId;
+            this.SizeInBytes = sizeInBytes;
+            this.Details = details;
+        }
+
+        [StructuredLogField]
+        public string Account { get; }
+
+        [StructuredLogField]
+        public string TaskHub { get; }
+
+        [StructuredLogField]
+        public string InstanceId { get; }
+
+        [StructuredLogField]
+        public string ExecutionId { get; }
+
+        [StructuredLogField]
+        public long SizeInBytes { get; }
+
+        [StructuredLogField]
+        public string Details { get; }
+
+        public override EventId EventId => new EventId(
+            EventIds.ThrottlingOrchestrationHistory,
+            nameof(EventIds.ThrottlingOrchestrationHistory));
+
+        public override LogLevel Level => LogLevel.Information;
+
+        protected override string CreateLogMessage() =>
+            $"Throttling orchestration history load for instance {this.InstanceId}: {this.Details})";
+
+        void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.ThrottlingOrchestrationHistory(
+            this.Account,
+            this.TaskHub,
+            this.InstanceId,
+            this.ExecutionId,
+            this.SizeInBytes,
+            this.Details,
+            Utils.AppName,
+            Utils.ExtensionVersion);
+    }
 }

--- a/src/DurableTask.AzureStorage/Logging/LogHelper.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogHelper.cs
@@ -855,6 +855,24 @@ namespace DurableTask.AzureStorage.Logging
             this.WriteStructuredLog(logEvent);
         }
 
+        internal void ThrottlingOrchestrationHistory(
+            string account,
+            string taskHub,
+            string instanceId,
+            string executionId,
+            long sizeInBytes,
+            string details)
+        {
+            var logEvent = new ThrottlingOrchestrationHistory(
+                account,
+                taskHub,
+                instanceId,
+                executionId,
+                sizeInBytes,
+                details);
+            this.WriteStructuredLog(logEvent);
+        }
+
         void WriteStructuredLog(ILogEvent logEvent, Exception exception = null)
         {
             LoggingExtensions.LogDurableEvent(this.log, logEvent, exception);

--- a/src/DurableTask.AzureStorage/Logging/LogHelper.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogHelper.cs
@@ -872,15 +872,13 @@ namespace DurableTask.AzureStorage.Logging
             string taskHub,
             string instanceId,
             string executionId,
-            long sizeInBytes,
             string details)
         {
-            var logEvent = new ThrottlingOrchestrationHistory(
+            var logEvent = new LogEvents.ThrottlingOrchestrationHistory(
                 account,
                 taskHub,
                 instanceId,
                 executionId,
-                sizeInBytes,
                 details);
             this.WriteStructuredLog(logEvent);
         }

--- a/src/DurableTask.AzureStorage/OrchestrationInstanceStatus.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationInstanceStatus.cs
@@ -33,5 +33,6 @@ namespace DurableTask.AzureStorage
         public string RuntimeStatus { get; set; }
         public DateTime? ScheduledStartTime { get; set; }
         public int Generation { get; set; }
+        public string Size { get; set; }
     }
 }

--- a/src/DurableTask.AzureStorage/OrchestrationMemoryManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationMemoryManager.cs
@@ -1,0 +1,112 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using DurableTask.AzureStorage.Tracking;
+using DurableTask.Core;
+
+namespace DurableTask.AzureStorage
+{
+    class OrchestrationMemoryManager
+    {
+        private AzureStorageOrchestrationServiceSettings settings;
+        private string storageAccountName;
+        private double messageVisibilityTimeout;
+        private long totalMemoryBytes;
+        private long? adjustedTotalMemory;
+        private long pendingMemory;
+        private readonly object lockObject = new object();
+
+        public OrchestrationMemoryManager(AzureStorageOrchestrationServiceSettings settings, string storageAccountName, long? memoryBufferBytes = null)
+        {
+            this.settings = settings;
+            this.storageAccountName = storageAccountName;
+            this.messageVisibilityTimeout = settings.ControlQueueVisibilityTimeout.TotalMilliseconds;
+            this.totalMemoryBytes = settings.MemoryLimitBytes;
+            this.adjustedTotalMemory = this.totalMemoryBytes - memoryBufferBytes;
+        }
+
+        async Task<bool> WaitUntilMemoryReservedAsync(OrchestrationState state, CancellationToken cancellationToken)
+        {
+            long bytesNeeded = state.Size;
+            string instanceId = state.OrchestrationInstance.InstanceId;
+            string executonId = state.OrchestrationInstance.ExecutionId;
+
+            int attemptNumber = 1;
+            double elapsed = 0;
+            while (elapsed < this.messageVisibilityTimeout && !cancellationToken.IsCancellationRequested)
+            {
+                var currentlyAllocatedMemory = Process.GetCurrentProcess().PrivateMemorySize64;
+
+                lock (this.lockObject)
+                {
+                    if (bytesNeeded + currentlyAllocatedMemory + this.pendingMemory <= this.adjustedTotalMemory)
+                    {
+                        this.pendingMemory += bytesNeeded;
+                        return true;
+                    }
+                }
+                //TODO: can make this an exponential backoff
+                int delayInMs = 1000;
+
+                this.settings.Logger.ThrottlingOrchestrationHistory(
+                   this.storageAccountName,
+                   this.settings.TaskHubName,
+                   instanceId,
+                   executonId,
+                   bytesNeeded,
+                   $"Not enough memory to load orchestrator history. Retrying in {delayInMs}ms. Total elapsed time: {elapsed}. Attempt number {attemptNumber}");
+
+                await Task.Delay(delayInMs, cancellationToken);
+                elapsed += delayInMs;
+                attemptNumber++;
+            }
+
+            return false;
+        }
+
+        void FreeMemoryReserve(long bytesToFree)
+        {
+            lock (this.lockObject)
+            {
+                this.pendingMemory -= bytesToFree;
+            }
+        }
+
+        public async Task<OrchestrationHistory> GetHistoryEventsAsync(ITrackingStore trackingStore, OrchestrationState state, CancellationToken cancellationToken)
+        {
+            bool memoryReserved = false;
+
+            try
+            {
+                memoryReserved = await this.WaitUntilMemoryReservedAsync(state, cancellationToken);
+
+                OrchestrationHistory history = await trackingStore.GetHistoryEventsAsync(
+                   state.OrchestrationInstance.InstanceId,
+                   state.OrchestrationInstance.ExecutionId,
+                   cancellationToken);
+
+                return history;
+            }
+            finally
+            {
+                if (memoryReserved)
+                {
+                    this.FreeMemoryReserve(state.Size);
+                }
+            }
+        }
+    }
+}

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -808,6 +808,7 @@ namespace DurableTask.AzureStorage.Tracking
                     ["ScheduledStartTime"] = new EntityProperty(executionStartedEvent.ScheduledStartTime),
                     ["ExecutionId"] = new EntityProperty(executionStartedEvent.OrchestrationInstance.ExecutionId),
                     ["Generation"] = new EntityProperty(executionStartedEvent.Generation),
+                    ["Size"] = new EntityProperty(0),
                 }
             };
 
@@ -921,6 +922,7 @@ namespace DurableTask.AzureStorage.Tracking
                     ["CustomStatus"] = new EntityProperty(newRuntimeState.Status ?? "null"),
                     ["ExecutionId"] = new EntityProperty(executionId),
                     ["LastUpdatedTime"] = new EntityProperty(newEvents.Last().Timestamp),
+                    ["Size"] = new EntityProperty(newRuntimeState.Size),
                 }
             };
            

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -531,6 +531,7 @@ namespace DurableTask.AzureStorage.Tracking
             orchestrationState.Output = orchestrationInstanceStatus.Output;
             orchestrationState.ScheduledStartTime = orchestrationInstanceStatus.ScheduledStartTime;
             orchestrationState.Generation = orchestrationInstanceStatus.Generation;
+            orchestrationState.Size = long.Parse(orchestrationInstanceStatus.Size);
 
             if (this.settings.FetchLargeMessageDataEnabled)
             {
@@ -837,7 +838,7 @@ namespace DurableTask.AzureStorage.Tracking
                     ["ScheduledStartTime"] = new EntityProperty(executionStartedEvent.ScheduledStartTime),
                     ["ExecutionId"] = new EntityProperty(executionStartedEvent.OrchestrationInstance.ExecutionId),
                     ["Generation"] = new EntityProperty(executionStartedEvent.Generation),
-                    ["Size"] = new EntityProperty(0),
+                    ["Size"] = new EntityProperty("0"),
                 }
             };
 
@@ -951,7 +952,7 @@ namespace DurableTask.AzureStorage.Tracking
                     ["CustomStatus"] = new EntityProperty(newRuntimeState.Status ?? "null"),
                     ["ExecutionId"] = new EntityProperty(executionId),
                     ["LastUpdatedTime"] = new EntityProperty(newEvents.Last().Timestamp),
-                    ["Size"] = new EntityProperty(newRuntimeState.Size),
+                    ["Size"] = new EntityProperty(newRuntimeState.Size.ToString()),
                 }
             };
            

--- a/src/DurableTask.Core/Common/SizeUtils.cs
+++ b/src/DurableTask.Core/Common/SizeUtils.cs
@@ -1,0 +1,150 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+namespace DurableTask.Core.Common
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using DurableTask.Core;
+    using DurableTask.Core.History;
+
+    /// <summary>
+    /// Functionality for estimating the number of bytes of memory taken up by some commonly used objects.
+    /// </summary>
+    public class SizeUtils
+    {
+        /// <summary>
+        /// Returns the approximate number of bytes of memory used by the given orchestration state object.
+        /// </summary>
+        /// <param name="state">The object.</param>
+        /// <returns>The estimated number of bytes.</returns>
+        public static long GetEstimatedSize(OrchestrationRuntimeState state)
+        {
+            long sum = 0;
+            if (state != null)
+            {
+                sum += 120; // sum of members of constant size
+                sum += 2 * ((state.Status?.Length ?? 0) + (state.Output?.Length ?? 0) + (state.Name?.Length ?? 0) + (state.Input?.Length ?? 0) + (state.Version?.Length ?? 0));
+                sum += GetEstimatedSize(state.OrchestrationInstance) + GetEstimatedSize(state.ParentInstance);
+            }
+            return sum;
+        }
+
+        static long GetEstimatedSize(OrchestrationInstance instance)
+        {
+            return instance == null ? 0 : 32 + 2 * (instance.InstanceId?.Length ?? 0 + instance.ExecutionId?.Length ?? 0);
+        }
+
+        static long GetEstimatedSize(ParentInstance p)
+        {
+            return p == null ? 0 : 36 + 2 * (p.Name?.Length ?? 0 + p.Version?.Length ?? 0) + GetEstimatedSize(p.OrchestrationInstance);
+        }
+
+        /// <summary>
+        /// Returns the approximate number of bytes of memory used by the given history event object.
+        /// </summary>
+        /// <param name="historyEvent">The history event object.</param>
+        /// <returns>The estimated number of bytes.</returns>
+        public static long GetEstimatedSize(HistoryEvent historyEvent)
+        {
+            long estimate = 5 * 8; // estimated size of base class
+            void AddStringSize(string s) => estimate += 8 + ((s == null) ? 0 : 2 * s.Length);
+            switch (historyEvent)
+            {
+                case ContinueAsNewEvent continueAsNewEvent:
+                    AddStringSize(continueAsNewEvent.Result);
+                    break;
+                case EventRaisedEvent eventRaisedEvent:
+                    AddStringSize(eventRaisedEvent.Input);
+                    AddStringSize(eventRaisedEvent.Name);
+                    break;
+                case EventSentEvent eventSentEvent:
+                    AddStringSize(eventSentEvent.InstanceId);
+                    AddStringSize(eventSentEvent.Name);
+                    AddStringSize(eventSentEvent.Input);
+                    break;
+                case ExecutionCompletedEvent executionCompletedEvent:
+                    AddStringSize(executionCompletedEvent.Result);
+                    estimate += 8;
+                    break;
+                case ExecutionSuspendedEvent executionSuspendedEvent:
+                    AddStringSize(executionSuspendedEvent.Reason);
+                    break;
+                case ExecutionResumedEvent executionResumedEvent:
+                    AddStringSize(executionResumedEvent.Reason);
+                    break;
+                case ExecutionStartedEvent executionStartedEvent:
+                    AddStringSize(executionStartedEvent.Input);
+                    AddStringSize(executionStartedEvent.Name);
+                    AddStringSize(executionStartedEvent.OrchestrationInstance.InstanceId);
+                    AddStringSize(executionStartedEvent.OrchestrationInstance.ExecutionId);
+                    estimate += 8 + (executionStartedEvent.Tags == null ? 0
+                        : executionStartedEvent.Tags.Select(kvp => 20 + 2 * (kvp.Key.Length + kvp.Value.Length)).Sum());
+                    AddStringSize(executionStartedEvent.Version);
+                    AddStringSize(executionStartedEvent.ParentInstance?.OrchestrationInstance.InstanceId);
+                    AddStringSize(executionStartedEvent.ParentInstance?.OrchestrationInstance.ExecutionId);
+                    estimate += 8;
+                    break;
+                case ExecutionTerminatedEvent executionTerminatedEvent:
+                    AddStringSize(executionTerminatedEvent.Input);
+                    break;
+                case GenericEvent genericEvent:
+                    AddStringSize(genericEvent.Data);
+                    break;
+                case OrchestratorCompletedEvent:
+                    break;
+                case OrchestratorStartedEvent:
+                    break;
+                case SubOrchestrationInstanceCompletedEvent subOrchestrationInstanceCompletedEvent:
+                    estimate += 8;
+                    AddStringSize(subOrchestrationInstanceCompletedEvent.Result);
+                    break;
+                case SubOrchestrationInstanceCreatedEvent subOrchestrationInstanceCreatedEvent:
+                    AddStringSize(subOrchestrationInstanceCreatedEvent.Input);
+                    AddStringSize(subOrchestrationInstanceCreatedEvent.Input);
+                    AddStringSize(subOrchestrationInstanceCreatedEvent.Name);
+                    AddStringSize(subOrchestrationInstanceCreatedEvent.Version);
+                    break;
+                case SubOrchestrationInstanceFailedEvent subOrchestrationInstanceFailedEvent:
+                    estimate += 8;
+                    AddStringSize(subOrchestrationInstanceFailedEvent.Reason);
+                    AddStringSize(subOrchestrationInstanceFailedEvent.Details);
+                    break;
+                case TaskCompletedEvent taskCompletedEvent:
+                    estimate += 8;
+                    AddStringSize(taskCompletedEvent.Result);
+                    break;
+                case TaskFailedEvent taskFailedEvent:
+                    estimate += 8;
+                    AddStringSize(taskFailedEvent.Reason);
+                    AddStringSize(taskFailedEvent.Details);
+                    break;
+                case TaskScheduledEvent taskScheduledEvent:
+                    AddStringSize(taskScheduledEvent.Input);
+                    AddStringSize(taskScheduledEvent.Name);
+                    AddStringSize(taskScheduledEvent.Version);
+                    break;
+                case TimerCreatedEvent timerCreatedEvent:
+                    estimate += 8;
+                    break;
+                case TimerFiredEvent timerFiredEvent:
+                    estimate += 16;
+                    break;
+                default:
+                    break;
+            }
+            return estimate;
+        }
+    }
+}

--- a/src/DurableTask.Core/OrchestrationRuntimeState.cs
+++ b/src/DurableTask.Core/OrchestrationRuntimeState.cs
@@ -50,7 +50,7 @@ namespace DurableTask.Core
         /// <summary>
         /// Compressed size of the serialized state
         /// </summary>
-        public long CompressedSize;
+        public long CompressedSize { get; set; }
 
         /// <summary>
         /// Gets the execution completed event
@@ -60,12 +60,12 @@ namespace DurableTask.Core
         /// <summary>
         /// Size of the serialized state (uncompressed)
         /// </summary>
-        public long Size;
+        public long Size { get; set; }
 
         /// <summary>
         /// The string status of the runtime state
         /// </summary>
-        public string? Status;
+        public string? Status { get; set; }
 
         /// <summary>
         /// Creates a new instance of the OrchestrationRuntimeState
@@ -206,6 +206,7 @@ namespace DurableTask.Core
             }
 
             Events.Add(historyEvent);
+            this.Size += SizeUtils.GetEstimatedSize(historyEvent);
 
             if (isNewEvent)
             {

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -547,6 +547,7 @@ namespace DurableTask.Core
                 instanceState.Status = runtimeState.Status;
             }
 
+            runtimeState.Size += SizeUtils.GetEstimatedSize(runtimeState);
 
             await this.orchestrationService.CompleteTaskOrchestrationWorkItemAsync(
                 workItem,


### PR DESCRIPTION
Added Orchestration Memory Manager to prevent OutOfMemoryExceptions when loading in orchestration histories.

This memory manager checks currently allocated process memory and attempts to reserve the necessary memory or wait until the memory is available.

Added orchestration history size calculation stored in the instances table and an instances table lookup before pulling in orchestration history, adding 1 storage transaction per orchestration history load.