### PR TITLE
Replace STJ package with Newtonsoft

### DIFF
--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -20,8 +20,8 @@
   <!-- Version Info -->
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
-    <MinorVersion>15</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <MinorVersion>16</MinorVersion>
+    <PatchVersion>0</PatchVersion>
 
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <FileVersion>$(VersionPrefix).0</FileVersion>

--- a/src/DurableTask.AzureStorage/Tracking/TagsSerializer.cs
+++ b/src/DurableTask.AzureStorage/Tracking/TagsSerializer.cs
@@ -12,16 +12,16 @@
 //  ----------------------------------------------------------------------------------
 
 using System.Collections.Generic;
-using System.Text.Json;
+using Newtonsoft.Json;
 
 namespace DurableTask.AzureStorage.Tracking
 {
     internal static class TagsSerializer
     {
         public static string Serialize(IDictionary<string, string> tags)
-            => JsonSerializer.Serialize(tags);
+            => JsonConvert.SerializeObject(tags);
 
         public static IDictionary<string, string> Deserialize(string tags)
-            => JsonSerializer.Deserialize<Dictionary<string,string>>(tags);
+            => JsonConvert.DeserializeObject<Dictionary<string,string>>(tags);
     }
 }


### PR DESCRIPTION
The System.Text.Json package refers to Systems.Buffer which is not supported in DurableFunctions V1 host. Replace this package with Newtonsoft.