### PR TITLE
Fix bug where input is not passed along when signaling an entity

### DIFF
--- a/src/DurableTask.Core/TaskEntityDispatcher.cs
+++ b/src/DurableTask.Core/TaskEntityDispatcher.cs
@@ -712,6 +712,7 @@ namespace DurableTask.Core
                 Id = Guid.NewGuid(),
                 IsSignal = true,
                 Operation = action.Name,
+                Input = action.Input,
                 ScheduledTime = action.ScheduledTime,
             };
             string eventName;


### PR DESCRIPTION
As reported in https://github.com/Azure/azure-functions-durable-extension/issues/2690, the `TaskEntityDispatcher` contains a bug where the input field is lost when creating a entity request message representing a signal.