### PR TITLE
Add TaskContext null check in AsyncTaskActivity error handling

### DIFF
--- a/Test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
+++ b/Test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
@@ -148,6 +148,22 @@ namespace DurableTask.Core.Tests
             }
         }
 
+        [TestMethod]
+        public void TaskFailureOnNullContextTaskActivity()
+        {
+            TaskActivity activity = new ThrowInvalidOperationExceptionAsync();
+            string input = JsonConvert.SerializeObject(new string[] { "test" });
+
+            // Pass a null context to check that it doesn't affect error handling.
+            Task<string> task = activity.RunAsync(null, input);
+
+            Assert.IsTrue(task.IsFaulted);
+            Assert.IsNotNull(task.Exception);
+            Assert.IsNotNull(task.Exception?.InnerException);
+            Assert.IsInstanceOfType(task.Exception?.InnerException, typeof(TaskFailureException));
+            Assert.AreEqual("This is a test exception", task.Exception?.InnerException?.Message);
+        }
+
         class ExceptionHandlingOrchestration : TaskOrchestration<object, string>
         {
             public override async Task<object> RunTask(OrchestrationContext context, string input)
@@ -218,6 +234,14 @@ namespace DurableTask.Core.Tests
         class ThrowInvalidOperationException : TaskActivity<string, string>
         {
             protected override string Execute(TaskContext context, string input)
+            {
+                throw new InvalidOperationException("This is a test exception");
+            }
+        }
+
+        class ThrowInvalidOperationExceptionAsync : AsyncTaskActivity<string, string>
+        {
+            protected override Task<string> ExecuteAsync(TaskContext context, string input)
             {
                 throw new InvalidOperationException("This is a test exception");
             }

--- a/src/DurableTask.Core/TaskActivity.cs
+++ b/src/DurableTask.Core/TaskActivity.cs
@@ -136,7 +136,7 @@ namespace DurableTask.Core
             {
                 string details = null;
                 FailureDetails failureDetails = null;
-                if (context.ErrorPropagationMode == ErrorPropagationMode.SerializeExceptions)
+                if (context != null && context.ErrorPropagationMode == ErrorPropagationMode.SerializeExceptions)
                 {
                     details = Utils.SerializeCause(e, DataConverter);
                 }


### PR DESCRIPTION
This PR adds a null check during error handling in `AsyncTaskActivity`. As described in #1054, if the `context` parameter is passed as null to `RunAsync`, and the call to `ExecuteAsync` fails for some task-specific reason, the error handling code uses that parameter to check which error propagation mode is being used. If the parameter is null, an unexpected `NullReferenceException` will be raised, instead of the expected `TaskFailureException`.

A null check is added to prevent this from happening.