### PR TITLE
Adding exception information to spans (Replaces #694)

### DIFF
--- a/samples/DistributedTraceSample/Program.cs
+++ b/samples/DistributedTraceSample/Program.cs
@@ -118,7 +118,7 @@ namespace OpenTelemetrySample
             await client.WaitForOrchestrationAsync(helloSubOrchFailedInstance, TimeSpan.FromMinutes(5));
 
             Console.WriteLine("Done with Hello Sub-orchestration with failed sub-orchestration!");
-            
+
             // Hello Sequence with Timer
             OrchestrationInstance helloSeqWithTimerInstance = await client.CreateOrchestrationInstanceAsync(typeof(HelloSequenceWithTimer), null);
             await client.WaitForOrchestrationAsync(helloSeqWithTimerInstance, TimeSpan.FromMinutes(5));

--- a/samples/DistributedTraceSample/Program.cs
+++ b/samples/DistributedTraceSample/Program.cs
@@ -65,12 +65,19 @@ namespace OpenTelemetrySample
 
             // Hello Sequence
             OrchestrationInstance helloSeqInstance = await client.CreateOrchestrationInstanceAsync(
-                typeof(HelloFanOut),
-                //typeof(HelloSequence),
+                typeof(HelloSequence),
                 input: null);
             await client.WaitForOrchestrationAsync(helloSeqInstance, TimeSpan.FromMinutes(5));
 
             Console.WriteLine("Done with Hello Sequence!");
+
+            // Hello Fan Out
+            OrchestrationInstance helloFanOutInstance = await client.CreateOrchestrationInstanceAsync(
+                typeof(HelloFanOut),
+                input: null);
+            await client.WaitForOrchestrationAsync(helloSeqInstance, TimeSpan.FromMinutes(5));
+
+            Console.WriteLine("Done with Hello Fan Out!");
 
             // Hello Sequence throws exception
             OrchestrationInstance helloSeqExceptionInstance = await client.CreateOrchestrationInstanceAsync(

--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -130,7 +130,13 @@ namespace DurableTask.AzureStorage
 
         internal static bool TryGetLargeMessageReference(string messagePayload, out Uri blobUrl)
         {
-            return Uri.TryCreate(messagePayload, UriKind.Absolute, out blobUrl);
+            if (Uri.IsWellFormedUriString(messagePayload, UriKind.Absolute))
+            {
+                return Uri.TryCreate(messagePayload, UriKind.Absolute, out blobUrl);
+            }
+
+            blobUrl = null;
+            return false;
         }
 
         public async Task<MessageData> DeserializeQueueMessageAsync(QueueMessage queueMessage, string queueName)

--- a/src/DurableTask.Core/TaskActivityDispatcher.cs
+++ b/src/DurableTask.Core/TaskActivityDispatcher.cs
@@ -206,7 +206,7 @@ namespace DurableTask.Core
                                 : null;
                             responseEvent = new TaskFailedEvent(-1, scheduledEvent.EventId, e.Message, details, new FailureDetails(e));
 
-                            traceActivity?.SetStatus(ActivityStatusCode.Error, details);
+                            traceActivity?.SetStatus(ActivityStatusCode.Error, e.Message);
 
                             this.logHelper.TaskActivityFailure(orchestrationInstance, scheduledEvent.Name, (TaskFailedEvent)responseEvent, e);
                         }
@@ -224,7 +224,7 @@ namespace DurableTask.Core
                     string? details = this.IncludeDetails ? e.Details : null;
                     var failureEvent = new TaskFailedEvent(-1, scheduledEvent.EventId, e.Message, details, e.FailureDetails);
 
-                    traceActivity?.SetStatus(ActivityStatusCode.Error, details);
+                    traceActivity?.SetStatus(ActivityStatusCode.Error, e.Message);
 
                     this.logHelper.TaskActivityFailure(orchestrationInstance, scheduledEvent.Name, failureEvent, e);
                     CorrelationTraceClient.Propagate(() => CorrelationTraceClient.TrackException(e));

--- a/src/DurableTask.Core/TaskActivityDispatcher.cs
+++ b/src/DurableTask.Core/TaskActivityDispatcher.cs
@@ -205,6 +205,9 @@ namespace DurableTask.Core
                                 ? $"Unhandled exception while executing task: {e}"
                                 : null;
                             responseEvent = new TaskFailedEvent(-1, scheduledEvent.EventId, e.Message, details, new FailureDetails(e));
+
+                            traceActivity?.SetStatus(ActivityStatusCode.Error, details);
+
                             this.logHelper.TaskActivityFailure(orchestrationInstance, scheduledEvent.Name, (TaskFailedEvent)responseEvent, e);
                         }
 
@@ -220,12 +223,17 @@ namespace DurableTask.Core
                     TraceHelper.TraceExceptionInstance(TraceEventType.Error, "TaskActivityDispatcher-ProcessTaskFailure", taskMessage.OrchestrationInstance, e);
                     string? details = this.IncludeDetails ? e.Details : null;
                     var failureEvent = new TaskFailedEvent(-1, scheduledEvent.EventId, e.Message, details, e.FailureDetails);
+
+                    traceActivity?.SetStatus(ActivityStatusCode.Error, details);
+
                     this.logHelper.TaskActivityFailure(orchestrationInstance, scheduledEvent.Name, failureEvent, e);
                     CorrelationTraceClient.Propagate(() => CorrelationTraceClient.TrackException(e));
                     result = new ActivityExecutionResult { ResponseEvent = failureEvent };
                 }
                 catch (Exception middlewareException) when (!Utils.IsFatal(middlewareException))
                 {
+                    traceActivity?.SetStatus(ActivityStatusCode.Error, middlewareException.Message);
+
                     // These are considered retriable
                     this.logHelper.TaskActivityDispatcherError(workItem, $"Unhandled exception in activity middleware pipeline: {middlewareException}");
                     throw;

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -752,26 +752,26 @@ namespace DurableTask.Core
                         SubOrchestrationInstanceCreatedEvent subOrchestrationCreatedEvent = (SubOrchestrationInstanceCreatedEvent)workItem.OrchestrationRuntimeState.Events.FirstOrDefault(x => x.EventId == subOrchestrationInstanceCompletedEvent.TaskScheduledId);
 
                         // We immediately publish the activity span for this sub-orchestration by creating the activity and immediately calling Dispose() on it.
-                        TraceHelper.EmitTraceActivityForSubOrchestrationFinished(workItem.OrchestrationRuntimeState.OrchestrationInstance, subOrchestrationCreatedEvent);
+                        TraceHelper.EmitTraceActivityForSubOrchestrationCompleted(workItem.OrchestrationRuntimeState.OrchestrationInstance, subOrchestrationCreatedEvent);
                     }
                     else if (historyEvent is SubOrchestrationInstanceFailedEvent subOrchestrationInstanceFailedEvent)
                     {
                         SubOrchestrationInstanceCreatedEvent subOrchestrationCreatedEvent = (SubOrchestrationInstanceCreatedEvent)workItem.OrchestrationRuntimeState.Events.FirstOrDefault(x => x.EventId == subOrchestrationInstanceFailedEvent.TaskScheduledId);
 
                         // We immediately publish the activity span for this sub-orchestration by creating the activity and immediately calling Dispose() on it.
-                        TraceHelper.EmitTraceActivityForSubOrchestrationFinished(workItem.OrchestrationRuntimeState.OrchestrationInstance, subOrchestrationCreatedEvent, subOrchestrationInstanceFailedEvent, this.errorPropagationMode);
+                        TraceHelper.EmitTraceActivityForSubOrchestrationFailed(workItem.OrchestrationRuntimeState.OrchestrationInstance, subOrchestrationCreatedEvent, subOrchestrationInstanceFailedEvent, this.errorPropagationMode);
                     }
                 }
 
                 if (message.Event is TaskCompletedEvent taskCompletedEvent)
                 {
                     TaskScheduledEvent taskScheduledEvent = (TaskScheduledEvent)workItem.OrchestrationRuntimeState.Events.LastOrDefault(x => x.EventId == taskCompletedEvent.TaskScheduledId);
-                    TraceHelper.EmitActivityforTaskFinished(workItem.OrchestrationRuntimeState.OrchestrationInstance, taskScheduledEvent);
+                    TraceHelper.EmitTraceActivityForTaskCompleted(workItem.OrchestrationRuntimeState.OrchestrationInstance, taskScheduledEvent);
                 }
                 else if (message.Event is TaskFailedEvent taskFailedEvent)
                 {
                     TaskScheduledEvent taskScheduledEvent = (TaskScheduledEvent)workItem.OrchestrationRuntimeState.Events.LastOrDefault(x => x.EventId == taskFailedEvent.TaskScheduledId);
-                    TraceHelper.EmitActivityforTaskFinished(workItem.OrchestrationRuntimeState.OrchestrationInstance, taskScheduledEvent, taskFailedEvent, this.errorPropagationMode);
+                    TraceHelper.EmitTraceActivityForTaskFailed(workItem.OrchestrationRuntimeState.OrchestrationInstance, taskScheduledEvent, taskFailedEvent, this.errorPropagationMode);
                 }
 
                 workItem.OrchestrationRuntimeState.AddEvent(message.Event);

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -843,9 +843,18 @@ namespace DurableTask.Core
                 }
             }
 
-            DistributedTraceActivity.Current?.SetTag("dtfx.runtime_status", runtimeState.OrchestrationStatus.ToString());
-            DistributedTraceActivity.Current?.Stop();
-            DistributedTraceActivity.Current = null;
+            if (DistributedTraceActivity.Current != null)
+            {
+                if (completeOrchestratorAction.OrchestrationStatus == OrchestrationStatus.Failed)
+                {
+                    FailureDetails? failureDetails = runtimeState.FailureDetails;
+                    DistributedTraceActivity.Current?.SetStatus(ActivityStatusCode.Error, failureDetails?.ErrorMessage);
+                }
+
+                DistributedTraceActivity.Current?.SetTag("dtfx.runtime_status", runtimeState.OrchestrationStatus.ToString());
+                DistributedTraceActivity.Current?.Stop();
+                DistributedTraceActivity.Current = null;
+            }
 
             return null;
         }

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -855,7 +855,7 @@ namespace DurableTask.Core
 
                     taskMessage.Event = subOrchestrationFailedEvent;
 
-                    if (DistributedTraceActivity.Current != null && completeOrchestratorAction.OrchestrationStatus == OrchestrationStatus.Failed)
+                    if (completeOrchestratorAction.OrchestrationStatus == OrchestrationStatus.Failed)
                     {
                         AddFailureDetailstoActivity(runtimeState);
                     }
@@ -870,15 +870,12 @@ namespace DurableTask.Core
                 }
             }
 
-            if (DistributedTraceActivity.Current != null)
+            if (completeOrchestratorAction.OrchestrationStatus == OrchestrationStatus.Failed)
             {
-                if (completeOrchestratorAction.OrchestrationStatus == OrchestrationStatus.Failed)
-                {
-                    AddFailureDetailstoActivity(runtimeState);
-                }
-
-                ResetDistributedTraceActivity(runtimeState);
+                AddFailureDetailstoActivity(runtimeState);
             }
+
+            ResetDistributedTraceActivity(runtimeState);
 
             return null;
         }

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -855,13 +855,9 @@ namespace DurableTask.Core
 
                     taskMessage.Event = subOrchestrationFailedEvent;
 
-                    if (DistributedTraceActivity.Current != null)
+                    if (DistributedTraceActivity.Current != null && completeOrchestratorAction.OrchestrationStatus == OrchestrationStatus.Failed)
                     {
-                        if (completeOrchestratorAction.OrchestrationStatus == OrchestrationStatus.Failed)
-                        {
-                            FailureDetails? failureDetails = runtimeState.FailureDetails;
-                            DistributedTraceActivity.Current?.SetStatus(ActivityStatusCode.Error, failureDetails?.ErrorMessage);
-                        }
+                        AddFailureDetailstoActivity(runtimeState);
                     }
                 }
 
@@ -878,8 +874,7 @@ namespace DurableTask.Core
             {
                 if (completeOrchestratorAction.OrchestrationStatus == OrchestrationStatus.Failed)
                 {
-                    FailureDetails? failureDetails = runtimeState.FailureDetails;
-                    DistributedTraceActivity.Current?.SetStatus(ActivityStatusCode.Error, failureDetails?.ErrorMessage);
+                    AddFailureDetailstoActivity(runtimeState);
                 }
 
                 ResetDistributedTraceActivity(runtimeState);
@@ -893,6 +888,12 @@ namespace DurableTask.Core
             DistributedTraceActivity.Current?.SetTag("dtfx.runtime_status", runtimeState.OrchestrationStatus.ToString());
             DistributedTraceActivity.Current?.Stop();
             DistributedTraceActivity.Current = null;
+        }
+
+        private void AddFailureDetailstoActivity(OrchestrationRuntimeState runtimeState)
+        {
+            FailureDetails? failureDetails = runtimeState.FailureDetails;
+            DistributedTraceActivity.Current?.SetStatus(ActivityStatusCode.Error, failureDetails?.ErrorMessage);
         }
 
         TaskMessage ProcessScheduleTaskDecision(

--- a/src/DurableTask.Core/Tracing/DiagnosticActivityExtensions.cs
+++ b/src/DurableTask.Core/Tracing/DiagnosticActivityExtensions.cs
@@ -1,0 +1,87 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core.Tracing
+{
+    using System;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Reflection;
+
+    /// <summary>
+    /// Replica from System.Diagnostics.DiagnosticSource >= 6.0.0
+    /// </summary>
+    internal enum ActivityStatusCode
+    {
+        Unset = 0,
+        OK = 1,
+        Error = 2,
+    }
+
+    /// <summary>
+    /// Extensions for <see cref="FieldInfo"/>.
+    /// </summary>
+    internal static class DiagnosticActivityExtensions
+    {
+        private static readonly Action<Activity, string> s_setSpanId;
+        private static readonly Action<Activity, string> s_setId;
+        private static readonly Action<Activity, ActivityStatusCode, string> s_setStatus;
+
+        static DiagnosticActivityExtensions()
+        {
+            BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Instance;
+            s_setSpanId = typeof(Activity).GetField("_spanId", flags).CreateSetter<Activity, string>();
+            s_setId = typeof(Activity).GetField("_id", flags).CreateSetter<Activity, string>();
+            s_setStatus = CreateSetStatus();
+        }
+
+        public static void SetId(this Activity activity, string id)
+            => s_setId(activity, id);
+        public static void SetSpanId(this Activity activity, string spanId)
+            => s_setSpanId(activity, spanId);
+        public static void SetStatus(this Activity activity, ActivityStatusCode status, string description)
+            => s_setStatus(activity, status, description);
+
+        private static Action<Activity, ActivityStatusCode, string> CreateSetStatus()
+        {
+            MethodInfo method = typeof(Activity).GetMethod("SetStatus");
+            if (method is null)
+            {
+                return (activity, status, description) => {
+                    if (activity is null)
+                    {
+                        throw new ArgumentNullException(nameof(activity));
+                    }
+                    string str = status switch
+                    {
+                        ActivityStatusCode.Unset => "UNSET",
+                        ActivityStatusCode.OK => "OK",
+                        ActivityStatusCode.Error => "ERROR",
+                        _ => null,
+                    };
+                    activity.SetTag("otel.status_code", str);
+                    activity.SetTag("otel.status_description", description);
+                };
+            }
+            ParameterExpression targetExp = Expression.Parameter(typeof(Activity), "target");
+            ParameterExpression status = Expression.Parameter(typeof(ActivityStatusCode), "status");
+            ParameterExpression description = Expression.Parameter(typeof(string), "description");
+            UnaryExpression convert = Expression.Convert(status, typeof(int));
+            convert = Expression.Convert(convert, method.GetParameters().First().ParameterType);
+            MethodCallExpression callExp = Expression.Call(targetExp, method, convert, description);
+            return Expression.Lambda<Action<Activity, ActivityStatusCode, string>>(callExp, targetExp, status, description)
+                .Compile();
+        }
+    }
+}

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -134,7 +134,7 @@ namespace DurableTask.Core.Tracing
                 });
         }
 
-        internal static Activity? CreateTraceActivityForSubOrchestrationFinished(
+        internal static Activity? CreateTraceActivityForSubOrchestration(
             OrchestrationInstance? orchestrationInstance,
             SubOrchestrationInstanceCreatedEvent createdEvent)
         {
@@ -165,7 +165,7 @@ namespace DurableTask.Core.Tracing
             OrchestrationInstance? orchestrationInstance,
             SubOrchestrationInstanceCreatedEvent createdEvent)
         {
-            Activity? activity = CreateTraceActivityForSubOrchestrationFinished(orchestrationInstance, createdEvent);
+            Activity? activity = CreateTraceActivityForSubOrchestration(orchestrationInstance, createdEvent);
 
             activity?.Dispose();
         }
@@ -176,7 +176,7 @@ namespace DurableTask.Core.Tracing
             SubOrchestrationInstanceFailedEvent? failedEvent,
             ErrorPropagationMode errorPropagationMode)
         {
-            Activity? activity = CreateTraceActivityForSubOrchestrationFinished(orchestrationInstance, createdEvent);
+            Activity? activity = CreateTraceActivityForSubOrchestration(orchestrationInstance, createdEvent);
 
             if (activity is null)
             {
@@ -240,7 +240,7 @@ namespace DurableTask.Core.Tracing
             }
         }
 
-        internal static Activity? CreateTraceActivityForTaskFinished(
+        internal static Activity? CreateTraceActivityForTask(
             OrchestrationInstance? instance,
             TaskScheduledEvent taskScheduledEvent)
         {
@@ -276,7 +276,7 @@ namespace DurableTask.Core.Tracing
             OrchestrationInstance? orchestrationInstance,
             TaskScheduledEvent taskScheduledEvent)
         {
-            Activity? activity = CreateTraceActivityForTaskFinished(orchestrationInstance, taskScheduledEvent);
+            Activity? activity = CreateTraceActivityForTask(orchestrationInstance, taskScheduledEvent);
 
             activity?.Dispose();
         }
@@ -287,7 +287,7 @@ namespace DurableTask.Core.Tracing
             TaskFailedEvent? taskFailedEvent,
             ErrorPropagationMode errorPropagationMode)
         {
-            Activity? activity = CreateTraceActivityForTaskFinished(orchestrationInstance, taskScheduledEvent);
+            Activity? activity = CreateTraceActivityForTask(orchestrationInstance, taskScheduledEvent);
 
             if (activity is null)
             {

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -31,16 +31,6 @@ namespace DurableTask.Core.Tracing
 
         static readonly ActivitySource ActivityTraceSource = new ActivitySource(Source);
 
-        private static readonly Action<Activity, string> s_spanIdSet;
-        private static readonly Action<Activity, string> s_idSet;
-
-        static TraceHelper()
-        {
-            BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Instance;
-            s_spanIdSet = typeof(Activity).GetField("_spanId", flags).CreateSetter<Activity, string>();
-            s_idSet = typeof(Activity).GetField("_id", flags).CreateSetter<Activity, string>();
-        }
-
         internal static Activity? CreateActivityForNewOrchestration(ExecutionStartedEvent startEvent)
         {
             Activity? newActivity = ActivityTraceSource.StartActivity(
@@ -99,8 +89,8 @@ namespace DurableTask.Core.Tracing
 
             if (startEvent.ParentTraceContext.Id != null && startEvent.ParentTraceContext.SpanId != null)
             {
-                s_idSet(activity, startEvent.ParentTraceContext.Id!);
-                s_spanIdSet(activity, startEvent.ParentTraceContext.SpanId!);
+                activity.SetId(startEvent.ParentTraceContext.Id!);
+                activity.SetSpanId(startEvent.ParentTraceContext.SpanId!);
             }
             else
             {

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -173,20 +173,21 @@ namespace DurableTask.Core.Tracing
             // Adding additional tags for a SubOrchestrationInstanceFailedEvent
             if (failedEvent != null)
             {
-                activity.SetTag("otel.status_code", "ERROR");
+                string? statusDescription = "";
                 if (errorPropagationMode == ErrorPropagationMode.SerializeExceptions)
                 {
-                    string exceptionMessage = JsonDataConverter.Default.Deserialize<Exception>(failedEvent.Details).Message;
-                    activity.SetTag("otel.status_description", exceptionMessage);
+                    statusDescription = JsonDataConverter.Default.Deserialize<Exception>(failedEvent.Details).Message;
                 }
                 else if (errorPropagationMode == ErrorPropagationMode.UseFailureDetails)
                 {
                     FailureDetails? failureDetails = failedEvent.FailureDetails;
                     if (failureDetails != null)
                     {
-                        activity.SetTag("otel.status_description", failureDetails.ErrorMessage);
+                        statusDescription = failureDetails.ErrorMessage;
                     }
                 }
+
+                activity.SetStatus(ActivityStatusCode.Error, statusDescription);
             }
 
             activity.Dispose();
@@ -258,22 +259,22 @@ namespace DurableTask.Core.Tracing
 
             if (taskFailedEvent != null)
             {
-                newActivity.SetTag("otel.status_code", "ERROR");
+                string? statusDescription = "";
 
                 if (errorPropagationMode == ErrorPropagationMode.SerializeExceptions)
                 {
-                    string exceptionMessage = JsonDataConverter.Default.Deserialize<Exception>(taskFailedEvent.Details).Message;
-                    newActivity.SetTag("otel.status_description", exceptionMessage);
+                    statusDescription = JsonDataConverter.Default.Deserialize<Exception>(taskFailedEvent.Details).Message;
                 }
                 else if (errorPropagationMode == ErrorPropagationMode.UseFailureDetails)
                 {
                     FailureDetails? failureDetails = taskFailedEvent.FailureDetails;
                     if (failureDetails != null)
                     {
-                        newActivity.SetTag("otel.status_description", failureDetails.ErrorMessage);
+                        statusDescription = failureDetails.ErrorMessage;
                     }
                 }
 
+                newActivity.SetStatus(ActivityStatusCode.Error, statusDescription);
             }
 
             newActivity.Dispose();


### PR DESCRIPTION
Creating this PR as a replacement of #694 to clean up the commit history. The code changes are similar to the previous PR. This PR adds exception information to spans when an orchestration or activity throws an exception. It also adds `Activity` extension methods for `SetId()`, `SetSpanId()`, and `SetStatus()`. 

The following examples cover both `ErrorPropagationMode` settings

1) HelloSequenceException orchestration with the following `TaskHubWorker` settings
```
worker.ErrorPropagationMode = ErrorPropagationMode.UseFailureDetails;
worker.TaskActivityDispatcher.IncludeDetails = true;
worker.TaskOrchestrationDispatcher.IncludeDetails = true;
```
<img width="934" alt="image" src="https://user-images.githubusercontent.com/15795068/217108999-e85cb1cf-8b57-4847-aebc-c56a416be362.png">
<img width="934" alt="image" src="https://user-images.githubusercontent.com/15795068/217109050-09bbdee9-d78d-4829-8091-5d620c7c71da.png">
<img width="931" alt="image" src="https://user-images.githubusercontent.com/15795068/217109097-27f350e6-f57a-497c-a842-dc0aadea7d10.png">


2) ExceptionSubOrch orchestration with the following `TaskHubWorker` settings
worker.ErrorPropagationMode = ErrorPropagationMode.UseFailureDetails;
worker.TaskActivityDispatcher.IncludeDetails = true;
worker.TaskOrchestrationDispatcher.IncludeDetails = true;

<img width="932" alt="image" src="https://user-images.githubusercontent.com/15795068/217109139-4dd084aa-d9d6-4e72-9cc9-f865e3059862.png">
<img width="935" alt="image" src="https://user-images.githubusercontent.com/15795068/217109168-33c2706d-8a0e-435c-9087-e17407b695c1.png">
<img width="932" alt="image" src="https://user-images.githubusercontent.com/15795068/217109248-6cbab7fd-2bf3-4bbc-8ee9-bb6abefce07d.png">

3) HelloSequenceException orchestration with the following `TaskHubWorker` setting
worker.ErrorPropagationMode = ErrorPropagationMode.UseFailureDetails;

<img width="938" alt="image" src="https://user-images.githubusercontent.com/15795068/217108121-bc46dddb-98a4-4479-955e-484eabe84c84.png">
<img width="935" alt="image" src="https://user-images.githubusercontent.com/15795068/217108157-b9693596-7931-402d-99d1-45f003bb0ca1.png">
<img width="933" alt="image" src="https://user-images.githubusercontent.com/15795068/217108186-e901d2c0-57e8-4ed4-ac06-6a1c8156cc25.png">

4) ExceptionSubOrch orchestration with the following `TaskHubWorker` setting
worker.ErrorPropagationMode = ErrorPropagationMode.UseFailureDetails;

<img width="934" alt="image" src="https://user-images.githubusercontent.com/15795068/217108223-03b75f16-4f90-4f04-84ab-bbe6d451925e.png">
<img width="929" alt="image" src="https://user-images.githubusercontent.com/15795068/217108303-af476892-c98a-42ad-a0dd-a285a76eebd2.png">
<img width="932" alt="image" src="https://user-images.githubusercontent.com/15795068/217108337-c5b43ae8-2305-459a-a374-f0e2d7534eaf.png">

