### PR TITLE
Remove AzureServiceFabric build temporarily

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -19,7 +19,6 @@ steps:
       src/DurableTask.AzureStorage/DurableTask.AzureStorage.sln
       src/DurableTask.Emulator/DurableTask.Emulator.csproj
       src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
-      src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
       src/DurableTask.ApplicationInsights/DurableTask.ApplicationInsights.csproj
 
 # Build the filtered solution in release mode, specifying the continuous integration flag.

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -18,7 +18,6 @@ steps:
     projects: |
       src/DurableTask.AzureStorage/DurableTask.AzureStorage.sln
       src/DurableTask.Emulator/DurableTask.Emulator.csproj
-      src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
       src/DurableTask.ApplicationInsights/DurableTask.ApplicationInsights.csproj
 
 # Build the filtered solution in release mode, specifying the continuous integration flag.
@@ -49,24 +48,6 @@ steps:
     configuration: Release
     msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
 
-- task: VSBuild@1
-  displayName: 'Build (ServiceBus)'
-  inputs:
-    solution: 'src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj'
-    vsVersion: '16.0'
-    logFileVerbosity: minimal
-    configuration: Release
-    msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
-
-- task: VSBuild@1
-  displayName: 'Build (AzureServiceFabric)'
-  inputs:
-    solution: 'src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj'
-    vsVersion: '16.0'
-    logFileVerbosity: minimal
-    configuration: Release
-    platform: x64
-    msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
 
 - task: UseDotNet@2
   displayName: 'Use the .NET Core 2.1 SDK (required for build signing)'
@@ -146,26 +127,6 @@ steps:
     packDirectory: $(build.artifactStagingDirectory)
     packagesToPack: 'src/DurableTask.Emulator/DurableTask.Emulator.csproj'
 
-- task: DotNetCoreCLI@2
-  displayName: Generate nuget packages
-  inputs:
-    command: pack
-    verbosityPack: Minimal
-    configuration: Release
-    nobuild: true
-    packDirectory: $(build.artifactStagingDirectory)
-    packagesToPack: 'src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj'
-
-- task: DotNetCoreCLI@2
-  displayName: Generate nuget packages
-  inputs:
-    command: pack
-    verbosityPack: Minimal
-    configuration: Release
-    nobuild: true
-    packDirectory: $(build.artifactStagingDirectory)
-    packagesToPack: 'src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj'
-    buildProperties: 'Platform=x64'
 
 # Digitally sign all the nuget packages with the Microsoft certificate.
 # This appears to be an in-place signing job, which is convenient.


### PR DESCRIPTION
This PR don't need to be merged.

Remove    `src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj` from restore and build.  Since it includes `Newtonsoft.Json 7.0.1`  which will cause the release pipeline failed to restore. Remove this one temporarily to unblock the release process. 