### PR TITLE
Upgrade various dependencies with advisory warnings

### DIFF
--- a/samples/DurableTask.Samples/DurableTask.Samples.csproj
+++ b/samples/DurableTask.Samples/DurableTask.Samples.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="CommandLineParser" version="1.9.71" />
     <PackageReference Include="EnterpriseLibrary.SemanticLogging" Version="2.0.1406.1" />
     <PackageReference Include="ncrontab" version="1.0.0" />
-    <PackageReference Include="Newtonsoft.Json" version="11.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
+++ b/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
@@ -18,13 +18,11 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="ImpromptuInterface" Version="6.2.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
     <Reference Include="System.Web" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="ImpromptuInterface" Version="6.2.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
     <Reference Include="System.Web" />
   </ItemGroup>
 
@@ -32,7 +30,6 @@
     <!-- Restoring packages for netstandard2.0 causes warnings. As warnings are treated as errors, compilation will fail. -->
     <!-- Once the packages support netstandard2.0, this project will support netstandard2.0. -->
     <PackageReference Include="ImpromptuInterface" Version="7.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -35,7 +35,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
     <PackageReference Include="WindowsAzure.Storage" version="7.2.1" />
   </ItemGroup>
 

--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -51,6 +51,7 @@ namespace DurableTask.AzureStorage
             this.settings = settings;
             this.azureStorageClient = azureStorageClient;
             this.blobContainer = this.azureStorageClient.GetBlobContainerReference(blobContainerName);
+#pragma warning disable CS0618 // Type or member is obsolete
             this.taskMessageSerializerSettings = new JsonSerializerSettings
             {
                 TypeNameHandling = TypeNameHandling.Objects,
@@ -60,6 +61,7 @@ namespace DurableTask.AzureStorage
                 Binder = new TypeNameSerializationBinder(settings.CustomMessageTypeBinder),
 #endif
             };
+#pragma warning restore CS0618 // Type or member is obsolete
             this.serializer = JsonSerializer.Create(taskMessageSerializerSettings);
 
             if (this.settings.UseDataContractSerialization)

--- a/src/DurableTask.Core/Common/Utils.cs
+++ b/src/DurableTask.Core/Common/Utils.cs
@@ -58,7 +58,7 @@ namespace DurableTask.Core.Common
 #if NETSTANDARD2_0
             SerializationBinder = new PackageUpgradeSerializationBinder()
 #else
-            Binder = new PackageUpgradeSerializationBinder()
+            SerializationBinder = new PackageUpgradeSerializationBinder()
 #endif
         };
         private static readonly JsonSerializer DefaultObjectJsonSerializer = JsonSerializer.Create(ObjectJsonSettings);

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -32,7 +32,7 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -32,15 +32,14 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>
+	<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
     <PackageReference Include="System.Reactive.Core" Version="4.4.1" />
     <PackageReference Include="System.Reactive.Compatibility" Version="4.4.1" />

--- a/src/DurableTask.Core/Serializing/JsonDataConverter.cs
+++ b/src/DurableTask.Core/Serializing/JsonDataConverter.cs
@@ -42,7 +42,7 @@ namespace DurableTask.Core.Serializing
 #if NETSTANDARD2_0
                 SerializationBinder = new PackageUpgradeSerializationBinder()
 #else
-                Binder = new PackageUpgradeSerializationBinder()
+                SerializationBinder = new PackageUpgradeSerializationBinder()
 #endif
             })
         { }

--- a/src/DurableTask.Emulator/DurableTask.Emulator.csproj
+++ b/src/DurableTask.Emulator/DurableTask.Emulator.csproj
@@ -8,14 +8,6 @@
     <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Newtonsoft.Json" version="7.0.1" />
-  </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Newtonsoft.Json" version="13.0.1" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\DurableTask.Core\DurableTask.Core.csproj" />
   </ItemGroup>

--- a/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
+++ b/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
@@ -29,7 +29,6 @@
     <PackageReference Include="Microsoft.Data.OData" version="5.8.5" />
     <PackageReference Include="Microsoft.Data.Services.Client" version="5.8.5" />
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" />
-    <PackageReference Include="Newtonsoft.Json" version="7.0.1" />
     <PackageReference Include="System.Spatial" version="5.8.5" />
     <PackageReference Include="WindowsAzure.ServiceBus" version="4.1.3" />
     <PackageReference Include="WindowsAzure.Storage" version="7.0.0" />

--- a/src/DurableTask.ServiceBus/Tracking/AzureTableOrchestrationHistoryEventEntity.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureTableOrchestrationHistoryEventEntity.cs
@@ -38,7 +38,9 @@ namespace DurableTask.ServiceBus.Tracking
 #if NETSTANDARD2_0
             SerializationBinder = new PackageUpgradeSerializationBinder()
 #else
+#pragma warning disable CS0618 // Type or member is obsolete
             Binder = new PackageUpgradeSerializationBinder()
+#pragma warning restore CS0618 // Type or member is obsolete
 #endif
         };
 

--- a/test/DurableTask.AzureServiceFabric.Integration.Tests/DurableTask.AzureServiceFabric.Integration.Tests.csproj
+++ b/test/DurableTask.AzureServiceFabric.Integration.Tests/DurableTask.AzureServiceFabric.Integration.Tests.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="Newtonsoft.Json" version="12.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.6" />

--- a/test/DurableTask.AzureServiceFabric.Tests/DurableTask.AzureServiceFabric.Tests.csproj
+++ b/test/DurableTask.AzureServiceFabric.Tests/DurableTask.AzureServiceFabric.Tests.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
         <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
         <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-        <PackageReference Include="Newtonsoft.Json" version="7.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
     </ItemGroup>
 

--- a/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
+++ b/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
@@ -9,14 +9,12 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" />
-    <PackageReference Include="Newtonsoft.Json" version="7.0.1" />
     <PackageReference Include="WindowsAzure.Storage" version="7.2.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.6" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="WindowsAzure.Storage" version="9.3.3" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.0.0-beta.3" />
   </ItemGroup>

--- a/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj
+++ b/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="Newtonsoft.Json" version="7.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
@@ -18,7 +17,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DurableTask.ServiceBus.Tests/DurableTask.ServiceBus.Tests.csproj
+++ b/test/DurableTask.ServiceBus.Tests/DurableTask.ServiceBus.Tests.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="Newtonsoft.Json" version="7.0.1" />
     <PackageReference Include="System.Spatial" version="5.8.5" />
     <PackageReference Include="WindowsAzure.ServiceBus" version="4.1.3" />
     <PackageReference Include="WindowsAzure.Storage" version="7.0.0" />

--- a/test/DurableTask.SqlServer.Tests/DurableTask.SqlServer.Tests.csproj
+++ b/test/DurableTask.SqlServer.Tests/DurableTask.SqlServer.Tests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.6.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DurableTask.Test.Orchestrations/DurableTask.Test.Orchestrations.csproj
+++ b/test/DurableTask.Test.Orchestrations/DurableTask.Test.Orchestrations.csproj
@@ -4,14 +4,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Newtonsoft.Json" version="13.0.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Newtonsoft.Json" version="7.0.1" />
-  </ItemGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\..\src\DurableTask.Core\DurableTask.Core.csproj" />


### PR DESCRIPTION
As of recently, building the DTFx project failed with errors of the following kind:

> "Warning as Error: Package <package name> has a known high severity vulnerability" and it points to this advisory: <link>"

The warnings were for:
* Newtonsoft.Json < 13.0.1, which linked to: https://github.com/advisories/GHSA-5crp-9r3c-p9vr
* System.Data.SqlClient < 4.8.5, which linked to: https://github.com/advisories/GHSA-8g2p-5pqh-5jmc

In this PR, I upgrade these dependencies to remove the warnings. In particular,
* We upgrade `System.Data.SqlClient` to `4.8.5`. This is only used in our test project, so it's safe.

* We upgrade `Newtonsoft.Json` to `13.0.1` across the board. This is potentially less safe as it's a major version upgrade, and it's used in of the projects contained within the `DurableTask.sln` solution.

While making this upgrade, I also noticed that we reference `Newtonsoft.Json` in almost every `.csproj` despite it being a transitive dependency. To minimize our management burden in the future, I removed this transitive dependency from those `.csproj`s.