### PR TITLE
Implement orchestration work item renewal

### DIFF
--- a/src/DurableTask.Core/Logging/EventIds.cs
+++ b/src/DurableTask.Core/Logging/EventIds.cs
@@ -59,5 +59,9 @@ namespace DurableTask.Core.Logging
 
         public const int SuspendingInstance = 68;
         public const int ResumingInstance = 69;
+
+        public const int RenewOrchestrationWorkItemStarting = 70;
+        public const int RenewOrchestrationWorkItemCompleted = 71;
+        public const int RenewOrchestrationWorkItemFailed = 72;
     }
 }

--- a/src/DurableTask.Core/Logging/LogEvents.cs
+++ b/src/DurableTask.Core/Logging/LogEvents.cs
@@ -1546,5 +1546,88 @@ namespace DurableTask.Core.Logging
                     Utils.AppName,
                     Utils.PackageVersion);
         }
+
+        internal class RenewOrchestrationWorkItemStarting : StructuredLogEvent, IEventSourceEvent
+        {
+            public RenewOrchestrationWorkItemStarting(TaskOrchestrationWorkItem workItem)
+            {
+                this.InstanceId = workItem.InstanceId;
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.RenewOrchestrationWorkItemStarting,
+                nameof(EventIds.RenewOrchestrationWorkItemStarting));
+
+            public override LogLevel Level => LogLevel.Debug;
+
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Renewing orchestration work item";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.RenewOrchestrationWorkItemStarting(
+                    this.InstanceId,
+                    Utils.AppName,
+                    Utils.PackageVersion);
+        }
+
+        internal class RenewOrchestrationWorkItemCompleted : StructuredLogEvent, IEventSourceEvent
+        {
+            public RenewOrchestrationWorkItemCompleted(TaskOrchestrationWorkItem workItem)
+            {
+                this.InstanceId = workItem.InstanceId;
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.RenewOrchestrationWorkItemCompleted,
+                nameof(EventIds.RenewOrchestrationWorkItemCompleted));
+
+            public override LogLevel Level => LogLevel.Debug;
+
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Renewed orchestration work item";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.RenewOrchestrationWorkItemCompleted(
+                    this.InstanceId,
+                    Utils.AppName,
+                    Utils.PackageVersion);
+        }
+
+        internal class RenewOrchestrationWorkItemFailed : StructuredLogEvent, IEventSourceEvent
+        {
+            public RenewOrchestrationWorkItemFailed(TaskOrchestrationWorkItem workItem, Exception exception)
+            {
+                this.InstanceId = workItem.InstanceId;
+                this.Details = exception.ToString();
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.RenewOrchestrationWorkItemFailed,
+                nameof(EventIds.RenewOrchestrationWorkItemFailed));
+
+            public override LogLevel Level => LogLevel.Warning;
+
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Failed to renew orchestration work item: {this.Details}";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.RenewOrchestrationWorkItemFailed(
+                    this.InstanceId,
+                    this.Details,
+                    Utils.AppName,
+                    Utils.PackageVersion);
+        }
     }
 }

--- a/src/DurableTask.Core/Logging/LogHelper.cs
+++ b/src/DurableTask.Core/Logging/LogHelper.cs
@@ -523,6 +523,44 @@ namespace DurableTask.Core.Logging
                 this.WriteStructuredLog(new LogEvents.DiscardingMessage(workItem, message, reason));
             }
         }
+
+        /// <summary>
+        /// Logs that an orchestration work item renewal operation is starting.
+        /// </summary>
+        /// <param name="workItem">The work item to be renewed.</param>
+        internal void RenewOrchestrationWorkItemStarting(TaskOrchestrationWorkItem workItem)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.RenewOrchestrationWorkItemStarting(workItem));
+            }
+        }
+
+        /// <summary>
+        /// Logs that an orchestration work item renewal operation succeeded.
+        /// </summary>
+        /// <param name="workItem">The work item that was renewed.</param>
+        internal void RenewOrchestrationWorkItemCompleted(TaskOrchestrationWorkItem workItem)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.RenewOrchestrationWorkItemCompleted(workItem));
+            }
+        }
+
+        /// <summary>
+        /// Logs that an orchestration work item renewal operation failed.
+        /// </summary>
+        /// <param name="workItem">The work item that was to be renewed.</param>
+        /// <param name="exception">The renew failure exception.</param>
+        internal void RenewOrchestrationWorkItemFailed(TaskOrchestrationWorkItem workItem, Exception exception)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.RenewOrchestrationWorkItemFailed(workItem, exception), exception);
+            }
+        }
+
         #endregion
 
         #region Activity dispatcher

--- a/src/DurableTask.Core/Logging/StructuredEventSource.cs
+++ b/src/DurableTask.Core/Logging/StructuredEventSource.cs
@@ -813,5 +813,57 @@ namespace DurableTask.Core.Logging
                     ExtensionVersion);
             }
         }
+
+        [Event(EventIds.RenewOrchestrationWorkItemStarting, Level = EventLevel.Verbose, Version = 1)]
+        internal void RenewOrchestrationWorkItemStarting(
+            string InstanceId,
+            string AppName,
+            string ExtensionVersion)
+        {
+            if (this.IsEnabled(EventLevel.Verbose))
+            {
+                // TODO: Use WriteEventCore for better performance
+                this.WriteEvent(
+                    EventIds.RenewOrchestrationWorkItemStarting,
+                    InstanceId,
+                    AppName,
+                    ExtensionVersion);
+            }
+        }
+
+        [Event(EventIds.RenewOrchestrationWorkItemCompleted, Level = EventLevel.Verbose, Version = 1)]
+        internal void RenewOrchestrationWorkItemCompleted(
+            string InstanceId,
+            string AppName,
+            string ExtensionVersion)
+        {
+            if (this.IsEnabled(EventLevel.Verbose))
+            {
+                // TODO: Use WriteEventCore for better performance
+                this.WriteEvent(
+                    EventIds.RenewOrchestrationWorkItemCompleted,
+                    InstanceId,
+                    AppName,
+                    ExtensionVersion);
+            }
+        }
+
+        [Event(EventIds.RenewOrchestrationWorkItemFailed, Level = EventLevel.Error, Version = 1)]
+        internal void RenewOrchestrationWorkItemFailed(
+            string InstanceId,
+            string Details,
+            string AppName,
+            string ExtensionVersion)
+        {
+            if (this.IsEnabled(EventLevel.Error))
+            {
+                this.WriteEvent(
+                    EventIds.RenewOrchestrationWorkItemFailed,
+                    InstanceId,
+                    Details,
+                    AppName,
+                    ExtensionVersion);
+            }
+        }
     }
 }

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -147,6 +147,35 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
+        /// <summary>
+        /// End-to-end test which runs a slow orchestrator that causes work item renewal
+        /// </summary>
+        [DataTestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async Task LongRunningOrchestrator(bool enableExtendedSessions)
+        {
+            using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(
+                enableExtendedSessions,
+                modifySettingsAction: (AzureStorageOrchestrationServiceSettings settings) =>
+                {
+                    // set a short timeout so we can test that the renewal works
+                    settings.ControlQueueVisibilityTimeout = TimeSpan.FromSeconds(10);
+                }))
+            {
+                await host.StartAsync();
+
+                var client = await host.StartOrchestrationAsync(typeof(Orchestrations.LongRunningOrchestrator), "0");
+                var status = await client.WaitForCompletionAsync(StandardTimeout);
+
+                Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
+                Assert.AreEqual("ok", JToken.Parse(status?.Output));
+
+                await host.StopAsync();
+            }
+        }
+
+
         [TestMethod]
         public async Task GetAllOrchestrationStatuses()
         {
@@ -2333,6 +2362,23 @@ namespace DurableTask.AzureStorage.Tests
                     }
 
                     return base.RunTask(context, n);
+                }
+            }
+
+            internal class LongRunningOrchestrator : TaskOrchestration<string, string>
+            {
+                public override Task<string> RunTask(OrchestrationContext context, string input)
+                {
+                    Thread.Sleep(TimeSpan.FromSeconds(10));
+                    if (input == "0")
+                    {
+                        context.ContinueAsNew("1");
+                        return Task.FromResult("");
+                    }
+                    else
+                    {
+                        return Task.FromResult("ok");
+                    }
                 }
             }
 


### PR DESCRIPTION
This PR addresses a known weakness of the existing `TaskOrchestrationDispatcher`, namely that it does not always renew work items with the `IOrchestrationService`, which means they may expire prior to completing (see #112).

While this is rarely a problem (because typical orchestration work items complete very quickly) it has caused issues with entities in environments where long-running entity operations are used (see Azure/Azure-Functions#2337).

This PR fixes this problem.

- automatically renews TaskOrchestrationWorkItems in a expiration-time-based loop until they complete.
- adds a unit test to check that the renewal works.


