### PR TITLE
Use SerializeInternal in TaskOrchestrationContext

### DIFF
--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -97,7 +97,7 @@ namespace DurableTask.Core
             params object[] parameters)
         {
             int id = this.idCounter++;
-            string serializedInput = this.MessageDataConverter.Serialize(parameters);
+            string serializedInput = this.MessageDataConverter.SerializeInternal(parameters);
             var scheduleTaskTaskAction = new ScheduleTaskOrchestratorAction
             {
                 Id = id,
@@ -152,7 +152,7 @@ namespace DurableTask.Core
             IDictionary<string, string> tags)
         {
             int id = this.idCounter++;
-            string serializedInput = this.MessageDataConverter.Serialize(input);
+            string serializedInput = this.MessageDataConverter.SerializeInternal(input);
 
             string actualInstanceId = instanceId;
             if (string.IsNullOrWhiteSpace(actualInstanceId))
@@ -196,7 +196,7 @@ namespace DurableTask.Core
             }
 
             int id = this.idCounter++;
-            string serializedEventData = this.MessageDataConverter.Serialize(eventData);
+            string serializedEventData = this.MessageDataConverter.SerializeInternal(eventData);
 
             var action = new SendEventOrchestratorAction
             {
@@ -221,7 +221,7 @@ namespace DurableTask.Core
 
         void ContinueAsNewCore(string newVersion, object input)
         {
-            string serializedInput = this.MessageDataConverter.Serialize(input);
+            string serializedInput = this.MessageDataConverter.SerializeInternal(input);
 
             this.continueAsNew = new OrchestrationCompleteOrchestratorAction
             {


### PR DESCRIPTION
Expanding the usage of `.SerializeInternal` to give a way to address https://github.com/Azure/azure-functions-durable-extension/issues/2589

Opting for this route so we don't need to deserialize and re-serialize the event input.