### PR TITLE
Update RemoteOrchestrationServiceClient.cs

### DIFF
--- a/src/DurableTask.AzureServiceFabric/Remote/RemoteOrchestrationServiceClient.cs
+++ b/src/DurableTask.AzureServiceFabric/Remote/RemoteOrchestrationServiceClient.cs
@@ -378,7 +378,7 @@ namespace DurableTask.AzureServiceFabric.Remote
                         return response;
                     }
                 }
-                catch (Exception ex) when (ex is SocketException || ex is WebException)
+                catch (Exception ex) when (ex is SocketException || ex is WebException || ex is HttpRequestException)
                 {
                     exception = ex;
                 }


### PR DESCRIPTION
"Refactored Exception Handling in Retry Logic for RemoteOrchestrationServiceClient

The DurableTask.AzureServiceFabric NuGet package was previously using HttpWebRequest (.NET 4) and has since been updated to use HttpClient. However, the associated exception handling in the retry logic was not updated accordingly.

Originally, the catch block was designed to handle WebException, a legacy exception type associated with HttpWebRequest. HttpClient, however, throws HttpRequestException for request-related issues, not WebException.

This oversight led to the retry logic failing to function as intended, as it was not catching the correct exception type. This is particularly critical for the RemoteOrchestrationServiceClient, which relies on this retry mechanism to detect changes in the SF partition leader.

This commit updates the catch block to handle HttpRequestException, aligning with the HttpClient usage and restoring the intended functionality of the retry logic."