### PR TITLE
Patch tests post Newtonsoft.Json upgrade to 13.0.1

### DIFF
--- a/Test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
+++ b/Test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
@@ -61,26 +61,26 @@ namespace DurableTask.Core.Tests
             if (mode == ErrorPropagationMode.SerializeExceptions)
             {
                 // The exception should be deserializable
-                InvalidOperationException e = JsonConvert.DeserializeObject<InvalidOperationException>(state.Output);
+                InvalidOperationException? e = JsonConvert.DeserializeObject<InvalidOperationException>(state.Output);
                 Assert.IsNotNull(e);
-                Assert.AreEqual("This is a test exception", e.Message);
+                Assert.AreEqual("This is a test exception", e?.Message);
             }
             else if (mode == ErrorPropagationMode.UseFailureDetails)
             {
                 // The failure details should contain the relevant exception metadata
-                FailureDetails details = JsonConvert.DeserializeObject<FailureDetails>(state.Output);
+                FailureDetails? details = JsonConvert.DeserializeObject<FailureDetails>(state.Output);
                 Assert.IsNotNull(details);
-                Assert.AreEqual(typeof(InvalidOperationException).FullName, details.ErrorType);
-                Assert.IsTrue(details.IsCausedBy<InvalidOperationException>());
-                Assert.IsTrue(details.IsCausedBy<Exception>()); // check that base types work too
-                Assert.AreEqual("This is a test exception", details.ErrorMessage);
-                Assert.IsNotNull(details.StackTrace);
+                Assert.AreEqual(typeof(InvalidOperationException).FullName, details?.ErrorType);
+                Assert.IsTrue(details?.IsCausedBy<InvalidOperationException>() ?? false);
+                Assert.IsTrue(details?.IsCausedBy<Exception>() ?? false); // check that base types work too
+                Assert.AreEqual("This is a test exception", details?.ErrorMessage);
+                Assert.IsNotNull(details?.StackTrace);
 
                 // The callstack should be in the error details
                 string expectedCallstackSubstring = typeof(ThrowInvalidOperationException).FullName!.Replace('+', '.');
                 Assert.IsTrue(
-                    details.StackTrace!.IndexOf(expectedCallstackSubstring) > 0,
-                    $"Expected to find {expectedCallstackSubstring} in the exception details. Actual: {details.StackTrace}");
+                    details?.StackTrace!.IndexOf(expectedCallstackSubstring) > 0,
+                    $"Expected to find {expectedCallstackSubstring} in the exception details. Actual: {details?.StackTrace}");
             }
             else
             {

--- a/Test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
+++ b/Test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
@@ -70,17 +70,17 @@ namespace DurableTask.Core.Tests
                 // The failure details should contain the relevant exception metadata
                 FailureDetails? details = JsonConvert.DeserializeObject<FailureDetails>(state.Output);
                 Assert.IsNotNull(details);
-                Assert.AreEqual(typeof(InvalidOperationException).FullName, details?.ErrorType);
-                Assert.IsTrue(details?.IsCausedBy<InvalidOperationException>() ?? false);
-                Assert.IsTrue(details?.IsCausedBy<Exception>() ?? false); // check that base types work too
-                Assert.AreEqual("This is a test exception", details?.ErrorMessage);
-                Assert.IsNotNull(details?.StackTrace);
+                Assert.AreEqual(typeof(InvalidOperationException).FullName, details!.ErrorType);
+                Assert.IsTrue(details.IsCausedBy<InvalidOperationException>());
+                Assert.IsTrue(details.IsCausedBy<Exception>()); // check that base types work too
+                Assert.AreEqual("This is a test exception", details.ErrorMessage);
+                Assert.IsNotNull(details.StackTrace);
 
                 // The callstack should be in the error details
                 string expectedCallstackSubstring = typeof(ThrowInvalidOperationException).FullName!.Replace('+', '.');
                 Assert.IsTrue(
-                    details?.StackTrace!.IndexOf(expectedCallstackSubstring) > 0,
-                    $"Expected to find {expectedCallstackSubstring} in the exception details. Actual: {details?.StackTrace}");
+                    details.StackTrace!.IndexOf(expectedCallstackSubstring) > 0,
+                    $"Expected to find {expectedCallstackSubstring} in the exception details. Actual: {details.StackTrace}");
             }
             else
             {

--- a/Test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
+++ b/Test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
@@ -63,7 +63,7 @@ namespace DurableTask.Core.Tests
                 // The exception should be deserializable
                 InvalidOperationException? e = JsonConvert.DeserializeObject<InvalidOperationException>(state.Output);
                 Assert.IsNotNull(e);
-                Assert.AreEqual("This is a test exception", e?.Message);
+                Assert.AreEqual("This is a test exception", e!.Message);
             }
             else if (mode == ErrorPropagationMode.UseFailureDetails)
             {

--- a/src/DurableTask.Emulator/DurableTask.Emulator.csproj
+++ b/src/DurableTask.Emulator/DurableTask.Emulator.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Newtonsoft.Json" version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
+++ b/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
@@ -16,7 +16,7 @@
   <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.6" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="WindowsAzure.Storage" version="9.3.3" />
   </ItemGroup>
 

--- a/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj
+++ b/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DurableTask.Test.Orchestrations/DurableTask.Test.Orchestrations.csproj
+++ b/test/DurableTask.Test.Orchestrations/DurableTask.Test.Orchestrations.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Newtonsoft.Json" version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">


### PR DESCRIPTION
Follow up to: https://github.com/Azure/durabletask/pull/870

It appears that CI did not run on the PR above, leading to broken tests post-merge. This PR fixes that by updating our Newtonsoft references across the test projects