### PR TITLE
Rename OperationBatchRequest and OperationBatchResponse

### DIFF
--- a/src/DurableTask.Core/Entities/OperationFormat/EntityBatchRequest.cs
+++ b/src/DurableTask.Core/Entities/OperationFormat/EntityBatchRequest.cs
@@ -18,7 +18,7 @@ namespace DurableTask.Core.Entities.OperationFormat
     /// <summary>
     /// A request for execution of a batch of operations on an entity.
     /// </summary>
-    public class OperationBatchRequest
+    public class EntityBatchRequest
     {
         // NOTE: Actions must be serializable by a variety of different serializer types to support out-of-process execution.
         //       To ensure maximum compatibility, all properties should be public and settable by default.

--- a/src/DurableTask.Core/Entities/OperationFormat/EntityBatchResult.cs
+++ b/src/DurableTask.Core/Entities/OperationFormat/EntityBatchResult.cs
@@ -18,7 +18,7 @@ namespace DurableTask.Core.Entities.OperationFormat
     /// <summary>
     /// The results of executing a batch of operations on the entity out of process.
     /// </summary>
-    public class OperationBatchResult
+    public class EntityBatchResult
     {
         // NOTE: Actions must be serializable by a variety of different serializer types to support out-of-process execution.
         //       To ensure maximum compatibility, all properties should be public and settable by default.

--- a/src/DurableTask.Core/Entities/TaskEntity.cs
+++ b/src/DurableTask.Core/Entities/TaskEntity.cs
@@ -25,6 +25,6 @@ namespace DurableTask.Core.Entities
         /// <summary>
         /// Execute a batch of operations on an entity.
         /// </summary>
-        public abstract Task<EntityBatchResult> ExecuteOperationBatchAsync(EntityBatchRequest operations);
+        public abstract Task<EntityBatchResult> ExecuteOperationBatchAsync(EntityBatchRequest operations, EntityExecutionOptions options);
     }
 }

--- a/src/DurableTask.Core/Entities/TaskEntity.cs
+++ b/src/DurableTask.Core/Entities/TaskEntity.cs
@@ -25,6 +25,6 @@ namespace DurableTask.Core.Entities
         /// <summary>
         /// Execute a batch of operations on an entity.
         /// </summary>
-        public abstract Task<OperationBatchResult> ExecuteOperationBatchAsync(OperationBatchRequest operations, EntityExecutionOptions options);
+        public abstract Task<EntityBatchResult> ExecuteOperationBatchAsync(EntityBatchRequest operations);
     }
 }

--- a/src/DurableTask.Core/Logging/LogEvents.cs
+++ b/src/DurableTask.Core/Logging/LogEvents.cs
@@ -1184,7 +1184,7 @@ namespace DurableTask.Core.Logging
         /// </summary>
         internal class EntityBatchExecuting : StructuredLogEvent, IEventSourceEvent
         {
-            public EntityBatchExecuting(OperationBatchRequest request)
+            public EntityBatchExecuting(EntityBatchRequest request)
             {
                 this.InstanceId = request.InstanceId;
                 this.OperationCount = request.Operations.Count;
@@ -1223,7 +1223,7 @@ namespace DurableTask.Core.Logging
         /// </summary>
         internal class EntityBatchExecuted : StructuredLogEvent, IEventSourceEvent
         {
-            public EntityBatchExecuted(OperationBatchRequest request, OperationBatchResult result)
+            public EntityBatchExecuted(EntityBatchRequest request, EntityBatchResult result)
             {
                 this.InstanceId = request.InstanceId;
                 this.OperationCount = request.Operations.Count;

--- a/src/DurableTask.Core/Logging/LogHelper.cs
+++ b/src/DurableTask.Core/Logging/LogHelper.cs
@@ -566,7 +566,7 @@ namespace DurableTask.Core.Logging
         /// Logs that an entity operation batch is about to start executing.
         /// </summary>
         /// <param name="request">The batch request.</param>
-        internal void EntityBatchExecuting(OperationBatchRequest request)
+        internal void EntityBatchExecuting(EntityBatchRequest request)
         {
             if (this.IsStructuredLoggingEnabled)
             {
@@ -579,7 +579,7 @@ namespace DurableTask.Core.Logging
         /// </summary>
         /// <param name="request">The batch request.</param>
         /// <param name="result">The batch result.</param>
-        internal void EntityBatchExecuted(OperationBatchRequest request, OperationBatchResult result)
+        internal void EntityBatchExecuted(EntityBatchRequest request, EntityBatchResult result)
         {
             if (this.IsStructuredLoggingEnabled)
             {

--- a/src/DurableTask.Core/TaskEntityDispatcher.cs
+++ b/src/DurableTask.Core/TaskEntityDispatcher.cs
@@ -800,10 +800,10 @@ namespace DurableTask.Core
 
         #endregion
 
-        async Task<OperationBatchResult> ExecuteViaMiddlewareAsync(Work workToDoNow, OrchestrationInstance instance, string serializedEntityState)
+        async Task<EntityBatchResult> ExecuteViaMiddlewareAsync(Work workToDoNow, OrchestrationInstance instance, string serializedEntityState)
         {
             // the request object that will be passed to the worker
-            var request = new OperationBatchRequest()
+            var request = new EntityBatchRequest()
             {
                 InstanceId = instance.InstanceId,
                 EntityState = serializedEntityState,
@@ -828,7 +828,7 @@ namespace DurableTask.Core
                 // Check to see if the custom middleware intercepted and substituted the orchestration execution
                 // with its own execution behavior, providing us with the end results. If so, we can terminate
                 // the dispatch pipeline here.
-                var resultFromMiddleware = dispatchContext.GetProperty<OperationBatchResult>();
+                var resultFromMiddleware = dispatchContext.GetProperty<EntityBatchResult>();
                 if (resultFromMiddleware != null)
                 {
                     return;
@@ -854,7 +854,7 @@ namespace DurableTask.Core
                 dispatchContext.SetProperty(result);
             });
 
-            var result = dispatchContext.GetProperty<OperationBatchResult>();
+            var result = dispatchContext.GetProperty<EntityBatchResult>();
 
             this.logHelper.EntityBatchExecuted(request, result);
 


### PR DESCRIPTION
For better consistency across repositories and easier understanding, these are now named EntityBatchRequest and EntityBatchResponse.