### PR TITLE
[AzureServiceFabric] Handle missing ExecutionStartedEvent orchestrations

### DIFF
--- a/src/DurableTask.AzureServiceFabric/FabricOrchestrationService.cs
+++ b/src/DurableTask.AzureServiceFabric/FabricOrchestrationService.cs
@@ -159,7 +159,7 @@ namespace DurableTask.AzureServiceFabric
 
                 // Do not return the orchestration workitem if 'ExecutionStartedEvent' is missing.
                 // This can happen when an orchestration message like TerminateEvent is sent to an already finished orchestration
-                // TODO: Fix race this condition that introduced the bad orchestration
+                // TODO: Fix the race condition that introduced the bad orchestration
                 if (currentRuntimeState.ExecutionStartedEvent == null)
                 {
                     ServiceFabricProviderEventSource.Tracing.UnexpectedCodeCondition($"Orchestration with no execution started event found: {currentSession.SessionId}");

--- a/src/DurableTask.AzureServiceFabric/FabricOrchestrationService.cs
+++ b/src/DurableTask.AzureServiceFabric/FabricOrchestrationService.cs
@@ -149,12 +149,23 @@ namespace DurableTask.AzureServiceFabric
                 newMessages = await this.orchestrationProvider.ReceiveSessionMessagesAsync(currentSession);
 
                 var currentRuntimeState = new OrchestrationRuntimeState(currentSession.SessionState);
+
                 var workItem = new TaskOrchestrationWorkItem()
                 {
                     NewMessages = newMessages.Select(m => m.Value.TaskMessage).ToList(),
                     InstanceId = currentSession.SessionId.InstanceId,
                     OrchestrationRuntimeState = currentRuntimeState
                 };
+
+                // Do not return the orchestraiton if 'ExecutionStartedEvent' is missing.
+                // This can happen when an when an orchestration message like TerminateEvent is sent to an already finished orchestration
+                // TODO: Fix race this condition
+                if (currentRuntimeState.ExecutionStartedEvent == null)
+                {
+                    ServiceFabricProviderEventSource.Tracing.UnexpectedCodeCondition($"Orchestration with no execution started event found: {currentSession.SessionId}");
+                    await this.DropOrchestrationAsync(workItem);
+                    return null;
+                }
 
                 if (newMessages.Count == 0)
                 {
@@ -344,6 +355,33 @@ namespace DurableTask.AzureServiceFabric
             {
                 await HandleCompletedOrchestration(workItem);
             }
+        }
+
+        // Caller should ensure the workItem has reached terminal state.
+        private async Task DropOrchestrationAsync(TaskOrchestrationWorkItem workItem)
+        {
+            await RetryHelper.ExecuteWithRetryOnTransient(async () =>
+            {
+                using (var txn = this.stateManager.CreateTransaction())
+                {
+                    // DropSession does 2 things (like mentioned in the comments above) - remove the row from sessions dictionary
+                    // and delete the session messages dictionary. The second step is in a background thread and not part of transaction.
+                    // However even if this transaction failed but we ended up deleting session messages dictionary, that's ok - at
+                    // that time, it should be an empty dictionary and we would have updated the runtime session state to full completed
+                    // state in the transaction from Complete method. So the subsequent attempt would be able to complete the session.
+                    await this.orchestrationProvider.DropSession(txn, workItem.OrchestrationRuntimeState.OrchestrationInstance);
+                    await txn.CommitAsync();
+                }
+            }, uniqueActionIdentifier: $"OrchestrationId = '{workItem.InstanceId}', Action = '{nameof(HandleCompletedOrchestration)}'");
+
+            this.instanceStore.OnOrchestrationCompleted(workItem.OrchestrationRuntimeState.OrchestrationInstance);
+
+            string message = string.Format("Orchestration with instanceId : '{0}' and executionId : '{1}' dropped due to state corruption (missing ExecutionStartedEvent)",
+                workItem.InstanceId,
+                workItem.OrchestrationRuntimeState.OrchestrationInstance.ExecutionId);
+            ServiceFabricProviderEventSource.Tracing.LogOrchestrationInformation(workItem.InstanceId,
+                workItem.OrchestrationRuntimeState.OrchestrationInstance.ExecutionId,
+                message);
         }
 
         // Caller should ensure the workItem has reached terminal state.

--- a/src/DurableTask.AzureServiceFabric/FabricOrchestrationService.cs
+++ b/src/DurableTask.AzureServiceFabric/FabricOrchestrationService.cs
@@ -158,7 +158,7 @@ namespace DurableTask.AzureServiceFabric
                 };
 
                 // Do not return the orchestration workitem if 'ExecutionStartedEvent' is missing.
-                // This can happen an orchestration message like TerminateEvent is sent to an already finished orchestration
+                // This can happen when an orchestration message like TerminateEvent is sent to an already finished orchestration
                 // TODO: Fix race this condition that introduced the bad orchestration
                 if (currentRuntimeState.ExecutionStartedEvent == null)
                 {

--- a/src/DurableTask.AzureServiceFabric/FabricOrchestrationServiceClient.cs
+++ b/src/DurableTask.AzureServiceFabric/FabricOrchestrationServiceClient.cs
@@ -131,7 +131,7 @@ namespace DurableTask.AzureServiceFabric
             {
                 using (var txn = this.stateManager.CreateTransaction())
                 {
-                    // DropSession does 2 things : removs the row from sessions dictionary and delete the session messages dictionary.
+                    // DropSession does 2 things : removes the row from sessions dictionary and delete the session messages dictionary.
                     // The second step is in a background thread and not part of transaction.
                     // However even if this transaction failed but we ended up deleting session messages dictionary, that's ok - at
                     // that time, it should be an empty dictionary and we would have updated the runtime session state to full completed

--- a/src/DurableTask.AzureServiceFabric/FabricOrchestrationServiceClient.cs
+++ b/src/DurableTask.AzureServiceFabric/FabricOrchestrationServiceClient.cs
@@ -131,8 +131,8 @@ namespace DurableTask.AzureServiceFabric
             {
                 using (var txn = this.stateManager.CreateTransaction())
                 {
-                    // DropSession does 2 things (like mentioned in the comments above) - remove the row from sessions dictionary
-                    // and delete the session messages dictionary. The second step is in a background thread and not part of transaction.
+                    // DropSession does 2 things : removs the row from sessions dictionary and delete the session messages dictionary.
+                    // The second step is in a background thread and not part of transaction.
                     // However even if this transaction failed but we ended up deleting session messages dictionary, that's ok - at
                     // that time, it should be an empty dictionary and we would have updated the runtime session state to full completed
                     // state in the transaction from Complete method. So the subsequent attempt would be able to complete the session.

--- a/src/DurableTask.AzureServiceFabric/Stores/SessionProvider.cs
+++ b/src/DurableTask.AzureServiceFabric/Stores/SessionProvider.cs
@@ -116,7 +116,7 @@ namespace DurableTask.AzureServiceFabric.Stores
                                     }
                                     else
                                     {
-                                        // If the session state is cleared using ForceTerminateOrchestration + reason (cleanupstore) then we may endup with a stale entry in the queue
+                                        // If the session state is cleared using ForceTerminateOrchestration + reason (cleanupstore) then we may end up with a stale entry in the queue
                                         var errorMessage = $"Internal Server Error: Did not find the session object in reliable dictionary while having the session {returnInstanceId} in memory";
                                         ServiceFabricProviderEventSource.Tracing.UnexpectedCodeCondition(errorMessage);
                                         reEnqueueOnException = false;


### PR DESCRIPTION
This PR is handling the following cases:
1. When an orchestration is terminated, sometimes it's adding a TerminateEvent message to a non-existent instance id or execution id
2. If we clean up the session store then the in-memory session queue may still contain an entry which tries to find an already cleaned up session.