### PR TITLE
remove orchestration tags from entity action

### DIFF
--- a/src/DurableTask.Core/Entities/OperationFormat/StartNewOrchestrationOperationAction.cs
+++ b/src/DurableTask.Core/Entities/OperationFormat/StartNewOrchestrationOperationAction.cs
@@ -45,10 +45,5 @@ namespace DurableTask.Core.Entities.OperationFormat
         /// The input of the sub-orchestration.
         /// </summary>
         public string? Input { get; set; }
-
-        /// <summary>
-        /// Tags to be applied to the sub-orchestration.
-        /// </summary>
-        public IDictionary<string, string>? Tags { get; set; }
     }
 }

--- a/src/DurableTask.Core/TaskEntityDispatcher.cs
+++ b/src/DurableTask.Core/TaskEntityDispatcher.cs
@@ -777,7 +777,9 @@ namespace DurableTask.Core
             };
             var executionStartedEvent = new ExecutionStartedEvent(-1, action.Input)
             {
-                Tags = OrchestrationTags.MergeTags(action.Tags, runtimeState.Tags),
+                Tags = OrchestrationTags.MergeTags(
+                    runtimeState.Tags,
+                    new Dictionary<string, string>() { { OrchestrationTags.FireAndForget, "" } }),
                 OrchestrationInstance = destination,
                 ParentInstance = new ParentInstance
                 {


### PR DESCRIPTION
The entity SDK does not offer the ability to change the orchestration tags, so it is not necessary to include them in the `StartNewOrchestrationOperationAction` class.

When using this action, however, the `FireAndForget` tag is always added since entities always start orchestrations using fire-and-forget.