### PR TITLE
Make criticalSectionId of current critical section externally visible

### DIFF
--- a/src/DurableTask.Core/Entities/OrchestrationEntityContext.cs
+++ b/src/DurableTask.Core/Entities/OrchestrationEntityContext.cs
@@ -69,6 +69,11 @@ namespace DurableTask.Core.Entities
         public bool IsInsideCriticalSection => this.criticalSectionId != null;   
 
         /// <summary>
+        /// The ID of the current critical section, or null if not currently in a critical section.
+        /// </summary>
+        public Guid? CurrentCriticalSectionId => this.criticalSectionId;
+
+        /// <summary>
         /// Enumerate all the entities that are available for calling from within a critical section. 
         /// This set contains all the entities that were locked prior to entering the critical section,
         /// and for which there is not currently an operation call pending.


### PR DESCRIPTION
Previously, clients had to reconstruct this information on their own. Duplicating that logic seemed like a bad idea since it could easily get out of sync if there are future changes. Instead, we can just make this information accessible, which simplifies the clients.