### PR TITLE
Remove DTFx.AS and DTFx.Core preview suffix for public release

### DIFF
--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -30,7 +30,7 @@
     <!-- The assembly version is only the major/minor pair, making it easier to do in-place upgrades -->
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
     <!-- This version is used as the nuget package version -->
-    <Version>$(VersionPrefix)-preview.2</Version>
+    <Version>$(VersionPrefix)</Version>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -27,7 +27,7 @@
     <!-- The assembly version is only the major/minor pair, making it easier to do in-place upgrades -->
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
     <!-- This version is used as the nuget package version -->
-    <Version>$(VersionPrefix)-preview.2</Version>
+    <Version>$(VersionPrefix)</Version>
   </PropertyGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">


### PR DESCRIPTION
As titled. Remove DTFx.AS and DTFx.Core preview suffix for durable functions v2.13.0 public release.