### PR TITLE
SF Provider: memory leak: Create a new scope in HTTP controller DI on each BeginScope call

### DIFF
--- a/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
+++ b/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
@@ -6,7 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Microsoft.Azure.DurableTask.AzureServiceFabric</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.3.9</Version>
+    <Version>2.3.10</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <Title>Azure Service Fabric provider extension for the Durable Task Framework.</Title>

--- a/src/DurableTask.AzureServiceFabric/Service/DefaultDependencyResolver.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/DefaultDependencyResolver.cs
@@ -22,7 +22,8 @@ namespace DurableTask.AzureServiceFabric.Service
     /// <inheritdoc/>
     public sealed class DefaultDependencyResolver : IDependencyResolver
     {
-        private IServiceProvider provider;
+        private readonly IServiceProvider provider;
+        private readonly IServiceScope scope;
 
         /// <summary>
         /// Creates an instance of <see cref="DefaultDependencyResolver"/>.
@@ -31,6 +32,16 @@ namespace DurableTask.AzureServiceFabric.Service
         public DefaultDependencyResolver(IServiceProvider provider)
         {
             this.provider = provider ?? throw new ArgumentNullException(nameof(provider));
+        }
+
+        /// <summary>
+        /// Creates a private instance of <see cref="DefaultDependencyResolver"/> used when creating a new scope.
+        /// </summary>
+        /// <param name="scope">An instance of <see cref="IServiceScope"/> </param>
+        private DefaultDependencyResolver(IServiceScope scope)
+        {
+            this.scope = scope;
+            this.provider = scope.ServiceProvider;
         }
 
         /// <inheritdoc/>
@@ -48,14 +59,14 @@ namespace DurableTask.AzureServiceFabric.Service
         /// <inheritdoc/>
         public IDependencyScope BeginScope()
         {
-            return this;
+            return new DefaultDependencyResolver(this.provider.CreateScope());
         }
 
         #region IDisposable Support
         /// <inheritdoc />
         public void Dispose()
         {
-            // no-op
+            this.scope?.Dispose();
         }
         #endregion
     }


### PR DESCRIPTION
#### Create a new scope in HTTP controller dependency injection on each BeginScope call
Previous implementation used a single root scope for all HTTP requests. As the scope was never disposed, so didn't the controller & HTTP request/response objects, causing them to get accumulated in memory.
This change creates a new scope in `BeginScope()` API which will be disposed by request handler when the request completes. More information can be found here: [Dependency Injection in ASP.NET Web API 2 - ASP.NET 4.x | Microsoft Learn](https://learn.microsoft.com/en-us/aspnet/web-api/overview/advanced/dependency-injection#dependency-scope-and-controller-lifetime)