### PR TITLE
fix NullReferenceException on backends that do not implement IEntityOrchestrationService

### DIFF
--- a/src/DurableTask.Core/TaskHubWorker.cs
+++ b/src/DurableTask.Core/TaskHubWorker.cs
@@ -146,7 +146,7 @@ namespace DurableTask.Core
             this.entityManager = entityObjectManager ?? throw new ArgumentException("entityObjectManager");
             this.orchestrationService = orchestrationService ?? throw new ArgumentException("orchestrationService");
             this.logHelper = new LogHelper(loggerFactory?.CreateLogger("DurableTask.Core"));
-            this.dispatchEntitiesSeparately = (orchestrationService as IEntityOrchestrationService).EntityBackendProperties?.UseSeparateQueueForEntityWorkItems ?? false;
+            this.dispatchEntitiesSeparately = (orchestrationService as IEntityOrchestrationService)?.EntityBackendProperties?.UseSeparateQueueForEntityWorkItems ?? false;
         }
 
         /// <summary>


### PR DESCRIPTION

Observed NullReferenceException when using durabletask with a backend that does not support entities, even if not using entities at all.

The reason is a missing '?' in the check that determines whether to use the old or new entity dispatch design.

The fix is to add the missing '?'.
