### PR TITLE
Update distributed tracing code based on spec

### DIFF
--- a/src/DurableTask.Core/TaskActivityDispatcher.cs
+++ b/src/DurableTask.Core/TaskActivityDispatcher.cs
@@ -128,7 +128,7 @@ namespace DurableTask.Core
                 scheduledEvent = (TaskScheduledEvent)taskMessage.Event;
 
                 // Distributed tracing: start a new trace activity derived from the orchestration's trace context.
-                using Activity? traceActivity = TraceHelper.StartTraceActivityForTask(scheduledEvent, orchestrationInstance);
+                using Activity? traceActivity = TraceHelper.StartTraceActivityForSchedulingTask(scheduledEvent, orchestrationInstance);
 
                 this.logHelper.TaskActivityStarting(orchestrationInstance, scheduledEvent);
 

--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -609,12 +609,20 @@ namespace DurableTask.Core
 
             this.logHelper.SchedulingOrchestration(startedEvent);
 
-            using Activity newActivity = TraceHelper.CreateActivityForNewOrchestration(startedEvent);
+            using Activity newActivity = TraceHelper.StartActivityForNewOrchestration(startedEvent);
 
             CorrelationTraceClient.Propagate(() => CreateAndTrackDependencyTelemetry(requestTraceContext));
 
-            // Raised events and create orchestration calls use different methods so get handled separately
-            await this.ServiceClient.CreateTaskOrchestrationAsync(startMessage, dedupeStatuses);
+            try
+            {
+                // Raised events and create orchestration calls use different methods so get handled separately
+                await this.ServiceClient.CreateTaskOrchestrationAsync(startMessage, dedupeStatuses);
+            }
+            catch (Exception e)
+            {
+                TraceHelper.AddErrorDetailsToSpan(newActivity, e);
+                throw;
+            }
 
             if (eventData != null)
             {
@@ -694,7 +702,7 @@ namespace DurableTask.Core
             
             // Distributed Tracing
             EventRaisedEvent eventRaisedEvent = new EventRaisedEvent(-1, serializedInput) { Name = eventName };
-            using Activity traceActivity = TraceHelper.CreateActivityForNewEventRaised(eventRaisedEvent, orchestrationInstance);
+            using Activity traceActivity = TraceHelper.StartActivityForNewEventRaisedFromClient(eventRaisedEvent, orchestrationInstance);
 
             var taskMessage = new TaskMessage
             {

--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -711,8 +711,16 @@ namespace DurableTask.Core
             };
 
             this.logHelper.RaisingEvent(orchestrationInstance, (EventRaisedEvent)taskMessage.Event);
-            
-            await this.ServiceClient.SendTaskOrchestrationMessageAsync(taskMessage);
+
+            try
+            {
+                await this.ServiceClient.SendTaskOrchestrationMessageAsync(taskMessage);
+            }
+            catch(Exception e)
+            {
+                TraceHelper.AddErrorDetailsToSpan(traceActivity, e);
+                throw;
+            }
         }
 
         /// <summary>

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -308,7 +308,7 @@ namespace DurableTask.Core
             ExecutionStartedEvent startEvent =
                 runtimeState.ExecutionStartedEvent ??
                 workItem.NewMessages.Select(msg => msg.Event).OfType<ExecutionStartedEvent>().FirstOrDefault();
-            Activity? traceActivity = TraceHelper.StartTraceActivityForExecution(startEvent);
+            Activity? traceActivity = TraceHelper.StartTraceActivityForOrchestrationExecution(startEvent);
 
             OrchestrationState? instanceState = null;
 
@@ -745,7 +745,7 @@ namespace DurableTask.Core
                     if (historyEvent is TimerFiredEvent timerFiredEvent)
                     {
                         // We immediately publish the activity span for this timer by creating the activity and immediately calling Dispose() on it.
-                        TraceHelper.EmitTraceActivityForTimer(workItem.OrchestrationRuntimeState.OrchestrationInstance, message.Event.Timestamp, timerFiredEvent);
+                        TraceHelper.EmitTraceActivityForTimer(workItem.OrchestrationRuntimeState.OrchestrationInstance, workItem.OrchestrationRuntimeState.Name, message.Event.Timestamp, timerFiredEvent);
                     }
                     else if (historyEvent is SubOrchestrationInstanceCompletedEvent subOrchestrationInstanceCompletedEvent)
                     {
@@ -1060,7 +1060,7 @@ namespace DurableTask.Core
 
             // Distributed Tracing: start a new trace activity derived from the orchestration
             // for an EventRaisedEvent (external event)
-            using Activity? traceActivity = TraceHelper.StartTraceActivityForEventRaised(eventRaisedEvent, runtimeState.OrchestrationInstance, sendEventAction.Instance?.InstanceId);
+            using Activity? traceActivity = TraceHelper.StartTraceActivityForEventRaisedFromWorker(eventRaisedEvent, runtimeState.OrchestrationInstance, sendEventAction.Instance?.InstanceId);
 
             this.logHelper.RaisingEvent(runtimeState.OrchestrationInstance!, historyEvent);
 

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -745,7 +745,7 @@ namespace DurableTask.Core
                     if (historyEvent is TimerFiredEvent timerFiredEvent)
                     {
                         // We immediately publish the activity span for this timer by creating the activity and immediately calling Dispose() on it.
-                        TraceHelper.EmitTraceActivityForTimer(workItem.OrchestrationRuntimeState.OrchestrationInstance, message.Event.Timestamp, timerFiredEvent, workItem.OrchestrationRuntimeState.Version);
+                        TraceHelper.EmitTraceActivityForTimer(workItem.OrchestrationRuntimeState.OrchestrationInstance, message.Event.Timestamp, timerFiredEvent);
                     }
                     else if (historyEvent is SubOrchestrationInstanceCompletedEvent subOrchestrationInstanceCompletedEvent)
                     {
@@ -893,7 +893,7 @@ namespace DurableTask.Core
 
         private void ResetDistributedTraceActivity(OrchestrationRuntimeState runtimeState)
         {
-            DistributedTraceActivity.Current?.SetTag("durabletask.task.status", runtimeState.OrchestrationStatus.ToString());
+            TraceHelper.SetRuntimeStatusTag(runtimeState.OrchestrationStatus.ToString());
             DistributedTraceActivity.Current?.Stop();
             DistributedTraceActivity.Current = null;
         }

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -745,7 +745,7 @@ namespace DurableTask.Core
                     if (historyEvent is TimerFiredEvent timerFiredEvent)
                     {
                         // We immediately publish the activity span for this timer by creating the activity and immediately calling Dispose() on it.
-                        TraceHelper.EmitTraceActivityForTimer(workItem.OrchestrationRuntimeState.OrchestrationInstance, message.Event.Timestamp, (timerFiredEvent).FireAt);
+                        TraceHelper.EmitTraceActivityForTimer(workItem.OrchestrationRuntimeState.OrchestrationInstance, message.Event.Timestamp, timerFiredEvent, workItem.OrchestrationRuntimeState.Version);
                     }
                     else if (historyEvent is SubOrchestrationInstanceCompletedEvent subOrchestrationInstanceCompletedEvent)
                     {
@@ -893,7 +893,7 @@ namespace DurableTask.Core
 
         private void ResetDistributedTraceActivity(OrchestrationRuntimeState runtimeState)
         {
-            DistributedTraceActivity.Current?.SetTag("dtfx.runtime_status", runtimeState.OrchestrationStatus.ToString());
+            DistributedTraceActivity.Current?.SetTag("durabletask.task.status", runtimeState.OrchestrationStatus.ToString());
             DistributedTraceActivity.Current?.Stop();
             DistributedTraceActivity.Current = null;
         }
@@ -1060,7 +1060,7 @@ namespace DurableTask.Core
 
             // Distributed Tracing: start a new trace activity derived from the orchestration
             // for an EventRaisedEvent (external event)
-            using Activity? traceActivity = TraceHelper.StartTraceActivityForEventRaised(eventRaisedEvent, runtimeState.OrchestrationInstance);
+            using Activity? traceActivity = TraceHelper.StartTraceActivityForEventRaised(eventRaisedEvent, runtimeState.OrchestrationInstance, sendEventAction.Instance?.InstanceId);
 
             this.logHelper.RaisingEvent(runtimeState.OrchestrationInstance!, historyEvent);
 

--- a/src/DurableTask.Core/Tracing/Schema.cs
+++ b/src/DurableTask.Core/Tracing/Schema.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DurableTask.Core.Tracing
+{
+    internal static class Schema
+    {
+        internal static class Task
+        {
+            internal const string Type = "durabletask.type";
+            internal const string Name = "durabletask.task.name";
+            internal const string Version = "durabletask.task.version";
+            internal const string InstanceId = "durabletask.task.instance_id";
+            internal const string ExecutionId = "durabletask.task.execution_id";
+            internal const string Status = "durabletask.task.status";
+            internal const string TaskId = "durabletask.task.task_id";
+            internal const string EventTargetInstanceId = "durabletask.event.target_instance_id";
+            internal const string FireAt = "durabletask.fire_at";
+        }
+
+        internal static class Status
+        {
+            internal const string Code = "otel.status_code";
+            internal const string Description = "otel.status_description";
+        }
+    }
+}

--- a/src/DurableTask.Core/Tracing/Schema.cs
+++ b/src/DurableTask.Core/Tracing/Schema.cs
@@ -1,6 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
 
 namespace DurableTask.Core.Tracing
 {

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -18,7 +18,6 @@ namespace DurableTask.Core.Tracing
     using System.Diagnostics;
     using System.Globalization;
     using System.Runtime.ExceptionServices;
-    using System.Reflection;
     using DurableTask.Core.Common;
     using DurableTask.Core.History;
     using DurableTask.Core.Serializing;
@@ -32,7 +31,14 @@ namespace DurableTask.Core.Tracing
 
         static readonly ActivitySource ActivityTraceSource = new ActivitySource(Source);
 
-        internal static Activity? CreateActivityForNewOrchestration(ExecutionStartedEvent startEvent)
+        /// <summary>
+        /// Starts a new trace activity for scheduling an orchestration from the client.
+        /// </summary>
+        /// <param name="startEvent">The orchestration's execution started event.</param>
+        /// <returns>
+        /// Returns a newly started <see cref="Activity"/> with orchestration-specific metadata.
+        /// </returns>
+        internal static Activity? StartActivityForNewOrchestration(ExecutionStartedEvent startEvent)
         {
             Activity? newActivity = ActivityTraceSource.StartActivity(
                 name: CreateSpanName("create_orchestration", startEvent.Name, startEvent.Version),
@@ -40,10 +46,10 @@ namespace DurableTask.Core.Tracing
 
             if (newActivity != null)
             {
-                newActivity.SetTag("durabletask.type", "orchestration");
-                newActivity.SetTag("durabletask.task.name", startEvent.Name);
-                newActivity.SetTag("durabletask.task.instance_id", startEvent.OrchestrationInstance.InstanceId);
-                newActivity.SetTag("durabletask.task.execution_id", startEvent.OrchestrationInstance.ExecutionId);
+                newActivity.SetTag(Schema.Task.Type, "orchestration");
+                newActivity.SetTag(Schema.Task.Name, startEvent.Name);
+                newActivity.SetTag(Schema.Task.InstanceId, startEvent.OrchestrationInstance.InstanceId);
+                newActivity.SetTag(Schema.Task.ExecutionId, startEvent.OrchestrationInstance.ExecutionId);
 
                 if (!string.IsNullOrEmpty(startEvent.Version))
                 {
@@ -63,7 +69,7 @@ namespace DurableTask.Core.Tracing
         /// <returns>
         /// Returns a newly started <see cref="Activity"/> with orchestration-specific metadata.
         /// </returns>
-        internal static Activity? StartTraceActivityForExecution(ExecutionStartedEvent? startEvent)
+        internal static Activity? StartTraceActivityForOrchestrationExecution(ExecutionStartedEvent? startEvent)
         {
             if (startEvent == null)
             {
@@ -90,13 +96,13 @@ namespace DurableTask.Core.Tracing
                 return null;
             }
 
-            activity.SetTag("durabletask.type", "orchestration");
-            activity.SetTag("durabletask.task.name", startEvent.Name);
-            activity.SetTag("durabletask.task.instance_id", startEvent.OrchestrationInstance.InstanceId);
+            activity.SetTag(Schema.Task.Type, "orchestration");
+            activity.SetTag(Schema.Task.Name, startEvent.Name);
+            activity.SetTag(Schema.Task.InstanceId, startEvent.OrchestrationInstance.InstanceId);
 
             if (!string.IsNullOrEmpty(startEvent.Version))
             {
-                activity.SetTag("durabletask.task.version", startEvent.Version);
+                activity.SetTag(Schema.Task.Version, startEvent.Version);
             }
 
             if (startEvent.ParentTraceContext.Id != null && startEvent.ParentTraceContext.SpanId != null)
@@ -115,20 +121,17 @@ namespace DurableTask.Core.Tracing
             return DistributedTraceActivity.Current;
         }
 
-        internal static void SetRuntimeStatusTag(string runtimeStatus)
-        {
-            DistributedTraceActivity.Current?.SetTag("durabletask.task.status", runtimeStatus);
-        }
 
         /// <summary>
-        /// Starts a new trace activity for (task) activity execution.
+        /// Starts a new trace activity for (task) activity that represents the time between when the task message
+        /// is enqueued and completes.
         /// </summary>
         /// <param name="scheduledEvent">The associated <see cref="TaskScheduledEvent"/>.</param>
         /// <param name="instance">The associated orchestration instance metadata.</param>
         /// <returns>
         /// Returns a newly started <see cref="Activity"/> with (task) activity and orchestration-specific metadata.
         /// </returns>
-        internal static Activity? StartTraceActivityForTask(
+        internal static Activity? StartTraceActivityForSchedulingTask(
             TaskScheduledEvent scheduledEvent,
             OrchestrationInstance instance)
         {
@@ -147,67 +150,93 @@ namespace DurableTask.Core.Tracing
                 return null;
             }
 
-            newActivity.SetTag("durabletask.type", "activity");
-            newActivity.SetTag("durabletask.task.name", scheduledEvent.Name);
-            newActivity.SetTag("durabletask.task.instance_id", instance.InstanceId);
-            newActivity.SetTag("durabletask.task.task_id", scheduledEvent.EventId);
+            newActivity.SetTag(Schema.Task.Type, "activity");
+            newActivity.SetTag(Schema.Task.Name, scheduledEvent.Name);
+            newActivity.SetTag(Schema.Task.InstanceId, instance.InstanceId);
+            newActivity.SetTag(Schema.Task.TaskId, scheduledEvent.EventId);
 
             if (!string.IsNullOrEmpty(scheduledEvent.Version))
             {
-                newActivity.SetTag("durabletask.task.version", scheduledEvent.Version);
+                newActivity.SetTag(Schema.Task.Version, scheduledEvent.Version);
             }
 
             return newActivity;
         }
 
-        internal static Activity? CreateTraceActivityForSubOrchestration(
-            OrchestrationInstance? orchestrationInstance,
-            SubOrchestrationInstanceCreatedEvent createdEvent)
+        /// <summary>
+        /// Starts a new trace activity for (task) activity execution. 
+        /// </summary>
+        /// <param name="instance">The associated <see cref="OrchestrationInstance"/>.</param>
+        /// <param name="taskScheduledEvent">The associated <see cref="TaskScheduledEvent"/>.</param>
+        /// <returns>
+        /// Returns a newly started <see cref="Activity"/> with (task) activity and orchestration-specific metadata.
+        /// </returns>
+        internal static Activity? StartTraceActivityForTaskExecution(
+            OrchestrationInstance? instance,
+            TaskScheduledEvent taskScheduledEvent)
         {
-            if (orchestrationInstance == null || createdEvent == null)
+            if (taskScheduledEvent == null)
             {
                 return null;
             }
 
-            Activity? activity = ActivityTraceSource.StartActivity(
-                name: CreateSpanName("orchestration", createdEvent.Name, createdEvent.Version),
-                kind: ActivityKind.Client,
-                startTime: createdEvent.Timestamp,
-                parentContext: Activity.Current?.Context ?? default);
-
-            if (activity == null)
+            if (!taskScheduledEvent.TryGetParentTraceContext(out ActivityContext activityContext))
             {
                 return null;
             }
 
-            activity.SetTag("durabletask.type", "orchestration");
-            activity.SetTag("durabletask.task.name", createdEvent.Name);
-            activity.SetTag("durabletask.task.instance_id", orchestrationInstance?.InstanceId);
+            Activity? newActivity = ActivityTraceSource.StartActivity(
+                name: CreateSpanName("activity", taskScheduledEvent.Name, taskScheduledEvent.Version),
+                kind: ActivityKind.Server,
+                startTime: taskScheduledEvent.Timestamp,
+                parentContext: activityContext);
 
-            if (!string.IsNullOrEmpty(createdEvent.Version))
+            if (newActivity == null)
             {
-                activity.SetTag("durabletask.task.version", createdEvent.Version);
+                return null;
             }
 
-            return activity;
+            newActivity.AddTag(Schema.Task.Type, "activity");
+            newActivity.AddTag(Schema.Task.Name, taskScheduledEvent.Name);
+            newActivity.AddTag(Schema.Task.InstanceId, instance?.InstanceId);
+            newActivity.AddTag(Schema.Task.TaskId, taskScheduledEvent.EventId);
+
+            if (!string.IsNullOrEmpty(taskScheduledEvent.Version))
+            {
+                newActivity.AddTag(Schema.Task.Version, taskScheduledEvent.Version);
+            }
+
+            return newActivity;
         }
 
-        internal static void EmitTraceActivityForSubOrchestrationCompleted(
+        /// <summary>
+        /// Emits a new trace activity for a (task) activity that successfully completes.
+        /// </summary>
+        /// <param name="taskScheduledEvent">The associated <see cref="TaskScheduledEvent"/>.</param>
+        /// <param name="orchestrationInstance">The associated <see cref="OrchestrationInstance"/>.</param>
+        internal static void EmitTraceActivityForTaskCompleted(
             OrchestrationInstance? orchestrationInstance,
-            SubOrchestrationInstanceCreatedEvent createdEvent)
+            TaskScheduledEvent taskScheduledEvent)
         {
-            Activity? activity = CreateTraceActivityForSubOrchestration(orchestrationInstance, createdEvent);
+            Activity? activity = StartTraceActivityForTaskExecution(orchestrationInstance, taskScheduledEvent);
 
             activity?.Dispose();
         }
 
-        internal static void EmitTraceActivityForSubOrchestrationFailed(
+        /// <summary>
+        /// Emits a new trace activity for a (task) activity that fails.
+        /// </summary>
+        /// <param name="orchestrationInstance">The associated <see cref="OrchestrationInstance"/>.</param>
+        /// <param name="taskScheduledEvent">The associated <see cref="TaskScheduledEvent"/>.</param>
+        /// <param name="failedEvent">The associated <see cref="TaskFailedEvent"/>.</param>
+        /// <param name="errorPropagationMode">Specifies the method to propagate unhandled exceptions to parent orchestrations.</param>
+        internal static void EmitTraceActivityForTaskFailed(
             OrchestrationInstance? orchestrationInstance,
-            SubOrchestrationInstanceCreatedEvent createdEvent,
-            SubOrchestrationInstanceFailedEvent? failedEvent,
+            TaskScheduledEvent taskScheduledEvent,
+            TaskFailedEvent? failedEvent,
             ErrorPropagationMode errorPropagationMode)
         {
-            Activity? activity = CreateTraceActivityForSubOrchestration(orchestrationInstance, createdEvent);
+            Activity? activity = StartTraceActivityForTaskExecution(orchestrationInstance, taskScheduledEvent);
 
             if (activity is null)
             {
@@ -236,112 +265,92 @@ namespace DurableTask.Core.Tracing
             activity?.Dispose();
         }
 
-        internal static Activity? CreateActivityForNewEventRaised(EventRaisedEvent eventRaised, OrchestrationInstance instance)
+        /// <summary>
+        /// Starts a new trace activity for sub-orchestrations. Represents the time between enqueuing
+        /// the sub-orchestration message and it completing.
+        /// </summary>
+        /// <param name="orchestrationInstance">The associated <see cref="OrchestrationInstance"/>.</param>
+        /// <param name="createdEvent">The associated <see cref="SubOrchestrationInstanceCreatedEvent"/>.</param>
+        /// <returns>
+        /// Returns a newly started <see cref="Activity"/> with (task) activity and orchestration-specific metadata.
+        /// </returns>
+        internal static Activity? CreateTraceActivityForSchedulingSubOrchestration(
+            OrchestrationInstance? orchestrationInstance,
+            SubOrchestrationInstanceCreatedEvent createdEvent)
         {
-            Activity? newActivity = ActivityTraceSource.StartActivity(
-                name: CreateSpanName("orchestration_event", eventRaised.Name, null),
-                kind: ActivityKind.Producer,
-                parentContext: Activity.Current?.Context ?? default,
-                tags: new KeyValuePair<string, object?>[]
-                {
-                    new("durabletask.type", "event"),
-                    new("durabletask.task.name", eventRaised.Name),
-                    new("durabletask.event.target_instance_id", instance.InstanceId),
-                });
+            if (orchestrationInstance == null || createdEvent == null)
+            {
+                return null;
+            }
 
-            return newActivity;
-        }
-
-        internal static void EmitTraceActivityForTimer(OrchestrationInstance? instance, DateTime startTime, TimerFiredEvent timerFiredEvent)
-        {
-            Activity? newActivity = ActivityTraceSource.StartActivity(
-                name: "timer",
-                kind: ActivityKind.Internal,
-                startTime: startTime,
+            Activity? activity = ActivityTraceSource.StartActivity(
+                name: CreateSpanName("orchestration", createdEvent.Name, createdEvent.Version),
+                kind: ActivityKind.Client,
+                startTime: createdEvent.Timestamp,
                 parentContext: Activity.Current?.Context ?? default);
 
-            if (newActivity is not null)
+            if (activity == null)
             {
-                newActivity.AddTag("durabletask.type", "timer");
-                newActivity.AddTag("durabletask.fire_at", timerFiredEvent.FireAt.ToString("o"));
-                newActivity.AddTag("durabletask.task.instance_id", instance?.InstanceId);
-                newActivity.AddTag("durabletask.task.task_id", timerFiredEvent.TimerId);
-
-                newActivity.Dispose();
+                return null;
             }
+
+            activity.SetTag(Schema.Task.Type, "orchestration");
+            activity.SetTag(Schema.Task.Name, createdEvent.Name);
+            activity.SetTag(Schema.Task.InstanceId, orchestrationInstance?.InstanceId);
+
+            if (!string.IsNullOrEmpty(createdEvent.Version))
+            {
+                activity.SetTag(Schema.Task.Version, createdEvent.Version);
+            }
+
+            return activity;
         }
 
-        internal static Activity? CreateTraceActivityForTask(
-            OrchestrationInstance? instance,
-            TaskScheduledEvent taskScheduledEvent)
-        {
-            if (taskScheduledEvent == null)
-            {
-                return null;
-            }
-
-            if (!taskScheduledEvent.TryGetParentTraceContext(out ActivityContext activityContext))
-            {
-                return null;
-            }
-
-            Activity? newActivity = ActivityTraceSource.StartActivity(
-                name: CreateSpanName("activity", taskScheduledEvent.Name, taskScheduledEvent.Version),
-                kind: ActivityKind.Server,
-                startTime: taskScheduledEvent.Timestamp,
-                parentContext: activityContext);
-
-            if (newActivity == null)
-            {
-                return null;
-            }
-
-            newActivity.AddTag("durabletask.type", "activity");
-            newActivity.AddTag("durabletask.task.name", taskScheduledEvent.Name);
-            newActivity.AddTag("durabletask.task.instance_id", instance?.InstanceId);
-            newActivity.AddTag("durabletask.task_id", taskScheduledEvent.EventId);
-
-            if (!string.IsNullOrEmpty(taskScheduledEvent.Version))
-            {
-                newActivity.AddTag("durabletask.task.version", taskScheduledEvent.Version);
-            }
-
-            return newActivity;
-        }
-
-        internal static void EmitTraceActivityForTaskCompleted(
+        /// <summary>
+        /// Emits a new trace activity for sub-orchestration execution when the sub-orchestration
+        /// completes successfully.
+        /// </summary>
+        /// <param name="orchestrationInstance">The associated <see cref="OrchestrationInstance"/>.</param>
+        /// <param name="createdEvent">The associated <see cref="SubOrchestrationInstanceCreatedEvent"/>.</param>
+        internal static void EmitTraceActivityForSubOrchestrationCompleted(
             OrchestrationInstance? orchestrationInstance,
-            TaskScheduledEvent taskScheduledEvent)
+            SubOrchestrationInstanceCreatedEvent createdEvent)
         {
-            Activity? activity = CreateTraceActivityForTask(orchestrationInstance, taskScheduledEvent);
+            Activity? activity = CreateTraceActivityForSchedulingSubOrchestration(orchestrationInstance, createdEvent);
 
             activity?.Dispose();
         }
 
-        internal static void EmitTraceActivityForTaskFailed(
+        /// <summary>
+        /// Emits a new trace activity for sub-orchestration execution when the sub-orchestration fails.
+        /// </summary>
+        /// <param name="orchestrationInstance">The associated <see cref="OrchestrationInstance"/>.</param>
+        /// <param name="createdEvent">The associated <see cref="SubOrchestrationInstanceCreatedEvent"/>.</param>
+        /// <param name="failedEvent">The associated <see cref="SubOrchestrationInstanceCreatedEvent"/>.</param>
+        /// <param name="errorPropagationMode">Specifies the method to propagate unhandled exceptions to parent orchestrations.</param>
+        internal static void EmitTraceActivityForSubOrchestrationFailed(
             OrchestrationInstance? orchestrationInstance,
-            TaskScheduledEvent taskScheduledEvent,
-            TaskFailedEvent? taskFailedEvent,
+            SubOrchestrationInstanceCreatedEvent createdEvent,
+            SubOrchestrationInstanceFailedEvent? failedEvent,
             ErrorPropagationMode errorPropagationMode)
         {
-            Activity? activity = CreateTraceActivityForTask(orchestrationInstance, taskScheduledEvent);
+            Activity? activity = CreateTraceActivityForSchedulingSubOrchestration(orchestrationInstance, createdEvent);
 
             if (activity is null)
             {
                 return;
             }
 
-            if (taskFailedEvent != null)
+            if (failedEvent != null)
             {
                 string statusDescription = "";
-
                 if (errorPropagationMode == ErrorPropagationMode.SerializeExceptions)
                 {
-                    statusDescription = JsonDataConverter.Default.Deserialize<Exception>(taskFailedEvent.Details).Message;
+                    statusDescription = JsonDataConverter.Default.Deserialize<Exception>(failedEvent.Details).Message;
                 }
                 else if (errorPropagationMode == ErrorPropagationMode.UseFailureDetails)
                 {
-                    FailureDetails? failureDetails = taskFailedEvent.FailureDetails;
+                    FailureDetails? failureDetails = failedEvent.FailureDetails;
                     if (failureDetails != null)
                     {
                         statusDescription = failureDetails.ErrorMessage;
@@ -355,15 +364,15 @@ namespace DurableTask.Core.Tracing
         }
 
         /// <summary>
-        /// Starts a new trace activity for (task) activity execution.
+        /// Emits a new trace activity for events created from the worker.
         /// </summary>
         /// <param name="eventRaisedEvent">The associated <see cref="EventRaisedEvent"/>.</param>
-        /// <param name="instance">The associated orchestration instance metadata.</param>
-        /// <param name="targetInstanceId">The instance id of the orchestration instance that will receive the event.</param>
+        /// <param name="instance">The associated <see cref="OrchestrationInstance"/>.</param>
+        /// <param name="targetInstanceId">The instance id of the orchestration that will receive the event.</param>
         /// <returns>
         /// Returns a newly started <see cref="Activity"/> with (task) activity and orchestration-specific metadata.
         /// </returns>
-        internal static Activity? StartTraceActivityForEventRaised(
+        internal static Activity? StartTraceActivityForEventRaisedFromWorker(
             EventRaisedEvent eventRaisedEvent,
             OrchestrationInstance? instance,
             string? targetInstanceId)
@@ -378,10 +387,10 @@ namespace DurableTask.Core.Tracing
                 return null;
             }
 
-            newActivity.AddTag("durabletask.type", "event");
-            newActivity.AddTag("durabletask.task.name", eventRaisedEvent.Name);
-            newActivity.AddTag("durabletask.task.instance_id", instance?.InstanceId);
-            newActivity.AddTag("durabletask.task.execution_id", instance?.ExecutionId);
+            newActivity.AddTag(Schema.Task.Type, "event");
+            newActivity.AddTag(Schema.Task.Name, eventRaisedEvent.Name);
+            newActivity.AddTag(Schema.Task.InstanceId, instance?.InstanceId);
+            newActivity.AddTag(Schema.Task.ExecutionId, instance?.ExecutionId);
 
             if (!string.IsNullOrEmpty(targetInstanceId))
             {
@@ -389,6 +398,71 @@ namespace DurableTask.Core.Tracing
             }
 
             return newActivity;
+        }
+
+        /// <summary>
+        /// Creates a new trace activity for events created from the client.
+        /// </summary>
+        /// <param name="eventRaised">The associated <see cref="EventRaisedEvent"/>.</param>
+        /// <param name="instance">The associated <see cref="OrchestrationInstance"/>.</param>
+        /// <returns>
+        /// Returns a newly started <see cref="Activity"/> with (task) activity and orchestration-specific metadata.
+        /// </returns>
+        internal static Activity? StartActivityForNewEventRaisedFromClient(EventRaisedEvent eventRaised, OrchestrationInstance instance)
+        {
+            Activity? newActivity = ActivityTraceSource.StartActivity(
+                name: CreateSpanName("orchestration_event", eventRaised.Name, null),
+                kind: ActivityKind.Producer,
+                parentContext: Activity.Current?.Context ?? default,
+                tags: new KeyValuePair<string, object?>[]
+                {
+                    new(Schema.Task.Type, "event"),
+                    new(Schema.Task.Name, eventRaised.Name),
+                    new(Schema.Task.EventTargetInstanceId, instance.InstanceId),
+                });
+
+            return newActivity;
+        }
+
+        /// <summary>
+        /// Emits a new trace activity for timers.
+        /// </summary>
+        /// <param name="instance">The associated <see cref="OrchestrationInstance"/>.</param>
+        /// <param name="orchestrationName">The name of the orchestration invoking the timer.</param>
+        /// <param name="startTime">The timer's start time.</param>
+        /// <param name="timerFiredEvent">The associated <see cref="TimerFiredEvent"/>.</param>
+        internal static void EmitTraceActivityForTimer(
+            OrchestrationInstance? instance,
+            string orchestrationName,
+            DateTime startTime,
+            TimerFiredEvent timerFiredEvent)
+        {
+            Activity? newActivity = ActivityTraceSource.StartActivity(
+                name: "timer",
+                kind: ActivityKind.Internal,
+                startTime: startTime,
+                parentContext: Activity.Current?.Context ?? default);
+
+            if (newActivity is not null)
+            {
+                newActivity.AddTag(Schema.Task.Type, "timer");
+                newActivity.AddTag(Schema.Task.Name, orchestrationName);
+                newActivity.AddTag(Schema.Task.InstanceId, instance?.InstanceId);
+                newActivity.AddTag(Schema.Task.FireAt, timerFiredEvent.FireAt.ToString("o"));
+                newActivity.AddTag(Schema.Task.TaskId, timerFiredEvent.TimerId);
+
+                newActivity.Dispose();
+            }
+        }
+
+        internal static void SetRuntimeStatusTag(string runtimeStatus)
+        {
+            DistributedTraceActivity.Current?.SetTag(Schema.Task.Status, runtimeStatus);
+        }
+
+        internal static void AddErrorDetailsToSpan(Activity? activity, Exception e)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, e.Message.ToString());
         }
 
         static string CreateSpanName(string spanDescription, string? taskName, string? taskVersion)

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -213,14 +213,14 @@ namespace DurableTask.Core.Tracing
         internal static Activity? CreateActivityForNewEventRaised(EventRaisedEvent eventRaised, OrchestrationInstance instance)
         {
             Activity? newActivity = ActivityTraceSource.StartActivity(
-                name: eventRaised.Name,
+                name: CreateActivityName("orchestration_event", eventRaised.Name, null),
                 kind: ActivityKind.Producer,
                 parentContext: Activity.Current?.Context ?? default,
                 tags: new KeyValuePair<string, object?>[]
                 {
                     new("durabletask.type", "event"),
-                    new("durabletask.task.instance_id", instance.InstanceId),
-                    new("durabletask.task.execution_id", instance.ExecutionId),
+                    new("durabletask.task.name", eventRaised.Name),
+                    new("durabletask.event.target_instance_id", instance.InstanceId),
                 });
 
             return newActivity;

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -124,7 +124,7 @@ namespace DurableTask.Core.Tracing
 
         /// <summary>
         /// Starts a new trace activity for (task) activity that represents the time between when the task message
-        /// is enqueued and completes.
+        /// is enqueued and when the response message is received.
         /// </summary>
         /// <param name="scheduledEvent">The associated <see cref="TaskScheduledEvent"/>.</param>
         /// <param name="instance">The associated orchestration instance metadata.</param>

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -53,7 +53,7 @@ namespace DurableTask.Core.Tracing
 
                 if (!string.IsNullOrEmpty(startEvent.Version))
                 {
-                    newActivity.SetTag("durabletask.task.version", startEvent.Version);
+                    newActivity.SetTag(Schema.Task.Version, startEvent.Version);
                 }
                 
                 startEvent.SetParentTraceContext(newActivity);
@@ -394,7 +394,7 @@ namespace DurableTask.Core.Tracing
 
             if (!string.IsNullOrEmpty(targetInstanceId))
             {
-                newActivity.AddTag("durabletask.event.target_instance_id", targetInstanceId);
+                newActivity.AddTag(Schema.Task.EventTargetInstanceId, targetInstanceId);
             }
 
             return newActivity;

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -272,7 +272,7 @@ namespace DurableTask.Core.Tracing
             }
 
             newActivity.AddTag("durabletask.type", "activity");
-            newActivity.AddTag("durabletask.task.name", "activity");
+            newActivity.AddTag("durabletask.task.name", taskScheduledEvent.Name);
             newActivity.AddTag("durabletask.task.version", taskScheduledEvent.Version);
             newActivity.AddTag("durabletask.task.instance_id", instance?.InstanceId);
             newActivity.AddTag("durabletask.task_id", taskScheduledEvent.EventId);


### PR DESCRIPTION
This PR updates the distributed tracing with OpenTelemetry code based on the spec in #847.

Scenarios from the spec that are not addressed:
- Span Status (e.g. OK, ERROR) (refer to comment in this PR for discussion)
- Fire and forget sub-orchestrations (not supporting for early preview)
- Event links (based on the conversation in the spec, it looks like we need to discuss the user experience more after the early preview)