### PR TITLE
Add private setter for TraceParent

### DIFF
--- a/src/DurableTask.Core/Tracing/DistributedTraceContext.cs
+++ b/src/DurableTask.Core/Tracing/DistributedTraceContext.cs
@@ -44,7 +44,7 @@ namespace DurableTask.Core.Tracing
         /// The W3C traceparent data: https://www.w3.org/TR/trace-context/#traceparent-header
         /// </summary>
         [DataMember]
-        public string TraceParent { get; }
+        public string TraceParent { get; private set; }
 
         /// <summary>
         /// The optional W3C tracestate parameter: https://www.w3.org/TR/trace-context/#tracestate-header


### PR DESCRIPTION
This PR adds a private setter for `TraceParent` to allow it to get serialized. Without this addition, we weren't able to run Netherite apps with the distributed tracing changes because we were seeing this exception: `InvalidDataContractException: No set method for property 'TraceParent' in type 'DurableTask.Core.Tracing.DistributedTraceContext'.`

I'm open to other approaches that solve this issue instead of adding a private setter.