### PR TITLE
Fix entity preview bugs

### DIFF
--- a/src/DurableTask.AzureStorage/EntityTrackingStoreQueries.cs
+++ b/src/DurableTask.AzureStorage/EntityTrackingStoreQueries.cs
@@ -140,6 +140,7 @@ namespace DurableTask.AzureStorage
             do
             {
                 DurableStatusQueryResult page = await this.trackingStore.GetStateAsync(condition, 100, continuationToken, cancellation);
+                continuationToken = page.ContinuationToken;
 
                 var tasks = new List<Task>();
                 foreach (OrchestrationState state in page.OrchestrationState)

--- a/src/DurableTask.Core/Logging/LogEvents.cs
+++ b/src/DurableTask.Core/Logging/LogEvents.cs
@@ -1252,8 +1252,8 @@ namespace DurableTask.Core.Logging
             public int EntityStateLength { get; }
 
             public override EventId EventId => new EventId(
-                EventIds.EntityBatchExecuting,
-                nameof(EventIds.EntityBatchExecuting));
+                EventIds.EntityBatchExecuted,
+                nameof(EventIds.EntityBatchExecuted));
 
             public override LogLevel Level => LogLevel.Information;
 

--- a/src/DurableTask.Core/TaskHubWorker.cs
+++ b/src/DurableTask.Core/TaskHubWorker.cs
@@ -122,7 +122,7 @@ namespace DurableTask.Core
                 orchestrationObjectManager,
                 activityObjectManager,
                 new NameVersionObjectManager<TaskEntity>(),
-                loggerFactory: null)
+                loggerFactory)
         {
         }
 


### PR DESCRIPTION
Fixes three bugs:

- CleanEntityStorage not reading continuation token, so only processing first page of results
- Wrong event id used by one of the log events
- loggerFactory parameter not being passed on to base constructor