### PR TITLE
Revise entity state and status format and access

### DIFF
--- a/src/DurableTask.Core/Entities/ClientEntityHelpers.cs
+++ b/src/DurableTask.Core/Entities/ClientEntityHelpers.cs
@@ -69,6 +69,7 @@ namespace DurableTask.Core.Entities
                 Id = "fix-orphaned-lock", // we don't know the original id but it does not matter
             };
 
+            var jmessage = JToken.FromObject(message, Serializer.InternalSerializer);
             return new EventToSend(EntityMessageEventNames.ReleaseMessageEventName, jmessage, targetInstance);
         }
 
@@ -78,13 +79,11 @@ namespace DurableTask.Core.Entities
         /// </summary>
         public static string? GetEntityState(string? serializedSchedulerState)
         {
-           if (serializedSchedulerState == null)
-           {
+            if (serializedSchedulerState == null)
+            {
                 return null;
-           }
-            return new EventToSend(EntityMessageEventNames.ReleaseMessageEventName, jmessage, targetInstance);
-        }
-
+            }
+           
             var schedulerState = JsonConvert.DeserializeObject<SchedulerState>(serializedSchedulerState, Serializer.InternalSerializerSettings)!;
             return schedulerState.EntityState;
         }

--- a/src/DurableTask.Core/Entities/ClientEntityHelpers.cs
+++ b/src/DurableTask.Core/Entities/ClientEntityHelpers.cs
@@ -69,22 +69,38 @@ namespace DurableTask.Core.Entities
                 Id = "fix-orphaned-lock", // we don't know the original id but it does not matter
             };
 
-            var jmessage = JToken.FromObject(message, Serializer.InternalSerializer);
-
             return new EventToSend(EntityMessageEventNames.ReleaseMessageEventName, jmessage, targetInstance);
         }
 
         /// <summary>
-        /// Extracts the user-defined entity state (as a serialized string) from the scheduler state (also a serialized string).
+        /// Extracts the user-defined entity state from the serialized scheduler state. The result is the serialized state,
+        /// or null if the entity has no state.
         /// </summary>
-        /// <param name="serializedSchedulerState">The state of the scheduler, as a serialized string.</param>
-        /// <param name="entityState">The entity state</param>
-        /// <returns>True if the entity exists, or false otherwise</returns>
-        public static bool TryGetEntityStateFromSerializedSchedulerState(string serializedSchedulerState, out string? entityState)
+        public static string? GetEntityState(string? serializedSchedulerState)
         {
-            var schedulerState = JsonConvert.DeserializeObject<SchedulerState>(serializedSchedulerState, Serializer.InternalSerializerSettings);
-            entityState = schedulerState!.EntityState;
-            return schedulerState.EntityExists;
+           if (serializedSchedulerState == null)
+           {
+                return null;
+           }
+            return new EventToSend(EntityMessageEventNames.ReleaseMessageEventName, jmessage, targetInstance);
+        }
+
+            var schedulerState = JsonConvert.DeserializeObject<SchedulerState>(serializedSchedulerState, Serializer.InternalSerializerSettings)!;
+            return schedulerState.EntityState;
+        }
+
+        /// <summary>
+        /// Gets the entity status from the serialized custom status of the orchestration.
+        /// or null if the entity has no state.
+        /// </summary>
+        public static EntityStatus? GetEntityStatus(string? orchestrationCustomStatus)
+        {
+            if (orchestrationCustomStatus == null)
+            {
+                return null;
+            }
+
+            return JsonConvert.DeserializeObject<EntityStatus>(orchestrationCustomStatus, Serializer.InternalSerializerSettings)!;
         }
     }
 }

--- a/src/DurableTask.Core/Entities/StateFormat/EntityStatus.cs
+++ b/src/DurableTask.Core/Entities/StateFormat/EntityStatus.cs
@@ -23,9 +23,24 @@ namespace DurableTask.Core.Entities
     public class EntityStatus
     {
         /// <summary>
+        /// The JSON property name for the entityExists property.  
+        /// </summary>
+        const string EntityExistsProperyName = "entityExists";
+
+        /// <summary>
+        /// A fast shortcut for checking whether an entity exists, looking at the serialized json string directly. Used by queries.
+        /// </summary>
+        /// <param name="serializedJson"></param>
+        /// <returns></returns>
+        public static bool TestEntityExists(string serializedJson)
+        {
+            return serializedJson.Contains(EntityExistsProperyName);
+        }
+
+        /// <summary>
         /// Whether this entity exists or not.
         /// </summary>
-        [DataMember(Name = "entityExists", EmitDefaultValue = false)]
+        [DataMember(Name = EntityExistsProperyName, EmitDefaultValue = false)]
         public bool EntityExists { get; set; }
 
         /// <summary>

--- a/src/DurableTask.Core/Entities/StateFormat/SchedulerState.cs
+++ b/src/DurableTask.Core/Entities/StateFormat/SchedulerState.cs
@@ -24,11 +24,8 @@ namespace DurableTask.Core.Entities
     [DataContract]
     internal class SchedulerState
     {
-        /// <summary>
-        /// Whether this entity exists or not.
-        /// </summary>
-        [DataMember(Name = "exists", EmitDefaultValue = false)]
-        public bool EntityExists { get; set; }
+        [IgnoreDataMember]
+        public bool EntityExists => this.EntityState != null;
 
         /// <summary>
         /// The last serialized entity state.

--- a/src/DurableTask.Core/TaskEntityDispatcher.cs
+++ b/src/DurableTask.Core/TaskEntityDispatcher.cs
@@ -268,7 +268,6 @@ namespace DurableTask.Core
 
                         // update the entity state based on the result
                         schedulerState.EntityState = result.EntityState;
-                        schedulerState.EntityExists = result.EntityState != null;
 
                         // perform the actions
                         foreach (var action in result.Actions!)


### PR DESCRIPTION
Three changes here:
- on the entity scheduler state: since we are maintaining the invariant (entity exists) <=> (serialized state is not null) there is no reason for defining (and serializing/deserializing) an `entityExists` field. Instead, just use a property.
- in client entity helpers, provide access to helper functions so external code can deserialize strings that represent `EntityStatus` and `SchedulerState` without us having to make the serialization format public.  This is needed by backends that provide entity query functionality directly. 
- also provide a shortcut (optimized) way to determine if an entity exists when looking at the entity status. Again, this is useful for backends implementing queries.