### PR TITLE
Update Log Info for GetMessagesAsync

### DIFF
--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -184,7 +184,7 @@ namespace DurableTask.AzureStorage.Messaging
                     }
                 }
 
-                this.Release(CloseReason.Shutdown, $"ControlQueue GetMessagesAsync cancelled by: {(this.releaseCancellationToken.IsCancellationRequested ? "control queue released token cancelled" : "")} {(cancellationToken.IsCancellationRequested ? "shutdown token cancelled" : "")}");
+                this.Release(cancellationToken.IsCancellationRequested ? CloseReason.Shutdown : CloseReason.LeaseLost, $"ControlQueue GetMessagesAsync cancelled by: {(this.releaseCancellationToken.IsCancellationRequested ? "control queue released token cancelled" : "")} {(cancellationToken.IsCancellationRequested ? "shutdown token cancelled" : "")}");
                 return EmptyMessageList;
             }
         }


### PR DESCRIPTION
To enhance the logging clarity in the `GetMessageAsync` method, update the log to include both lease loss and shutdown as cancellation reasons. This will provide more detailed information in the Kusto logs.

**Old implementation**:
<img width="771" alt="image" src="https://github.com/Azure/durabletask/assets/110135109/70617c75-0a83-41fe-82ad-1e77cf27259b">
When least lost happened, the method still logged cancellation reason as `shutdown`. 

**Update**:
when queues are released due to lease loss, the log specifies the reason as `lease lost` rather than `shutdown`. 