### PR TITLE
Add RawInput to workaround double-serialization issue

### DIFF
--- a/src/DurableTask.Core/Serializing/DataConverter.cs
+++ b/src/DurableTask.Core/Serializing/DataConverter.cs
@@ -14,6 +14,7 @@
 namespace DurableTask.Core.Serializing
 {
     using System;
+    using DurableTask.Core.Serializing.Internal;
 
     /// <summary>
     /// Abstract class for serializing and deserializing data
@@ -58,6 +59,18 @@ namespace DurableTask.Core.Serializing
             }
 
             return (T)result;
+        }
+
+        internal string SerializeInternal(object value)
+        {
+#pragma warning disable CS0618 // Type or member is obsolete. Intentional internal usage.
+            if (value is RawInput raw)
+            {
+                return raw.Value;
+            }
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            return this.Serialize(value);
         }
     }
 }

--- a/src/DurableTask.Core/Serializing/Internal/RawInput.cs
+++ b/src/DurableTask.Core/Serializing/Internal/RawInput.cs
@@ -1,0 +1,42 @@
+//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+#nullable enable
+using System;
+
+namespace DurableTask.Core.Serializing.Internal
+{
+    /// <summary>
+    /// This is an internal API that supports the DurableTask infrastructure and not subject to the same compatibility
+    /// standards as public APIs. It may be changed or removed without notice in any release. You should only use it
+    /// directly in your code with extreme caution and knowing that doing so can result in application failures when
+    /// updating to a new DurableTask release.
+    /// </summary>
+    [Obsolete("Not for public consumption.")]
+    public sealed class RawInput
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RawInput" /> class.
+        /// </summary>
+        /// <param name="value">The raw input value to use.</param>
+        public RawInput(string? value)
+        {
+            this.Value = value;
+        }
+
+        /// <summary>
+        /// Gets the raw input value.
+        /// </summary>
+        public string? Value { get; }
+    }
+}

--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -591,7 +591,7 @@ namespace DurableTask.Core
                 ExecutionId = Guid.NewGuid().ToString("N"),
             };
 
-            string serializedOrchestrationData = this.defaultConverter.Serialize(orchestrationInput);
+            string serializedOrchestrationData = this.defaultConverter.SerializeInternal(orchestrationInput);
             var startedEvent = new ExecutionStartedEvent(-1, serializedOrchestrationData)
             {
                 Tags = orchestrationTags,
@@ -626,7 +626,7 @@ namespace DurableTask.Core
 
             if (eventData != null)
             {
-                string serializedEventData = this.defaultConverter.Serialize(eventData);
+                string serializedEventData = this.defaultConverter.SerializeInternal(eventData);
                 var eventRaisedEvent = new EventRaisedEvent(-1, serializedEventData) { Name = eventName };
 
                 this.logHelper.RaisingEvent(orchestrationInstance, eventRaisedEvent);
@@ -694,7 +694,7 @@ namespace DurableTask.Core
                 throw new ArgumentException(nameof(orchestrationInstance));
             }
 
-            string serializedInput = this.defaultConverter.Serialize(eventData);
+            string serializedInput = this.defaultConverter.SerializeInternal(eventData);
             
             // Distributed Tracing
             EventRaisedEvent eventRaisedEvent = new EventRaisedEvent(-1, serializedInput) { Name = eventName };


### PR DESCRIPTION
This PR is to address a conflicting need in Durable Functions extension. We want to use `TaskHubClient` from within `LocalGrpcListener` so that we leverage all the logic there, especially the distributed tracing work. However, our input is already serialized and `TaskHubClient` would double serialize it. To work around this an "internal" API called `RawInput` has been added. When this type is used as the input for `TaskHubClient`, we will directly use `RawInput.Value` instead of serializing the input.

`RawInput` is "internal" in the sense that it is `public`, but in an `.Internal` namespace, with an `[Obsolete]` attribute, and xmldoc advising customers to use the type at their own risk. This is a pattern used in a few .NET libraries (efcore, webjobs, functions worker, etc) to address the internal-yet-public functionality.