### PR TITLE
SF Provider: Fix OrchestrationAlreadyExists status code from 400 to 409

### DIFF
--- a/src/DurableTask.AzureServiceFabric/Service/FabricOrchestrationServiceController.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/FabricOrchestrationServiceController.cs
@@ -71,7 +71,7 @@ namespace DurableTask.AzureServiceFabric.Service
             }
             catch (OrchestrationAlreadyExistsException ex)
             {
-                return Content<OrchestrationAlreadyExistsException>(System.Net.HttpStatusCode.BadRequest, ex);
+                return Content<OrchestrationAlreadyExistsException>(System.Net.HttpStatusCode.Conflict, ex);
             }
             catch (NotSupportedException ex)
             {

--- a/src/DurableTask.Core/Tracing/DistributedTraceContext.cs
+++ b/src/DurableTask.Core/Tracing/DistributedTraceContext.cs
@@ -20,6 +20,7 @@ namespace DurableTask.Core.Tracing
     /// W3C-compliant distributed trace context.
     /// Spec: https://www.w3.org/TR/trace-context/.
     /// </summary>
+    [DataContract]
     public class DistributedTraceContext
     {
         /// <summary>

--- a/test/DurableTask.AzureServiceFabric.Integration.Tests/FunctionalTests.cs
+++ b/test/DurableTask.AzureServiceFabric.Integration.Tests/FunctionalTests.cs
@@ -19,6 +19,7 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests
     using System.Threading.Tasks;
     using DurableTask.AzureServiceFabric.Exceptions;
     using DurableTask.Core;
+    using DurableTask.Core.Exceptions;
     using DurableTask.Test.Orchestrations.Performance;
 
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -371,6 +372,24 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests
 
             result = await this.taskHubClient.WaitForOrchestrationAsync(instance, TimeSpan.FromMinutes(2));
             Assert.AreEqual(OrchestrationStatus.Completed, result.OrchestrationStatus);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(OrchestrationAlreadyExistsException))]
+        public async Task Duplicate_Orchestration_Instance_Fails_With_OrchestrationAlreadyExistsException()
+        {
+            var instanceId = nameof(Duplicate_Orchestration_Instance_Fails_With_OrchestrationAlreadyExistsException);
+            var input = new TestOrchestrationData()
+            {
+                NumberOfParallelTasks = 0,
+                NumberOfSerialTasks = 1,
+                MaxDelay = 15,
+                MinDelay = 15,
+                DelayUnit = TimeSpan.FromSeconds(1),
+            };
+
+            var instance = await this.taskHubClient.CreateOrchestrationInstanceAsync(typeof(TestOrchestration), instanceId, input);
+            var instance2 = await this.taskHubClient.CreateOrchestrationInstanceAsync(typeof(TestOrchestration), instanceId, input);
         }
 
         [TestMethod]


### PR DESCRIPTION
Service Fabric Provider's `TaskHubClient` expects HTTP 409 in order to process `OrchestrationAlreadyExistsException`, however, the service was throwing HTTP 400 instead, causing the error to be treated as an unknown service error.

Sample response the client receives where the `OrchestrationAlreasyExistsException` is left serialized inside the `RemoteServiceException` message string:


> DurableTask.AzureServiceFabric.Exceptions.RemoteServiceException: CreateTaskOrchestrationAsync failed with status code BadRequest: {"$type":"DurableTask.Core.Exceptions.OrchestrationAlreadyExistsException, DurableTask.Core","ClassName":"DurableTask.Core.Exceptions.OrchestrationAlreadyExistsException","Message":"An orchestration with id '725779b1-b39f-4428-8568-98690f6b4872' is already running.","Data":null,"InnerException":null,"HelpURL":null,"StackTraceString":"   at DurableTask.AzureServiceFabric.FabricOrchestrationServiceClient.<CreateTaskOrchestrationAsync>d__5.MoveNext() in /_/src/DurableTask.AzureServiceFabric/FabricOrchestrationServiceClient.cs:line 51
...TRUNCATED


In addition, while testing the changes, the SF provider was broken to due the `DistributedTraceContext` class missing the `DataContract` attribute. The serialization over the wire was failing with the following error:

> DurableTask.AzureServiceFabric.Exceptions.RemoteServiceException: CreateTaskOrchestrationAsync failed with status code InternalServerError: {"$type":"System.Runtime.Serialization.InvalidDataContractException, System.Runtime.Serialization","ClassName":"System.Runtime.Serialization.InvalidDataContractException","Message":"Type 'DurableTask.Core.Tracing.DistributedTraceContext' cannot be serialized. Consider marking it with the DataContractAttribute attribute, and marking all of its members you want serialized with the DataMemberAttribute attribute.  If the type is a collection, consider marking it with the CollectionDataContractAttribute.  See the Microsoft .NET Framework documentation for other supported types."
...TRUNCATED
