### PR TITLE
Enable Tags to be surfaced via TaskHubClient

### DIFF
--- a/src/DurableTask.AzureStorage/OrchestrationInstanceStatus.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationInstanceStatus.cs
@@ -14,6 +14,7 @@
 namespace DurableTask.AzureStorage
 {
     using System;
+    using System.Collections.Generic;
     using Microsoft.WindowsAzure.Storage.Table;
 
     /// <summary>
@@ -33,5 +34,6 @@ namespace DurableTask.AzureStorage
         public string RuntimeStatus { get; set; }
         public DateTime? ScheduledStartTime { get; set; }
         public int Generation { get; set; }
+        public IDictionary<string, string> Tags { get; set; }
     }
 }

--- a/src/DurableTask.AzureStorage/Tracking/TagsSerializer.cs
+++ b/src/DurableTask.AzureStorage/Tracking/TagsSerializer.cs
@@ -1,0 +1,27 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace DurableTask.AzureStorage.Tracking
+{
+    internal static class TagsSerializer
+    {
+        public static string Serialize(IDictionary<string, string> tags)
+            => JsonSerializer.Serialize(tags);
+
+        public static IDictionary<string, string> Deserialize(string tags)
+            => JsonSerializer.Deserialize<Dictionary<string,string>>(tags);
+    }
+}


### PR DESCRIPTION
This change adds a property to the Azure tracking table ("Tags") that will store the tags for an orchestration. If it is too large, it is offloaded to a blob rather than being stored as a property.

As part of this change, `OrchestrationInstanceStatus` from the table is no longer created with reflection; instead, properties are searched for and then set on the status DTO.

Fixes #840
