### PR TITLE
[AzureServiceFabric] Fix issues related to Terminate orchestration

### DIFF
--- a/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
+++ b/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
@@ -6,7 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Microsoft.Azure.DurableTask.AzureServiceFabric</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.3.7</Version>
+    <Version>2.3.8</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <Title>Azure Service Fabric provider extension for the Durable Task Framework.</Title>

--- a/src/DurableTask.AzureServiceFabric/FabricOrchestrationService.cs
+++ b/src/DurableTask.AzureServiceFabric/FabricOrchestrationService.cs
@@ -352,7 +352,7 @@ namespace DurableTask.AzureServiceFabric
         {
             await CompleteOrchestrationAsync(workItem);
 
-            string message = string.Format($"{nameof(DropOrchestrationAsync)}: Dropped. Orchestration history: {JsonConvert.SerializeObject(workItem.OrchestrationRuntimeState.Events)}");
+            string message = $"{nameof(DropOrchestrationAsync)}: Dropped. Orchestration history: {JsonConvert.SerializeObject(workItem.OrchestrationRuntimeState.Events)}";
             ServiceFabricProviderEventSource.Tracing.LogOrchestrationInformation(workItem.InstanceId,
                 workItem.OrchestrationRuntimeState.OrchestrationInstance.ExecutionId,
                 message);

--- a/src/DurableTask.AzureServiceFabric/FabricOrchestrationServiceClient.cs
+++ b/src/DurableTask.AzureServiceFabric/FabricOrchestrationServiceClient.cs
@@ -136,7 +136,6 @@ namespace DurableTask.AzureServiceFabric
                         state = new OrchestrationState()
                         {
                             OrchestrationInstance = orchestrationInstance,
-                            OrchestrationStatus = OrchestrationStatus.Terminated,
                             LastUpdatedTime = DateTime.UtcNow,
                         };
                     }
@@ -162,7 +161,7 @@ namespace DurableTask.AzureServiceFabric
 
                 this.instanceStore.OnOrchestrationCompleted(orchestrationInstance);
 
-                string message = string.Format($"{nameof(ForceTerminateTaskOrchestrationAsync)}: Terminated with reason '{reason}'");
+                string message = $"{nameof(ForceTerminateTaskOrchestrationAsync)}: Terminated with reason '{reason}'";
                 ServiceFabricProviderEventSource.Tracing.LogOrchestrationInformation(instanceId, latestExecutionId, message);
             }
             else

--- a/src/DurableTask.AzureServiceFabric/FabricOrchestrationServiceClient.cs
+++ b/src/DurableTask.AzureServiceFabric/FabricOrchestrationServiceClient.cs
@@ -18,19 +18,16 @@ namespace DurableTask.AzureServiceFabric
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-
-    using DurableTask.Core;
-    using DurableTask.Core.Exceptions;
-    using DurableTask.Core.History;
-    using DurableTask.Core.Tracking;
     using DurableTask.AzureServiceFabric.Stores;
     using DurableTask.AzureServiceFabric.TaskHelpers;
     using DurableTask.AzureServiceFabric.Tracing;
-
-    using Microsoft.ServiceFabric.Data;
-
-    using Newtonsoft.Json;
+    using DurableTask.Core;
+    using DurableTask.Core.Exceptions;
+    using DurableTask.Core.History;
     using DurableTask.Core.Serializing;
+    using DurableTask.Core.Tracking;
+    using Microsoft.ServiceFabric.Data;
+    using Newtonsoft.Json;
 
     class FabricOrchestrationServiceClient : IOrchestrationServiceClient, IFabricProviderClient
     {
@@ -124,28 +121,55 @@ namespace DurableTask.AzureServiceFabric
 
             if (latestExecutionId == null)
             {
-                throw new ArgumentException($"No execution id found for given instanceId {instanceId}, can only terminate the latest execution of a given orchestration");
+                throw new InvalidOperationException($"No execution id found for given instanceId {instanceId}, can only terminate the latest execution of a given orchestration");
             }
 
+            var orchestrationInstance = new OrchestrationInstance { InstanceId = instanceId, ExecutionId = latestExecutionId };
             if (reason?.Trim().StartsWith("CleanupStore", StringComparison.OrdinalIgnoreCase) == true)
             {
                 using (var txn = this.stateManager.CreateTransaction())
                 {
+                    var stateInstance = await this.instanceStore.GetOrchestrationStateAsync(instanceId, latestExecutionId);
+                    var state = stateInstance?.State;
+                    if (state == null)
+                    {
+                        state = new OrchestrationState()
+                        {
+                            OrchestrationInstance = orchestrationInstance,
+                            OrchestrationStatus = OrchestrationStatus.Terminated,
+                            LastUpdatedTime = DateTime.UtcNow,
+                        };
+                    }
+
+                    state.OrchestrationStatus = OrchestrationStatus.Terminated;
+                    state.Output = $"Orchestration dropped with reason '{reason}'";
+
+                    await this.instanceStore.WriteEntitiesAsync(txn, new InstanceEntityBase[]
+                    {
+                        new OrchestrationStateInstanceEntity()
+                        {
+                            State = state
+                        }
+                    }); ;
                     // DropSession does 2 things : removes the row from sessions dictionary and delete the session messages dictionary.
                     // The second step is in a background thread and not part of transaction.
                     // However even if this transaction failed but we ended up deleting session messages dictionary, that's ok - at
                     // that time, it should be an empty dictionary and we would have updated the runtime session state to full completed
                     // state in the transaction from Complete method. So the subsequent attempt would be able to complete the session.
-                    var instance = new OrchestrationInstance { InstanceId = instanceId, ExecutionId = latestExecutionId };
-                    await this.orchestrationProvider.DropSession(txn, instance);
+                    await this.orchestrationProvider.DropSession(txn, orchestrationInstance);
                     await txn.CommitAsync();
                 }
+
+                this.instanceStore.OnOrchestrationCompleted(orchestrationInstance);
+
+                string message = string.Format($"{nameof(ForceTerminateTaskOrchestrationAsync)}: Terminated with reason '{reason}'");
+                ServiceFabricProviderEventSource.Tracing.LogOrchestrationInformation(instanceId, latestExecutionId, message);
             }
             else
             {
                 var taskMessage = new TaskMessage
                 {
-                    OrchestrationInstance = new OrchestrationInstance { InstanceId = instanceId, ExecutionId = latestExecutionId },
+                    OrchestrationInstance = orchestrationInstance,
                     Event = new ExecutionTerminatedEvent(-1, reason)
                 };
 

--- a/src/DurableTask.AzureServiceFabric/Remote/RemoteOrchestrationServiceClient.cs
+++ b/src/DurableTask.AzureServiceFabric/Remote/RemoteOrchestrationServiceClient.cs
@@ -31,6 +31,7 @@ namespace DurableTask.AzureServiceFabric.Remote
 
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
+    using System.Web.Http.Results;
 
     /// <summary>
     /// Allows to interact with a remote IOrchestrationServiceClient
@@ -122,7 +123,8 @@ namespace DurableTask.AzureServiceFabric.Remote
             {
                 if (!response.IsSuccessStatusCode)
                 {
-                    throw new RemoteServiceException("Unable to terminate task instance", response.StatusCode);
+                    var message = await response.Content.ReadAsStringAsync();
+                    throw new RemoteServiceException($"Unable to terminate task instance. Error: {response.StatusCode}:{message}", response.StatusCode);
                 }
             }
         }

--- a/src/DurableTask.AzureServiceFabric/Stores/SessionProvider.cs
+++ b/src/DurableTask.AzureServiceFabric/Stores/SessionProvider.cs
@@ -20,13 +20,10 @@ namespace DurableTask.AzureServiceFabric.Stores
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-
-    using DurableTask.Core;
     using DurableTask.AzureServiceFabric.TaskHelpers;
     using DurableTask.AzureServiceFabric.Tracing;
-
+    using DurableTask.Core;
     using Microsoft.ServiceFabric.Data;
-    using System.Windows.Forms;
 
     /// <summary>
     /// There are three interesting methods in this class that require some explanation.

--- a/src/DurableTask.AzureServiceFabric/Utils.cs
+++ b/src/DurableTask.AzureServiceFabric/Utils.cs
@@ -28,7 +28,7 @@ namespace DurableTask.AzureServiceFabric
             var runtimeState = workitem.OrchestrationRuntimeState;
             if (runtimeState == null)
             {
-                throw new ArgumentNullException("runtime");
+                throw new ArgumentNullException("runtimeState");
             }
 
             if (runtimeState.ExecutionStartedEvent != null)

--- a/src/DurableTask.AzureServiceFabric/Utils.cs
+++ b/src/DurableTask.AzureServiceFabric/Utils.cs
@@ -23,25 +23,52 @@ namespace DurableTask.AzureServiceFabric
 
     internal static class Utils
     {
-        public static OrchestrationState BuildOrchestrationState(OrchestrationRuntimeState runtimeState)
+        public static OrchestrationState BuildOrchestrationState(TaskOrchestrationWorkItem workitem)
         {
-            return new OrchestrationState
+            var runtimeState = workitem.OrchestrationRuntimeState;
+            if (runtimeState == null)
             {
-                OrchestrationInstance = runtimeState.OrchestrationInstance,
-                ParentInstance = runtimeState.ParentInstance,
-                Name = runtimeState.Name,
-                Version = runtimeState.Version,
-                Status = runtimeState.Status,
-                Tags = runtimeState.Tags,
-                OrchestrationStatus = runtimeState.OrchestrationStatus,
-                CreatedTime = runtimeState.CreatedTime,
-                CompletedTime = runtimeState.CompletedTime,
-                LastUpdatedTime = DateTime.UtcNow,
-                Size = runtimeState.Size,
-                CompressedSize = runtimeState.CompressedSize,
-                Input = runtimeState.Input,
-                Output = runtimeState.Output
-            };
+                throw new ArgumentNullException("runtime");
+            }
+
+            if (runtimeState.ExecutionStartedEvent != null)
+            {
+                return new OrchestrationState
+                {
+                    OrchestrationInstance = runtimeState.OrchestrationInstance,
+                    ParentInstance = runtimeState.ParentInstance,
+                    Name = runtimeState.Name,
+                    Version = runtimeState.Version,
+                    Status = runtimeState.Status,
+                    Tags = runtimeState.Tags,
+                    OrchestrationStatus = runtimeState.OrchestrationStatus,
+                    CreatedTime = runtimeState.CreatedTime,
+                    CompletedTime = runtimeState.CompletedTime,
+                    LastUpdatedTime = DateTime.UtcNow,
+                    Size = runtimeState.Size,
+                    CompressedSize = runtimeState.CompressedSize,
+                    Input = runtimeState.Input,
+                    Output = runtimeState.Output
+                };
+            }
+            else
+            {
+                // Create a custom state for a bad orchestration
+                return new OrchestrationState
+                {
+                    OrchestrationInstance = new OrchestrationInstance { InstanceId = workitem.InstanceId },
+                    ParentInstance = runtimeState.ParentInstance,
+                    Status = runtimeState.Status,
+                    Tags = runtimeState.Tags,
+                    OrchestrationStatus = OrchestrationStatus.Terminated,
+                    CompletedTime = runtimeState.CompletedTime,
+                    LastUpdatedTime = DateTime.UtcNow,
+                    Size = runtimeState.Size,
+                    CompressedSize = runtimeState.CompressedSize,
+                    Output = "Orchestration dropped"
+                };
+            }
+
         }
 
         public static TimeSpan Measure(Action action)

--- a/test/DurableTask.AzureServiceFabric.Integration.Tests/FunctionalTests.cs
+++ b/test/DurableTask.AzureServiceFabric.Integration.Tests/FunctionalTests.cs
@@ -415,7 +415,7 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests
             var testData = new TestOrchestrationData()
             {
                 NumberOfParallelTasks = 0,
-                NumberOfSerialTasks = 5,
+                NumberOfSerialTasks = 100,
                 MaxDelay = 5,
                 MinDelay = 5,
                 DelayUnit = TimeSpan.FromSeconds(1),

--- a/test/DurableTask.AzureServiceFabric.Integration.Tests/FunctionalTests.cs
+++ b/test/DurableTask.AzureServiceFabric.Integration.Tests/FunctionalTests.cs
@@ -415,7 +415,7 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests
             var testData = new TestOrchestrationData()
             {
                 NumberOfParallelTasks = 0,
-                NumberOfSerialTasks = 2,
+                NumberOfSerialTasks = 5,
                 MaxDelay = 5,
                 MinDelay = 5,
                 DelayUnit = TimeSpan.FromSeconds(1),
@@ -433,6 +433,53 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests
 
             Assert.AreEqual(OrchestrationStatus.Terminated, result.OrchestrationStatus);
             Assert.AreEqual(reason, result.Output);
+        }
+
+        [TestMethod]
+        public async Task ForceTerminate_Already_Finished_Orchestration()
+        {
+            var testData = new TestOrchestrationData()
+            {
+                NumberOfParallelTasks = 0,
+                NumberOfSerialTasks = 2,
+                MaxDelay = 1,
+                MinDelay = 1,
+                DelayUnit = TimeSpan.FromMilliseconds(1),
+            };
+
+            var instance = await this.taskHubClient.CreateOrchestrationInstanceAsync(typeof(TestOrchestration), testData);
+            await Task.Delay(TimeSpan.FromSeconds(1));
+
+            var result = await this.taskHubClient.WaitForOrchestrationAsync(instance, TimeSpan.FromMinutes(1));
+
+            Assert.AreEqual(OrchestrationStatus.Completed, result.OrchestrationStatus);
+
+            var reason = "Testing terminatiom of already finished orchestration";
+
+            await Assert.ThrowsExceptionAsync<RemoteServiceException>(() => this.taskHubClient.TerminateInstanceAsync(instance, reason));
+        }
+
+        [TestMethod]
+        public async Task ForceTerminate_With_CleanupStore()
+        {
+            var testData = new TestOrchestrationData()
+            {
+                NumberOfParallelTasks = 0,
+                NumberOfSerialTasks = 5,
+                MaxDelay = 5,
+                MinDelay = 5,
+                DelayUnit = TimeSpan.FromSeconds(1),
+            };
+
+            var instance = await this.taskHubClient.CreateOrchestrationInstanceAsync(typeof(TestOrchestration), testData);
+            await Task.Delay(TimeSpan.FromMilliseconds(1));
+
+            var reason = "CleanupStore";
+            await this.taskHubClient.TerminateInstanceAsync(instance, reason);
+            var result = await this.taskHubClient.WaitForOrchestrationAsync(instance, TimeSpan.FromMinutes(1));
+
+            Assert.AreEqual(OrchestrationStatus.Terminated, result.OrchestrationStatus);
+            Assert.IsTrue(result.Output.Contains(reason));
         }
 
         [TestMethod]


### PR DESCRIPTION
Summary of changes:
1. Fix: Terminating an already finished orchestration causes Terminate event left out in the session provider. It causes "System.InvalidOperationException: An ExecutionStarted event is required."
2. Fix: When an orchestration is terminated, an already running task is left out in the ActivityProvider queue causing the activity provider to choke.
3. Fix: Cleanup the orchestration that exists without ExecutionStartedEvent upon Release
4. Added more test cases to test Terminate orchestration