### PR TITLE
Add format check for blob Urls

### DIFF
--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -130,7 +130,13 @@ namespace DurableTask.AzureStorage
 
         internal static bool TryGetLargeMessageReference(string messagePayload, out Uri blobUrl)
         {
-            return Uri.TryCreate(messagePayload, UriKind.Absolute, out blobUrl);
+            if (Uri.IsWellFormedUriString(messagePayload, UriKind.Absolute))
+            {
+                return Uri.TryCreate(messagePayload, UriKind.Absolute, out blobUrl);
+            }
+
+            blobUrl = null;
+            return false;
         }
 
         public async Task<MessageData> DeserializeQueueMessageAsync(QueueMessage queueMessage, string queueName)

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -1755,6 +1755,33 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
+        /// <summary>
+        /// End-to-end test which validates that exception messages that are considered valid Urls in the Uri.TryCreate() method
+        /// are handled with an additional Uri format check
+        /// </summary>
+        [DataTestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async Task LargeTextMessagePayloads_URIFormatCheck(bool enableExtendedSessions)
+        {
+            using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(enableExtendedSessions, fetchLargeMessages: true))
+            {
+                await host.StartAsync();
+
+                string message = this.GenerateMediumRandomStringPayload().ToString();
+                var client = await host.StartOrchestrationAsync(typeof(Orchestrations.ThrowException), "durabletask.core.exceptions.taskfailedexception: Task failed with an unhandled exception: This is an invalid operation.)");
+                var status = await client.WaitForCompletionAsync(TimeSpan.FromMinutes(2));
+
+                //Ensure that orchestration state querying also retrieves messages 
+                status = (await client.GetStateAsync(status.OrchestrationInstance.InstanceId)).First();
+
+                Assert.AreEqual(OrchestrationStatus.Failed, status?.OrchestrationStatus);
+                Assert.IsTrue(status?.Output.Contains("invalid operation") == true);
+
+                await host.StopAsync();
+            }
+        }
+
         private StringBuilder GenerateMediumRandomStringPayload(int numChars = 128*1024, short utf8ByteSize = 1, short utf16ByteSize = 2)
         {
             string Chars;
@@ -2745,6 +2772,24 @@ namespace DurableTask.AzureStorage.Tests
                     {
                         this.waitForApprovalHandle.SetResult(approvalResult);
                     }
+                }
+            }
+
+            [KnownType(typeof(Activities.Throw))]
+            internal class ThrowException : TaskOrchestration<string, string>
+            {
+                public override async Task<string> RunTask(OrchestrationContext context, string message)
+                {
+                    if (string.IsNullOrEmpty(message))
+                    {
+                        // This throw happens directly in the orchestration.
+                        throw new Exception(message);
+                    }
+
+                    // This throw happens in the implementation of an activity.
+                    await context.ScheduleTask<string>(typeof(Activities.Throw), message);
+                    return null;
+
                 }
             }
 


### PR DESCRIPTION
This issue is originally mentioned in [this comment](https://github.com/Azure/durabletask/pull/853#discussion_r1087081311) from PR #853.

This PR adds a format check for the message before creating a URI. There are some cases where `Uri.TryCreate()` doesn't check the format of its input and `Uri.IsWellFormedUriString()` covers those cases.