### PR TITLE
Fix Bugs in new v12 Azure Storage

### DIFF
--- a/Test/DurableTask.AzureStorage.Tests/MessageManagerTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/MessageManagerTests.cs
@@ -25,13 +25,13 @@ namespace DurableTask.AzureStorage.Tests
         [DataRow("foo/bar/b@z.tar.gz")]
         public void GetBlobUrlUnescaped(string blob)
         {
-            const string container = "@entity12345";
             var settings = new AzureStorageOrchestrationServiceSettings
             {
                 StorageAccountClientProvider = new StorageAccountClientProvider("UseDevelopmentStorage=true"),
             };
 
-            var manager = new MessageManager(settings, new AzureStorageClient(settings), "@entity12345");
+            const string container = "@entity12345";
+            var manager = new MessageManager(settings, new AzureStorageClient(settings), container);
             Assert.AreEqual("http://127.0.0.1:10000/devstoreaccount1/" + container + "/" + blob, manager.GetBlobUrl(blob));
         }
     }

--- a/Test/DurableTask.AzureStorage.Tests/MessageManagerTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/MessageManagerTests.cs
@@ -1,0 +1,38 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+#nullable enable
+namespace DurableTask.AzureStorage.Tests
+{
+    using DurableTask.AzureStorage.Storage;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class MessageManagerTests
+    {
+        [DataTestMethod]
+        [DataRow("blob.bin")]
+        [DataRow("@#$%!")]
+        [DataRow("foo/bar/b@z.tar.gz")]
+        public void GetBlobUrlUnescaped(string blob)
+        {
+            const string container = "@entity12345";
+            var settings = new AzureStorageOrchestrationServiceSettings
+            {
+                StorageAccountClientProvider = new StorageAccountClientProvider("UseDevelopmentStorage=true"),
+            };
+
+            var manager = new MessageManager(settings, new AzureStorageClient(settings), "@entity12345");
+            Assert.AreEqual("http://127.0.0.1:10000/devstoreaccount1/" + container + "/" + blob, manager.GetBlobUrl(blob));
+        }
+    }
+}

--- a/Test/DurableTask.AzureStorage.Tests/MessageManagerTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/MessageManagerTests.cs
@@ -32,7 +32,8 @@ namespace DurableTask.AzureStorage.Tests
 
             const string container = "@entity12345";
             var manager = new MessageManager(settings, new AzureStorageClient(settings), container);
-            Assert.AreEqual("http://127.0.0.1:10000/devstoreaccount1/" + container + "/" + blob, manager.GetBlobUrl(blob));
+            var expected = $"http://127.0.0.1:10000/devstoreaccount1/{container}/{blob}";
+            Assert.AreEqual(expected, manager.GetBlobUrl(blob));
         }
     }
 }

--- a/Test/DurableTask.AzureStorage.Tests/MessageManagerTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/MessageManagerTests.cs
@@ -26,7 +26,6 @@ namespace DurableTask.AzureStorage.Tests
         [DataTestMethod]
         [DataRow("System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib],[System.String, System.Private.CoreLib]]")]
         [DataRow("System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.String, mscorlib]]")]
-
         public void DeserializesStandardTypes(string dictionaryType)
         {
             // Given
@@ -101,10 +100,7 @@ namespace DurableTask.AzureStorage.Tests
                 });
 
             return new MessageManager(
-                new AzureStorageOrchestrationServiceSettings
-                {
-                    CustomMessageTypeBinder = binder
-                },
+                new AzureStorageOrchestrationServiceSettings { CustomMessageTypeBinder = binder },
                 azureStorageClient,
                 "$root");
         }

--- a/Test/DurableTask.AzureStorage.Tests/MessageManagerTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/MessageManagerTests.cs
@@ -13,12 +13,63 @@
 #nullable enable
 namespace DurableTask.AzureStorage.Tests
 {
+    using System;
+    using System.Collections.Generic;
     using DurableTask.AzureStorage.Storage;
+    using DurableTask.Core.History;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json;
 
     [TestClass]
     public class MessageManagerTests
     {
+        [DataTestMethod]
+        [DataRow("System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib],[System.String, System.Private.CoreLib]]")]
+        [DataRow("System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.String, mscorlib]]")]
+
+        public void DeserializesStandardTypes(string dictionaryType)
+        {
+            // Given
+            var message = GetMessage(dictionaryType);
+            var messageManager = SetupMessageManager(new PrimitiveTypeBinder());
+
+            // When
+            var deserializedMessage = messageManager.DeserializeMessageData(message);
+
+            // Then
+            Assert.IsInstanceOfType(deserializedMessage.TaskMessage.Event, typeof(ExecutionStartedEvent));
+            ExecutionStartedEvent startedEvent = (ExecutionStartedEvent)deserializedMessage.TaskMessage.Event;
+            Assert.AreEqual("tagValue", startedEvent.Tags["tag1"]);
+        }
+
+        [TestMethod]
+        public void FailsDeserializingUnknownTypes()
+        {
+            // Given
+            var message = GetMessage("RandomType");
+            var messageManager = SetupMessageManager(new KnownTypeBinder());
+
+            // When/Then
+            Assert.ThrowsException<JsonSerializationException>(() => messageManager.DeserializeMessageData(message));
+        }
+
+
+        [TestMethod]
+        public void DeserializesCustomTypes()
+        {
+            // Given
+            var message = GetMessage("KnownType");
+            var messageManager = SetupMessageManager(new KnownTypeBinder());
+
+            // When
+            var deserializedMessage = messageManager.DeserializeMessageData(message);
+
+            // Then
+            Assert.IsInstanceOfType(deserializedMessage.TaskMessage.Event, typeof(ExecutionStartedEvent));
+            ExecutionStartedEvent startedEvent = (ExecutionStartedEvent)deserializedMessage.TaskMessage.Event;
+            Assert.AreEqual("tagValue", startedEvent.Tags["tag1"]);
+        }
+
         [DataTestMethod]
         [DataRow("blob.bin")]
         [DataRow("@#$%!")]
@@ -34,6 +85,71 @@ namespace DurableTask.AzureStorage.Tests
             var manager = new MessageManager(settings, new AzureStorageClient(settings), container);
             var expected = $"http://127.0.0.1:10000/devstoreaccount1/{container}/{blob}";
             Assert.AreEqual(expected, manager.GetBlobUrl(blob));
+        }
+
+        private string GetMessage(string dictionaryType)
+            => "{\"$type\":\"DurableTask.AzureStorage.MessageData\",\"ActivityId\":\"5406d369-4369-4673-afae-6671a2fa1e57\",\"TaskMessage\":{\"$type\":\"DurableTask.Core.TaskMessage\",\"Event\":{\"$type\":\"DurableTask.Core.History.ExecutionStartedEvent\",\"OrchestrationInstance\":{\"$type\":\"DurableTask.Core.OrchestrationInstance\",\"InstanceId\":\"2.2-34a2c9d4-306e-4467-8470-a8018b2e4f11\",\"ExecutionId\":\"aae324dcc8f943e490b37ec5e5bbf9da\"},\"EventType\":0,\"ParentInstance\":null,\"Name\":\"OrchestrationName\",\"Version\":\"2.0\",\"Input\":\"input\",\"Tags\":{\"$type\":\""
+            + dictionaryType
+            + "\",\"tag1\":\"tagValue\"},\"Correlation\":null,\"ScheduledStartTime\":null,\"Generation\":0,\"EventId\":-1,\"IsPlayed\":false,\"Timestamp\":\"2023-03-24T20:53:05.9093518Z\"},\"SequenceNumber\":0,\"OrchestrationInstance\":{\"$type\":\"DurableTask.Core.OrchestrationInstance\",\"InstanceId\":\"2.2-34a2c9d4-306e-4467-8470-a8018b2e4f11\",\"ExecutionId\":\"aae324dcc8f943e490b37ec5e5bbf9da\"}},\"CompressedBlobName\":null,\"SequenceNumber\":40,\"Sender\":{\"InstanceId\":\"\",\"ExecutionId\":\"\"},\"SerializableTraceContext\":null}\r\n\r\n";
+
+        private MessageManager SetupMessageManager(ICustomTypeBinder binder)
+        {
+            var azureStorageClient = new AzureStorageClient(
+                new AzureStorageOrchestrationServiceSettings
+                {
+                    StorageAccountClientProvider = new StorageAccountClientProvider("UseDevelopmentStorage=true"),
+                });
+
+            return new MessageManager(
+                new AzureStorageOrchestrationServiceSettings
+                {
+                    CustomMessageTypeBinder = binder
+                },
+                azureStorageClient,
+                "$root");
+        }
+    }
+
+    internal class KnownTypeBinder : ICustomTypeBinder
+    {
+        public void BindToName(Type serializedType, out string assemblyName, out string typeName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Type? BindToType(string assemblyName, string typeName)
+        {
+            if (typeName == "KnownType")
+            {
+                return typeof(Dictionary<string, string>);
+            }
+
+            return null;
+        }
+    }
+
+    internal class PrimitiveTypeBinder : ICustomTypeBinder
+    {
+        readonly bool hasStandardLib;
+
+        public PrimitiveTypeBinder() 
+        {
+            hasStandardLib = typeof(string).AssemblyQualifiedName!.Contains("mscorlib");
+        }
+
+        public void BindToName(Type serializedType, out string assemblyName, out string typeName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Type BindToType(string assemblyName, string typeName)
+        {
+            if (hasStandardLib)
+            {
+                return Type.GetType(typeName.Replace("System.Private.CoreLib", "mscorlib"))!;
+            }
+
+            return Type.GetType(typeName.Replace("mscorlib", "System.Private.CoreLib"))!;
         }
     }
 }

--- a/Test/DurableTask.AzureStorage.Tests/Net/UriPathTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/Net/UriPathTests.cs
@@ -19,11 +19,15 @@ namespace DurableTask.AzureStorage.Net
     public class UriPathTests
     {
         [DataTestMethod]
+        [DataRow("", "", "")]
         [DataRow("", "bar/baz", "bar/baz")]
         [DataRow("foo", "", "foo")]
+        [DataRow("foo", "/", "foo/")]
         [DataRow("foo", "bar", "foo/bar")]
-        [DataRow("foo/", "bar", "foo/bar")]
         [DataRow("foo", "/bar", "foo/bar")]
+        [DataRow("foo/", "", "foo/")]
+        [DataRow("foo/", "/", "foo/")]
+        [DataRow("foo/", "bar", "foo/bar")]
         [DataRow("foo/", "/bar", "foo/bar")]
         [DataRow("/foo//", "//bar/baz", "/foo///bar/baz")]
         public void Combine(string path1, string path2, string expected)

--- a/Test/DurableTask.AzureStorage.Tests/Net/UriPathTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/Net/UriPathTests.cs
@@ -1,0 +1,34 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+#nullable enable
+namespace DurableTask.AzureStorage.Net
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class UriPathTests
+    {
+        [DataTestMethod]
+        [DataRow("", "bar/baz", "bar/baz")]
+        [DataRow("foo", "", "foo")]
+        [DataRow("foo", "bar", "foo/bar")]
+        [DataRow("foo/", "bar", "foo/bar")]
+        [DataRow("foo", "/bar", "foo/bar")]
+        [DataRow("foo/", "/bar", "foo/bar")]
+        [DataRow("/foo//", "//bar/baz", "/foo///bar/baz")]
+        public void Combine(string path1, string path2, string expected)
+        {
+            Assert.AreEqual(expected, UriPath.Combine(path1, path2));
+        }
+    }
+}

--- a/Test/DurableTask.AzureStorage.Tests/Storage/TableClientExtensionsTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/Storage/TableClientExtensionsTests.cs
@@ -1,0 +1,52 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureStorage.Tests.Storage
+{
+    using System;
+    using Azure.Data.Tables;
+    using DurableTask.AzureStorage.Storage;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class TableClientExtensionsTests
+    {
+        const string EmulatorAccountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+
+        [TestMethod]
+        public void GetUri_ConnectionString()
+        {
+            TableClient client;
+
+            client = new TableClient("UseDevelopmentStorage=true", "bar");
+            Assert.AreEqual(new Uri("http://127.0.0.1:10002/devstoreaccount1/bar"), client.GetUri());
+
+            client = new TableClient($"DefaultEndpointsProtocol=https;AccountName=foo;AccountKey={EmulatorAccountKey};TableEndpoint=https://foo.table.core.windows.net/;", "bar");
+            Assert.AreEqual(new Uri("https://foo.table.core.windows.net/bar"), client.GetUri());
+        }
+
+        [TestMethod]
+        public void GetUri_ServiceEndpoint()
+        {
+            var client = new TableClient(new Uri("https://foo.table.core.windows.net/"), "bar", new TableSharedKeyCredential("foo", EmulatorAccountKey));
+            Assert.AreEqual(new Uri("https://foo.table.core.windows.net/bar"), client.GetUri());
+        }
+
+        [TestMethod]
+        public void GetUri_TableEndpoint()
+        {
+            var client = new TableClient(new Uri("https://foo.table.core.windows.net/bar"));
+            Assert.AreEqual(new Uri("https://foo.table.core.windows.net/bar"), client.GetUri());
+        }
+    }
+}

--- a/Test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
+++ b/Test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
@@ -61,16 +61,16 @@ namespace DurableTask.Core.Tests
             if (mode == ErrorPropagationMode.SerializeExceptions)
             {
                 // The exception should be deserializable
-                InvalidOperationException e = JsonConvert.DeserializeObject<InvalidOperationException>(state.Output);
+                InvalidOperationException? e = JsonConvert.DeserializeObject<InvalidOperationException>(state.Output);
                 Assert.IsNotNull(e);
-                Assert.AreEqual("This is a test exception", e.Message);
+                Assert.AreEqual("This is a test exception", e!.Message);
             }
             else if (mode == ErrorPropagationMode.UseFailureDetails)
             {
                 // The failure details should contain the relevant exception metadata
-                FailureDetails details = JsonConvert.DeserializeObject<FailureDetails>(state.Output);
+                FailureDetails? details = JsonConvert.DeserializeObject<FailureDetails>(state.Output);
                 Assert.IsNotNull(details);
-                Assert.AreEqual(typeof(InvalidOperationException).FullName, details.ErrorType);
+                Assert.AreEqual(typeof(InvalidOperationException).FullName, details!.ErrorType);
                 Assert.IsTrue(details.IsCausedBy<InvalidOperationException>());
                 Assert.IsTrue(details.IsCausedBy<Exception>()); // check that base types work too
                 Assert.AreEqual("This is a test exception", details.ErrorMessage);

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -138,16 +138,16 @@ steps:
     packDirectory: $(build.artifactStagingDirectory)
     packagesToPack: 'src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj'
 
-# - task: DotNetCoreCLI@2
-#   displayName: Generate nuget packages
-#   inputs:
-#     command: pack
-#     verbosityPack: Minimal
-#     configuration: Release
-#     nobuild: true
-#     packDirectory: $(build.artifactStagingDirectory)
-#     packagesToPack: 'src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj'
-#     buildProperties: 'Platform=x64'
+- task: DotNetCoreCLI@2
+  displayName: Generate nuget packages
+  inputs:
+    command: pack
+    verbosityPack: Minimal
+    configuration: Release
+    nobuild: true
+    packDirectory: $(build.artifactStagingDirectory)
+    packagesToPack: 'src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj'
+    buildProperties: 'Platform=x64'
 
 # Digitally sign all the nuget packages with the Microsoft certificate.
 # This appears to be an in-place signing job, which is convenient.

--- a/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
+++ b/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
@@ -6,7 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Microsoft.Azure.DurableTask.AzureServiceFabric</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.3.6</Version>
+    <Version>2.3.7</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <Title>Azure Service Fabric provider extension for the Durable Task Framework.</Title>

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -150,7 +150,7 @@ namespace DurableTask.AzureStorage
         public bool UseAppLease { get; set; } = true;
 
         /// <summary>
-        /// If UseAppLease is true, gets or sets the AppLeaaseOptions used for acquiring the lease to start the application.
+        /// If UseAppLease is true, gets or sets the AppLeaseOptions used for acquiring the lease to start the application.
         /// </summary>
         public AppLeaseOptions AppLeaseOptions { get; set; } = AppLeaseOptions.DefaultOptions;
 
@@ -160,13 +160,12 @@ namespace DurableTask.AzureStorage
         public StorageAccountClientProvider? StorageAccountClientProvider { get; set; }
 
         /// <summary>
-        /// Gets or sets the storage provider for Azure Table Storage, which is used for the Tracking Store
-        /// that records the progress of orchestrations and entities.
+        /// Gets or sets the optional client provider for the Tracking Store that records the progress of orchestrations and entities.
         /// </summary>
         /// <remarks>
         /// If the value is <see langword="null"/>, then the <see cref="StorageAccountClientProvider"/> is used instead.
         /// </remarks>
-        public IStorageServiceClientProvider<TableServiceClient, TableClientOptions>? TrackingServiceClientProvider { get; set; }
+        public TrackingServiceClientProvider? TrackingServiceClientProvider { get; set; }
 
         /// <summary>
         ///  Should we carry over unexecuted raised events to the next iteration of an orchestration on ContinueAsNew
@@ -198,6 +197,11 @@ namespace DurableTask.AzureStorage
         /// Gets or sets a value indicating whether to disable the ExecutionStarted de-duplication logic.
         /// </summary>
         public bool DisableExecutionStartedDeduplication { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional custom type binder used when trying to deserialize queued messages.
+        /// </summary>
+        public ICustomTypeBinder? CustomMessageTypeBinder { get; set; }
 
         /// <summary>
         /// Returns bool indicating is the <see cref="TrackingServiceClientProvider"/> has been set.

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -8,11 +8,11 @@
     <Description>Azure Storage provider extension for the Durable Task Framework.</Description>
     <PackageTags>Azure Task Durable Orchestration Workflow Activity Reliable AzureStorage</PackageTags>
     <PackageId>Microsoft.Azure.DurableTask.AzureStorage</PackageId>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl> 
-    <EmbedUntrackedSources>true</EmbedUntrackedSources> 
-    <DebugSymbols>true</DebugSymbols> 
-    <DebugType>embedded</DebugType> 
-    <IncludeSymbols>false</IncludeSymbols> 
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>embedded</DebugType>
+    <IncludeSymbols>false</IncludeSymbols>
     <!--NuGet licenseUrl and PackageIconUrl/iconUrl deprecation. -->
     <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -24,7 +24,7 @@
     <PatchVersion>0</PatchVersion>
 
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
-    <VersionSuffix>preview.1</VersionSuffix>
+    <VersionSuffix>preview.2</VersionSuffix>
     <FileVersion>$(VersionPrefix).0</FileVersion>
     <!-- FileVersionRevision is expected to be set by the CI. This is useful for distinguishing between multiple builds of the same version. -->
     <FileVersion Condition="'$(FileVersionRevision)' != ''">$(VersionPrefix).$(FileVersionRevision)</FileVersion>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -35,11 +35,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.27.0" />
-    <PackageReference Include="Azure.Data.Tables" Version="12.7.1" />
+    <PackageReference Include="Azure.Core" Version="1.31.0" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.8.0" />
     <!-- The below version of Azure.Storage.Blobs must align with the Functions Host -->
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.12.0" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.14.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -51,7 +51,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -34,12 +34,15 @@
     <Version>$(VersionPrefix)-$(VersionSuffix)</Version>
   </PropertyGroup>
 
+  <!-- The below versions must align with the Functions Host -->
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.31.0" />
-    <PackageReference Include="Azure.Data.Tables" Version="12.8.0" />
-    <!-- The below version of Azure.Storage.Blobs must align with the Functions Host -->
+    <PackageReference Include="Azure.Core" Version="1.25.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.14.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Data.Tables" Version="12.6.1" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.12.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>

--- a/src/DurableTask.AzureStorage/ICustomTypeBinder.cs
+++ b/src/DurableTask.AzureStorage/ICustomTypeBinder.cs
@@ -1,0 +1,41 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+using System;
+
+namespace DurableTask.AzureStorage
+{
+    /// <summary>
+    /// Abstraction to prevent surfacing the dynamic loading between System.Runtime.Serialization.SerializationBinder and Newtonsoft.Json.Serialization.ISerializationBinder
+    /// Used when deserializing QueueMessages to MessageData to allow providing custom type binding. 
+    /// Does not support custom bindings for DurableTask types
+    /// </summary>
+    public interface ICustomTypeBinder
+    {
+        /// <summary>
+        /// When implemented, controls the binding of a serialized object to a type.
+        /// </summary>
+        /// <param name="serializedType">The type of the object the formatter creates a new instance of.</param>
+        /// <param name="assemblyName">Specifies the System.Reflection.Assembly name of the serialized object.</param>
+        /// <param name="typeName">Specifies the System.Type name of the serialized object.</param>
+        void BindToName(Type serializedType, out string assemblyName, out string typeName);
+
+        /// <summary>
+        /// When implemented, controls the binding of a serialized object to a type.
+        /// </summary>
+        /// <param name="assemblyName">Specifies the System.Reflection.Assembly name of the serialized object.</param>
+        /// <param name="typeName">Specifies the System.Type name of the serialized object</param>
+        /// <returns>The type of the object the formatter creates a new instance of.</returns>
+        Type BindToType(string assemblyName, string typeName);
+    }
+}

--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -233,7 +233,7 @@ namespace DurableTask.AzureStorage
 
         public string GetBlobUrl(string blobName)
         {
-            return this.blobContainer.GetBlobReference(blobName).AbsoluteUri;
+            return Uri.UnescapeDataString(this.blobContainer.GetBlobReference(blobName).Uri.AbsoluteUri);
         }
 
         public ArraySegment<byte> Decompress(Stream blobStream)

--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -138,7 +138,13 @@ namespace DurableTask.AzureStorage
 
         internal static bool TryGetLargeMessageReference(string messagePayload, out Uri blobUrl)
         {
-            return Uri.TryCreate(messagePayload, UriKind.Absolute, out blobUrl);
+            if (Uri.IsWellFormedUriString(messagePayload, UriKind.Absolute))
+            {
+                return Uri.TryCreate(messagePayload, UriKind.Absolute, out blobUrl);
+            }
+
+            blobUrl = null;
+            return false;
         }
 
         public async Task<MessageData> DeserializeQueueMessageAsync(QueueMessage queueMessage, string queueName, CancellationToken cancellationToken = default)

--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -62,9 +62,9 @@ namespace DurableTask.AzureStorage
             {
                 TypeNameHandling = TypeNameHandling.Objects,
 #if NETSTANDARD2_0
-                SerializationBinder = new TypeNameSerializationBinder(),
+                SerializationBinder = new TypeNameSerializationBinder(settings.CustomMessageTypeBinder),
 #else
-                Binder = new TypeNameSerializationBinder(),
+                Binder = new TypeNameSerializationBinder(settings.CustomMessageTypeBinder),
 #endif
             };
             this.serializer = JsonSerializer.Create(taskMessageSerializerSettings);
@@ -318,27 +318,39 @@ namespace DurableTask.AzureStorage
 #if NETSTANDARD2_0
     class TypeNameSerializationBinder : ISerializationBinder
     {
+        readonly ICustomTypeBinder customBinder;
+        public TypeNameSerializationBinder(ICustomTypeBinder customBinder) 
+        {
+            this.customBinder = customBinder;
+        }
+
         public void BindToName(Type serializedType, out string assemblyName, out string typeName)
         {
-            TypeNameSerializationHelper.BindToName(serializedType, out assemblyName, out typeName);
+            TypeNameSerializationHelper.BindToName(customBinder, serializedType, out assemblyName, out typeName);
         }
 
         public Type BindToType(string assemblyName, string typeName)
         {
-            return TypeNameSerializationHelper.BindToType(assemblyName, typeName);
+            return TypeNameSerializationHelper.BindToType(customBinder, assemblyName, typeName);
         }
     }
 #else
     class TypeNameSerializationBinder : SerializationBinder
     {
+        readonly ICustomTypeBinder customBinder;
+        public TypeNameSerializationBinder(ICustomTypeBinder customBinder)
+        {
+            this.customBinder = customBinder;
+        }
+
         public override void BindToName(Type serializedType, out string assemblyName, out string typeName)
         {
-            TypeNameSerializationHelper.BindToName(serializedType, out assemblyName, out typeName);
+            TypeNameSerializationHelper.BindToName(customBinder, serializedType, out assemblyName, out typeName);
         }
 
         public override Type BindToType(string assemblyName, string typeName)
         {
-            return TypeNameSerializationHelper.BindToType(assemblyName, typeName);
+            return TypeNameSerializationHelper.BindToType(customBinder, assemblyName, typeName);
         }
     }
 #endif
@@ -347,13 +359,20 @@ namespace DurableTask.AzureStorage
         static readonly Assembly DurableTaskCore = typeof(DurableTask.Core.TaskMessage).Assembly;
         static readonly Assembly DurableTaskAzureStorage = typeof(AzureStorageOrchestrationService).Assembly;
 
-        public static void BindToName(Type serializedType, out string assemblyName, out string typeName)
+        public static void BindToName(ICustomTypeBinder customBinder, Type serializedType, out string assemblyName, out string typeName)
         {
-            assemblyName = null;
-            typeName = serializedType.FullName;
+            if (customBinder != null)
+            {
+                customBinder.BindToName(serializedType, out assemblyName, out typeName);
+            }
+            else
+            {
+                assemblyName = null;
+                typeName = serializedType.FullName;
+            }
         }
 
-        public static Type BindToType(string assemblyName, string typeName)
+        public static Type BindToType(ICustomTypeBinder customBinder, string assemblyName, string typeName)
         {
             if (typeName.StartsWith("DurableTask.Core"))
             {
@@ -364,7 +383,7 @@ namespace DurableTask.AzureStorage
                 return DurableTaskAzureStorage.GetType(typeName, throwOnError: true);
             }
 
-            return Type.GetType(typeName, throwOnError: true);
+            return customBinder?.BindToType(assemblyName, typeName) ?? Type.GetType(typeName, throwOnError: true);
         }
     }
 }

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -185,7 +185,7 @@ namespace DurableTask.AzureStorage.Messaging
                     }
                 }
 
-                this.Release(CloseReason.Shutdown, "ControlQueue GetMessagesAsync");
+                this.Release(CloseReason.Shutdown, $"ControlQueue GetMessagesAsync cancelled by: {(this.releaseCancellationToken.IsCancellationRequested ? "control queue released token cancelled" : "")} {(cancellationToken.IsCancellationRequested ? "shutdown token cancelled" : "")}");
                 return EmptyMessageList;
             }
         }

--- a/src/DurableTask.AzureStorage/Net/UriPath.cs
+++ b/src/DurableTask.AzureStorage/Net/UriPath.cs
@@ -1,0 +1,55 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+#nullable enable
+namespace DurableTask.AzureStorage.Net
+{
+    using System;
+
+    static class UriPath
+    {
+        public static string Combine(string path1, string path2)
+        {
+            if (path1 == null)
+            {
+                throw new ArgumentNullException(nameof(path1));
+            }
+
+            if (path2 == null)
+            {
+                throw new ArgumentNullException(nameof(path2));
+            }
+
+            if (path1.Length == 0)
+            {
+                return path2;
+            }
+            else if (path2.Length == 0)
+            {
+                return path1;
+            }
+
+            if (path1[path1.Length - 1] == '/')
+            {
+                return path2[0] == '/' ? path1 + path2.Substring(1) : path1 + path2;
+            }
+            else if (path2[0] == '/')
+            {
+                return path1 + path2;
+            }
+            else
+            {
+                return path1 + '/' + path2;
+            }
+        }
+    }
+}

--- a/src/DurableTask.AzureStorage/Net/UriPath.cs
+++ b/src/DurableTask.AzureStorage/Net/UriPath.cs
@@ -38,16 +38,22 @@ namespace DurableTask.AzureStorage.Net
                 return path1;
             }
 
+            // Path1 ends with a '/'
+            // E.g. path1 = "foo/"
             if (path1[path1.Length - 1] == '/')
             {
-                return path2[0] == '/' ? path1 + path2.Substring(1) : path1 + path2;
+                return path2[0] == '/'
+                    ? path1 + path2.Substring(1) // E.g. Combine("foo/", "/bar") == "foo/bar"
+                    : path1 + path2;             // E.g. Combine("foo/", "bar") == "foo/bar"
             }
             else if (path2[0] == '/')
             {
+                // E.g. Combine("foo", "/bar") == "foo/bar"
                 return path1 + path2;
             }
             else
             {
+                // E.g. Combine("foo", "bar") == "foo/bar"
                 return path1 + '/' + path2;
             }
         }

--- a/src/DurableTask.AzureStorage/Storage/AzureStorageClient.cs
+++ b/src/DurableTask.AzureStorage/Storage/AzureStorageClient.cs
@@ -46,13 +46,17 @@ namespace DurableTask.AzureStorage.Storage
             var timeoutPolicy = new LeaseTimeoutHttpPipelinePolicy(this.Settings.LeaseRenewInterval);
             var monitoringPolicy = new MonitoringHttpPipelinePolicy(this.Stats);
 
-            this.blobClient = CreateClient(settings.StorageAccountClientProvider.Blob, ConfigureClientPolicies);
             this.queueClient = CreateClient(settings.StorageAccountClientProvider.Queue, ConfigureClientPolicies);
-            this.tableClient = CreateClient(
-                settings.HasTrackingStoreStorageAccount
-                    ? settings.TrackingServiceClientProvider!
-                    : settings.StorageAccountClientProvider.Table,
-                ConfigureClientPolicies);
+            if (settings.HasTrackingStoreStorageAccount)
+            {
+                this.blobClient = CreateClient(settings.TrackingServiceClientProvider!.Blob, ConfigureClientPolicies);
+                this.tableClient = CreateClient(settings.TrackingServiceClientProvider!.Table, ConfigureClientPolicies);
+            }
+            else
+            {
+                this.blobClient = CreateClient(settings.StorageAccountClientProvider.Blob, ConfigureClientPolicies);
+                this.tableClient = CreateClient(settings.StorageAccountClientProvider.Table, ConfigureClientPolicies);
+            }
 
             void ConfigureClientPolicies<TClientOptions>(TClientOptions options) where TClientOptions : ClientOptions
             {

--- a/src/DurableTask.AzureStorage/Storage/BlobContainer.cs
+++ b/src/DurableTask.AzureStorage/Storage/BlobContainer.cs
@@ -14,15 +14,13 @@
 namespace DurableTask.AzureStorage.Storage
 {
     using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Azure;
     using Azure.Storage.Blobs;
     using Azure.Storage.Blobs.Models;
     using Azure.Storage.Blobs.Specialized;
+    using DurableTask.AzureStorage.Net;
 
     class BlobContainer
     {
@@ -40,7 +38,7 @@ namespace DurableTask.AzureStorage.Storage
 
         public Blob GetBlobReference(string blobName, string? blobPrefix = null)
         {
-            string fullBlobName = blobPrefix != null ? Path.Combine(blobPrefix, blobName) : blobName;
+            string fullBlobName = blobPrefix != null ? UriPath.Combine(blobPrefix, blobName) : blobName;
             return this.azureStorageClient.GetBlobReference(this.containerName, fullBlobName);
         }
 

--- a/src/DurableTask.AzureStorage/Storage/Queue.cs
+++ b/src/DurableTask.AzureStorage/Storage/Queue.cs
@@ -32,12 +32,10 @@ namespace DurableTask.AzureStorage.Storage
         {
             this.azureStorageClient = azureStorageClient;
             this.stats = this.azureStorageClient.Stats;
-            this.Name = queueName;
-
-            this.queueClient = queueServiceClient.GetQueueClient(this.Name);
+            this.queueClient = queueServiceClient.GetQueueClient(queueName);
         }
 
-        public string Name { get; }
+        public string Name => this.queueClient.Name;
 
         public Uri Uri => this.queueClient.Uri;
 

--- a/src/DurableTask.AzureStorage/Storage/Table.cs
+++ b/src/DurableTask.AzureStorage/Storage/Table.cs
@@ -42,7 +42,7 @@ namespace DurableTask.AzureStorage.Storage
 
         public string Name => this.tableClient.Name;
 
-        internal Uri Uri => this.tableClient.Uri;
+        internal Uri? Uri => this.tableClient.GetUri(); // TODO: Replace with Uri property
 
         public async Task<bool> CreateIfNotExistsAsync(CancellationToken cancellationToken = default)
         {

--- a/src/DurableTask.AzureStorage/Storage/Table.cs
+++ b/src/DurableTask.AzureStorage/Storage/Table.cs
@@ -34,14 +34,13 @@ namespace DurableTask.AzureStorage.Storage
         public Table(AzureStorageClient azureStorageClient, TableServiceClient tableServiceClient, string tableName)
         {
             this.azureStorageClient = azureStorageClient;
-            this.Name = tableName;
             this.stats = this.azureStorageClient.Stats;
 
             this.tableServiceClient = tableServiceClient;
             this.tableClient = tableServiceClient.GetTableClient(tableName);
         }
 
-        public string Name { get; }
+        public string Name => this.tableClient.Name;
 
         internal Uri Uri => this.tableClient.Uri;
 

--- a/src/DurableTask.AzureStorage/Storage/TableClientExtensions.cs
+++ b/src/DurableTask.AzureStorage/Storage/TableClientExtensions.cs
@@ -1,0 +1,49 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+#nullable enable
+namespace DurableTask.AzureStorage.Storage
+{
+    using System;
+    using System.Linq.Expressions;
+    using System.Reflection;
+    using Azure.Data.Tables;
+
+    static class TableClientExtensions
+    {
+        public static Uri? GetUri(this TableClient tableClient)
+        {
+            if (tableClient == null)
+            {
+                throw new ArgumentNullException(nameof(tableClient));
+            }
+
+            Uri? endpoint = GetEndpointFunc(tableClient);
+            return endpoint != null ? new TableUriBuilder(endpoint) { Tablename = tableClient.Name }.ToUri() : null;
+        }
+
+        static readonly Func<TableClient, Uri?> GetEndpointFunc = CreateGetEndpointFunc();
+
+        static Func<TableClient, Uri?> CreateGetEndpointFunc()
+        {
+            Type tableClientType = typeof(TableClient);
+            ParameterExpression clientParam = Expression.Parameter(typeof(TableClient), "client");
+            FieldInfo? endpointField = tableClientType.GetField("_endpoint", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            Expression<Func<TableClient, Uri?>> lambdaExpr = endpointField != null
+                ? Expression.Lambda<Func<TableClient, Uri?>>(Expression.Field(clientParam, endpointField), clientParam)
+                : Expression.Lambda<Func<TableClient, Uri?>>(Expression.Constant(null, typeof(Uri)), clientParam);
+
+            return lambdaExpr.Compile();
+        }
+    }
+}

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -787,8 +787,11 @@ namespace DurableTask.AzureStorage.Tracking
         /// <inheritdoc />
         public override Task StartAsync(CancellationToken cancellationToken = default)
         {
-            ServicePointManager.FindServicePoint(this.HistoryTable.Uri).UseNagleAlgorithm = false;
-            ServicePointManager.FindServicePoint(this.InstancesTable.Uri).UseNagleAlgorithm = false;
+            if (this.HistoryTable.Uri != null)
+                ServicePointManager.FindServicePoint(this.HistoryTable.Uri).UseNagleAlgorithm = false;
+
+            if (this.InstancesTable.Uri != null)
+                ServicePointManager.FindServicePoint(this.InstancesTable.Uri).UseNagleAlgorithm = false;
 
             return Task.CompletedTask;
         }

--- a/src/DurableTask.AzureStorage/TrackingServiceClientProvider.cs
+++ b/src/DurableTask.AzureStorage/TrackingServiceClientProvider.cs
@@ -18,30 +18,28 @@ namespace DurableTask.AzureStorage
     using Azure.Core;
     using Azure.Data.Tables;
     using Azure.Storage.Blobs;
-    using Azure.Storage.Queues;
 
     /// <summary>
-    /// Represents a client provider for the services exposed by an Azure Storage Account.
+    /// Represents a client provider for the services used to track the execution of Durable Tasks.
     /// </summary>
-    public sealed class StorageAccountClientProvider : TrackingServiceClientProvider
+    public class TrackingServiceClientProvider
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="StorageAccountClientProvider"/> class that returns
+        /// Initializes a new instance of the <see cref="TrackingServiceClientProvider"/> class that returns
         /// service clients using the given <paramref name="connectionString"/>.
         /// </summary>
         /// <param name="connectionString">An Azure Storage connection string.</param>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="connectionString"/> is <see langword="null"/> or consists entirely of white space characters.
         /// </exception>
-        public StorageAccountClientProvider(string connectionString)
+        public TrackingServiceClientProvider(string connectionString)
             : this(
                   StorageServiceClientProvider.ForBlob(connectionString),
-                  StorageServiceClientProvider.ForQueue(connectionString),
                   StorageServiceClientProvider.ForTable(connectionString))
         { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="StorageAccountClientProvider"/> class that returns
+        /// Initializes a new instance of the <see cref="TrackingServiceClientProvider"/> class that returns
         /// service clients using the given <paramref name="accountName"/> and credential.
         /// </summary>
         /// <param name="accountName">An Azure Storage account name.</param>
@@ -54,54 +52,54 @@ namespace DurableTask.AzureStorage
         /// <para>-or-</para>
         /// <para><paramref name="tokenCredential"/> is <see langword="null"/>.</para>
         /// </exception>
-        public StorageAccountClientProvider(string accountName, TokenCredential tokenCredential)
+        public TrackingServiceClientProvider(string accountName, TokenCredential tokenCredential)
             : this(
                   StorageServiceClientProvider.ForBlob(accountName, tokenCredential),
-                  StorageServiceClientProvider.ForQueue(accountName, tokenCredential),
                   StorageServiceClientProvider.ForTable(accountName, tokenCredential))
         { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="StorageAccountClientProvider"/> class that returns
+        /// Initializes a new instance of the <see cref="TrackingServiceClientProvider"/> class that returns
         /// service clients using the given service URIs and credential.
         /// </summary>
         /// <param name="blobServiceUri">An Azure Blob Storage service URI.</param>
-        /// <param name="queueServiceUri">An Azure Queue Storage service URI.</param>
         /// <param name="tableServiceUri">An Azure Table Storage service URI.</param>
         /// <param name="tokenCredential">A token credential for accessing the storage services.</param>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="blobServiceUri"/>, <paramref name="queueServiceUri"/>,
-        /// <paramref name="tableServiceUri"/>, or <paramref name="tokenCredential"/> is <see langword="null"/>.
+        /// <paramref name="blobServiceUri"/>, <paramref name="tableServiceUri"/>,
+        /// or <paramref name="tokenCredential"/> is <see langword="null"/>.
         /// </exception>
-        public StorageAccountClientProvider(Uri blobServiceUri, Uri queueServiceUri, Uri tableServiceUri, TokenCredential tokenCredential)
+        public TrackingServiceClientProvider(Uri blobServiceUri, Uri tableServiceUri, TokenCredential tokenCredential)
             : this(
                   StorageServiceClientProvider.ForBlob(blobServiceUri, tokenCredential),
-                  StorageServiceClientProvider.ForQueue(queueServiceUri, tokenCredential),
                   StorageServiceClientProvider.ForTable(tableServiceUri, tokenCredential))
         { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="StorageAccountClientProvider"/> class that returns
+        /// Initializes a new instance of the <see cref="TrackingServiceClientProvider"/> class that returns
         /// service clients using the given client providers.
         /// </summary>
         /// <param name="blob">An Azure Blob Storage service client provider.</param>
-        /// <param name="queue">An Azure Queue Storage service client provider.</param>
         /// <param name="table">An Azure Table Storage service client provider.</param>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="blob"/>, <paramref name="queue"/>, or <paramref name="table"/> is <see langword="null"/>.
+        /// <paramref name="blob"/> or <paramref name="table"/> is <see langword="null"/>.
         /// </exception>
-        public StorageAccountClientProvider(
+        public TrackingServiceClientProvider(
             IStorageServiceClientProvider<BlobServiceClient, BlobClientOptions> blob,
-            IStorageServiceClientProvider<QueueServiceClient, QueueClientOptions> queue,
             IStorageServiceClientProvider<TableServiceClient, TableClientOptions> table)
-            : base(blob, table)
         {
-            this.Queue = queue ?? throw new ArgumentNullException(nameof(queue));
+            this.Blob = blob ?? throw new ArgumentNullException(nameof(blob));
+            this.Table = table ?? throw new ArgumentNullException(nameof(table));
         }
 
         /// <summary>
-        /// Gets the client provider for Azure Queue Storage.
+        /// Gets the client provider for Azure Blob Storage.
         /// </summary>
-        public IStorageServiceClientProvider<QueueServiceClient, QueueClientOptions> Queue { get; }
+        public IStorageServiceClientProvider<BlobServiceClient, BlobClientOptions> Blob { get; }
+
+        /// <summary>
+        /// Gets the client provider for Azure Table Storage.
+        /// </summary>
+        public IStorageServiceClientProvider<TableServiceClient, TableClientOptions> Table { get; }
     }
 }

--- a/src/DurableTask.Core/Common/Utils.cs
+++ b/src/DurableTask.Core/Common/Utils.cs
@@ -102,9 +102,9 @@ namespace DurableTask.Core.Common
         /// <param name="serializer">The serializer whose config will guide the deserialization.</param>
         /// <param name="jsonString">The JSON-string to deserialize.</param>
         /// <returns></returns>
-        public static T DeserializeFromJson<T>(JsonSerializer serializer, string jsonString)
+        public static T? DeserializeFromJson<T>(JsonSerializer serializer, string jsonString)
         {
-            T obj;
+            T? obj;
             using (var reader = new StringReader(jsonString))
             using (var jsonReader = new JsonTextReader(reader))
             {
@@ -120,7 +120,7 @@ namespace DurableTask.Core.Common
         /// <param name="jsonString">The JSON-string to deserialize.</param>
         /// <param name="type">The expected de-serialization type.</param>
         /// <returns></returns>
-        public static object DeserializeFromJson(string jsonString, Type type)
+        public static object? DeserializeFromJson(string jsonString, Type type)
         {
             return DeserializeFromJson(DefaultSerializer, jsonString, type);
         }
@@ -133,9 +133,9 @@ namespace DurableTask.Core.Common
         /// <param name="jsonString">The JSON-string to deserialize.</param>
         /// <param name="type">The expected de-serialization type.</param>
         /// <returns></returns>
-        public static object DeserializeFromJson(JsonSerializer serializer, string jsonString, Type type)
+        public static object? DeserializeFromJson(JsonSerializer serializer, string jsonString, Type type)
         {
-            object obj;
+            object? obj;
             using (var reader = new StringReader(jsonString))
             using (var jsonReader = new JsonTextReader(reader))
             {
@@ -258,7 +258,7 @@ namespace DurableTask.Core.Common
         /// <summary>
         /// Reads and deserializes an Object from the supplied stream
         /// </summary>
-        public static T ReadObjectFromStream<T>(Stream objectStream)
+        public static T? ReadObjectFromStream<T>(Stream objectStream)
         {
             return ReadObjectFromByteArray<T>(ReadBytesFromStream(objectStream));
         }
@@ -285,7 +285,7 @@ namespace DurableTask.Core.Common
         /// <summary>
         /// Deserializes an Object from the supplied bytes
         /// </summary>
-        public static T ReadObjectFromByteArray<T>(byte[] serializedBytes)
+        public static T? ReadObjectFromByteArray<T>(byte[] serializedBytes)
         {
             var jsonString = Encoding.UTF8.GetString(serializedBytes);
             return DeserializeFromJson<T>(DefaultObjectJsonSerializer, jsonString);

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -17,8 +17,8 @@
   <!-- Version Info -->
   <PropertyGroup>
     <MajorVersion>2</MajorVersion>
-    <MinorVersion>12</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <MinorVersion>13</MinorVersion>
+    <PatchVersion>0</PatchVersion>
 
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <FileVersion>$(VersionPrefix).0</FileVersion>
@@ -37,7 +37,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.Core/Logging/EventIds.cs
+++ b/src/DurableTask.Core/Logging/EventIds.cs
@@ -59,5 +59,9 @@ namespace DurableTask.Core.Logging
 
         public const int SuspendingInstance = 68;
         public const int ResumingInstance = 69;
+
+        public const int RenewOrchestrationWorkItemStarting = 70;
+        public const int RenewOrchestrationWorkItemCompleted = 71;
+        public const int RenewOrchestrationWorkItemFailed = 72;
     }
 }

--- a/src/DurableTask.Core/Logging/LogEvents.cs
+++ b/src/DurableTask.Core/Logging/LogEvents.cs
@@ -1546,5 +1546,88 @@ namespace DurableTask.Core.Logging
                     Utils.AppName,
                     Utils.PackageVersion);
         }
+
+        internal class RenewOrchestrationWorkItemStarting : StructuredLogEvent, IEventSourceEvent
+        {
+            public RenewOrchestrationWorkItemStarting(TaskOrchestrationWorkItem workItem)
+            {
+                this.InstanceId = workItem.InstanceId;
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.RenewOrchestrationWorkItemStarting,
+                nameof(EventIds.RenewOrchestrationWorkItemStarting));
+
+            public override LogLevel Level => LogLevel.Debug;
+
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Renewing orchestration work item";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.RenewOrchestrationWorkItemStarting(
+                    this.InstanceId,
+                    Utils.AppName,
+                    Utils.PackageVersion);
+        }
+
+        internal class RenewOrchestrationWorkItemCompleted : StructuredLogEvent, IEventSourceEvent
+        {
+            public RenewOrchestrationWorkItemCompleted(TaskOrchestrationWorkItem workItem)
+            {
+                this.InstanceId = workItem.InstanceId;
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.RenewOrchestrationWorkItemCompleted,
+                nameof(EventIds.RenewOrchestrationWorkItemCompleted));
+
+            public override LogLevel Level => LogLevel.Debug;
+
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Renewed orchestration work item";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.RenewOrchestrationWorkItemCompleted(
+                    this.InstanceId,
+                    Utils.AppName,
+                    Utils.PackageVersion);
+        }
+
+        internal class RenewOrchestrationWorkItemFailed : StructuredLogEvent, IEventSourceEvent
+        {
+            public RenewOrchestrationWorkItemFailed(TaskOrchestrationWorkItem workItem, Exception exception)
+            {
+                this.InstanceId = workItem.InstanceId;
+                this.Details = exception.ToString();
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.RenewOrchestrationWorkItemFailed,
+                nameof(EventIds.RenewOrchestrationWorkItemFailed));
+
+            public override LogLevel Level => LogLevel.Warning;
+
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Failed to renew orchestration work item: {this.Details}";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.RenewOrchestrationWorkItemFailed(
+                    this.InstanceId,
+                    this.Details,
+                    Utils.AppName,
+                    Utils.PackageVersion);
+        }
     }
 }

--- a/src/DurableTask.Core/Logging/LogHelper.cs
+++ b/src/DurableTask.Core/Logging/LogHelper.cs
@@ -523,6 +523,44 @@ namespace DurableTask.Core.Logging
                 this.WriteStructuredLog(new LogEvents.DiscardingMessage(workItem, message, reason));
             }
         }
+
+        /// <summary>
+        /// Logs that an orchestration work item renewal operation is starting.
+        /// </summary>
+        /// <param name="workItem">The work item to be renewed.</param>
+        internal void RenewOrchestrationWorkItemStarting(TaskOrchestrationWorkItem workItem)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.RenewOrchestrationWorkItemStarting(workItem));
+            }
+        }
+
+        /// <summary>
+        /// Logs that an orchestration work item renewal operation succeeded.
+        /// </summary>
+        /// <param name="workItem">The work item that was renewed.</param>
+        internal void RenewOrchestrationWorkItemCompleted(TaskOrchestrationWorkItem workItem)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.RenewOrchestrationWorkItemCompleted(workItem));
+            }
+        }
+
+        /// <summary>
+        /// Logs that an orchestration work item renewal operation failed.
+        /// </summary>
+        /// <param name="workItem">The work item that was to be renewed.</param>
+        /// <param name="exception">The renew failure exception.</param>
+        internal void RenewOrchestrationWorkItemFailed(TaskOrchestrationWorkItem workItem, Exception exception)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.RenewOrchestrationWorkItemFailed(workItem, exception), exception);
+            }
+        }
+
         #endregion
 
         #region Activity dispatcher

--- a/src/DurableTask.Core/Logging/StructuredEventSource.cs
+++ b/src/DurableTask.Core/Logging/StructuredEventSource.cs
@@ -813,5 +813,57 @@ namespace DurableTask.Core.Logging
                     ExtensionVersion);
             }
         }
+
+        [Event(EventIds.RenewOrchestrationWorkItemStarting, Level = EventLevel.Verbose, Version = 1)]
+        internal void RenewOrchestrationWorkItemStarting(
+            string InstanceId,
+            string AppName,
+            string ExtensionVersion)
+        {
+            if (this.IsEnabled(EventLevel.Verbose))
+            {
+                // TODO: Use WriteEventCore for better performance
+                this.WriteEvent(
+                    EventIds.RenewOrchestrationWorkItemStarting,
+                    InstanceId,
+                    AppName,
+                    ExtensionVersion);
+            }
+        }
+
+        [Event(EventIds.RenewOrchestrationWorkItemCompleted, Level = EventLevel.Verbose, Version = 1)]
+        internal void RenewOrchestrationWorkItemCompleted(
+            string InstanceId,
+            string AppName,
+            string ExtensionVersion)
+        {
+            if (this.IsEnabled(EventLevel.Verbose))
+            {
+                // TODO: Use WriteEventCore for better performance
+                this.WriteEvent(
+                    EventIds.RenewOrchestrationWorkItemCompleted,
+                    InstanceId,
+                    AppName,
+                    ExtensionVersion);
+            }
+        }
+
+        [Event(EventIds.RenewOrchestrationWorkItemFailed, Level = EventLevel.Error, Version = 1)]
+        internal void RenewOrchestrationWorkItemFailed(
+            string InstanceId,
+            string Details,
+            string AppName,
+            string ExtensionVersion)
+        {
+            if (this.IsEnabled(EventLevel.Error))
+            {
+                this.WriteEvent(
+                    EventIds.RenewOrchestrationWorkItemFailed,
+                    InstanceId,
+                    Details,
+                    AppName,
+                    ExtensionVersion);
+            }
+        }
     }
 }

--- a/src/DurableTask.Emulator/DurableTask.Emulator.csproj
+++ b/src/DurableTask.Emulator/DurableTask.Emulator.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Newtonsoft.Json" version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageOrchestrationServiceSettingsTest.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageOrchestrationServiceSettingsTest.cs
@@ -21,10 +21,12 @@ namespace DurableTask.AzureStorage.Tests
         [TestMethod]
         public void TrackingStoreStorageAccountDetailsNotSet()
         {
-            var settings = new AzureStorageOrchestrationServiceSettings()
+            var settings = new AzureStorageOrchestrationServiceSettings
             {
                 TaskHubName = "foo",
             };
+
+            Assert.IsFalse(settings.HasTrackingStoreStorageAccount);
             Assert.AreEqual("fooHistory", settings.HistoryTableName);
             Assert.AreEqual("fooInstances", settings.InstanceTableName);
         }
@@ -32,12 +34,14 @@ namespace DurableTask.AzureStorage.Tests
         [TestMethod]
         public void TrackingStoreStorageAccountDetailsHasSet()
         {
-            var settings = new AzureStorageOrchestrationServiceSettings()
+            var settings = new AzureStorageOrchestrationServiceSettings
             {
                 TaskHubName = "foo",
                 TrackingStoreNamePrefix = "bar",
-                TrackingServiceClientProvider = StorageServiceClientProvider.ForTable("connectionString"),
+                TrackingServiceClientProvider = new TrackingServiceClientProvider("connectionString"),
             };
+
+            Assert.IsTrue(settings.HasTrackingStoreStorageAccount);
             Assert.AreEqual("barHistory", settings.HistoryTableName);
             Assert.AreEqual("barInstances", settings.InstanceTableName);
         }

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -1693,6 +1693,33 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
+        /// <summary>
+        /// End-to-end test which validates that exception messages that are considered valid Urls in the Uri.TryCreate() method
+        /// are handled with an additional Uri format check
+        /// </summary>
+        [DataTestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async Task LargeTextMessagePayloads_URIFormatCheck(bool enableExtendedSessions)
+        {
+            using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(enableExtendedSessions, fetchLargeMessages: true))
+            {
+                await host.StartAsync();
+
+                string message = this.GenerateMediumRandomStringPayload().ToString();
+                var client = await host.StartOrchestrationAsync(typeof(Orchestrations.ThrowException), "durabletask.core.exceptions.taskfailedexception: Task failed with an unhandled exception: This is an invalid operation.)");
+                var status = await client.WaitForCompletionAsync(TimeSpan.FromMinutes(2));
+
+                //Ensure that orchestration state querying also retrieves messages 
+                status = (await client.GetStateAsync(status.OrchestrationInstance.InstanceId)).First();
+
+                Assert.AreEqual(OrchestrationStatus.Failed, status?.OrchestrationStatus);
+                Assert.IsTrue(status?.Output.Contains("invalid operation") == true);
+
+                await host.StopAsync();
+            }
+        }
+
         private StringBuilder GenerateMediumRandomStringPayload(int numChars = 128*1024, short utf8ByteSize = 1, short utf16ByteSize = 2)
         {
             string Chars;
@@ -2683,6 +2710,24 @@ namespace DurableTask.AzureStorage.Tests
                     {
                         this.waitForApprovalHandle.SetResult(approvalResult);
                     }
+                }
+            }
+
+            [KnownType(typeof(Activities.Throw))]
+            internal class ThrowException : TaskOrchestration<string, string>
+            {
+                public override async Task<string> RunTask(OrchestrationContext context, string message)
+                {
+                    if (string.IsNullOrEmpty(message))
+                    {
+                        // This throw happens directly in the orchestration.
+                        throw new Exception(message);
+                    }
+
+                    // This throw happens in the implementation of an activity.
+                    await context.ScheduleTask<string>(typeof(Activities.Throw), message);
+                    return null;
+
                 }
             }
 

--- a/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
+++ b/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
@@ -16,7 +16,7 @@
   <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.6" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
   </ItemGroup>
 

--- a/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj
+++ b/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DurableTask.Test.Orchestrations/DurableTask.Test.Orchestrations.csproj
+++ b/test/DurableTask.Test.Orchestrations/DurableTask.Test.Orchestrations.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Newtonsoft.Json" version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">


### PR DESCRIPTION
A few tests failed when updating Durable Task in the Durable Functions Extension. Includes the following changes:
- [X] Merge with `main`
- [X] Escape blob URLs generated by `MessageManager`
- [X] Refactor storage account service client constructors
- [X] Use new `TrackingServiceClientProvider` for the property of the same name in the orchestration service settings given that both blob and table clients are necessary
  - `StorageAccountClientProvider` now derives from this new type
- [X] Quality-of-life: change URL path separator for blobs
- [X] Align storage package versions with that of the Azure Functions host
  - This includes using a version of the `TableClient` without a `Uri` property, and so it must be computed using reflection

I made the following changes (plus tests). I also bumped the preview version:
- `/TrackingServiceClientProvider.cs`
- `/Net/UriPath.cs`
- `/Storage/Blob.cs`
- `/Storage/BlobContainer.cs`
- `/Storage/Queue.cs`
- `/Storage/Table.cs`
- `/Storage/TableClientExtensions.cs`