### PR TITLE
Add orchestrator scheduled actions check when suspended

### DIFF
--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -572,12 +572,12 @@ namespace DurableTask.Core
         {
             this.IsSuspended = true;
 
-            //When the orchestrator is suspended, a task could potentially be added to the orchestratorActionsMap.
-            //This could lead to the task being executed repeatedly without completion until the orchestrator is resumed.
-            //To prevent this scenario, check if orchestratorActionsMap is empty before proceeding.
+            // When the orchestrator is suspended, a task could potentially be added to the orchestratorActionsMap.
+            // This could lead to the task being executed repeatedly without completion until the orchestrator is resumed.
+            // To prevent this scenario, check if orchestratorActionsMap is empty before proceeding.
             if (this.orchestratorActionsMap.Any())
             {
-                //If not, store its contents to a temporary dictionary to allow processing of the task later when orchestrator resumes.
+                // If not, store its contents to a temporary dictionary to allow processing of the task later when orchestrator resumes.
                 foreach (var pair in this.orchestratorActionsMap)
                 {
                     this.suspendedActionsMap.Add(pair.Key, pair.Value);
@@ -589,7 +589,8 @@ namespace DurableTask.Core
         public void HandleExecutionResumedEvent(ExecutionResumedEvent resumedEvent, Action<HistoryEvent> eventProcessor)
         {
             this.IsSuspended = false;
-            
+
+            // Add the actions stored in the suspendedActionsMap before back to orchestratorActionsMap to ensure proper sequencing.
             if (this.suspendedActionsMap.Any())
             {
                 foreach(var pair in this.suspendedActionsMap)


### PR DESCRIPTION
This PR fixes issue [#2519](https://github.com/Azure/azure-functions-durable-extension/issues/2519)

When calling SuspendAsync URL, condition can happen that the orchestrator is suspended when there is already an action scheduled and added to the `orchestratorActionsMap`. However, our design will add any later event into a temporary queue during suspended time. Thus, this scheduled action will never be removed or completed and will be executed endless times until orchestrator is resumed. And this execution history will also be added to the History Table which will cause the non-deterministic error when orchestrator is resumed. 

The race condition occurs when an `ExecutionSuspended` message is processed after `TaskCompleted`. Additionally, there is a subsequent activity task pending scheduling after the completion of this task. During the processing`TaskCompleted`, the result is sent back to the extension level, and thus, durable extension will go to the next line and then schedule a new task, adds it to the action map which will cause the issue. 

For debug, we can verify if a task has been executed multiple times **by checking if column`TaskEventId` in Kusto or `TaskScheduledId` in History Table.** Each task should have a unique identifier in these fields.

The fix of this PR is to guarantee `orchestratorActionsMap` is empty when orchestrator is suspended.  Basically, we will check the `orchestratorActionsMap` when suspending an orchestrator. If `orchestratorActionsMap` is not null, the action will be saved to a temporary dictionary and will be added back to the `orchestratorActionsMap` when the orchestrator is resumed. 