### PR TITLE
Allow customizing type binding for dequeued Azure Storage messages

### DIFF
--- a/Test/DurableTask.AzureStorage.Tests/MessageManagerTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/MessageManagerTests.cs
@@ -1,0 +1,137 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureStorage.Tests
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Reflection;
+    using System.Text.RegularExpressions;
+    using System.Threading.Tasks;
+    using DurableTask.AzureStorage.Storage;
+    using DurableTask.Core.History;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json;
+
+    [TestClass]
+    public class MessageManagerTests
+    {
+        [DataTestMethod]
+        [DataRow("System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib],[System.String, System.Private.CoreLib]]")]
+        [DataRow("System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.String, mscorlib]]")]
+
+        public void DeserializesStandardTypes(string dictionaryType)
+        {
+            // Given
+            var message = GetMessage(dictionaryType);
+            var messageManager = SetupMessageManager(new PrimitiveTypeBinder());
+
+            // When
+            var deserializedMessage = messageManager.DeserializeMessageData(message);
+
+            // Then
+            Assert.IsInstanceOfType(deserializedMessage.TaskMessage.Event, typeof(ExecutionStartedEvent));
+            ExecutionStartedEvent startedEvent = (ExecutionStartedEvent)deserializedMessage.TaskMessage.Event;
+            Assert.AreEqual("tagValue", startedEvent.Tags["tag1"]);
+        }
+
+        [TestMethod]
+        public void FailsDeserializingUnknownTypes()
+        {
+            // Given
+            var message = GetMessage("RandomType");
+            var messageManager = SetupMessageManager(new KnownTypeBinder());
+
+            // When/Then
+            Assert.ThrowsException<JsonSerializationException>(() => messageManager.DeserializeMessageData(message));
+        }
+
+
+        [TestMethod]
+        public void DeserializesCustomTypes()
+        {
+            // Given
+            var message = GetMessage("KnownType");
+            var messageManager = SetupMessageManager(new KnownTypeBinder());
+
+            // When
+            var deserializedMessage = messageManager.DeserializeMessageData(message);
+
+            // Then
+            Assert.IsInstanceOfType(deserializedMessage.TaskMessage.Event, typeof(ExecutionStartedEvent));
+            ExecutionStartedEvent startedEvent = (ExecutionStartedEvent)deserializedMessage.TaskMessage.Event;
+            Assert.AreEqual("tagValue", startedEvent.Tags["tag1"]);
+        }
+
+        private string GetMessage(string dictionaryType)
+            => "{\"$type\":\"DurableTask.AzureStorage.MessageData\",\"ActivityId\":\"5406d369-4369-4673-afae-6671a2fa1e57\",\"TaskMessage\":{\"$type\":\"DurableTask.Core.TaskMessage\",\"Event\":{\"$type\":\"DurableTask.Core.History.ExecutionStartedEvent\",\"OrchestrationInstance\":{\"$type\":\"DurableTask.Core.OrchestrationInstance\",\"InstanceId\":\"2.2-34a2c9d4-306e-4467-8470-a8018b2e4f11\",\"ExecutionId\":\"aae324dcc8f943e490b37ec5e5bbf9da\"},\"EventType\":0,\"ParentInstance\":null,\"Name\":\"OrchestrationName\",\"Version\":\"2.0\",\"Input\":\"input\",\"Tags\":{\"$type\":\""
+            + dictionaryType
+            + "\",\"tag1\":\"tagValue\"},\"Correlation\":null,\"ScheduledStartTime\":null,\"Generation\":0,\"EventId\":-1,\"IsPlayed\":false,\"Timestamp\":\"2023-03-24T20:53:05.9093518Z\"},\"SequenceNumber\":0,\"OrchestrationInstance\":{\"$type\":\"DurableTask.Core.OrchestrationInstance\",\"InstanceId\":\"2.2-34a2c9d4-306e-4467-8470-a8018b2e4f11\",\"ExecutionId\":\"aae324dcc8f943e490b37ec5e5bbf9da\"}},\"CompressedBlobName\":null,\"SequenceNumber\":40,\"Sender\":{\"InstanceId\":\"\",\"ExecutionId\":\"\"},\"SerializableTraceContext\":null}\r\n\r\n";
+
+        private MessageManager SetupMessageManager(ICustomTypeBinder binder)
+        {
+            var azureStorageClient = new AzureStorageClient(new AzureStorageOrchestrationServiceSettings() { StorageConnectionString = "UseDevelopmentStorage=true" });
+            return new MessageManager(
+                new AzureStorageOrchestrationServiceSettings()
+                {
+                    CustomMessageTypeBinder = binder
+                },
+                azureStorageClient,
+                "$root");
+        }
+    }
+
+    internal class KnownTypeBinder : ICustomTypeBinder
+    {
+        public void BindToName(Type serializedType, out string assemblyName, out string typeName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Type BindToType(string assemblyName, string typeName)
+        {
+            if (typeName == "KnownType")
+            {
+                return typeof(Dictionary<string, string>);
+            }
+
+            return null;
+        }
+    }
+
+    internal class PrimitiveTypeBinder : ICustomTypeBinder
+    {
+        bool hasStandardLib;
+        public PrimitiveTypeBinder() 
+        {
+            hasStandardLib = typeof(string).AssemblyQualifiedName.Contains("mscorlib");
+        }
+
+        public void BindToName(Type serializedType, out string assemblyName, out string typeName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Type BindToType(string assemblyName, string typeName)
+        {
+            if (hasStandardLib)
+            {
+                return Type.GetType(typeName.Replace("System.Private.CoreLib", "mscorlib"));
+            }
+
+            return Type.GetType(typeName.Replace("mscorlib", "System.Private.CoreLib"));
+        }
+    }
+}

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -191,7 +191,7 @@ namespace DurableTask.AzureStorage
         /// In case of null, StorageAccountDetails is applied. 
         /// </summary>
         public StorageAccountDetails TrackingStoreStorageAccountDetails { get; set; }
-        
+
         /// <summary>
         ///  Should we carry over unexecuted raised events to the next iteration of an orchestration on ContinueAsNew
         /// </summary>
@@ -249,6 +249,11 @@ namespace DurableTask.AzureStorage
         /// Gets or sets the window duration (in seconds) in which we count the number of timed out request before recycling the app.
         /// </summary>
         public TimeSpan StorageRequestsTimeoutCooldown { get; set; } = TimeSpan.FromMinutes(5);
+
+        /// <summary>
+        /// Gets or Sets an optional custom type binder used when trying to deserialize queued messages
+        /// </summary>
+        public ICustomTypeBinder CustomMessageTypeBinder { get; set; }
 
         /// <summary>
         /// Returns bool indicating is the TrackingStoreStorageAccount has been set.

--- a/src/DurableTask.AzureStorage/ICustomTypeBinder.cs
+++ b/src/DurableTask.AzureStorage/ICustomTypeBinder.cs
@@ -1,0 +1,41 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+using System;
+
+namespace DurableTask.AzureStorage
+{
+    /// <summary>
+    /// Abstraction to prevent surfacing the dynamic loading between System.Runtime.Serialization.SerializationBinder and Newtonsoft.Json.Serialization.ISerializationBinder
+    /// Used when deserializing QueueMessages to MessageData to allow providing custom type binding. 
+    /// Does not support custom bindings for DurableTask types
+    /// </summary>
+    public interface ICustomTypeBinder
+    {
+        /// <summary>
+        /// When implemented, controls the binding of a serialized object to a type.
+        /// </summary>
+        /// <param name="serializedType">The type of the object the formatter creates a new instance of.</param>
+        /// <param name="assemblyName">Specifies the System.Reflection.Assembly name of the serialized object.</param>
+        /// <param name="typeName">Specifies the System.Type name of the serialized object.</param>
+        void BindToName(Type serializedType, out string assemblyName, out string typeName);
+
+        /// <summary>
+        /// When implemented, controls the binding of a serialized object to a type.
+        /// </summary>
+        /// <param name="assemblyName">Specifies the System.Reflection.Assembly name of the serialized object.</param>
+        /// <param name="typeName">Specifies the System.Type name of the serialized object</param>
+        /// <returns>The type of the object the formatter creates a new instance of.</returns>
+        Type BindToType(string assemblyName, string typeName);
+    }
+}

--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -55,9 +55,9 @@ namespace DurableTask.AzureStorage
             {
                 TypeNameHandling = TypeNameHandling.Objects,
 #if NETSTANDARD2_0
-                SerializationBinder = new TypeNameSerializationBinder(),
+                SerializationBinder = new TypeNameSerializationBinder(settings.CustomMessageTypeBinder),
 #else
-                Binder = new TypeNameSerializationBinder(),
+                Binder = new TypeNameSerializationBinder(settings.CustomMessageTypeBinder),
 #endif
             };
             this.serializer = JsonSerializer.Create(taskMessageSerializerSettings);
@@ -312,27 +312,39 @@ namespace DurableTask.AzureStorage
 #if NETSTANDARD2_0
     class TypeNameSerializationBinder : ISerializationBinder
     {
+        readonly ICustomTypeBinder customBinder;
+        public TypeNameSerializationBinder(ICustomTypeBinder customBinder) 
+        {
+            this.customBinder = customBinder;
+        }
+
         public void BindToName(Type serializedType, out string assemblyName, out string typeName)
         {
-            TypeNameSerializationHelper.BindToName(serializedType, out assemblyName, out typeName);
+            TypeNameSerializationHelper.BindToName(customBinder, serializedType, out assemblyName, out typeName);
         }
 
         public Type BindToType(string assemblyName, string typeName)
         {
-            return TypeNameSerializationHelper.BindToType(assemblyName, typeName);
+            return TypeNameSerializationHelper.BindToType(customBinder, assemblyName, typeName);
         }
     }
 #else
     class TypeNameSerializationBinder : SerializationBinder
     {
+        readonly ICustomTypeBinder customBinder;
+        public TypeNameSerializationBinder(ICustomTypeBinder customBinder)
+        {
+            this.customBinder = customBinder;
+        }
+
         public override void BindToName(Type serializedType, out string assemblyName, out string typeName)
         {
-            TypeNameSerializationHelper.BindToName(serializedType, out assemblyName, out typeName);
+            TypeNameSerializationHelper.BindToName(customBinder, serializedType, out assemblyName, out typeName);
         }
 
         public override Type BindToType(string assemblyName, string typeName)
         {
-            return TypeNameSerializationHelper.BindToType(assemblyName, typeName);
+            return TypeNameSerializationHelper.BindToType(customBinder, assemblyName, typeName);
         }
     }
 #endif
@@ -341,13 +353,20 @@ namespace DurableTask.AzureStorage
         static readonly Assembly DurableTaskCore = typeof(DurableTask.Core.TaskMessage).Assembly;
         static readonly Assembly DurableTaskAzureStorage = typeof(AzureStorageOrchestrationService).Assembly;
 
-        public static void BindToName(Type serializedType, out string assemblyName, out string typeName)
+        public static void BindToName(ICustomTypeBinder customBinder, Type serializedType, out string assemblyName, out string typeName)
         {
-            assemblyName = null;
-            typeName = serializedType.FullName;
+            if (customBinder == null)
+            {
+                customBinder.BindToName(serializedType, out assemblyName, out typeName);
+            }
+            else
+            {
+                assemblyName = null;
+                typeName = serializedType.FullName;
+            }
         }
 
-        public static Type BindToType(string assemblyName, string typeName)
+        public static Type BindToType(ICustomTypeBinder customBinder, string assemblyName, string typeName)
         {
             if (typeName.StartsWith("DurableTask.Core"))
             {
@@ -358,7 +377,7 @@ namespace DurableTask.AzureStorage
                 return DurableTaskAzureStorage.GetType(typeName, throwOnError: true);
             }
 
-            return Type.GetType(typeName, throwOnError: true);
+            return customBinder?.BindToType(assemblyName, typeName) ?? Type.GetType(typeName, throwOnError: true);
         }
     }
 }

--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -355,7 +355,7 @@ namespace DurableTask.AzureStorage
 
         public static void BindToName(ICustomTypeBinder customBinder, Type serializedType, out string assemblyName, out string typeName)
         {
-            if (customBinder == null)
+            if (customBinder != null)
             {
                 customBinder.BindToName(serializedType, out assemblyName, out typeName);
             }


### PR DESCRIPTION
Allow custom type binding for system types, Fixing #877

We are solving the deserialization problem by allowing configuration based bindings.
We cannot get rid of the Type handling in general due to the inheritance based logic used after deserialization. 