### PR TITLE
Rename includeStateless to includeTransient in entity queries

### DIFF
--- a/src/DurableTask.AzureStorage/EntityTrackingStoreQueries.cs
+++ b/src/DurableTask.AzureStorage/EntityTrackingStoreQueries.cs
@@ -107,7 +107,7 @@ namespace DurableTask.AzureStorage
                 entityResult = new List<EntityMetadata>();
                 foreach (OrchestrationState entry in states)
                 {
-                    EntityMetadata? entityMetadata = await this.GetEntityMetadataAsync(entry, filter.IncludeStateless, filter.IncludeState);
+                    EntityMetadata? entityMetadata = await this.GetEntityMetadataAsync(entry, filter.IncludeTransient, filter.IncludeState);
                     if (entityMetadata.HasValue)
                     {
                         entityResult.Add(entityMetadata.Value);

--- a/src/DurableTask.AzureStorage/EntityTrackingStoreQueries.cs
+++ b/src/DurableTask.AzureStorage/EntityTrackingStoreQueries.cs
@@ -200,7 +200,7 @@ namespace DurableTask.AzureStorage
             };
         }
 
-        async ValueTask<EntityMetadata?> GetEntityMetadataAsync(OrchestrationState? state, bool includeStateless, bool includeState)
+        async ValueTask<EntityMetadata?> GetEntityMetadataAsync(OrchestrationState? state, bool includeTransient, bool includeState)
         {
             if (state == null)
             {
@@ -209,7 +209,7 @@ namespace DurableTask.AzureStorage
 
             if (!includeState)
             {
-                if (!includeStateless)
+                if (!includeTransient)
                 {
                     // it is possible that this entity was logically deleted even though its orchestration was not purged yet.
                     // we can check this efficiently (i.e. without deserializing anything) by looking at just the custom status
@@ -247,7 +247,7 @@ namespace DurableTask.AzureStorage
                 string? serializedEntityState = ClientEntityHelpers.GetEntityState(serializedSchedulerState);
 
                 // return the result to the user
-                if (!includeStateless && serializedEntityState == null)
+                if (!includeTransient && serializedEntityState == null)
                 {
                     return null;
                 }

--- a/src/DurableTask.Core/Entities/EntityBackendQueries.cs
+++ b/src/DurableTask.Core/Entities/EntityBackendQueries.cs
@@ -112,14 +112,15 @@ namespace DurableTask.Core.Entities
             public bool IncludeState { get; set; }
 
             /// <summary>
-            /// Gets a value indicating whether to include metadata about entities that have no user-defined state.
+            /// Gets a value indicating whether to include metadata about transient entities.
             /// </summary>
-            /// <remarks> Stateless entities occur when the storage provider is tracking metadata about an entity for synchronization purposes
-            /// even though the entity does not "logically" exist, in the sense that it has no application-defined state.
-            /// Stateless entities are usually transient. For example, they may be in the process of being created or deleted, or 
-            /// they may have been locked by a critical section.
+            /// <remarks> Transient entities are entities that do not have an application-defined state, but for which the storage provider is
+            /// tracking metadata for synchronization purposes.
+            /// For example, a transient entity may be observed when the entity is in the process of being created or deleted, or
+            /// when the entity has been locked by a critical section. By default, transient entities are not included in queries since they are
+            /// considered to "not exist" from the perspective of the user application.
             /// </remarks>
-            public bool IncludeStateless { get; set; }
+            public bool IncludeTransient { get; set; }
 
             /// <summary>
             /// Gets or sets the desired size of each page to return.


### PR DESCRIPTION
As discussed, we updated terminology across all repos to "transient entities" when talking about entities that do not have an application-defined state.