### PR TITLE
Store large data blobs in "shared" container when using a dedicated tracking store

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -111,7 +111,14 @@ namespace DurableTask.AzureStorage
             this.azureStorageClient = new AzureStorageClient(settings);
             this.stats = this.azureStorageClient.Stats;
 
-            string compressedMessageBlobContainerName = $"{settings.TaskHubName.ToLowerInvariant()}-largemessages";
+            // if using a shared tracking store, large input/output blobs should also be on a shared blob container
+            var containerNamePrefix = this.settings.TaskHubName.ToLowerInvariant();
+            if (this.settings.HasTrackingStoreStorageAccount)
+            {
+                containerNamePrefix = this.settings.TrackingStoreNamePrefix.ToLowerInvariant();
+            }
+            string compressedMessageBlobContainerName = $"{containerNamePrefix}-largemessages";
+
             this.messageManager = new MessageManager(this.settings, this.azureStorageClient, compressedMessageBlobContainerName);
 
             this.allControlQueues = new ConcurrentDictionary<string, ControlQueue>();


### PR DESCRIPTION
**Context:**
(1) Large inputs and outputs to DF APIs are stored in blob storage. Traditionally, they are stored in a blob container of the same name as the application's taskhub.

For example, if app A has taskhub "myhubA", then its blobs will be stored in the container of name `myhubA-largemessages/`, so that it's blob URIs will be roughly of the form "myhubA-largemessages/<blobName>".

(2), When using dedicated tracking store, customers are able to share an instance and history table across multiple apps. Normally, instance and history table names are prefixed by the application's taskhub name, but when a dedicated tracking store is used, the prefix of these tables will be the value in the customer's `TrackingStoreNamePrefix` setting in `host.json`.

**Problem scenario:**
Consider the case where you have two apps (appA, and appB, with taskhubs myhubA and myhubB respectively) which share a tracking store with prefix "mySharedStore".

Assume both apps both interact with a singleton orchestrator with id "mySingletonOrch".

In this case, we run the risk of the following buggy sequence.

(1) App A creates an entry for "mySingletonOrch" in "mySharedStoreInstances".  Because "mySingletonOrch" received a large input, it's input is serialized as a blob inside "myhubA-largemessages/mySignletonOrchBlob" and this URL is stored as part of the entry to "mySingletonOrch" in the instance table.

(2) App B now tries to do some processing for "mySingletonOrch". It sees that there's already an entry for it in the instances table (created by app A). It sees that it's input is in blob storage, so it tries to download it. However, app B incorrectly assumes that the input can be found in **it's taskhub container** so it looks for "mySingletonOrchBlob" in "myhubB" and fails to find it.

_Now the request for mySingletonOrch will fail indefinitely due to a "blob not found" exception, it is a poison message._

**Solution:**

There are 2 solutions to this problem, I think both should be implemented.
(1) When using a tracking store, input/output blobs should not be stored in a taskhub's blob container. They should be stored in a shared blob container whose name corresponds to the trackingStore prefix. This makes sense because now the instance and history table will share the same prefix as their blobs.

(2) When downloading blobs, we should make no assumptions about the blob container where those blobs are found. If we access to the absolute URI, we should use it to download the blobs from the right container. We don't do this today, we assume the blob container is fixed at application startup.

This PR implements (1). I'm hoping we can implement (2) in a follow up PR.