### PR TITLE
Log warning on multiple execution completed events and allow termination to override previous execution completed events

### DIFF
--- a/src/DurableTask.Core/Logging/EventIds.cs
+++ b/src/DurableTask.Core/Logging/EventIds.cs
@@ -63,5 +63,7 @@ namespace DurableTask.Core.Logging
         public const int RenewOrchestrationWorkItemStarting = 70;
         public const int RenewOrchestrationWorkItemCompleted = 71;
         public const int RenewOrchestrationWorkItemFailed = 72;
+
+        public const int OrchestrationDebugTrace = 73;
     }
 }

--- a/src/DurableTask.Core/Logging/LogEvents.cs
+++ b/src/DurableTask.Core/Logging/LogEvents.cs
@@ -1629,5 +1629,45 @@ namespace DurableTask.Core.Logging
                     Utils.AppName,
                     Utils.PackageVersion);
         }
+
+        internal class OrchestrationDebugTrace : StructuredLogEvent, IEventSourceEvent
+        {
+            public OrchestrationDebugTrace(string instanceId, string executionId, string details)
+            {
+                this.InstanceId = instanceId;
+                this.ExecutionId = executionId;
+                this.Details = details;
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string Name { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.OrchestrationDebugTrace,
+                nameof(EventIds.OrchestrationDebugTrace));
+
+            public override LogLevel Level => LogLevel.Debug;
+
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Orchestration Debug Trace: {this.Details}";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.OrchestrationDebugTrace(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.Details,
+                    Utils.AppName,
+                    Utils.PackageVersion);
+        }
+
     }
 }

--- a/src/DurableTask.Core/Logging/LogHelper.cs
+++ b/src/DurableTask.Core/Logging/LogHelper.cs
@@ -678,6 +678,14 @@ namespace DurableTask.Core.Logging
         }
         #endregion
 
+        internal void OrchestrationDebugTrace(string instanceId, string executionId, string details)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.OrchestrationDebugTrace(instanceId, executionId, details));
+            }
+        }
+
         void WriteStructuredLog(ILogEvent logEvent, Exception? exception = null)
         {
             this.log?.LogDurableEvent(logEvent, exception);

--- a/src/DurableTask.Core/Logging/StructuredEventSource.cs
+++ b/src/DurableTask.Core/Logging/StructuredEventSource.cs
@@ -865,5 +865,25 @@ namespace DurableTask.Core.Logging
                     ExtensionVersion);
             }
         }
+
+        [Event(EventIds.OrchestrationDebugTrace, Level = EventLevel.Verbose, Version = 1)]
+        internal void OrchestrationDebugTrace(
+            string InstanceId,
+            string ExecutionId,
+            string Details,
+            string AppName,
+            string ExtensionVersion)
+        {
+            if (this.IsEnabled(EventLevel.Verbose))
+            {
+                this.WriteEvent(
+                    EventIds.OrchestrationDebugTrace,
+                    InstanceId,
+                    ExecutionId,
+                    Details,
+                    AppName,
+                    ExtensionVersion);
+            }
+        }
     }
 }

--- a/src/DurableTask.Core/OrchestrationRuntimeState.cs
+++ b/src/DurableTask.Core/OrchestrationRuntimeState.cs
@@ -262,12 +262,17 @@ namespace DurableTask.Core
             {
                 if (ExecutionCompletedEvent != null)
                 {
-                    throw new InvalidOperationException(
-                        "Multiple ExecutionCompletedEvent found, potential corruption in state storage");
+                    TraceHelper.Trace(TraceEventType.Warning,
+                        "OrchestrationRuntimeState-DuplicateEvent",
+                        "The orchestration '{0}' already received an 'ExecutionCompletedEvent' with id {1} but is now receiving a new one with id {2}. The latter event will be discarded.",
+                        this.OrchestrationInstance?.InstanceId ?? "",
+                        ExecutionCompletedEvent.EventId,
+                        completedEvent.EventId);
                 }
-
-                ExecutionCompletedEvent = completedEvent;
-                orchestrationStatus = completedEvent.OrchestrationStatus;
+                else { 
+                    ExecutionCompletedEvent = completedEvent;
+                    orchestrationStatus = completedEvent.OrchestrationStatus;
+                }
             }
             else if (historyEvent is ExecutionSuspendedEvent)
             {

--- a/src/DurableTask.Core/OrchestrationRuntimeState.cs
+++ b/src/DurableTask.Core/OrchestrationRuntimeState.cs
@@ -284,14 +284,14 @@ namespace DurableTask.Core
                     {
                         // If the orchestration planned to continue-as-new but termination is requested, we transition to the terminated state.
                         // This is because termination should be considered to be forceful.
-                        log += "Discarding previous 'ExecutionCompletedEvent' as termination is forceful.";
+                        log += " Discarding previous 'ExecutionCompletedEvent' as termination is forceful.";
                         ExecutionCompletedEvent = completedEvent;
                         orchestrationStatus = completedEvent.OrchestrationStatus;
                     }
                     else
                     {
                         // otherwise, we ignore the new event.
-                        log += "Discarding new 'ExecutionCompletedEvent'.";
+                        log += " Discarding new 'ExecutionCompletedEvent'.";
                     }
 
                     LogHelper?.OrchestrationDebugTrace(this.OrchestrationInstance?.InstanceId ?? "", this.OrchestrationInstance?.ExecutionId ?? "", log);

--- a/src/DurableTask.Core/OrchestrationRuntimeState.cs
+++ b/src/DurableTask.Core/OrchestrationRuntimeState.cs
@@ -272,16 +272,18 @@ namespace DurableTask.Core
                     {
                         // If the new event requests termination, we override the pre-existing execution completed event. This is because termination should be considered to be forceful.
                         log += "Discarding previous 'ExecutionCompletedEvent' as termination is forceful.";
+                        ExecutionCompletedEvent = completedEvent;
+                        orchestrationStatus = completedEvent.OrchestrationStatus;
                     }
                     else
                     {
+                        // otherwise, we ignore the new event.
                         log += "Discarding new 'ExecutionCompletedEvent'.";
                     }
 
                     TraceHelper.Trace(TraceEventType.Warning, "OrchestrationRuntimeState-DuplicateEvent", log);
                 }
-                ExecutionCompletedEvent = completedEvent;
-                orchestrationStatus = completedEvent.OrchestrationStatus;
+
             }
             else if (historyEvent is ExecutionSuspendedEvent)
             {

--- a/src/DurableTask.Core/OrchestrationRuntimeState.cs
+++ b/src/DurableTask.Core/OrchestrationRuntimeState.cs
@@ -264,7 +264,6 @@ namespace DurableTask.Core
                 {
                     // It's not generally expected to receive multiple execution completed events for a given orchestrator, but it's possible under certain race conditions.
                     // For example: when an orchestrator is signaled to terminate at the same time as it attempts to continue-as-new.
-
                     var log = $"The orchestration '{this.OrchestrationInstance?.InstanceId ?? ""}' " +
                         $"had already received an 'ExecutionCompletedEvent' with EventId={ExecutionCompletedEvent.EventId} " +
                         $"and orchestrationStatus={orchestrationStatus} but is now receiving a new one with id={completedEvent.EventId} and orchestrationStatus={completedEvent.OrchestrationStatus}. ";

--- a/src/DurableTask.Core/OrchestrationRuntimeState.cs
+++ b/src/DurableTask.Core/OrchestrationRuntimeState.cs
@@ -267,7 +267,7 @@ namespace DurableTask.Core
 
                     var log = $"The orchestration '{this.OrchestrationInstance?.InstanceId ?? ""}' " +
                         $"had already received an 'ExecutionCompletedEvent' with EventId={ExecutionCompletedEvent.EventId} " +
-                        $"and orchestrationStatus={orchestrationStatus} but it now receiving a new one with id={completedEvent.EventId} and orchestrationStatus={completedEvent.OrchestrationStatus}. ";
+                        $"and orchestrationStatus={orchestrationStatus} but is now receiving a new one with id={completedEvent.EventId} and orchestrationStatus={completedEvent.OrchestrationStatus}. ";
                     
                     if (orchestrationStatus != OrchestrationStatus.Terminated && completedEvent.OrchestrationStatus == OrchestrationStatus.Terminated)
                     {

--- a/src/DurableTask.Core/OrchestrationRuntimeState.cs
+++ b/src/DurableTask.Core/OrchestrationRuntimeState.cs
@@ -268,9 +268,10 @@ namespace DurableTask.Core
                         $"had already received an 'ExecutionCompletedEvent' with EventId={ExecutionCompletedEvent.EventId} " +
                         $"and orchestrationStatus={orchestrationStatus} but is now receiving a new one with id={completedEvent.EventId} and orchestrationStatus={completedEvent.OrchestrationStatus}. ";
                     
-                    if (orchestrationStatus != OrchestrationStatus.Terminated && completedEvent.OrchestrationStatus == OrchestrationStatus.Terminated)
+                    if (orchestrationStatus == OrchestrationStatus.ContinuedAsNew && completedEvent.OrchestrationStatus == OrchestrationStatus.Terminated)
                     {
-                        // If the new event requests termination, we override the pre-existing execution completed event. This is because termination should be considered to be forceful.
+                        // If the orchestration planned to continue-as-new but termination is requested, we transition to the terminated state.
+                        // This is because termination should be considered to be forceful.
                         log += "Discarding previous 'ExecutionCompletedEvent' as termination is forceful.";
                         ExecutionCompletedEvent = completedEvent;
                         orchestrationStatus = completedEvent.OrchestrationStatus;

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -296,6 +296,7 @@ namespace DurableTask.Core
             IList<HistoryEvent>? carryOverEvents = null;
             string? carryOverStatus = null;
 
+            workItem.OrchestrationRuntimeState.LogHelper = this.logHelper;
             OrchestrationRuntimeState runtimeState = workItem.OrchestrationRuntimeState;
 
             runtimeState.AddEvent(new OrchestratorStartedEvent(-1));


### PR DESCRIPTION
Replaces: https://github.com/Azure/durabletask/pull/901/files
From this feedback: https://github.com/Azure/durabletask/pull/901/files#r1316325503

Currently, we throw an exception if we receive multiple `ExecutionCompletedEvent`s. That behavior is a bit too strict because it is possible for multiple `ExecutionCompletedEvent`s to be received at once. For example: when a termination signal arrives at the same time as an orchestrator is requested to continue-as-new.

This PR introduces two changes to this behavior:
(1) Instead of throwing an exception like we do today, we now log a warning notifying the reader that we've found multiple execution completed events and how DTFx is resolving this conflict.

(2) If orchestrator is ~not in the terminated state and the a new event aims to terminate it, the new event overrides the previously encountered `ExecutionCompletedEvent`~ planning to continue-as-new but a termination request is received, we transition to the "Terminated" state; this is because termination should be forceful. In all other cases, we discard the new execution completed event.