### PR TITLE
[AzureServiceFabric] Minor fixes, more test cases and package version to 2.3.9

### DIFF
--- a/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
+++ b/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
@@ -6,7 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Microsoft.Azure.DurableTask.AzureServiceFabric</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.3.8</Version>
+    <Version>2.3.9</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <Title>Azure Service Fabric provider extension for the Durable Task Framework.</Title>

--- a/src/DurableTask.AzureServiceFabric/FabricOrchestrationServiceClient.cs
+++ b/src/DurableTask.AzureServiceFabric/FabricOrchestrationServiceClient.cs
@@ -155,8 +155,10 @@ namespace DurableTask.AzureServiceFabric
                     // However even if this transaction failed but we ended up deleting session messages dictionary, that's ok - at
                     // that time, it should be an empty dictionary and we would have updated the runtime session state to full completed
                     // state in the transaction from Complete method. So the subsequent attempt would be able to complete the session.
-                    await this.orchestrationProvider.DropSession(txn, orchestrationInstance);
+                    await this.orchestrationProvider.DropSessionAsync(txn, orchestrationInstance);
                     await txn.CommitAsync();
+
+                    // TODO: Renmove from FabricOrchestrationService.SessionInfo dictionary and SessionProvider.lockedSessions
                 }
 
                 this.instanceStore.OnOrchestrationCompleted(orchestrationInstance);

--- a/src/DurableTask.AzureServiceFabric/Stores/SessionProvider.cs
+++ b/src/DurableTask.AzureServiceFabric/Stores/SessionProvider.cs
@@ -352,7 +352,7 @@ namespace DurableTask.AzureServiceFabric.Stores
             }
         }
 
-        public async Task DropSession(ITransaction txn, OrchestrationInstance instance)
+        public async Task DropSessionAsync(ITransaction txn, OrchestrationInstance instance)
         {
             if (instance == null)
             {

--- a/test/DurableTask.AzureServiceFabric.Integration.Tests/FunctionalTests.cs
+++ b/test/DurableTask.AzureServiceFabric.Integration.Tests/FunctionalTests.cs
@@ -483,6 +483,68 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests
         }
 
         [TestMethod]
+        public async Task ForceTerminate_With_CleanupStore_Start_New_Orchestration_With_Same_InstanceId()
+        {
+            string instanceId = "ForceTerminate_With_CleanupStore_Start_New_Orchestration_With_Same_InstanceId";
+            var testData = new TestOrchestrationData()
+            {
+                NumberOfParallelTasks = 0,
+                NumberOfSerialTasks = 5,
+                MaxDelay = 5,
+                MinDelay = 5,
+                DelayUnit = TimeSpan.FromSeconds(1),
+            };
+
+            var instance = await this.taskHubClient.CreateOrchestrationInstanceAsync(typeof(TestOrchestration), instanceId, testData);
+            await Task.Delay(TimeSpan.FromMilliseconds(1));
+
+            var reason = "CleanupStore";
+            await this.taskHubClient.TerminateInstanceAsync(instance, reason);
+            var result = await this.taskHubClient.WaitForOrchestrationAsync(instance, TimeSpan.FromMinutes(1));
+
+            Assert.AreEqual(OrchestrationStatus.Terminated, result.OrchestrationStatus);
+            Assert.IsTrue(result.Output.Contains(reason));
+
+            instance = await this.taskHubClient.CreateOrchestrationInstanceAsync(typeof(TestOrchestration), instanceId, testData);
+            await Task.Delay(TimeSpan.FromMilliseconds(1));
+
+            result = await this.taskHubClient.WaitForOrchestrationAsync(instance, TimeSpan.FromMinutes(1));
+
+            Assert.AreEqual(OrchestrationStatus.Completed, result.OrchestrationStatus);
+        }
+
+        [TestMethod]
+        public async Task ForceTerminate_And_Start_New_Orchestration_With_Same_InstanceId()
+        {
+            string instanceId = "ForceTerminate_And_Start_New_Orchestration_With_Same_InstanceId";
+            var testData = new TestOrchestrationData()
+            {
+                NumberOfParallelTasks = 0,
+                NumberOfSerialTasks = 5,
+                MaxDelay = 5,
+                MinDelay = 5,
+                DelayUnit = TimeSpan.FromSeconds(1),
+            };
+
+            var instance = await this.taskHubClient.CreateOrchestrationInstanceAsync(typeof(TestOrchestration), instanceId, testData);
+            await Task.Delay(TimeSpan.FromMilliseconds(1));
+
+            var reason = "ForceTerminate_And_Start_New_Orchestration_With_Same_InstanceId";
+            await this.taskHubClient.TerminateInstanceAsync(instance, reason);
+            var result = await this.taskHubClient.WaitForOrchestrationAsync(instance, TimeSpan.FromMinutes(1));
+
+            Assert.AreEqual(OrchestrationStatus.Terminated, result.OrchestrationStatus);
+            Assert.IsTrue(result.Output.Contains(reason));
+
+            instance = await this.taskHubClient.CreateOrchestrationInstanceAsync(typeof(TestOrchestration), instanceId, testData);
+            await Task.Delay(TimeSpan.FromMilliseconds(1));
+
+            result = await this.taskHubClient.WaitForOrchestrationAsync(instance, TimeSpan.FromMinutes(1));
+
+            Assert.AreEqual(OrchestrationStatus.Completed, result.OrchestrationStatus);
+        }
+
+        [TestMethod]
         public async Task Purge_Removes_State()
         {
             var instance = await this.taskHubClient.CreateOrchestrationInstanceAsync(typeof(SimpleOrchestrationWithTasks), null);


### PR DESCRIPTION
1. Drop orchestration in CompleteTaskOrchestrationWorkItemAsync if ExecutionStartedEvent missing
2. Unlock/remove session
3. Test cases