### PR TITLE
[ServiceFabricProviderV1] Enable customer serializer for reliable collections.

### DIFF
--- a/DurableTask.ServiceFabric.sln
+++ b/DurableTask.ServiceFabric.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26403.7
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.34301.259
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{501E1168-418C-4832-B88C-617735BD02C9}"
 	ProjectSection(SolutionItems) = preProject
@@ -51,6 +51,7 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{CA924781-AE52-45FA-A817-C39C822FB782}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{CA924781-AE52-45FA-A817-C39C822FB782}.Debug|Any CPU.Build.0 = Debug|x64
 		{CA924781-AE52-45FA-A817-C39C822FB782}.Debug|x64.ActiveCfg = Debug|x64
 		{CA924781-AE52-45FA-A817-C39C822FB782}.Debug|x64.Build.0 = Debug|x64
 		{CA924781-AE52-45FA-A817-C39C822FB782}.Debug|x64.Deploy.0 = Debug|x64
@@ -59,6 +60,7 @@ Global
 		{CA924781-AE52-45FA-A817-C39C822FB782}.Release|x64.Build.0 = Release|x64
 		{CA924781-AE52-45FA-A817-C39C822FB782}.Release|x64.Deploy.0 = Release|x64
 		{95D6C9C7-F7A0-4125-840D-1854BEC24978}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{95D6C9C7-F7A0-4125-840D-1854BEC24978}.Debug|Any CPU.Build.0 = Debug|x64
 		{95D6C9C7-F7A0-4125-840D-1854BEC24978}.Debug|x64.ActiveCfg = Debug|x64
 		{95D6C9C7-F7A0-4125-840D-1854BEC24978}.Debug|x64.Build.0 = Debug|x64
 		{95D6C9C7-F7A0-4125-840D-1854BEC24978}.Release|Any CPU.ActiveCfg = Release|x64
@@ -170,5 +172,6 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		EnterpriseLibraryConfigurationToolBinariesPath = packages\TransientFaultHandling.Core.5.1.1209.1\lib\NET4
+		SolutionGuid = {BCE9A2EE-C1D3-4F37-8500-E112D840827F}
 	EndGlobalSection
 EndGlobal

--- a/Test/DurableTask.ServiceFabric.Test/AssemblySetup.cs
+++ b/Test/DurableTask.ServiceFabric.Test/AssemblySetup.cs
@@ -42,9 +42,9 @@ namespace DurableTask.ServiceFabric.Test
         {
             get
             {
-                var sourceRoot = Environment.GetEnvironmentVariable("SourceRoot") ?? string.Empty;
-                var applicationPath = Path.Combine(sourceRoot.Trim(), "Test", "TestFabricApplication", "TestFabricApplication");
-
+                //var sourceRoot = Environment.GetEnvironmentVariable("SourceRoot") ?? string.Empty;
+                //var applicationPath = Path.Combine(sourceRoot.Trim(), "Test", "TestFabricApplication", "TestFabricApplication");
+                var applicationPath = Path.Combine(Directory.GetCurrentDirectory(), @"..\..\..\TestFabricApplication\TestFabricApplication");
                 if (!Directory.Exists(applicationPath))
                 {
                     throw new Exception("Could not find test application path, define SourceRoot environment variable to the source path");

--- a/Test/TestFabricApplication/TestFabricApplication/TestFabricApplication.sfproj
+++ b/Test/TestFabricApplication/TestFabricApplication/TestFabricApplication.sfproj
@@ -1,10 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" InitialTargets=";ValidateMSBuildFiles">
-  <Import Project="..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.0\build\Microsoft.VisualStudio.Azure.Fabric.Application.props" Condition="Exists('..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.0\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" />
+  <Import Project="..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.6\build\Microsoft.VisualStudio.Azure.Fabric.Application.props" Condition="Exists('..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.6\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>ca924781-ae52-45fa-a817-c39c822fb782</ProjectGuid>
-    <ProjectVersion>1.6</ProjectVersion>
+    <ProjectVersion>2.1</ProjectVersion>
     <MinToolsVersion>1.5</MinToolsVersion>
+    <SupportedMSBuildNuGetPackageVersion>1.7.6</SupportedMSBuildNuGetPackageVersion>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -38,9 +39,9 @@
     <ApplicationProjectTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Service Fabric Tools\Microsoft.VisualStudio.Azure.Fabric.ApplicationProject.targets</ApplicationProjectTargetsPath>
   </PropertyGroup>
   <Import Project="$(ApplicationProjectTargetsPath)" Condition="Exists('$(ApplicationProjectTargetsPath)')" />
-  <Import Project="..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.0\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets" Condition="Exists('..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.0\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" />
-  <Target Name="ValidateMSBuildFiles">
-    <Error Condition="!Exists('..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.0\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" Text="Unable to find the '..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.0\build\Microsoft.VisualStudio.Azure.Fabric.Application.props' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package" />
-    <Error Condition="!Exists('..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.0\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" Text="Unable to find the '..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.0\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package" />
+  <Import Project="..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.6\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets" Condition="Exists('..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.6\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" />
+  <Target Name="ValidateMSBuildFiles" BeforeTargets="PrepareForBuild">
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.6\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" Text="Unable to find the '..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.6\build\Microsoft.VisualStudio.Azure.Fabric.Application.props' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package." />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.6\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" Text="Unable to find the '..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.6\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package." />
   </Target>
 </Project>

--- a/Test/TestFabricApplication/TestFabricApplication/packages.config
+++ b/Test/TestFabricApplication/TestFabricApplication/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.VisualStudio.Azure.Fabric.MSBuild" version="1.6.0" />
+  <package id="Microsoft.VisualStudio.Azure.Fabric.MSBuild" version="1.7.6" targetFramework="net40" />
 </packages>

--- a/Test/TestFabricApplication/TestStatefulService/CustomDataContractStateSerializer.cs
+++ b/Test/TestFabricApplication/TestStatefulService/CustomDataContractStateSerializer.cs
@@ -40,7 +40,7 @@ namespace TestStatefulService
             using (var memoryStream = new MemoryStream(bytes))
             {
                 using (var reader = XmlDictionaryReader.CreateBinaryReader(memoryStream, XmlDictionaryReaderQuotas.Max))
-                using (var customReader = new CustomerXmlDictionaryReader(reader, typeof(T).Namespace))
+                using (var customReader = new CustomerXmlDictionaryReader(reader, typeof(T)))
                 {
                     return (T) this.serializer.ReadObject(customReader);
                 }

--- a/Test/TestFabricApplication/TestStatefulService/CustomDataContractStateSerializer.cs
+++ b/Test/TestFabricApplication/TestStatefulService/CustomDataContractStateSerializer.cs
@@ -1,0 +1,111 @@
+//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+
+namespace TestStatefulService
+{
+    using System.IO;
+    using System.Runtime.Serialization;
+    using System.Xml;
+    using Microsoft.ServiceFabric.Data;
+
+    internal class CustomDataContractStateSerializer<T> : IStateSerializer<T>
+    {
+        /// <summary>
+        /// The serializer.
+        /// </summary>
+        private readonly DataContractSerializer serializer = new DataContractSerializer(typeof(T));
+
+        /// <summary>
+        /// Converts byte[] to T
+        /// </summary>
+        /// <param name="binaryReader">Reader containing the serialized data.</param>
+        /// <returns>Deserialized version of T.</returns>
+        public T Read(BinaryReader binaryReader)
+        {
+            var size = binaryReader.ReadInt32();
+
+            var bytes = binaryReader.ReadBytes(size);
+
+            using (var memoryStream = new MemoryStream(bytes))
+            {
+                using (var reader = XmlDictionaryReader.CreateBinaryReader(memoryStream, XmlDictionaryReaderQuotas.Max))
+                using (var customReader = new CustomerXmlDictionaryReader(reader, typeof(T).Namespace))
+                {
+                    return (T) this.serializer.ReadObject(customReader);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Converts IEnumerable of byte[] to T
+        /// </summary>
+        /// <param name="baseValue"></param>
+        /// <param name="reader">Reader containing the serialized data.</param>
+        /// <returns>Deserialized version of T.</returns>
+        public T Read(T baseValue, BinaryReader reader)
+        {
+            return this.Read(reader);
+        }
+
+        /// <summary>
+        /// Converts T to byte array.
+        /// </summary>
+        /// <param name="value">T to be serialized.</param>
+        /// <param name="binaryWriter"></param>
+        /// <returns>Serialized version of T.</returns>
+        public void Write(T value, BinaryWriter binaryWriter)
+        {
+            using (var memoryStream = new MemoryStream())
+            {
+                using (var innerWriter = new BinaryWriter(memoryStream))
+                {
+                    innerWriter.Write(int.MinValue);
+
+                    using (
+                        var binaryDictionaryWriter = XmlDictionaryWriter.CreateBinaryWriter(
+                            memoryStream,
+                            null,
+                            null,
+                            false))
+                    {
+                        this.serializer.WriteObject(binaryDictionaryWriter, value);
+                        binaryDictionaryWriter.Flush();
+                    }
+
+                    var lastPosition = (int) memoryStream.Position;
+
+                    memoryStream.Position = 0;
+
+                    innerWriter.Write(lastPosition - sizeof(int));
+
+                    memoryStream.Position = lastPosition;
+
+                    binaryWriter.Write(memoryStream.GetBuffer(), 0, lastPosition);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Converts T to byte array.
+        /// </summary>
+        /// <param name="newValue"></param>
+        /// <param name="binaryWriter">Writer to which the serialized data should be written.</param>
+        /// <param name="currentValue"></param>
+        /// <returns>Serialized version of T.</returns>
+        public void Write(T currentValue, T newValue, BinaryWriter binaryWriter)
+        {
+            this.Write(newValue, binaryWriter);
+        }
+    }
+}

--- a/Test/TestFabricApplication/TestStatefulService/CustomerXmlDictionaryReader.cs
+++ b/Test/TestFabricApplication/TestStatefulService/CustomerXmlDictionaryReader.cs
@@ -1,0 +1,135 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace TestStatefulService
+{
+    internal class CustomerXmlDictionaryReader : XmlDictionaryReader
+    {
+        XmlDictionaryReader innerReader;
+        string targetNamespace;
+        public CustomerXmlDictionaryReader(XmlDictionaryReader innerReader, string targetNamespace)
+        {
+            this.innerReader = innerReader;
+            this.targetNamespace = targetNamespace;
+
+        }
+
+        public override int AttributeCount => this.innerReader.AttributeCount;
+
+        public override string BaseURI => this.innerReader.BaseURI;
+
+        public override int Depth => this.innerReader.Depth;
+
+        public override bool EOF => this.innerReader.EOF;
+
+        public override bool IsEmptyElement => this.innerReader.IsEmptyElement;
+
+        public override string LocalName => this.innerReader.LocalName;
+
+        public override string NamespaceURI
+        {
+            get
+            {
+                // Alter the old namespace
+                UriBuilder builder = new UriBuilder(innerReader.NamespaceURI);
+                var segments = builder.Uri.Segments;
+                if (!segments.LastOrDefault().EndsWith("/") && segments.LastOrDefault() != this.targetNamespace)
+                {
+                    segments[segments.Length - 1] = this.targetNamespace;
+                    builder.Path = String.Join("", segments);
+                    return builder.Uri.ToString();
+                }
+
+                return innerReader.NamespaceURI;
+            }
+        }
+
+        public override XmlNameTable NameTable => this.innerReader.NameTable;
+
+        public override XmlNodeType NodeType => this.innerReader.NodeType;
+
+        public override string Prefix => this.innerReader.Prefix;
+
+        public override ReadState ReadState => this.innerReader.ReadState;
+
+        public override string Value => this.innerReader.Value;
+
+        public override string GetAttribute(int i)
+        {
+            return this.innerReader.GetAttribute(i);
+        }
+
+        public override string GetAttribute(string name)
+        {
+            return this.innerReader.GetAttribute(name);
+        }
+
+        public override string GetAttribute(string name, string namespaceURI)
+        {
+            return this.innerReader.GetAttribute(name, namespaceURI);
+        }
+
+        public override string LookupNamespace(string prefix)
+        {
+            return this.innerReader.LookupNamespace(prefix);
+        }
+
+        public override bool MoveToAttribute(string name)
+        {
+            return this.innerReader.MoveToAttribute(name);
+        }
+
+        public override bool MoveToAttribute(string name, string ns)
+        {
+            return this.innerReader.MoveToAttribute(name, ns);
+        }
+
+        public override bool MoveToElement()
+        {
+            return this.innerReader.MoveToElement();
+        }
+
+        public override bool MoveToFirstAttribute()
+        {
+            return this.innerReader.MoveToFirstAttribute();
+        }
+
+        public override bool MoveToNextAttribute()
+        {
+            return this.innerReader.MoveToNextAttribute();
+        }
+
+        public override bool Read()
+        {
+            return this.innerReader.Read();
+        }
+
+        public override bool ReadAttributeValue()
+        {
+            return this.innerReader.ReadAttributeValue();
+        }
+
+        public override void ResolveEntity()
+        {
+            this.innerReader.ResolveEntity();
+        }
+    }
+}

--- a/Test/TestFabricApplication/TestStatefulService/TestStatefulService.cs
+++ b/Test/TestFabricApplication/TestStatefulService/TestStatefulService.cs
@@ -18,6 +18,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DurableTask;
+using DurableTask.History;
 using DurableTask.ServiceFabric;
 using DurableTask.Test.Orchestrations.Perf;
 using Microsoft.ServiceFabric.Services.Communication.Runtime;
@@ -49,6 +50,12 @@ namespace TestStatefulService
             this.fabricProviderFactory = new FabricOrchestrationProviderFactory(this.StateManager, settings);
             this.fabricProvider = this.fabricProviderFactory.CreateProvider();
             this.client = new TaskHubClient(fabricProvider.OrchestrationServiceClient);
+
+            this.StateManager.TryAddStateSerializer(new CustomDataContractStateSerializer<TaskMessageItem>());
+            this.StateManager.TryAddStateSerializer(new CustomDataContractStateSerializer<TaskMessage>());
+            this.StateManager.TryAddStateSerializer(new CustomDataContractStateSerializer<HistoryEvent>());
+            this.StateManager.TryAddStateSerializer(new CustomDataContractStateSerializer<OrchestrationInstance>());
+            this.StateManager.TryAddStateSerializer(new CustomDataContractStateSerializer<EventType>());
         }
 
         /// <summary>

--- a/Test/TestFabricApplication/TestStatefulService/TestStatefulService.cs
+++ b/Test/TestFabricApplication/TestStatefulService/TestStatefulService.cs
@@ -52,10 +52,6 @@ namespace TestStatefulService
             this.client = new TaskHubClient(fabricProvider.OrchestrationServiceClient);
 
             this.StateManager.TryAddStateSerializer(new CustomDataContractStateSerializer<TaskMessageItem>());
-            this.StateManager.TryAddStateSerializer(new CustomDataContractStateSerializer<TaskMessage>());
-            this.StateManager.TryAddStateSerializer(new CustomDataContractStateSerializer<HistoryEvent>());
-            this.StateManager.TryAddStateSerializer(new CustomDataContractStateSerializer<OrchestrationInstance>());
-            this.StateManager.TryAddStateSerializer(new CustomDataContractStateSerializer<EventType>());
         }
 
         /// <summary>

--- a/Test/TestFabricApplication/TestStatefulService/TestStatefulService.csproj
+++ b/Test/TestFabricApplication/TestStatefulService/TestStatefulService.csproj
@@ -13,6 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <IsServiceFabricServiceProject>True</IsServiceFabricServiceProject>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
     <DebugSymbols>true</DebugSymbols>
@@ -113,8 +114,11 @@
       <HintPath>..\..\..\packages\Microsoft.AspNet.WebApi.Owin.5.2.3\lib\net45\System.Web.Http.Owin.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CustomDataContractStateSerializer.cs" />
+    <Compile Include="CustomerXmlDictionaryReader.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />
     <Compile Include="TestOrchestrations\CounterException.cs" />

--- a/src/DurableTask.ServiceFabric/TaskMessageItem.cs
+++ b/src/DurableTask.ServiceFabric/TaskMessageItem.cs
@@ -16,17 +16,29 @@ namespace DurableTask.ServiceFabric
     using System;
     using System.Runtime.Serialization;
 
+    /// <summary>
+    /// This wrapper is used with Service Fabric collections to persist TaskMessage.
+    /// </summary>
     [DataContract]
-    sealed class TaskMessageItem : IExtensibleDataObject
+    public sealed class TaskMessageItem : IExtensibleDataObject
     {
+        /// <summary>
+        /// This wrapper is used with Service Fabric collections to persist TaskMessage.
+        /// </summary>
         public TaskMessageItem(TaskMessage taskMessage)
         {
             this.TaskMessage = taskMessage ?? throw new ArgumentNullException(nameof(taskMessage));
         }
 
+        /// <summary>
+        /// TaskMessage defined in TaskHub Core.
+        /// </summary>
         [DataMember]
         public TaskMessage TaskMessage { get; private set; }
 
+        /// <summary>
+        /// TaskMessage ExtensionData.
+        /// </summary>
         public ExtensionDataObject ExtensionData { get; set; }
     }
 }


### PR DESCRIPTION
This change is to allow the applications to customize serialization for the classes used with Service Fabric Reliable collections.