### PR TITLE
Update task activity ActivityKind values and parents

### DIFF
--- a/src/DurableTask.Core/History/SubOrchestrationInstanceCreatedEvent.cs
+++ b/src/DurableTask.Core/History/SubOrchestrationInstanceCreatedEvent.cs
@@ -58,5 +58,11 @@ namespace DurableTask.Core.History
         /// </summary>
         [DataMember]
         public string Input { get; set; }
+
+        /// <summary>
+        /// Gets or sets the sub orchestration's client span Id
+        /// </summary>
+        [DataMember]
+        public string ClientSpanId { get; set; }
     }
 }

--- a/src/DurableTask.Core/History/TaskScheduledEvent.cs
+++ b/src/DurableTask.Core/History/TaskScheduledEvent.cs
@@ -84,11 +84,5 @@ namespace DurableTask.Core.History
         /// </summary>
         [DataMember]
         public DistributedTraceContext? ParentTraceContext { get; set; }
-
-        /// <summary>
-        /// The W3C span id associated with this task's client span.
-        /// </summary>
-        [DataMember]
-        public string? ClientSpanId { get; set; }
     }
 }

--- a/src/DurableTask.Core/History/TaskScheduledEvent.cs
+++ b/src/DurableTask.Core/History/TaskScheduledEvent.cs
@@ -84,5 +84,11 @@ namespace DurableTask.Core.History
         /// </summary>
         [DataMember]
         public DistributedTraceContext? ParentTraceContext { get; set; }
+
+        /// <summary>
+        /// The W3C span id associated with this task's client span.
+        /// </summary>
+        [DataMember]
+        public string? ClientSpanId { get; set; }
     }
 }

--- a/src/DurableTask.Core/ISupportsDurableTraceContext.cs
+++ b/src/DurableTask.Core/ISupportsDurableTraceContext.cs
@@ -61,8 +61,8 @@ namespace DurableTask.Core
             if (activityContext != null)
             {
                 wrapper.ParentTraceContext = new DistributedTraceContext(
-                    "00"+"-"+activityContext.TraceId.ToString()+"-"+activityContext.SpanId.ToString()+"-01",
-                    activityContext.TraceState?.ToString());
+                    "00-" + activityContext.TraceId.ToString() + "-" + activityContext.SpanId.ToString() + "-0" + ((int)activityContext.TraceFlags),
+                    activityContext.TraceState);
             }
         }
     }

--- a/src/DurableTask.Core/ISupportsDurableTraceContext.cs
+++ b/src/DurableTask.Core/ISupportsDurableTraceContext.cs
@@ -60,8 +60,9 @@ namespace DurableTask.Core
         {
             if (activityContext != null)
             {
+                // TODO: update trace flags casting to handle 2 digits
                 wrapper.ParentTraceContext = new DistributedTraceContext(
-                    "00-" + activityContext.TraceId.ToString() + "-" + activityContext.SpanId.ToString() + "-0" + ((int)activityContext.TraceFlags),
+                    $"00-{activityContext.TraceId}-{activityContext.SpanId}-0{activityContext.TraceFlags:d}",
                     activityContext.TraceState);
             }
         }

--- a/src/DurableTask.Core/ISupportsDurableTraceContext.cs
+++ b/src/DurableTask.Core/ISupportsDurableTraceContext.cs
@@ -55,5 +55,15 @@ namespace DurableTask.Core
                     activity.TraceStateString);
             }
         }
+
+        internal static void SetParentTraceContext(this ISupportsDurableTraceContext wrapper, ActivityContext activityContext)
+        {
+            if (activityContext != null)
+            {
+                wrapper.ParentTraceContext = new DistributedTraceContext(
+                    "00"+"-"+activityContext.TraceId.ToString()+"-"+activityContext.SpanId.ToString()+"-01",
+                    activityContext.TraceState?.ToString());
+            }
+        }
     }
 }

--- a/src/DurableTask.Core/OrchestrationRuntimeState.cs
+++ b/src/DurableTask.Core/OrchestrationRuntimeState.cs
@@ -351,6 +351,7 @@ namespace DurableTask.Core
                     Name = subOrchestrationInstanceCreatedEvent.Name,
                     Version = subOrchestrationInstanceCreatedEvent.Version,
                     Input = "[..snipped..]",
+                    ClientSpanId = subOrchestrationInstanceCreatedEvent.ClientSpanId,
                 };
             }
             else if (evt is SubOrchestrationInstanceCompletedEvent subOrchestrationInstanceCompletedEvent)

--- a/src/DurableTask.Core/TaskActivityDispatcher.cs
+++ b/src/DurableTask.Core/TaskActivityDispatcher.cs
@@ -128,7 +128,7 @@ namespace DurableTask.Core
                 scheduledEvent = (TaskScheduledEvent)taskMessage.Event;
 
                 // Distributed tracing: start a new trace activity derived from the orchestration's trace context.
-                using Activity? traceActivity = TraceHelper.StartTraceActivityForSchedulingTask(scheduledEvent, orchestrationInstance);
+                using Activity? traceActivity = TraceHelper.StartTraceActivityForTaskExecution(scheduledEvent, orchestrationInstance);
 
                 this.logHelper.TaskActivityStarting(orchestrationInstance, scheduledEvent);
 

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -933,14 +933,15 @@ namespace DurableTask.Core
                 version: scheduleTaskOrchestratorAction.Version,
                 input: scheduleTaskOrchestratorAction.Input);
 
-            ActivitySpanId clientSpanId;
+            ActivitySpanId clientSpanId = ActivitySpanId.CreateRandom();
+
             if (parentTraceActivity != null)
             {
-                clientSpanId = ActivitySpanId.CreateRandom();
-                scheduledEvent.ClientSpanId = clientSpanId.ToString();
+                ActivityContext activityContext = new(parentTraceActivity.TraceId, clientSpanId, parentTraceActivity.ActivityTraceFlags, parentTraceActivity.TraceStateString);
+                scheduledEvent.SetParentTraceContext(activityContext);
             }
 
-            scheduledEvent.SetParentTraceContext(parentTraceActivity);
+
 
             taskMessage.Event = scheduledEvent;
             taskMessage.OrchestrationInstance = runtimeState.OrchestrationInstance;
@@ -955,10 +956,9 @@ namespace DurableTask.Core
 
                 if (parentTraceActivity != null)
                 {
-                    scheduledEvent.ClientSpanId = clientSpanId.ToString();
+                    ActivityContext activityContext = new(parentTraceActivity.TraceId, clientSpanId, parentTraceActivity.ActivityTraceFlags, parentTraceActivity.TraceStateString);
+                    scheduledEvent.SetParentTraceContext(activityContext);
                 }
-
-                scheduledEvent.SetParentTraceContext(parentTraceActivity);
             }
 
             this.logHelper.SchedulingActivity(

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -1018,6 +1018,9 @@ namespace DurableTask.Core
                 historyEvent.Input = createSubOrchestrationAction.Input;
             }
 
+            ActivitySpanId clientSpanId = ActivitySpanId.CreateRandom();
+            historyEvent.ClientSpanId = clientSpanId.ToString();
+
             runtimeState.AddEvent(historyEvent);
 
             var taskMessage = new TaskMessage();
@@ -1041,7 +1044,11 @@ namespace DurableTask.Core
                 Version = createSubOrchestrationAction.Version
             };
 
-            startedEvent.SetParentTraceContext(parentTraceActivity);
+            if (parentTraceActivity != null)
+            {
+                ActivityContext activityContext = new ActivityContext(parentTraceActivity.TraceId, clientSpanId, parentTraceActivity.ActivityTraceFlags, parentTraceActivity.TraceStateString);
+                startedEvent.SetParentTraceContext(activityContext);
+            }
 
             this.logHelper.SchedulingOrchestration(startedEvent);
 

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -933,6 +933,13 @@ namespace DurableTask.Core
                 version: scheduleTaskOrchestratorAction.Version,
                 input: scheduleTaskOrchestratorAction.Input);
 
+            ActivitySpanId clientSpanId;
+            if (parentTraceActivity != null)
+            {
+                clientSpanId = ActivitySpanId.CreateRandom();
+                scheduledEvent.ClientSpanId = clientSpanId.ToString();
+            }
+
             scheduledEvent.SetParentTraceContext(parentTraceActivity);
 
             taskMessage.Event = scheduledEvent;
@@ -945,6 +952,11 @@ namespace DurableTask.Core
                     eventId: scheduleTaskOrchestratorAction.Id,
                     name: scheduleTaskOrchestratorAction.Name,
                     version: scheduleTaskOrchestratorAction.Version);
+
+                if (parentTraceActivity != null)
+                {
+                    scheduledEvent.ClientSpanId = clientSpanId.ToString();
+                }
 
                 scheduledEvent.SetParentTraceContext(parentTraceActivity);
             }

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -941,8 +941,6 @@ namespace DurableTask.Core
                 scheduledEvent.SetParentTraceContext(activityContext);
             }
 
-
-
             taskMessage.Event = scheduledEvent;
             taskMessage.OrchestrationInstance = runtimeState.OrchestrationInstance;
             taskMessage.OrchestrationExecutionContext = GetOrchestrationExecutionContext(runtimeState);

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -193,8 +193,10 @@ namespace DurableTask.Core.Tracing
 
             if (taskScheduledEvent.ParentTraceContext != null)
             {
-                ActivityContext.TryParse(taskScheduledEvent.ParentTraceContext.TraceParent, taskScheduledEvent.ParentTraceContext?.TraceState, out ActivityContext parentContext);
-                newActivity.SetSpanId(parentContext.SpanId.ToString());
+                if (ActivityContext.TryParse(taskScheduledEvent.ParentTraceContext.TraceParent, taskScheduledEvent.ParentTraceContext?.TraceState, out ActivityContext parentContext))
+                {
+                    newActivity.SetSpanId(parentContext.SpanId.ToString());
+                }
             }
 
             newActivity.AddTag(Schema.Task.Type, "activity");

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -148,7 +148,7 @@ namespace DurableTask.Core.Tracing
             {
                 return null;
             }
-            
+
             newActivity.SetTag(Schema.Task.Type, "activity");
             newActivity.SetTag(Schema.Task.Name, scheduledEvent.Name);
             newActivity.SetTag(Schema.Task.InstanceId, instance.InstanceId);

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -296,6 +296,8 @@ namespace DurableTask.Core.Tracing
                 return null;
             }
 
+            activity.SetSpanId(createdEvent.ClientSpanId);
+
             activity.SetTag(Schema.Task.Type, "orchestration");
             activity.SetTag(Schema.Task.Name, createdEvent.Name);
             activity.SetTag(Schema.Task.InstanceId, orchestrationInstance?.InstanceId);

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -123,15 +123,14 @@ namespace DurableTask.Core.Tracing
 
 
         /// <summary>
-        /// Starts a new trace activity for (task) activity that represents the time between when the task message
-        /// is enqueued and when the response message is received.
+        /// Starts a new trace activity for (task) activity execution. 
         /// </summary>
         /// <param name="scheduledEvent">The associated <see cref="TaskScheduledEvent"/>.</param>
         /// <param name="instance">The associated orchestration instance metadata.</param>
         /// <returns>
         /// Returns a newly started <see cref="Activity"/> with (task) activity and orchestration-specific metadata.
         /// </returns>
-        internal static Activity? StartTraceActivityForSchedulingTask(
+        internal static Activity? StartTraceActivityForTaskExecution(
             TaskScheduledEvent scheduledEvent,
             OrchestrationInstance instance)
         {
@@ -140,10 +139,13 @@ namespace DurableTask.Core.Tracing
                 return null;
             }
 
+            ActivitySpanId clientSpanId = ActivitySpanId.CreateFromString(scheduledEvent.ClientSpanId?.ToCharArray());
+            ActivityContext parentContext = new ActivityContext(activityContext.TraceId, clientSpanId, activityContext.TraceFlags, activityContext.TraceState, activityContext.IsRemote);
+
             Activity? newActivity = ActivityTraceSource.StartActivity(
                 name: CreateSpanName("activity", scheduledEvent.Name, scheduledEvent.Version),
-                kind: ActivityKind.Client,
-                parentContext: activityContext);
+                kind: ActivityKind.Server,
+                parentContext: parentContext);
 
             if (newActivity == null)
             {
@@ -164,14 +166,15 @@ namespace DurableTask.Core.Tracing
         }
 
         /// <summary>
-        /// Starts a new trace activity for (task) activity execution. 
+        /// Starts a new trace activity for (task) activity that represents the time between when the task message
+        /// is enqueued and when the response message is received.
         /// </summary>
         /// <param name="instance">The associated <see cref="OrchestrationInstance"/>.</param>
         /// <param name="taskScheduledEvent">The associated <see cref="TaskScheduledEvent"/>.</param>
         /// <returns>
         /// Returns a newly started <see cref="Activity"/> with (task) activity and orchestration-specific metadata.
         /// </returns>
-        internal static Activity? StartTraceActivityForTaskExecution(
+        internal static Activity? StartTraceActivityForSchedulingTask(
             OrchestrationInstance? instance,
             TaskScheduledEvent taskScheduledEvent)
         {
@@ -196,6 +199,8 @@ namespace DurableTask.Core.Tracing
                 return null;
             }
 
+            newActivity.SetSpanId(taskScheduledEvent.ClientSpanId);
+
             newActivity.AddTag(Schema.Task.Type, "activity");
             newActivity.AddTag(Schema.Task.Name, taskScheduledEvent.Name);
             newActivity.AddTag(Schema.Task.InstanceId, instance?.InstanceId);
@@ -218,7 +223,8 @@ namespace DurableTask.Core.Tracing
             OrchestrationInstance? orchestrationInstance,
             TaskScheduledEvent taskScheduledEvent)
         {
-            Activity? activity = StartTraceActivityForTaskExecution(orchestrationInstance, taskScheduledEvent);
+            // The parent of this is the parent orchestration span ID. It should be the client span which started this
+            Activity? activity = StartTraceActivityForSchedulingTask(orchestrationInstance, taskScheduledEvent);
 
             activity?.Dispose();
         }
@@ -236,7 +242,7 @@ namespace DurableTask.Core.Tracing
             TaskFailedEvent? failedEvent,
             ErrorPropagationMode errorPropagationMode)
         {
-            Activity? activity = StartTraceActivityForTaskExecution(orchestrationInstance, taskScheduledEvent);
+            Activity? activity = StartTraceActivityForSchedulingTask(orchestrationInstance, taskScheduledEvent);
 
             if (activity is null)
             {

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -139,7 +139,7 @@ namespace DurableTask.Core.Tracing
                 return null;
             }
 
-            ActivitySpanId clientSpanId = ActivitySpanId.CreateFromString(scheduledEvent.ClientSpanId?.ToCharArray());
+            ActivitySpanId clientSpanId = string.IsNullOrEmpty(scheduledEvent.ClientSpanId) ? default : ActivitySpanId.CreateFromString(scheduledEvent.ClientSpanId.AsSpan());
             ActivityContext parentContext = new ActivityContext(activityContext.TraceId, clientSpanId, activityContext.TraceFlags, activityContext.TraceState, activityContext.IsRemote);
 
             Activity? newActivity = ActivityTraceSource.StartActivity(
@@ -190,7 +190,7 @@ namespace DurableTask.Core.Tracing
 
             Activity? newActivity = ActivityTraceSource.StartActivity(
                 name: CreateSpanName("activity", taskScheduledEvent.Name, taskScheduledEvent.Version),
-                kind: ActivityKind.Server,
+                kind: ActivityKind.Client,
                 startTime: taskScheduledEvent.Timestamp,
                 parentContext: activityContext);
 


### PR DESCRIPTION
This PR updates the `ActivityKind` values for task activity spans and also makes the task activity client span the parent of the task activity server span.

<img width="805" alt="image" src="https://user-images.githubusercontent.com/15795068/230560878-169df542-5aca-47d7-b853-47f66f27679e.png">
