### PR TITLE
support task registration from interface with inheritance, generics, method overloading

### DIFF
--- a/DurableTask.sln
+++ b/DurableTask.sln
@@ -320,7 +320,7 @@ Global
 		{D818ED4C-29B9-431F-8D09-EE8C82510E25} = {240FA679-D5A7-41CA-BA22-70B45A966088}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		EnterpriseLibraryConfigurationToolBinariesPath = packages\TransientFaultHandling.Core.5.1.1209.1\lib\NET4
 		SolutionGuid = {2D63A120-9394-48D9-8CA9-1184364FB854}
+		EnterpriseLibraryConfigurationToolBinariesPath = packages\TransientFaultHandling.Core.5.1.1209.1\lib\NET4
 	EndGlobalSection
 EndGlobal

--- a/DurableTask.sln
+++ b/DurableTask.sln
@@ -320,7 +320,7 @@ Global
 		{D818ED4C-29B9-431F-8D09-EE8C82510E25} = {240FA679-D5A7-41CA-BA22-70B45A966088}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {2D63A120-9394-48D9-8CA9-1184364FB854}
 		EnterpriseLibraryConfigurationToolBinariesPath = packages\TransientFaultHandling.Core.5.1.1209.1\lib\NET4
+		SolutionGuid = {2D63A120-9394-48D9-8CA9-1184364FB854}
 	EndGlobalSection
 EndGlobal

--- a/src/DurableTask.Core/NameVersionHelper.cs
+++ b/src/DurableTask.Core/NameVersionHelper.cs
@@ -102,6 +102,17 @@ namespace DurableTask.Core
             return declaringType + "." + methodName;
         }
 
+        /// <summary>
+        /// Gets the fully qualified method name by joining a prefix representing the declaring type and a suffix representing the parameter list.
+        /// For example,
+        /// "DurableTask.Emulator.Tests.EmulatorFunctionalTests+IInheritedTestOrchestrationTasksB`2[System.Int32,System.String].Juggle.(Int32,Boolean)"
+        /// would be the result for the method `Juggle(int, bool)` as member of
+        /// generic type interface declared like `DurableTask.Emulator.Tests.EmulatorFunctionalTests.IInheritedTestOrchestrationTasksB{int, string}`,
+        /// even if the method were inherited from a base interface.
+        /// </summary>
+        /// <param name="declaringType">typically the result of call to Type.ToString(): Type.FullName is more verbose</param>
+        /// <param name="methodInfo"></param>
+        /// <returns></returns>
         internal static string GetFullyQualifiedMethodName(string declaringType, MethodInfo methodInfo)
         {
             IEnumerable<string> paramTypeNames = methodInfo.GetParameters().Select(x => x.ParameterType.Name);

--- a/src/DurableTask.Core/NameVersionHelper.cs
+++ b/src/DurableTask.Core/NameVersionHelper.cs
@@ -14,7 +14,9 @@
 namespace DurableTask.Core
 {
     using System;
+    using System.Collections.Generic;
     using System.Dynamic;
+    using System.Linq;
     using System.Reflection;
 
     /// <summary>
@@ -98,6 +100,46 @@ namespace DurableTask.Core
             }
 
             return declaringType + "." + methodName;
+        }
+
+        internal static string GetFullyQualifiedMethodName(string declaringType, MethodInfo methodInfo)
+        {
+            IEnumerable<string> paramTypeNames = methodInfo.GetParameters().Select(x => x.ParameterType.Name);
+            string paramTypeNamesCsv = string.Join(",", paramTypeNames);
+            string methodNameWithParameterList = $"{methodInfo.Name}.({paramTypeNamesCsv})";
+            return GetFullyQualifiedMethodName(declaringType, methodNameWithParameterList);
+        }
+
+        /// <summary>
+        /// Gets all methods from an interface, including those inherited from a base interface
+        /// </summary>
+        /// <param name="t"></param>
+        /// <param name="getMethodUniqueId"></param>
+        /// <param name="visited"></param>
+        /// <returns></returns>
+        internal static IList<MethodInfo> GetAllInterfaceMethods(Type t, Func<MethodInfo, string> getMethodUniqueId, HashSet<string> visited = null)
+        {
+            if (visited == null)
+            {
+                visited = new HashSet<string>();
+            }
+            List<MethodInfo> result = new List<MethodInfo>();
+            foreach (MethodInfo m in t.GetMethods())
+            {
+                string name = getMethodUniqueId(m);
+                if (!visited.Contains(name))
+                {
+                    // In some cases, such as when a generic type interface inherits an interface with the same name, Task.GetMethod includes the methods from the base interface.
+                    // This check is to avoid dupicates from these.
+                    result.Add(m);
+                    visited.Add(name);
+                }
+            }
+            foreach (Type baseInterface in t.GetInterfaces())
+            {
+                result.AddRange(GetAllInterfaceMethods(baseInterface, getMethodUniqueId, visited: visited));
+            }
+            return result;
         }
     }
 }

--- a/src/DurableTask.Core/OrchestrationContext.cs
+++ b/src/DurableTask.Core/OrchestrationContext.cs
@@ -98,7 +98,7 @@ namespace DurableTask.Core
         /// <returns></returns>
         public virtual T CreateClient<T>(bool useFullyQualifiedMethodNames) where T : class
         {
-            return this.CreateClient<T>(() => new ScheduleProxy(this, useFullyQualifiedMethodNames));
+            return CreateClient<T>(() => new ScheduleProxy(this, useFullyQualifiedMethodNames));
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace DurableTask.Core
         /// <exception cref="InvalidOperationException"></exception>
         public virtual T CreateClientV2<T>() where T : class
         {
-            return this.CreateClient<T>(() => new ScheduleProxyV2(this, typeof(T).FullName));
+            return CreateClient<T>(() => new ScheduleProxyV2(this, typeof(T).ToString()));
         }
 
         /// <summary>
@@ -415,7 +415,7 @@ namespace DurableTask.Core
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
         /// <exception cref="InvalidOperationException"></exception>
-        private T CreateClient<T>(Func<IInterceptor> createScheduleProxy) where T : class
+        private static T CreateClient<T>(Func<IInterceptor> createScheduleProxy) where T : class
         {
             if (!typeof(T).IsInterface && !typeof(T).IsClass)
             {

--- a/src/DurableTask.Core/OrchestrationContext.cs
+++ b/src/DurableTask.Core/OrchestrationContext.cs
@@ -91,27 +91,25 @@ namespace DurableTask.Core
         ///     If true, the method name translation from the interface contains
         ///     the interface name, if false then only the method name is used
         /// </param>
+        /// <remarks>
+        ///     This is deprecated and exists only for back-compatibility.
+        ///     See <see cref="CreateClientV2"/>, which adds support for C# interface features such as inheritance, generics, and method overloading.
+        /// </remarks>
         /// <returns></returns>
         public virtual T CreateClient<T>(bool useFullyQualifiedMethodNames) where T : class
         {
-            if (!typeof(T).IsInterface && !typeof(T).IsClass)
-            {
-                throw new InvalidOperationException($"{nameof(T)} must be an interface or class.");
-            }
+            return this.CreateClient<T>(() => new ScheduleProxy(this, useFullyQualifiedMethodNames));
+        }
 
-            IInterceptor scheduleProxy = new ScheduleProxy(this, useFullyQualifiedMethodNames);
-
-            if (typeof(T).IsClass)
-            {
-                if (typeof(T).IsSealed)
-                {
-                    throw new InvalidOperationException("Class cannot be sealed.");
-                }
-
-                return ProxyGenerator.CreateClassProxy<T>(scheduleProxy);
-            }
-
-            return ProxyGenerator.CreateInterfaceProxyWithoutTarget<T>(scheduleProxy);
+        /// <summary>
+        ///     Create a proxy client class to schedule remote TaskActivities via a strongly typed interface.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException"></exception>
+        public virtual T CreateClientV2<T>() where T : class
+        {
+            return this.CreateClient<T>(() => new ScheduleProxyV2(this, typeof(T).FullName));
         }
 
         /// <summary>
@@ -410,5 +408,33 @@ namespace DurableTask.Core
         ///     the first execution of this orchestration instance.
         /// </param>
         public abstract void ContinueAsNew(string newVersion, object input);
+
+        /// <summary>
+        ///     Create a proxy client class to schedule remote TaskActivities via a strongly typed interface.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException"></exception>
+        private T CreateClient<T>(Func<IInterceptor> createScheduleProxy) where T : class
+        {
+            if (!typeof(T).IsInterface && !typeof(T).IsClass)
+            {
+                throw new InvalidOperationException($"{nameof(T)} must be an interface or class.");
+            }
+
+            IInterceptor scheduleProxy = createScheduleProxy();
+
+            if (typeof(T).IsClass)
+            {
+                if (typeof(T).IsSealed)
+                {
+                    throw new InvalidOperationException("Class cannot be sealed.");
+                }
+
+                return ProxyGenerator.CreateClassProxy<T>(scheduleProxy);
+            }
+
+            return ProxyGenerator.CreateInterfaceProxyWithoutTarget<T>(scheduleProxy);
+        }
     }
 }

--- a/src/DurableTask.Core/ScheduleProxy.cs
+++ b/src/DurableTask.Core/ScheduleProxy.cs
@@ -21,6 +21,10 @@ namespace DurableTask.Core
     using Castle.DynamicProxy;
     using DurableTask.Core.Common;
 
+    /// <remarks>
+    ///     This is deprecated and exists only for back-compatibility.
+    ///     See <see cref="ScheduleProxyV2"/>, which adds support for C# interface features such as inheritance, generics, and method overloading.
+    /// </remarks>
     internal class ScheduleProxy : IInterceptor
     {
         private readonly OrchestrationContext context;
@@ -64,7 +68,7 @@ namespace DurableTask.Core
                 arguments.Add(new Utils.TypeMetadata { AssemblyName = typeArg.Assembly.FullName!, FullyQualifiedTypeName = typeArg.FullName });
             }
 
-            string normalizedMethodName = NameVersionHelper.GetDefaultName(invocation.Method, this.useFullyQualifiedMethodNames);
+            string normalizedMethodName = this.NormalizeMethodName(invocation.Method);
 
             if (returnType == typeof(Task))
             {
@@ -92,6 +96,11 @@ namespace DurableTask.Core
             });
 
             return;
+        }
+
+        protected virtual string NormalizeMethodName(MethodInfo method)
+        {
+            return NameVersionHelper.GetDefaultName(method, this.useFullyQualifiedMethodNames);
         }
     }
 }

--- a/src/DurableTask.Core/ScheduleProxyV2.cs
+++ b/src/DurableTask.Core/ScheduleProxyV2.cs
@@ -28,6 +28,7 @@ namespace DurableTask.Core
 
         protected override string NormalizeMethodName(MethodInfo method)
         {
+            // uses declaring type defined externally because MethodInfo members, such as Method.DeclaringType, could return the base type that the method inherits from
             return string.IsNullOrEmpty(this.declaringTypeFullName) ? method.Name : NameVersionHelper.GetFullyQualifiedMethodName(this.declaringTypeFullName, method);
         }
     }

--- a/src/DurableTask.Core/ScheduleProxyV2.cs
+++ b/src/DurableTask.Core/ScheduleProxyV2.cs
@@ -1,0 +1,34 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core
+{
+    using System.Reflection;
+    using Castle.DynamicProxy;
+
+    internal class ScheduleProxyV2 : ScheduleProxy, IInterceptor
+    {
+        private readonly string declaringTypeFullName;
+
+        public ScheduleProxyV2(OrchestrationContext context, string declaringTypeFullName)
+            : base(context)
+        {
+            this.declaringTypeFullName = declaringTypeFullName;
+        }
+
+        protected override string NormalizeMethodName(MethodInfo method)
+        {
+            return string.IsNullOrEmpty(this.declaringTypeFullName) ? method.Name : NameVersionHelper.GetFullyQualifiedMethodName(this.declaringTypeFullName, method);
+        }
+    }
+}

--- a/src/DurableTask.Core/TaskHubWorker.cs
+++ b/src/DurableTask.Core/TaskHubWorker.cs
@@ -439,6 +439,10 @@ namespace DurableTask.Core
         ///     and version set to an empty string. Methods can then be invoked from task orchestrations
         ///     by calling ScheduleTask(name, version) with name as the method name and string.Empty as the version.
         /// </summary>
+        /// <remarks>
+        ///     This is deprecated and exists only for back-compatibility.
+        ///     See <see cref="AddTaskActivitiesFromInterfaceV2"/>, which adds support for C# interface features such as inheritance, generics, and method overloading.
+        /// </remarks>
         /// <typeparam name="T">Interface</typeparam>
         /// <param name="activities">Object that implements this interface</param>
         public TaskHubWorker AddTaskActivitiesFromInterface<T>(T activities)
@@ -452,6 +456,10 @@ namespace DurableTask.Core
         ///     and version set to an empty string. Methods can then be invoked from task orchestrations
         ///     by calling ScheduleTask(name, version) with name as the method name and string.Empty as the version.
         /// </summary>
+        /// <remarks>
+        ///     This is deprecated and exists only for back-compatibility.
+        ///     See <see cref="AddTaskActivitiesFromInterfaceV2"/>, which adds support for C# interface features such as inheritance, generics, and method overloading.
+        /// </remarks>
         /// <typeparam name="T">Interface</typeparam>
         /// <param name="activities">Object that implements this interface</param>
         /// <param name="useFullyQualifiedMethodNames">
@@ -469,6 +477,23 @@ namespace DurableTask.Core
         ///     and version set to an empty string. Methods can then be invoked from task orchestrations
         ///     by calling ScheduleTask(name, version) with name as the method name and string.Empty as the version.
         /// </summary>
+        /// <typeparam name="T">Interface</typeparam>
+        /// <param name="activities">Object that implements this interface</param>
+        public TaskHubWorker AddTaskActivitiesFromInterfaceV2<T>(object activities)
+        {
+            return this.AddTaskActivitiesFromInterfaceV2(typeof(T), activities);
+        }
+
+        /// <summary>
+        ///     Infers and adds every method in the specified interface T on the
+        ///     passed in object as a different TaskActivity with Name set to the method name
+        ///     and version set to an empty string. Methods can then be invoked from task orchestrations
+        ///     by calling ScheduleTask(name, version) with name as the method name and string.Empty as the version.
+        /// </summary>
+        /// <remarks>
+        ///     This is deprecated and exists only for back-compatibility.
+        ///     See <see cref="AddTaskActivitiesFromInterfaceV2"/>, which adds support for C# interface features such as inheritance, generics, and method overloading.
+        /// </remarks>
         /// <param name="interface">Interface type.</param>
         /// <param name="activities">Object that implements the <paramref name="interface"/> interface</param>
         /// <param name="useFullyQualifiedMethodNames">
@@ -477,16 +502,7 @@ namespace DurableTask.Core
         /// </param>
         public TaskHubWorker AddTaskActivitiesFromInterface(Type @interface, object activities, bool useFullyQualifiedMethodNames = false)
         {
-            if (!@interface.IsInterface)
-            {
-                throw new Exception("Contract can only be an interface.");
-            }
-
-            if (!@interface.IsAssignableFrom(activities.GetType()))
-            {
-                throw new ArgumentException($"{activities.GetType().FullName} does not implement {@interface.FullName}", nameof(activities));
-            }
-
+            this.ValidateActivitiesInterfaceType(@interface, activities);
             foreach (MethodInfo methodInfo in @interface.GetMethods())
             {
                 TaskActivity taskActivity = new ReflectionBasedTaskActivity(activities, methodInfo);
@@ -495,6 +511,29 @@ namespace DurableTask.Core
                         NameVersionHelper.GetDefaultName(methodInfo, useFullyQualifiedMethodNames),
                         NameVersionHelper.GetDefaultVersion(methodInfo), taskActivity);
                 this.activityManager.Add(creator);
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        ///     Infers and adds every method in the specified interface T on the
+        ///     passed in object as a different TaskActivity with Name set to the method name
+        ///     and version set to an empty string. Methods can then be invoked from task orchestrations
+        ///     by calling ScheduleTask(name, version) with name as the method name and string.Empty as the version.
+        /// </summary>
+        /// <param name="interface">Interface type.</param>
+        /// <param name="activities">Object that implements the <paramref name="interface"/> interface</param>
+        public TaskHubWorker AddTaskActivitiesFromInterfaceV2(Type @interface, object activities)
+        {
+            this.ValidateActivitiesInterfaceType(@interface, activities);
+            var methods = NameVersionHelper.GetAllInterfaceMethods(@interface, (MethodInfo m) => NameVersionHelper.GetFullyQualifiedMethodName(@interface.FullName, m));
+            foreach (MethodInfo methodInfo in methods)
+            {
+                TaskActivity taskActivity = new ReflectionBasedTaskActivity(activities, methodInfo);
+                string name = NameVersionHelper.GetFullyQualifiedMethodName(@interface.FullName, methodInfo);
+                ObjectCreator<TaskActivity> creator = new NameValueObjectCreator<TaskActivity>(name, NameVersionHelper.GetDefaultVersion(methodInfo), taskActivity);
+                this.AddTaskActivities(creator);
             }
 
             return this;
@@ -589,6 +628,19 @@ namespace DurableTask.Core
         public void Dispose()
         {
             ((IDisposable)this.slimLock).Dispose();
+        }
+
+        private void ValidateActivitiesInterfaceType(Type @interface, object activities)
+        {
+            if (!@interface.IsInterface)
+            {
+                throw new Exception("Contract can only be an interface.");
+            }
+
+            if (!@interface.IsAssignableFrom(activities.GetType()))
+            {
+                throw new ArgumentException($"type {activities.GetType().FullName} does not implement {@interface.FullName}");
+            }
         }
     }
 }

--- a/src/DurableTask.Core/TaskHubWorker.cs
+++ b/src/DurableTask.Core/TaskHubWorker.cs
@@ -527,11 +527,11 @@ namespace DurableTask.Core
         public TaskHubWorker AddTaskActivitiesFromInterfaceV2(Type @interface, object activities)
         {
             this.ValidateActivitiesInterfaceType(@interface, activities);
-            var methods = NameVersionHelper.GetAllInterfaceMethods(@interface, (MethodInfo m) => NameVersionHelper.GetFullyQualifiedMethodName(@interface.FullName, m));
+            var methods = NameVersionHelper.GetAllInterfaceMethods(@interface, (MethodInfo m) => NameVersionHelper.GetFullyQualifiedMethodName(@interface.ToString(), m));
             foreach (MethodInfo methodInfo in methods)
             {
                 TaskActivity taskActivity = new ReflectionBasedTaskActivity(activities, methodInfo);
-                string name = NameVersionHelper.GetFullyQualifiedMethodName(@interface.FullName, methodInfo);
+                string name = NameVersionHelper.GetFullyQualifiedMethodName(@interface.ToString(), methodInfo);
                 ObjectCreator<TaskActivity> creator = new NameValueObjectCreator<TaskActivity>(name, NameVersionHelper.GetDefaultVersion(methodInfo), taskActivity);
                 this.AddTaskActivities(creator);
             }

--- a/test/DurableTask.Emulator.Tests/EmulatorFunctionalTests.cs
+++ b/test/DurableTask.Emulator.Tests/EmulatorFunctionalTests.cs
@@ -314,11 +314,163 @@ namespace DurableTask.Emulator.Tests
             await worker.StopAsync(true);
         }
 
+        [TestMethod]
+        public async Task RegisterOrchestrationTasksFromInterface_InterfaceUsingInheritanceGenericsMethodOverloading_OrchestrationSuccess()
+        {
+            var orchestrationService = new LocalOrchestrationService();
+
+            var worker = new TaskHubWorker(orchestrationService);
+            await worker.AddTaskOrchestrations(typeof(TestInheritedTasksOrchestration))
+                .AddTaskActivitiesFromInterfaceV2<IInheritedTestOrchestrationTasksA>(new InheritedTestOrchestrationTasksA())
+                .AddTaskActivitiesFromInterfaceV2(typeof(IInheritedTestOrchestrationTasksB), new InheritedTestOrchestrationTasksB())
+                .StartAsync();
+
+            var client = new TaskHubClient(orchestrationService);
+            OrchestrationInstance id = await client.CreateOrchestrationInstanceAsync(typeof(TestInheritedTasksOrchestration),
+                null);
+
+            var state = await client.WaitForOrchestrationAsync(id, TimeSpan.FromSeconds(30), CancellationToken.None);
+            Assert.AreEqual(OrchestrationStatus.Completed, state.OrchestrationStatus);
+
+            Assert.AreEqual(InheritedTestOrchestrationTasksA.BumbleResult, TestInheritedTasksOrchestration.BumbleResultA);
+            Assert.AreEqual(InheritedTestOrchestrationTasksA.WobbleResult, TestInheritedTasksOrchestration.WobbleResultA);
+            Assert.AreEqual(InheritedTestOrchestrationTasksA.DerivedTaskResult, TestInheritedTasksOrchestration.DerivedTaskResultA);
+            Assert.AreEqual(InheritedTestOrchestrationTasksA.JuggleResult, TestInheritedTasksOrchestration.JuggleResultA);
+
+            Assert.AreEqual(InheritedTestOrchestrationTasksB.BumbleResult, TestInheritedTasksOrchestration.BumbleResultB);
+            Assert.AreEqual(InheritedTestOrchestrationTasksB.WobbleResult, TestInheritedTasksOrchestration.WobbleResultB);
+            Assert.AreEqual(InheritedTestOrchestrationTasksB.OverloadedWobbleResult1, TestInheritedTasksOrchestration.OverloadedWobbleResult1B);
+            Assert.AreEqual(InheritedTestOrchestrationTasksB.OverloadedWobbleResult2, TestInheritedTasksOrchestration.OverloadedWobbleResult2B);
+            Assert.AreEqual(InheritedTestOrchestrationTasksB.JuggleResult, TestInheritedTasksOrchestration.JuggleResultB);
+        }
+
         private static void AssertTagsEqual(IDictionary<string, string> expectedTags, IDictionary<string, string> actualTags)
         {
             Assert.IsNotNull(actualTags);
             Assert.AreEqual(expectedTags.Count, actualTags.Count);
             Assert.IsTrue(expectedTags.All(tag => actualTags.TryGetValue(tag.Key, out var value) && value == tag.Value));
+        }
+
+        // base interface without generic type parameters
+        public interface IBaseTestOrchestrationTasks
+        {
+            Task<int> Juggle(int toss, bool withFlair);
+        }
+
+        // generic type base interface inheriting non-generic type with same name
+        public interface IBaseTestOrchestrationTasks<TIn, TOut> : IBaseTestOrchestrationTasks
+        {
+            Task<TOut> Bumble(TIn fumble, bool likeAKlutz);
+            Task<TOut> Wobble(TIn jiggle, bool withGusto);
+        }
+
+        // interface with derived task
+        public interface IInheritedTestOrchestrationTasksA : IBaseTestOrchestrationTasks<string, string>
+        {
+            Task<string> DerivedTask(int i);
+        }
+
+        // interface with overloaded method
+        public interface IInheritedTestOrchestrationTasksB : IBaseTestOrchestrationTasks<string, string>
+        {
+            // this method overloads methods from both inherited interface and this interface
+            Task<string> Wobble(string name);
+            Task<string> Wobble(int id);
+        }
+
+        public class InheritedTestOrchestrationTasksA : IInheritedTestOrchestrationTasksA
+        {
+            public const string BumbleResult = nameof(Bumble) + "-A";
+            public const string WobbleResult = nameof(Wobble) + "-A";
+            public const string DerivedTaskResult = nameof(DerivedTask) + "-A";
+            public const int JuggleResult = 419;
+
+            public Task<string> Bumble(string fumble, bool likeAKlutz)
+            {
+                return Task.FromResult(BumbleResult);
+            }
+
+            public Task<string> Wobble(string jiggle, bool withGusto)
+            {
+                return Task.FromResult(WobbleResult);
+            }
+
+            public Task<string> DerivedTask(int i)
+            {
+                return Task.FromResult(DerivedTaskResult);
+            }
+
+            public Task<int> Juggle(int toss, bool withFlair)
+            {
+                return Task.FromResult(JuggleResult);
+            }
+        }
+
+        public class InheritedTestOrchestrationTasksB : IInheritedTestOrchestrationTasksB
+        {
+            public const string BumbleResult = nameof(Bumble) + "-B";
+            public const string WobbleResult = nameof(Wobble) + "-B";
+            public const string OverloadedWobbleResult1 = nameof(Wobble) + "-B-overloaded-1";
+            public const string OverloadedWobbleResult2 = nameof(Wobble) + "-B-overloaded-2";
+            public const int JuggleResult = 420;
+
+            public Task<string> Bumble(string fumble, bool likeAKlutz)
+            {
+                return Task.FromResult(BumbleResult);
+            }
+
+            public Task<string> Wobble(string jiggle, bool withGusto)
+            {
+                return Task.FromResult(WobbleResult);
+            }
+
+            public Task<string> Wobble(string name)
+            {
+                return Task.FromResult(OverloadedWobbleResult1);
+            }
+
+            public Task<string> Wobble(int id)
+            {
+                return Task.FromResult(OverloadedWobbleResult2);
+            }
+
+            public Task<int> Juggle(int toss, bool withFlair)
+            {
+                return Task.FromResult(JuggleResult);
+            }
+        }
+
+        public class TestInheritedTasksOrchestration : TaskOrchestration<string, string>
+        {
+            // HACK: This is just a hack to communicate result of orchestration back to test
+            public static string BumbleResultA;
+            public static string WobbleResultA;
+            public static string DerivedTaskResultA;
+            public static int JuggleResultA;
+            public static string BumbleResultB;
+            public static string WobbleResultB;
+            public static string OverloadedWobbleResult1B;
+            public static string OverloadedWobbleResult2B;
+            public static int JuggleResultB;
+
+            public override async Task<string> RunTask(OrchestrationContext context, string input)
+            {
+                var tasksA = context.CreateClientV2<IInheritedTestOrchestrationTasksA>();
+                var tasksB = context.CreateClientV2<IInheritedTestOrchestrationTasksB>();
+
+                BumbleResultA = await tasksA.Bumble(string.Empty, false);
+                WobbleResultA = await tasksA.Wobble(string.Empty, false);
+                DerivedTaskResultA = await tasksA.DerivedTask(0);
+                JuggleResultA = await tasksA.Juggle(1, true);
+
+                BumbleResultB = await tasksB.Bumble(string.Empty, false);
+                WobbleResultB = await tasksB.Wobble(string.Empty, false);
+                OverloadedWobbleResult1B = await tasksB.Wobble("name");
+                OverloadedWobbleResult2B = await tasksB.Wobble(1);
+                JuggleResultB = await tasksB.Juggle(1, true);
+
+                return string.Empty;
+            }
         }
     }
 }


### PR DESCRIPTION
there is a bug in `TaskHubWorker.AddTaskActivitiesFromInterface` where each method of a registered interface is keyed by a weak "qualified name" that hits collisions when using C# code reuse features such as inheritance, generics, method overloading.
This is reproducible even with `useFullyQualifiedMethodNames = true`.
This PR fixes by making a stronger qualified name in "V2" methods for task registration and client creation.
It is essential to keep the "V1" methods for back-compatibility.