### PR TITLE
Patch advisories

### DIFF
--- a/samples/DurableTask.Samples/DurableTask.Samples.csproj
+++ b/samples/DurableTask.Samples/DurableTask.Samples.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="CommandLineParser" version="1.9.71" />
     <PackageReference Include="EnterpriseLibrary.SemanticLogging" Version="2.0.1406.1" />
     <PackageReference Include="ncrontab" version="1.0.0" />
-    <PackageReference Include="Newtonsoft.Json" version="11.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -35,7 +35,8 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
+    <!--Newtonsoft.Json 7.0.1 is kept for backwards compatibility with Functions runtime V1, so we supress warning NU1903. -->
+    <PackageReference Include="Newtonsoft.Json" Version="7.0.1" NoWarn="NU1903"/>
     <PackageReference Include="WindowsAzure.Storage" version="7.2.1" />
   </ItemGroup>
 

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -35,8 +35,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
-    <!--Newtonsoft.Json 7.0.1 is kept for backwards compatibility with Functions runtime V1, so we supress warning NU1903. -->
-    <PackageReference Include="Newtonsoft.Json" Version="7.0.1" NoWarn="NU1903"/>
     <PackageReference Include="WindowsAzure.Storage" version="7.2.1" />
   </ItemGroup>
 

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -32,7 +32,8 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
+    <!--Newtonsoft.Json 7.0.1 is kept for backwards compatibility with Functions runtime V1, so we supress warning NU1903. -->
+    <PackageReference Include="Newtonsoft.Json" Version="7.0.1" NoWarn="NU1903" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/DurableTask.Emulator/DurableTask.Emulator.csproj
+++ b/src/DurableTask.Emulator/DurableTask.Emulator.csproj
@@ -8,14 +8,6 @@
     <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Newtonsoft.Json" version="7.0.1" />
-  </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Newtonsoft.Json" version="13.0.1" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\DurableTask.Core\DurableTask.Core.csproj" />
   </ItemGroup>

--- a/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
+++ b/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
@@ -9,14 +9,12 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" />
-    <PackageReference Include="Newtonsoft.Json" version="7.0.1" />
     <PackageReference Include="WindowsAzure.Storage" version="7.2.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.6" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="WindowsAzure.Storage" version="9.3.3" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.0.0-beta.3" />
   </ItemGroup>

--- a/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj
+++ b/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="Newtonsoft.Json" version="7.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
@@ -18,7 +17,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DurableTask.SqlServer.Tests/DurableTask.SqlServer.Tests.csproj
+++ b/test/DurableTask.SqlServer.Tests/DurableTask.SqlServer.Tests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.6.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DurableTask.Test.Orchestrations/DurableTask.Test.Orchestrations.csproj
+++ b/test/DurableTask.Test.Orchestrations/DurableTask.Test.Orchestrations.csproj
@@ -4,14 +4,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Newtonsoft.Json" version="13.0.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Newtonsoft.Json" version="7.0.1" />
-  </ItemGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\..\src\DurableTask.Core\DurableTask.Core.csproj" />


### PR DESCRIPTION
_Replaces:_ https://github.com/Azure/durabletask/pull/1020

As of recently, building the DTFx project failed with errors of the following kind:

> "Warning as Error: Package <package name> has a known high severity vulnerability" and it points to this advisory: <link>"

The warnings were for:
* Newtonsoft.Json < 13.0.1, which linked to: https://github.com/advisories/GHSA-5crp-9r3c-p9vr
* System.Data.SqlClient < 4.8.5, which linked to: https://github.com/advisories/GHSA-8g2p-5pqh-5jmc

In response, I made the following changes:
* Upgraded `System.Data.SqlClient` to `4.8.5`. This is only used in our test project, so it's safe.
* Suppressed the warning on our `Newtonsoft.Json` version `7.0.1` dependency, which we use on the `net462` TFM for backwards compatibility with Functions V1.  I chose to suppress it to minimize breaking customers, and because Functions V1 is soon to be EOL.
* Finally, I removed redundant references to `Newtonsoft.Json` in our test projects, and in DTFx.AzureStorage. We already make receive `Newtonsoft.Json` transitively, so having these dependencies only adds to our maintanance burden afaict.

**Note:** the warnings still appear for DTFx.ServiceBus and DTFx.AzureServiceFabric. I did not apply my changes there as I know those projects are maintained by separate teams. I can contribute a PR to their projects once this one is merged.