### PR TITLE
Fix exception when Continue-as-New and Termination happens at the same time

### DIFF
--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -805,7 +805,7 @@ namespace DurableTask.Core
             out bool continuedAsNew)
         {
             ExecutionCompletedEvent executionCompletedEvent;
-            continuedAsNew = (completeOrchestratorAction.OrchestrationStatus == OrchestrationStatus.ContinuedAsNew);
+            continuedAsNew = (completeOrchestratorAction.OrchestrationStatus == OrchestrationStatus.ContinuedAsNew) && (runtimeState.OrchestrationStatus != OrchestrationStatus.Terminated);
             if (completeOrchestratorAction.OrchestrationStatus == OrchestrationStatus.ContinuedAsNew)
             {
                 executionCompletedEvent = new ContinueAsNewEvent(completeOrchestratorAction.Id,
@@ -819,7 +819,10 @@ namespace DurableTask.Core
                     completeOrchestratorAction.FailureDetails);
             }
 
-            runtimeState.AddEvent(executionCompletedEvent);
+            if (runtimeState.OrchestrationStatus != OrchestrationStatus.Terminated)
+            {
+                runtimeState.AddEvent(executionCompletedEvent);
+            }
 
             this.logHelper.OrchestrationCompleted(runtimeState, completeOrchestratorAction);
             TraceHelper.TraceInstance(


### PR DESCRIPTION
Stop Continue-as-New when runtime state already in terminated status

Related issue: https://github.com/Azure/azure-functions-durable-extension/issues/2264