### PR TITLE
Update newtonsoft.json from 11.0.2 to 13.0.1

### DIFF
--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -41,7 +41,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <!--Change the Storage SDK version with extreme caution, otherwise may break Durable Functions usage with Azure Storage Extension. -->
     <PackageReference Include="WindowsAzure.Storage" version="9.3.1" />
   </ItemGroup>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -41,7 +41,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <!--Change the Storage SDK version with extreme caution, otherwise may break Durable Functions usage with Azure Storage Extension. -->
     <PackageReference Include="WindowsAzure.Storage" version="9.3.1" />
   </ItemGroup>

--- a/src/DurableTask.Core/Common/Utils.cs
+++ b/src/DurableTask.Core/Common/Utils.cs
@@ -102,9 +102,9 @@ namespace DurableTask.Core.Common
         /// <param name="serializer">The serializer whose config will guide the deserialization.</param>
         /// <param name="jsonString">The JSON-string to deserialize.</param>
         /// <returns></returns>
-        public static T DeserializeFromJson<T>(JsonSerializer serializer, string jsonString)
+        public static T? DeserializeFromJson<T>(JsonSerializer serializer, string jsonString)
         {
-            T obj;
+            T? obj;
             using (var reader = new StringReader(jsonString))
             using (var jsonReader = new JsonTextReader(reader))
             {
@@ -120,7 +120,7 @@ namespace DurableTask.Core.Common
         /// <param name="jsonString">The JSON-string to deserialize.</param>
         /// <param name="type">The expected de-serialization type.</param>
         /// <returns></returns>
-        public static object DeserializeFromJson(string jsonString, Type type)
+        public static object? DeserializeFromJson(string jsonString, Type type)
         {
             return DeserializeFromJson(DefaultSerializer, jsonString, type);
         }
@@ -133,9 +133,9 @@ namespace DurableTask.Core.Common
         /// <param name="jsonString">The JSON-string to deserialize.</param>
         /// <param name="type">The expected de-serialization type.</param>
         /// <returns></returns>
-        public static object DeserializeFromJson(JsonSerializer serializer, string jsonString, Type type)
+        public static object? DeserializeFromJson(JsonSerializer serializer, string jsonString, Type type)
         {
-            object obj;
+            object? obj;
             using (var reader = new StringReader(jsonString))
             using (var jsonReader = new JsonTextReader(reader))
             {
@@ -258,7 +258,7 @@ namespace DurableTask.Core.Common
         /// <summary>
         /// Reads and deserializes an Object from the supplied stream
         /// </summary>
-        public static T ReadObjectFromStream<T>(Stream objectStream)
+        public static T? ReadObjectFromStream<T>(Stream objectStream)
         {
             return ReadObjectFromByteArray<T>(ReadBytesFromStream(objectStream));
         }
@@ -285,7 +285,7 @@ namespace DurableTask.Core.Common
         /// <summary>
         /// Deserializes an Object from the supplied bytes
         /// </summary>
-        public static T ReadObjectFromByteArray<T>(byte[] serializedBytes)
+        public static T? ReadObjectFromByteArray<T>(byte[] serializedBytes)
         {
             var jsonString = Encoding.UTF8.GetString(serializedBytes);
             return DeserializeFromJson<T>(DefaultObjectJsonSerializer, jsonString);

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -37,7 +37,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -17,7 +17,7 @@
   <!-- Version Info -->
   <PropertyGroup>
     <MajorVersion>2</MajorVersion>
-    <MinorVersion>12</MinorVersion>
+    <MinorVersion>13</MinorVersion>
     <PatchVersion>1</PatchVersion>
 
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>


### PR DESCRIPTION
This will remove certain static analysis warnings due to vulnerabilities. At runtime, our dependency is already being replaced with the newtonsoft.json version brought in by WebJobs, which is already `13.0.1`, so this change should be safe.

The change also required that we update the code in a few places to account for the possibility of the deserialization returning `null`. You will a few types being updated to include the `?` modifier as a result.