### PR TITLE
[for private package]

### DIFF
--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -30,7 +30,7 @@
     <!-- The assembly version is only the major/minor pair, making it easier to do in-place upgrades -->
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
     <!-- This version is used as the nuget package version -->
-    <Version>$(VersionPrefix)</Version>
+    <Version>$(VersionPrefix)-private-1</Version>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">


### PR DESCRIPTION
Related: https://github.com/Azure/azure-functions-durable-extension/issues/2534

In the issue linked above, we saw a worker using the DTFx.Azure Storage taking over 10 hours to release ownership over a queue it had stopped listening to. Since then, the user has changed to utilizing the Netherite backend, where they seem to be experiencing other issues.

This PR, not to be merged, is to discuss a private mitigation where, if a control queue that we have stopped listening to does not have it's ownership released in over 10 minutes, then we fail fast. Obviously, this is a rather aggressive strategy, so this is not a long term solution nor one we should incorporate in the official release as-is.