### PR TITLE
Fix TableClient.Uri When Endpoint Contains SAS Tokens

### DIFF
--- a/Test/DurableTask.AzureStorage.Tests/Storage/TableClientExtensionsTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/Storage/TableClientExtensionsTests.cs
@@ -50,7 +50,7 @@ namespace DurableTask.AzureStorage.Tests.Storage
             client = new TableClient(new Uri("https://foo.table.core.windows.net/bar"));
             Assert.AreEqual(new Uri("https://foo.table.core.windows.net/bar"), client.GetUri());
 
-            client = new TableClient(new Uri("https://foo.table.core.windows.net/bar?sv=2019-12-12&ss=t&srt=s&sp=rwdlacu&se=2020-08-28T23:45:30Z&st=2020-08-26T15:45:30Z&spr=https&sig=mySig&tn=someTableName"));
+            client = new TableClient(new Uri("https://foo.table.core.windows.net/bar?sv=2019-12-12&ss=t&srt=s&sp=rwdlacu&se=2020-08-28T23:45:30Z&st=2020-08-26T15:45:30Z&spr=https&sig=mySig&tn=bar"));
             Assert.AreEqual(new Uri("https://foo.table.core.windows.net/bar"), client.GetUri());
         }
     }

--- a/Test/DurableTask.AzureStorage.Tests/Storage/TableClientExtensionsTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/Storage/TableClientExtensionsTests.cs
@@ -45,7 +45,12 @@ namespace DurableTask.AzureStorage.Tests.Storage
         [TestMethod]
         public void GetUri_TableEndpoint()
         {
-            var client = new TableClient(new Uri("https://foo.table.core.windows.net/bar"));
+            TableClient client;
+
+            client = new TableClient(new Uri("https://foo.table.core.windows.net/bar"));
+            Assert.AreEqual(new Uri("https://foo.table.core.windows.net/bar"), client.GetUri());
+
+            client = new TableClient(new Uri("https://foo.table.core.windows.net/bar?sv=2019-12-12&ss=t&srt=s&sp=rwdlacu&se=2020-08-28T23:45:30Z&st=2020-08-26T15:45:30Z&spr=https&sig=mySig&tn=someTableName"));
             Assert.AreEqual(new Uri("https://foo.table.core.windows.net/bar"), client.GetUri());
         }
     }

--- a/src/DurableTask.AzureStorage/Storage/TableClientExtensions.cs
+++ b/src/DurableTask.AzureStorage/Storage/TableClientExtensions.cs
@@ -28,7 +28,9 @@ namespace DurableTask.AzureStorage.Storage
             }
 
             Uri? endpoint = GetEndpointFunc(tableClient);
-            return endpoint != null ? new TableUriBuilder(endpoint) { Tablename = tableClient.Name }.ToUri() : null;
+            return endpoint != null
+                ? new TableUriBuilder(endpoint) { Query = null, Sas = null, Tablename = tableClient.Name }.ToUri()
+                : null;
         }
 
         static readonly Func<TableClient, Uri?> GetEndpointFunc = CreateGetEndpointFunc();


### PR DESCRIPTION
I fixed a [bug with `TableClient.Uri`](https://github.com/Azure/azure-sdk-for-net/pull/35566) yesterday related to the Azurite URL, but I also realized the implementation I wrote here did not account for possible SAS tokens in the table endpoint. So this change incorporates it.

I also re-merged with main because apparently some history was not included 😦 We probably shouldn't squash for changes into the feature branch