### PR TITLE
Add Distributed Tracing spec

### DIFF
--- a/docs/telemetry/traces/semantic-conventions.md
+++ b/docs/telemetry/traces/semantic-conventions.md
@@ -10,6 +10,17 @@ This document serves as a specification for Distributed Tracing in the DurableTa
 ## Specification
 The following only applies to `DurableTask.Core`
 
+## Table of Contents
+1. [Attributes](#attributes)
+2. Spans <br>
+    a. [Client: Starting an Orchestration](#client-starting-an-orchestration)<br>
+    b. [Client: Starting a sub-orchestration](#client-starting-a-sub-orchestration)<br>
+    c. [Worker: Running an Orchestration](#worker-running-an-orchestration)<br>
+    d. [Worker: Starting an Activity](#worker-starting-an-activity)<br>
+    e. [Worker: Running an Activity](#worker-running-an-activity)<br>
+    f. [Worker: Timer](#worker-timer)<br>
+    g. [Sending an Event](#sending-an-event)<br>
+
 ### Attributes
 These attributes are all new, defined by us, and specific to DurableTask. All attributes here begin with the “durabletask” prefix.
 
@@ -30,7 +41,7 @@ durabletask.event.instance_id | string | The target orchestration instance ID of
 [2] When instance ID is not available (e.g. activities) use the parent orchestration's instance ID
 
 ### Spans
-#### Client – Starting an Orchestration
+#### Client: Starting an Orchestration
 
 Represents enqueueing a new orchestration via TaskHubClient to the backend.
 
@@ -58,7 +69,7 @@ Attributes:
 | durabletask.task.execution_id  | Execution ID of the enqueued orchestration  |
 | exception.*  | Exception details on failure. |
 
-#### Client - Starting a sub-orchestration
+#### Client: Starting a sub-orchestration
 
 Represents enqueueing and waiting for a sub-orchestration to complete 
 
@@ -85,7 +96,7 @@ Attributes:
 | exception.*   | Exception details on failure |
 
 
-#### Worker – Running an Orchestration
+#### Worker: Running an Orchestration
 
 Represents enqueueing a new orchestration via TaskHubClient to the backend
 
@@ -113,7 +124,7 @@ Attributes:
 | exception.*   | Exception details on failure |
 
 
-#### Worker - Starting an Activity
+#### Worker: Starting an Activity
 
 Represents enqueueing an activity
 
@@ -140,7 +151,7 @@ Attributes:
 | durabletask.task.task_id   | ID of the current task  |
 | exception.*   | Exception details on failure |
 
-#### Worker - Running an Activity
+#### Worker: Running an Activity
 
 Represents the activity executing
 
@@ -168,7 +179,7 @@ Attributes:
 | exception.*   | Exception details on failure |
 
 
-#### Worker - Timer
+#### Worker: Timer
 
 Represents the Durable Timer
 

--- a/docs/telemetry/traces/semantic-conventions.md
+++ b/docs/telemetry/traces/semantic-conventions.md
@@ -33,8 +33,9 @@ durabletask.event.instance_id | string | The target orchestration instance ID of
 
 Represents enqueueing a new orchestration via TaskHubClient to the backend.
 
-| Name  | create\_orchestration\|\|\{orchestrationName\}\(\|\|\{orchestrationVersion\}\)?  |
+| Span Property | Span Value |
 |---|---|
+| Name  | `create_orchestration||{orchestrationName}(||{orchestrationVersion})?`  |
 | Kind  | Producer  |
 | Start  | Before submitting the new orchestration to the backend  |
 | End  | After the orchestration has been submitted to the backend  |
@@ -56,19 +57,16 @@ Attributes:
 | durabletask.task.execution_id  | Execution ID of the enqueued orchestration  |
 | exception.*  | Exception details on failure. |
 
-Note: Backends SHOULD enrich this activity with additional attributes, links, or events as appropriate.
-
 #### Client - Starting a sub-orchestration
 
 Represents enqueueing and waiting for a sub-orchestration to complete 
 
-| Name   | orchestration\|\|\{orchestrationName\}\(\|\| \{orchestrationVersion\}\)?   |
+| Span Property | Span Value |
 |---|---|
-| Kind   | Standard: Client   |
-|  | Fire and forget: Producer  |
+| Name   | `orchestration||{orchestrationName}(||{orchestrationVersion})?`   |
+| Kind   | Standard: Client<br />Fire and forget: Producer  |
 | Start   | When the parent orchestration enqueues a message to execute the sub\-orchestration  |
-| End   | Standard: When the parent orchestration is notified that the sub\-orchestration completed\.  |
-|  | Fire and forget: After the sub\-orchestration started event is enqueued  |
+| End   | Standard: When the parent orchestration is notified that the sub\-orchestration completed\.<br />Fire and forget: After the sub\-orchestration started event is enqueued  |
 | Status   | OK – successfully enqueued<br />Error – failed to enqueue for any reason   |
 | Links   | None   |
 | Events   | TBD   |
@@ -90,8 +88,9 @@ Attributes:
 
 Represents enqueueing a new orchestration via TaskHubClient to the backend
 
-| Name   | orchestration\|\|\{orchestrationName\}\(\|\|\{orchestrationVersion\}\)?   |
+| Span Property | Span Value |
 |---|---|
+| Name   | `orchestration||{orchestrationName}(||{orchestrationVersion})?`   |
 | Kind   | Server   |
 | Start   | Before the orchestration starts executing\.  |
 | End   | After the orchestration has finished executing\.   |
@@ -117,8 +116,9 @@ Attributes:
 
 Represents enqueueing an activity
 
-| Name   | activity\|\|\{activityName\}\(\|\|\{orchestrationVersion\}\)?   |
+| Span Property | Span Value |
 |---|---|
+| Name   | `activity||{activityName}(||{orchestrationVersion})?`   |
 | Kind   | Client   |
 | Start   | Before enqueuing the activity  |
 | End   | After the activity has finished executing\.   |
@@ -143,8 +143,9 @@ Attributes:
 
 Represents the activity executing
 
-| Name   | activity\|\|\{activityName\}\(\|\| \{orchestrationVersion\}\)?   |
+| Span Property | Span Value |
 |---|---|
+| Name   | `activity||{activityName}(|| {orchestrationVersion})?`   |
 | Kind   | Server   |
 | Start   | Before the activity starts executing\.  |
 | End   | After the activity has finished executing\.   |
@@ -170,8 +171,9 @@ Attributes:
 
 Represents the Durable Timer
 
-| Name    | timer    |
+| Span Property | Span Value |
 |---|---|
+| Name    | `timer`    |
 | Kind    | Internal    |
 | Start    | When the timer is created   |
 | End    | When the TimerFired event is processed    |
@@ -196,8 +198,9 @@ Attributes:
 
 Represents sending an event to an orchestration
 
-| Name    | orchestration\_event\|\|\{orchestration\_name\}  |
+| Span Property | Span Value |
 |---|---|
+| Name    | `orchestration_event||{orchestration_name}`  |
 | Kind    | Client  |
 | Start    | Before sending the event  |
 | End    | From client: when the event has been sent <br />From worker: when the event message has been created \(this will have a negligible duration, but we want a span for a link\) |
@@ -216,27 +219,3 @@ Attributes:
 | durabletask.event.instance_id  | The instance ID of the target orchestration (the one receiving the event).    |
 | durabletask.task.instance_id    | Instance ID of the orchestration that is sending the event. Not present if sent from the client.  |
 | durabletask.task.execution_id   | Execution ID of the orchestration that is sending the event. Not present if sent from the client. |
-
-#### Receiving an Event
-
-Represents an orchestration receiving an event
-
-| Name    | orchestration\_event\|\|\{orchestration\_name\}  |
-|---|---|
-| Kind    | Consumer  |
-| Start    | When the event message is raised  |
-| End    | After the event is processed  |
-| Status    | OK – event received<br />Error – event failed to be read  |
-| Links    | The orchestration span that produced this event  |
-| Events    | None  |
-| Parent    | Current active span\. |
-
-&nbsp;
-Attributes:
-
-| Name    | Value    |
-|---|---|
-| durabletask.type    | “event”    |
-| durabletask.event.name  | The name of the event being received.  |
-| durabletask.task.instance_id    | Instance ID of the orchestration that received the event.  |
-| durabletask.task.execution_id   | Execution ID of the orchestration that received the event. |

--- a/docs/telemetry/traces/semantic-conventions.md
+++ b/docs/telemetry/traces/semantic-conventions.md
@@ -1,26 +1,27 @@
 # DurableTask Distributed Tracing Specification
+**Status**: [Experimental](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/document-status.md)
 
 ## Overview
-This document is to serve as a specification for distributed tracing in DurableTask Framework. This will include a list of all spans, their attributes, and detailed information about what constitutes each respective span.
+This document serves as a specification for distributed tracing in the DurableTask Framework. It includes a list of all spans, their attributes, and detailed information about what constitutes each respective span. We want to gather community feedback and encourage any comments with suggestions and questions. 
 
 ## References
-- [Open Telemetry Trace Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions "Open Telemetry Trace Semantic Conventions") – various trace semantic conventions we will be referencing throughout this document. Particularly, we will be pulling in some attributes defined in these files.
+- [Open Telemetry Trace Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions "Open Telemetry Trace Semantic Conventions") – various trace semantic conventions we  reference throughout this document. Particularly, we pull in some attributes defined in these files.
 
 ## Specification
 The following only applies to DurableTask.Core
 
 ### Attributes
-These attributes are all new, defined by us, and specific to DurableTask Framework. All attributes here will begin with the “durabletask” prefix.
+These attributes are all new, defined by us, and specific to DurableTask Framework. All attributes here begin with the “durabletask” prefix.
 
 Name | Type | Description | Requirement Level
 ---|---|---|---
 durabletask.type | string | The type of durable event occurring. Options: “activity”, “orchestration”, “timer”, “event” | Required
-durabletask.task.name | string | The name of the durable task being invoked. This is the name it was queued with, not necessarily the name of the handler class/type. | Required
-durabletask.task.version | string | The version of the task being ran.  | Conditionally Required [1]
-durabletask.task.instance_id |  string | The execution ID of the task being ran. This will be unique for all tasks. | Required [2]
-durabletask.task.execution_id | string | The execution ID of the task being ran. This will be unique for all tasks. | Required [2]
+durabletask.task.name | string | The name of the durable task being invoked. This is the name it was scheduled with, not necessarily the name of the handler class/type. | Required
+durabletask.task.version | string | The version of the task being executed.  | Conditionally Required [1]
+durabletask.task.instance_id |  string | The execution ID of the task being ran. This is unique for all tasks. | Required [2]
+durabletask.task.execution_id | string | The execution ID of the task being ran. This is unique for all tasks. | Required [2]
 durabletask.task.task_id | integer | The ID / index of the task within the orchestration. | Conditionally required
-durabletask.task.result | string | The terminal status of a task. Options: “Succeeded”, “Failed”, “Terminated”, "Suspended" | Required
+durabletask.task.result | string | The terminal status of a task. Options: “Succeeded”, “Failed”, “Terminated” | Required
 durabletask.event.name | string | The name of the event being raised. | Required
 durabletask.event.instance_id | string | The target orchestration instance ID of a raised event. | Required
 
@@ -37,8 +38,8 @@ Represents enqueueing a new orchestration via TaskHubClient to the backend.
 |---|---|
 | Name  | `create_orchestration\|\|{orchestrationName}(\|\|{orchestrationVersion})?`  |
 | Kind  | Producer  |
-| Start  | Before submitting the new orchestration to the backend  |
-| End  | After the orchestration has been submitted to the backend  |
+| Start  | Timestamp before submitting the new orchestration to the backend  |
+| End  | Timestamp after the orchestration has been submitted to the backend  |
 | Status  | OK – successfully enqueued<br />Error – failed to enqueue for any reason  |
 | Status Description  | On failure – exception message which caused failure  |
 | Links  | None  |
@@ -65,8 +66,8 @@ Represents enqueueing and waiting for a sub-orchestration to complete
 |---|---|
 | Name   | `orchestration\|\|{orchestrationName}(\|\|{orchestrationVersion})?`   |
 | Kind   | Standard: Client<br />Fire and forget: Producer  |
-| Start   | When the parent orchestration enqueues a message to execute the sub\-orchestration  |
-| End   | Standard: When the parent orchestration is notified that the sub\-orchestration completed\.<br />Fire and forget: After the sub\-orchestration started event is enqueued  |
+| Start   | Timestamp of when the parent orchestration enqueues a message to execute the sub\-orchestration  |
+| End   | Standard: Timestamp of when the parent orchestration is notified that the sub\-orchestration completed\.<br />Fire and forget: Timestamp after the sub\-orchestration started event is enqueued  |
 | Status   | OK – successfully enqueued<br />Error – failed to enqueue for any reason   |
 | Links   | None   |
 | Events   | TBD   |
@@ -92,8 +93,8 @@ Represents enqueueing a new orchestration via TaskHubClient to the backend
 |---|---|
 | Name   | `orchestration\|\|{orchestrationName}(\|\|{orchestrationVersion})?`   |
 | Kind   | Server   |
-| Start   | Before the orchestration starts executing\.  |
-| End   | After the orchestration has finished executing\.   |
+| Start   | Timestamp before the orchestration starts executing\.  |
+| End   | Timestamp after the orchestration has finished executing\.   |
 | Status   | OK – successfully completed<br />Error – failed  |
 | Links   | Spans from “Sending an Event”\.  |
 | Events   | Received events – name of the event, and timestamp of the first time this event has been played  |
@@ -120,8 +121,8 @@ Represents enqueueing an activity
 |---|---|
 | Name   | `activity\|\|{activityName}(\|\|{orchestrationVersion})?`   |
 | Kind   | Client   |
-| Start   | Before enqueuing the activity  |
-| End   | After the activity has finished executing\.   |
+| Start   | Timestamp before enqueuing the activity  |
+| End   | Timestamp after the activity has finished executing\.   |
 | Status   | OK – successfully enqueued<br />Error – failed to enqueue for any reason   |
 | Links   | None   |
 | Events   | TBD   |
@@ -147,8 +148,8 @@ Represents the activity executing
 |---|---|
 | Name   | `activity\|\|{activityName}(\|\| {orchestrationVersion})?`   |
 | Kind   | Server   |
-| Start   | Before the activity starts executing\.  |
-| End   | After the activity has finished executing\.   |
+| Start   | Timestamp before the activity starts executing\.  |
+| End   | Timestamp after the activity has finished executing\.   |
 | Status   | OK – successfully completed<br />Error – failed  |
 | Links   | None   |
 | Events   | TBD   |
@@ -175,8 +176,8 @@ Represents the Durable Timer
 |---|---|
 | Name    | `timer`    |
 | Kind    | Internal    |
-| Start    | When the timer is created   |
-| End    | When the TimerFired event is processed    |
+| Start    | Timestamp of when the timer is created   |
+| End    | Timestamp of when the TimerFired event is processed    |
 | Status    | OK – timer successfully completed<br />Error – timer cancellation   |
 | Links    | None    |
 | Events    | TBD    |
@@ -202,8 +203,8 @@ Represents sending an event to an orchestration
 |---|---|
 | Name    | `orchestration_event\|\|{orchestration_name}`  |
 | Kind    | Producer |
-| Start    | Before sending the event  |
-| End    | From client: when the event has been sent <br />From worker: when the event message has been created \(this will have a negligible duration, but we want a span for a link\) |
+| Start    | Timestamp efore sending the event  |
+| End    | From client: Timestamp of when the event has been sent <br />From worker: Timestamp of when the event message has been created \(this has a negligible duration, but we want a span for a link\) |
 | Status    | OK – event sent<br />Error – event failed to send  |
 | Links    | None    |
 | Events    | None  |
@@ -216,6 +217,6 @@ Attributes:
 |---|---|
 | durabletask.type    | “event”    |
 | durabletask.event.name  | The name of the event being sent.  |
-| durabletask.event.instance_id  | The instance ID of the target orchestration (the one receiving the event).    |
+| durabletask.event.target_instance_id  | The instance ID of the target orchestration (the one receiving the event).    |
 | durabletask.task.instance_id    | Instance ID of the orchestration that is sending the event. Not present if sent from the client.  |
 | durabletask.task.execution_id   | Execution ID of the orchestration that is sending the event. Not present if sent from the client. |

--- a/docs/telemetry/traces/semantic-conventions.md
+++ b/docs/telemetry/traces/semantic-conventions.md
@@ -162,8 +162,8 @@ Attributes:
 |---|---|
 | durabletask.type   | “activity”   |
 | durabletask.task.name   | Name of the activity   |
-| durabletask.task.version   | Version of the invoked orchestration enqueued. Omitted if null version.   |
-| durabletask.task.instance_id   | Instance ID of the invoked orchestration   |
+| durabletask.task.version   | Version of the invoking orchestration enqueued. Omitted if null version.   |
+| durabletask.task.instance_id   | Instance ID of the invoking orchestration   |
 | durabletask.task.task_id   | ID of the current task  |
 | exception.*   | Exception details on failure |
 
@@ -190,8 +190,8 @@ Attributes:
 |---|---|
 | durabletask.type    | “timer”    |
 | durabletask.fire_at  | Configured FireAt time displayed in ISO 8601 format  |
-| durabletask.task.version    | Version of the invoked orchestration enqueued. Omitted if null version.    |
-| durabletask.task.instance_id    | Instance ID of the invoked orchestration    |
+| durabletask.task.version    | Version of the invoking orchestration enqueued. Omitted if null version.    |
+| durabletask.task.instance_id    | Instance ID of the invoking orchestration    |
 | durabletask.task.task_id   | ID of the current task |
 
 

--- a/docs/telemetry/traces/semantic-conventions.md
+++ b/docs/telemetry/traces/semantic-conventions.md
@@ -35,7 +35,7 @@ Represents enqueueing a new orchestration via TaskHubClient to the backend.
 
 | Span Property | Span Value |
 |---|---|
-| Name  | `create_orchestration||{orchestrationName}(||{orchestrationVersion})?`  |
+| Name  | `create_orchestration\|\|{orchestrationName}(\|\|{orchestrationVersion})?`  |
 | Kind  | Producer  |
 | Start  | Before submitting the new orchestration to the backend  |
 | End  | After the orchestration has been submitted to the backend  |
@@ -63,7 +63,7 @@ Represents enqueueing and waiting for a sub-orchestration to complete
 
 | Span Property | Span Value |
 |---|---|
-| Name   | `orchestration||{orchestrationName}(||{orchestrationVersion})?`   |
+| Name   | `orchestration\|\|{orchestrationName}(\|\|{orchestrationVersion})?`   |
 | Kind   | Standard: Client<br />Fire and forget: Producer  |
 | Start   | When the parent orchestration enqueues a message to execute the sub\-orchestration  |
 | End   | Standard: When the parent orchestration is notified that the sub\-orchestration completed\.<br />Fire and forget: After the sub\-orchestration started event is enqueued  |
@@ -90,7 +90,7 @@ Represents enqueueing a new orchestration via TaskHubClient to the backend
 
 | Span Property | Span Value |
 |---|---|
-| Name   | `orchestration||{orchestrationName}(||{orchestrationVersion})?`   |
+| Name   | `orchestration\|\|{orchestrationName}(\|\|{orchestrationVersion})?`   |
 | Kind   | Server   |
 | Start   | Before the orchestration starts executing\.  |
 | End   | After the orchestration has finished executing\.   |
@@ -118,7 +118,7 @@ Represents enqueueing an activity
 
 | Span Property | Span Value |
 |---|---|
-| Name   | `activity||{activityName}(||{orchestrationVersion})?`   |
+| Name   | `activity\|\|{activityName}(\|\|{orchestrationVersion})?`   |
 | Kind   | Client   |
 | Start   | Before enqueuing the activity  |
 | End   | After the activity has finished executing\.   |
@@ -145,7 +145,7 @@ Represents the activity executing
 
 | Span Property | Span Value |
 |---|---|
-| Name   | `activity||{activityName}(|| {orchestrationVersion})?`   |
+| Name   | `activity\|\|{activityName}(\|\| {orchestrationVersion})?`   |
 | Kind   | Server   |
 | Start   | Before the activity starts executing\.  |
 | End   | After the activity has finished executing\.   |
@@ -200,7 +200,7 @@ Represents sending an event to an orchestration
 
 | Span Property | Span Value |
 |---|---|
-| Name    | `orchestration_event||{orchestration_name}`  |
+| Name    | `orchestration_event\|\|{orchestration_name}`  |
 | Kind    | Producer |
 | Start    | Before sending the event  |
 | End    | From client: when the event has been sent <br />From worker: when the event message has been created \(this will have a negligible duration, but we want a span for a link\) |

--- a/docs/telemetry/traces/semantic-conventions.md
+++ b/docs/telemetry/traces/semantic-conventions.md
@@ -201,7 +201,7 @@ Represents sending an event to an orchestration
 | Span Property | Span Value |
 |---|---|
 | Name    | `orchestration_event||{orchestration_name}`  |
-| Kind    | Client  |
+| Kind    | Producer |
 | Start    | Before sending the event  |
 | End    | From client: when the event has been sent <br />From worker: when the event message has been created \(this will have a negligible duration, but we want a span for a link\) |
 | Status    | OK – event sent<br />Error – event failed to send  |

--- a/docs/telemetry/traces/semantic-conventions.md
+++ b/docs/telemetry/traces/semantic-conventions.md
@@ -2,23 +2,23 @@
 **Status**: [Experimental](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/document-status.md)
 
 ## Overview
-This document serves as a specification for distributed tracing in the DurableTask Framework. It includes a list of all spans, their attributes, and detailed information about what constitutes each respective span. We want to gather community feedback and encourage any comments with suggestions and questions. 
+This document serves as a specification for Distributed Tracing in the DurableTask Framework. It includes a list of all spans, their attributes, and detailed information about what constitutes each respective span. We want to gather community feedback and encourage any comments with suggestions and questions. 
 
 ## References
-- [Open Telemetry Trace Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions "Open Telemetry Trace Semantic Conventions") – various trace semantic conventions we  reference throughout this document. Particularly, we pull in some attributes defined in these files.
+- [Open Telemetry Trace Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions "Open Telemetry Trace Semantic Conventions") – various trace semantic conventions we reference throughout this document. Particularly, we pull in some attributes defined in these files.
 
 ## Specification
-The following only applies to DurableTask.Core
+The following only applies to `DurableTask.Core`
 
 ### Attributes
-These attributes are all new, defined by us, and specific to DurableTask Framework. All attributes here begin with the “durabletask” prefix.
+These attributes are all new, defined by us, and specific to DurableTask. All attributes here begin with the “durabletask” prefix.
 
 Name | Type | Description | Requirement Level
 ---|---|---|---
 durabletask.type | string | The type of durable event occurring. Options: “activity”, “orchestration”, “timer”, “event” | Required
 durabletask.task.name | string | The name of the durable task being invoked. This is the name it was scheduled with, not necessarily the name of the handler class/type. | Required
 durabletask.task.version | string | The version of the task being executed.  | Conditionally Required [1]
-durabletask.task.instance_id |  string | The execution ID of the task being ran. This is unique for all tasks. | Required [2]
+durabletask.task.instance_id |  string | The instance ID of the task being ran. This is unique for all tasks. | Required [2]
 durabletask.task.execution_id | string | The execution ID of the task being ran. This is unique for all tasks. | Required [2]
 durabletask.task.task_id | integer | The ID / index of the task within the orchestration. | Conditionally required
 durabletask.task.result | string | The terminal status of a task. Options: “Succeeded”, “Failed”, “Terminated” | Required
@@ -27,7 +27,7 @@ durabletask.event.instance_id | string | The target orchestration instance ID of
 
 [1] durabletask.task.version may be omitted when version is null. 
 
-[2] When instance ID or execution ID is not available (e.g. activities) use the parent orchestration's instance ID
+[2] When instance ID is not available (e.g. activities) use the parent orchestration's instance ID
 
 ### Spans
 #### Client – Starting an Orchestration

--- a/docs/telemetry/traces/semantic-conventions.md
+++ b/docs/telemetry/traces/semantic-conventions.md
@@ -4,12 +4,6 @@
 ## Overview
 This document serves as a specification for Distributed Tracing in the DurableTask Framework. It includes a list of all spans, their attributes, and detailed information about what constitutes each respective span. We want to gather community feedback and encourage any comments with suggestions and questions. 
 
-## References
-- [Open Telemetry Trace Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions "Open Telemetry Trace Semantic Conventions") – various trace semantic conventions we reference throughout this document. Particularly, we pull in some attributes defined in these files.
-
-## Specification
-The following only applies to `DurableTask.Core`
-
 ## Table of Contents
 1. [Attributes](#attributes)
 2. Spans <br>
@@ -20,6 +14,12 @@ The following only applies to `DurableTask.Core`
     e. [Worker: Running an Activity](#worker-running-an-activity)<br>
     f. [Worker: Timer](#worker-timer)<br>
     g. [Sending an Event](#sending-an-event)<br>
+    
+## References
+- [Open Telemetry Trace Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions "Open Telemetry Trace Semantic Conventions") – various trace semantic conventions we reference throughout this document. Particularly, we pull in some attributes defined in these files.
+
+## Specification
+The following only applies to `DurableTask.Core`
 
 ### Attributes
 These attributes are all new, defined by us, and specific to DurableTask. All attributes here begin with the “durabletask” prefix.

--- a/docs/telemetry/traces/semantic-conventions.md
+++ b/docs/telemetry/traces/semantic-conventions.md
@@ -185,7 +185,7 @@ Represents the Durable Timer
 
 | Span Property | Span Value |
 |---|---|
-| Name    | `timer`    |
+| Name    | `orchestration:{orchestrationName}:timer`    |
 | Kind    | Internal    |
 | Start    | Timestamp of when the timer is created   |
 | End    | Timestamp of when the TimerFired event is processed    |

--- a/docs/telemetry/traces/semantic-conventions.md
+++ b/docs/telemetry/traces/semantic-conventions.md
@@ -36,7 +36,7 @@ Represents enqueueing a new orchestration via TaskHubClient to the backend.
 
 | Span Property | Span Value |
 |---|---|
-| Name  | `create_orchestration\|\|{orchestrationName}(\|\|{orchestrationVersion})?`  |
+| Name  | `create_orchestration:{orchestrationName}(@{orchestrationVersion})?`  |
 | Kind  | Producer  |
 | Start  | Timestamp before submitting the new orchestration to the backend  |
 | End  | Timestamp after the orchestration has been submitted to the backend  |
@@ -64,7 +64,7 @@ Represents enqueueing and waiting for a sub-orchestration to complete
 
 | Span Property | Span Value |
 |---|---|
-| Name   | `orchestration\|\|{orchestrationName}(\|\|{orchestrationVersion})?`   |
+| Name   | `orchestration:{orchestrationName}(@{orchestrationVersion})?`   |
 | Kind   | Standard: Client<br />Fire and forget: Producer  |
 | Start   | Timestamp of when the parent orchestration enqueues a message to execute the sub\-orchestration  |
 | End   | Standard: Timestamp of when the parent orchestration is notified that the sub\-orchestration completed\.<br />Fire and forget: Timestamp after the sub\-orchestration started event is enqueued  |
@@ -91,7 +91,7 @@ Represents enqueueing a new orchestration via TaskHubClient to the backend
 
 | Span Property | Span Value |
 |---|---|
-| Name   | `orchestration\|\|{orchestrationName}(\|\|{orchestrationVersion})?`   |
+| Name   | `orchestration:{orchestrationName}(@{orchestrationVersion})?`   |
 | Kind   | Server   |
 | Start   | Timestamp before the orchestration starts executing\.  |
 | End   | Timestamp after the orchestration has finished executing\.   |
@@ -119,7 +119,7 @@ Represents enqueueing an activity
 
 | Span Property | Span Value |
 |---|---|
-| Name   | `activity\|\|{activityName}(\|\|{orchestrationVersion})?`   |
+| Name   | `activity:{activityName}(@{orchestrationVersion})?`   |
 | Kind   | Client   |
 | Start   | Timestamp before enqueuing the activity  |
 | End   | Timestamp after the activity has finished executing\.   |
@@ -146,7 +146,7 @@ Represents the activity executing
 
 | Span Property | Span Value |
 |---|---|
-| Name   | `activity\|\|{activityName}(\|\| {orchestrationVersion})?`   |
+| Name   | `activity:{activityName}(@{orchestrationVersion})?`   |
 | Kind   | Server   |
 | Start   | Timestamp before the activity starts executing\.  |
 | End   | Timestamp after the activity has finished executing\.   |
@@ -162,8 +162,8 @@ Attributes:
 |---|---|
 | durabletask.type   | “activity”   |
 | durabletask.task.name   | Name of the activity   |
-| durabletask.task.version   | Version of the related orchestration enqueued. Omitted if null version.   |
-| durabletask.task.instance_id   | Instance ID of the related orchestration   |
+| durabletask.task.version   | Version of the invoked orchestration enqueued. Omitted if null version.   |
+| durabletask.task.instance_id   | Instance ID of the invoked orchestration   |
 | durabletask.task.task_id   | ID of the current task  |
 | exception.*   | Exception details on failure |
 
@@ -190,8 +190,8 @@ Attributes:
 |---|---|
 | durabletask.type    | “timer”    |
 | durabletask.fire_at  | Configured FireAt time displayed in ISO 8601 format  |
-| durabletask.task.version    | Version of the related orchestration enqueued. Omitted if null version.    |
-| durabletask.task.instance_id    | Instance ID of the related orchestration    |
+| durabletask.task.version    | Version of the invoked orchestration enqueued. Omitted if null version.    |
+| durabletask.task.instance_id    | Instance ID of the invoked orchestration    |
 | durabletask.task.task_id   | ID of the current task |
 
 
@@ -201,7 +201,7 @@ Represents sending an event to an orchestration
 
 | Span Property | Span Value |
 |---|---|
-| Name    | `orchestration_event\|\|{orchestration_name}`  |
+| Name    | `orchestration_event:{orchestration_name}`  |
 | Kind    | Producer |
 | Start    | Timestamp efore sending the event  |
 | End    | From client: Timestamp of when the event has been sent <br />From worker: Timestamp of when the event message has been created \(this has a negligible duration, but we want a span for a link\) |

--- a/semantic-conventions.md
+++ b/semantic-conventions.md
@@ -1,0 +1,242 @@
+# DurableTask Distributed Tracing Specification
+
+## Overview
+This document is to serve as a specification for distributed tracing in DurableTask Framework. This will include a list of all spans, their attributes, and detailed information about what constitutes each respective span.
+
+## References
+- [Open Telemetry Trace Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions "Open Telemetry Trace Semantic Conventions") – various trace semantic conventions we will be referencing throughout this document. Particularly, we will be pulling in some attributes defined in these files.
+
+## Specification
+The following only applies to DurableTask.Core
+
+### Attributes
+These attributes are all new, defined by us, and specific to DurableTask Framework. All attributes here will begin with the “durabletask” prefix.
+
+Name | Type | Description | Requirement Level
+---|---|---|---
+durabletask.type | string | The type of durable event occurring. Options: “activity”, “orchestration”, “timer”, “event” | Required
+durabletask.task.name | string | The name of the durable task being invoked. This is the name it was queued with, not necessarily the name of the handler class/type. | Required
+durabletask.task.version | string | The version of the task being ran.  | Conditionally Required [1]
+durabletask.task.instance_id |  string | The execution ID of the task being ran. This will be unique for all tasks. | Required [2]
+durabletask.task.execution_id | string | The execution ID of the task being ran. This will be unique for all tasks. | Required [2]
+durabletask.task.task_id | integer | The ID / index of the task within the orchestration. | Conditionally required
+durabletask.task.result | string | The terminal status of a task. Options: “Succeeded”, “Failed”, “Terminated”, "Suspended" | Required
+durabletask.event.name | string | The name of the event being raised. | Required
+durabletask.event.instance_id | string | The target orchestration instance ID of a raised event. | Required
+
+[1] durabletask.task.version may be omitted when version is null. 
+
+[2] When instance ID or execution ID is not available (e.g. activities) use the parent orchestration's instance ID
+
+### Spans
+#### Client – Starting an Orchestration
+
+Represents enqueueing a new orchestration via TaskHubClient to the backend.
+
+| Name  | create\_orchestration\|\|\{orchestrationName\}\(\|\|\{orchestrationVersion\}\)?  |
+|---|---|
+| Kind  | Producer  |
+| Start  | Before submitting the new orchestration to the backend  |
+| End  | After the orchestration has been submitted to the backend  |
+| Status  | OK – successfully enqueued<br />Error – failed to enqueue for any reason  |
+| Status Description  | On failure – exception message which caused failure  |
+| Links  | None  |
+| Events  | TBD  |
+| Parent  | Enclosing span |
+
+&nbsp;
+Attributes:
+
+| Name  | Value  |
+|---|---|
+| durabletask.type | "orchestration" |
+| durabletask.task.name  | Name of the enqueued orchestration  |
+| durabletask.task.version  | Version of the orchestration enqueued. Omitted if null version.  |
+| durabletask.task.instance_id  | Instance ID of the enqueued orchestration  |
+| durabletask.task.execution_id  | Execution ID of the enqueued orchestration  |
+| exception.*  | Exception details on failure. |
+
+Note: Backends SHOULD enrich this activity with additional attributes, links, or events as appropriate.
+
+#### Client - Starting a sub-orchestration
+
+Represents enqueueing and waiting for a sub-orchestration to complete 
+
+| Name   | orchestration\|\|\{orchestrationName\}\(\|\| \{orchestrationVersion\}\)?   |
+|---|---|
+| Kind   | Standard: Client   |
+|  | Fire and forget: Producer  |
+| Start   | When the parent orchestration enqueues a message to execute the sub\-orchestration  |
+| End   | Standard: When the parent orchestration is notified that the sub\-orchestration completed\.  |
+|  | Fire and forget: After the sub\-orchestration started event is enqueued  |
+| Status   | OK – successfully enqueued<br />Error – failed to enqueue for any reason   |
+| Links   | None   |
+| Events   | TBD   |
+| Parent   | “Running an orchestration” span for parent orchestration |
+
+&nbsp;
+Attributes:
+
+| Name   | Value   |
+|---|---|
+| durabletask.type   | “orchestration”   |
+| durabletask.task.name   | Name of the enqueued sub-orchestration   |
+| durabletask.task.version   | Version of the sub-orchestration enqueued. Omitted if null version.   |
+| durabletask.task.instance_id   | Instance ID of the enqueued orchestration   |
+| exception.*   | Exception details on failure |
+
+
+#### Worker – Running an Orchestration
+
+Represents enqueueing a new orchestration via TaskHubClient to the backend
+
+| Name   | orchestration\|\|\{orchestrationName\}\(\|\|\{orchestrationVersion\}\)?   |
+|---|---|
+| Kind   | Server   |
+| Start   | Before the orchestration starts executing\.  |
+| End   | After the orchestration has finished executing\.   |
+| Status   | OK – successfully completed<br />Error – failed  |
+| Links   | Spans from “Sending an Event”\.  |
+| Events   | Received events – name of the event, and timestamp of the first time this event has been played  |
+| Parent   | “Starting an orchestration” or “starting a sub\-orchestration” |
+
+&nbsp;
+Attributes:
+
+| Name   | Value   |
+|---|---|
+| durabletask.type   | “orchestration”   |
+| durabletask.task.name   | Name of the enqueued orchestration   |
+| durabletask.task.version   | Version of the orchestration enqueued. Omitted if null version.   |
+| durabletask.task.instance_id   | Instance ID of the enqueued orchestration   |
+| Durabletask.task.status  | Orchestration status  |
+| exception.*   | Exception details on failure |
+
+
+#### Worker - Starting an Activity
+
+Represents enqueueing an activity
+
+| Name   | activity\|\|\{activityName\}\(\|\|\{orchestrationVersion\}\)?   |
+|---|---|
+| Kind   | Client   |
+| Start   | Before enqueuing the activity  |
+| End   | After the activity has finished executing\.   |
+| Status   | OK – successfully enqueued<br />Error – failed to enqueue for any reason   |
+| Links   | None   |
+| Events   | TBD   |
+| Parent   | “Running an orchestration” span |
+
+&nbsp;
+Attributes:
+
+| Name   | Value   |
+|---|---|
+| durabletask.type   | “activity”   |
+| durabletask.task.name   | Name of the enqueued sub-orchestration   |
+| durabletask.task.version   | Version of the sub-orchestration enqueued. Omitted if null version.   |
+| durabletask.task.instance_id   | Instance ID of the enqueued orchestration   |
+| durabletask.task.task_id   | ID of the current task  |
+| exception.*   | Exception details on failure |
+
+#### Worker - Running an Activity
+
+Represents the activity executing
+
+| Name   | activity\|\|\{activityName\}\(\|\| \{orchestrationVersion\}\)?   |
+|---|---|
+| Kind   | Server   |
+| Start   | Before the activity starts executing\.  |
+| End   | After the activity has finished executing\.   |
+| Status   | OK – successfully completed<br />Error – failed  |
+| Links   | None   |
+| Events   | TBD   |
+| Parent   | “Starting an activity” span |
+
+&nbsp;
+Attributes:
+
+| Name   | Value   |
+|---|---|
+| durabletask.type   | “activity”   |
+| durabletask.task.name   | Name of the activity   |
+| durabletask.task.version   | Version of the related orchestration enqueued. Omitted if null version.   |
+| durabletask.task.instance_id   | Instance ID of the related orchestration   |
+| durabletask.task.task_id   | ID of the current task  |
+| exception.*   | Exception details on failure |
+
+
+#### Worker - Timer
+
+Represents the Durable Timer
+
+| Name    | timer    |
+|---|---|
+| Kind    | Internal    |
+| Start    | When the timer is created   |
+| End    | When the TimerFired event is processed    |
+| Status    | OK – timer successfully completed<br />Error – timer cancellation   |
+| Links    | None    |
+| Events    | TBD    |
+| Parent    | “Running an orchestration” span |
+
+&nbsp;
+Attributes:
+
+| Name    | Value    |
+|---|---|
+| durabletask.type    | “timer”    |
+| durabletask.fire_at  | Configured FireAt time displayed in ISO 8601 format  |
+| durabletask.task.version    | Version of the related orchestration enqueued. Omitted if null version.    |
+| durabletask.task.instance_id    | Instance ID of the related orchestration    |
+| durabletask.task.task_id   | ID of the current task |
+
+
+#### Sending an Event
+
+Represents sending an event to an orchestration
+
+| Name    | orchestration\_event\|\|\{orchestration\_name\}  |
+|---|---|
+| Kind    | Client  |
+| Start    | Before sending the event  |
+| End    | From client: when the event has been sent <br />From worker: when the event message has been created \(this will have a negligible duration, but we want a span for a link\) |
+| Status    | OK – event sent<br />Error – event failed to send  |
+| Links    | None    |
+| Events    | None  |
+| Parent    | Current active span\. For orchestrations, typically the orchestration running span\. For client, whatever span is active or none if no active span\. |
+
+&nbsp;
+Attributes:
+
+| Name    | Value    |
+|---|---|
+| durabletask.type    | “event”    |
+| durabletask.event.name  | The name of the event being sent.  |
+| durabletask.event.instance_id  | The instance ID of the target orchestration (the one receiving the event).    |
+| durabletask.task.instance_id    | Instance ID of the orchestration that is sending the event. Not present if sent from the client.  |
+| durabletask.task.execution_id   | Execution ID of the orchestration that is sending the event. Not present if sent from the client. |
+
+#### Receiving an Event
+
+Represents an orchestration receiving an event
+
+| Name    | orchestration\_event\|\|\{orchestration\_name\}  |
+|---|---|
+| Kind    | Consumer  |
+| Start    | When the event message is raised  |
+| End    | After the event is processed  |
+| Status    | OK – event received<br />Error – event failed to be read  |
+| Links    | The orchestration span that produced this event  |
+| Events    | None  |
+| Parent    | Current active span\. |
+
+&nbsp;
+Attributes:
+
+| Name    | Value    |
+|---|---|
+| durabletask.type    | “event”    |
+| durabletask.event.name  | The name of the event being received.  |
+| durabletask.task.instance_id    | Instance ID of the orchestration that received the event.  |
+| durabletask.task.execution_id   | Execution ID of the orchestration that received the event. |


### PR DESCRIPTION
This PR adds a spec that outlines the semantic conventions we are using to implement distributed tracing in the DurableTask Framework. It follows the [Open Telemetry Trace Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions "Open Telemetry Trace Semantic Conventions").

Additional information:
The image below is an example of a distributed trace created from the current instrumentation implementation. Each blue or red bar (solid and dashed) is a **span**. The properties on the right are the span's **attributes**. The group of spans in this image make up a **trace**.

![image](https://user-images.githubusercontent.com/15795068/213314434-25f69c2e-b6ae-44c2-bdc3-2cae378c6415.png)
