### PR TITLE
Revise entity queries

### DIFF
--- a/src/DurableTask.AzureStorage/EntityTrackingStoreQueries.cs
+++ b/src/DurableTask.AzureStorage/EntityTrackingStoreQueries.cs
@@ -149,7 +149,7 @@ namespace DurableTask.AzureStorage
 
                         if (request.RemoveEmptyEntities)
                         {
-                            bool isEmptyEntity = !status.EntityExists && status.LockedBy == null && status.QueueSize == 0;
+                            bool isEmptyEntity = !status.EntityExists && status.LockedBy == null && status.BacklogQueueSize == 0;
                             bool safeToRemoveWithoutBreakingMessageSorterLogic = 
                                 (now - state.LastUpdatedTime > this.properties.EntityMessageReorderWindow);
                             if (isEmptyEntity && safeToRemoveWithoutBreakingMessageSorterLogic)
@@ -215,10 +215,14 @@ namespace DurableTask.AzureStorage
                     }
                 }
 
+                EntityStatus? status = ClientEntityHelpers.GetEntityStatus(state.Status);
+
                 return new EntityMetadata()
                 {
                     EntityId = EntityId.FromString(state.OrchestrationInstance.InstanceId),
                     LastModifiedTime = state.CreatedTime,
+                    BacklogQueueSize = status?.BacklogQueueSize ?? 0,
+                    LockedBy = status?.LockedBy,
                     SerializedState = null, // we were instructed to not include the state
                 };
             }
@@ -245,10 +249,14 @@ namespace DurableTask.AzureStorage
                 }
                 else
                 {
+                    EntityStatus? status = ClientEntityHelpers.GetEntityStatus(state.Status);
+
                     return new EntityMetadata()
                     {
                         EntityId = EntityId.FromString(state.OrchestrationInstance.InstanceId),
                         LastModifiedTime = state.CreatedTime,
+                        BacklogQueueSize = status?.BacklogQueueSize ?? 0,
+                        LockedBy = status?.LockedBy,
                         SerializedState = serializedEntityState,
                     };
                 }

--- a/src/DurableTask.Core/Entities/EntityBackendQueries.cs
+++ b/src/DurableTask.Core/Entities/EntityBackendQueries.cs
@@ -28,11 +28,11 @@ namespace DurableTask.Core.Entities
         /// </summary>
         /// <param name="id">The ID of the entity to get.</param>
         /// <param name="includeState"><c>true</c> to include entity state in the response, <c>false</c> to not.</param>
-        /// <param name="includeDeleted">whether to return metadata for a deleted entity (if such data was retained by the backend).</param>
+        /// <param name="includeStateless">whether to include metadata for entities without user-defined state.</param>
         /// <param name="cancellation">The cancellation token to cancel the operation.</param>
         /// <returns>a response containing metadata describing the entity.</returns>
         public abstract Task<EntityMetadata?> GetEntityAsync(
-            EntityId id, bool includeState = false, bool includeDeleted = false, CancellationToken cancellation = default);
+            EntityId id, bool includeState = false, bool includeStateless = false, CancellationToken cancellation = default);
 
         /// <summary>
         /// Queries entity instances based on the conditions specified in <paramref name="query"/>.
@@ -102,12 +102,14 @@ namespace DurableTask.Core.Entities
             public bool IncludeState { get; set; }
 
             /// <summary>
-            /// Gets or sets a value indicating whether or not to include deleted entities.
+            /// Gets a value indicating whether to include metadata about entities that have no user-defined state.
             /// </summary>
-            /// <remarks>
-            /// This setting is relevant only for providers which retain metadata for deleted entities (<see cref="EntityBackendProperties.SupportsImplicitEntityDeletion"/> is false).
+            /// <remarks> Stateless entities occur when the storage provider is tracking metadata about an entity for synchronization purposes
+            /// even though the entity does not "logically" exist, in the sense that it has no application-defined state.
+            /// Stateless entities are usually transient. For example, they may be in the process of being created or deleted, or 
+            /// they may have been locked by a critical section.
             /// </remarks>
-            public bool IncludeDeleted { get; set; }
+            public bool IncludeStateless { get; set; }
 
             /// <summary>
             /// Gets or sets the desired size of each page to return.

--- a/src/DurableTask.Core/Entities/EntityBackendQueries.cs
+++ b/src/DurableTask.Core/Entities/EntityBackendQueries.cs
@@ -67,6 +67,16 @@ namespace DurableTask.Core.Entities
             public DateTime LastModifiedTime { get; set; }
 
             /// <summary>
+            /// Gets the size of the backlog queue, if there is a backlog, and if that metric is supported by the backend.
+            /// </summary>
+            public int BacklogQueueSize { get; set; }
+
+            /// <summary>
+            /// Gets the instance id of the orchestration that has locked this entity, or null if the entity is not locked.
+            /// </summary>
+            public string? LockedBy { get; set; }
+
+            /// <summary>
             /// Gets or sets the serialized state for this entity. Can be null if the query
             /// specified to not include the state, or to include deleted entities.
             /// </summary>

--- a/src/DurableTask.Core/Entities/StateFormat/EntityStatus.cs
+++ b/src/DurableTask.Core/Entities/StateFormat/EntityStatus.cs
@@ -38,7 +38,7 @@ namespace DurableTask.Core.Entities
         }
 
         /// <summary>
-        /// Whether this entity exists or not.
+        /// Whether this entity currently has a user-defined state or not.
         /// </summary>
         [DataMember(Name = EntityExistsProperyName, EmitDefaultValue = false)]
         public bool EntityExists { get; set; }
@@ -47,7 +47,7 @@ namespace DurableTask.Core.Entities
         /// The size of the queue, i.e. the number of operations that are waiting for the current operation to complete.
         /// </summary>
         [DataMember(Name = "queueSize", EmitDefaultValue = false)]
-        public int QueueSize { get; set; }
+        public int BacklogQueueSize { get; set; }
 
         /// <summary>
         /// The instance id of the orchestration that currently holds the lock of this entity.

--- a/src/DurableTask.Core/TaskEntityDispatcher.cs
+++ b/src/DurableTask.Core/TaskEntityDispatcher.cs
@@ -345,7 +345,7 @@ namespace DurableTask.Core
                     var entityStatus = new EntityStatus()
                     {
                         EntityExists = schedulerState.EntityExists,
-                        QueueSize = schedulerState.Queue?.Count ?? 0,
+                        BacklogQueueSize = schedulerState.Queue?.Count ?? 0,
                         LockedBy = schedulerState.LockedBy,
                     };
                     var serializedEntityStatus = JsonConvert.SerializeObject(entityStatus, Serializer.InternalSerializerSettings);


### PR DESCRIPTION
Several changes here:

- rename 'includeDeleted' property to `includeStateless` because it is more accurate (there are other reasons than having been deleted why an entity could be stateless). Added a comment on this to explain a bit more.

- added `BackLogQueueSize` and `LockedBy` properties to the entity metadata returned by queries. This information was already being stored in storage but not returned by queries.