### PR TITLE
[Proposal] Adding control-queue monitor with dedicated orchestrator to each control-queue.

### DIFF
--- a/Test/DurableTask.AzureStorage.Tests/ControlQueueHelperTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/ControlQueueHelperTests.cs
@@ -48,7 +48,7 @@ namespace DurableTask.AzureStorage.Tests
                 PartitionCount = partitionCount,
                 ControlQueueHearbeatOrchestrationInterval = TimeSpan.FromSeconds(5),
                 ControlQueueOrchHeartbeatDetectionInterval = TimeSpan.FromSeconds(5),
-                ControlQueueOrchHeartbeatDetectionThreshold = TimeSpan.FromSeconds(5),
+                ControlQueueOrchHeartbeatLatencyThreshold = TimeSpan.FromSeconds(5),
             };
 
             azureStorageOrchestrationService = new AzureStorageOrchestrationService(settings);
@@ -106,7 +106,7 @@ namespace DurableTask.AzureStorage.Tests
 
             Assert.ThrowsException<InvalidOperationException>(() => { taskHubWorker.AddTaskOrchestrations(objectCreator); });
 
-            await Task.Delay(this.settings.ControlQueueOrchHeartbeatDetectionInterval + this.settings.ControlQueueOrchHeartbeatDetectionThreshold);
+            await Task.Delay(this.settings.ControlQueueOrchHeartbeatDetectionInterval + this.settings.ControlQueueOrchHeartbeatLatencyThreshold);
 
             var detectionCountDuplicate = new Dictionary<string, int>();
 
@@ -118,7 +118,7 @@ namespace DurableTask.AzureStorage.Tests
             }
 
 
-            await Task.Delay(this.settings.ControlQueueOrchHeartbeatDetectionInterval + this.settings.ControlQueueOrchHeartbeatDetectionThreshold);
+            await Task.Delay(this.settings.ControlQueueOrchHeartbeatDetectionInterval + this.settings.ControlQueueOrchHeartbeatLatencyThreshold);
             cancellationTokenSrc.Cancel();
 
             // Give it some time to cancel the ongoing operations.
@@ -131,7 +131,7 @@ namespace DurableTask.AzureStorage.Tests
                 detectionCountDuplicate[controlQueueName] = detectionCount[controlQueueName];
             }
 
-            await Task.Delay(this.settings.ControlQueueOrchHeartbeatDetectionInterval + this.settings.ControlQueueOrchHeartbeatDetectionThreshold);
+            await Task.Delay(this.settings.ControlQueueOrchHeartbeatDetectionInterval + this.settings.ControlQueueOrchHeartbeatLatencyThreshold);
 
             // Should trigger delegate for control-queue stuck.
             foreach (var controlQueueName in controlQueueToInstanceInfo.Keys)

--- a/Test/DurableTask.AzureStorage.Tests/ControlQueueHelperTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/ControlQueueHelperTests.cs
@@ -1,0 +1,279 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureStorage.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Data.SqlTypes;
+    using System.Linq;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using DurableTask.AzureStorage.ControlQueueHeartbeat;
+    using DurableTask.Core;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class ControlQueueHelperTests
+    {
+        IControlQueueHelper controlQueueHelper;
+        AzureStorageOrchestrationService azureStorageOrchestrationService;
+        AzureStorageOrchestrationServiceSettings settings;
+        int partitionCount = 4;
+        Dictionary<string, int> controlQueueNumberToNameMap;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            settings = new AzureStorageOrchestrationServiceSettings()
+            {
+                StorageConnectionString = TestHelpers.GetTestStorageAccountConnectionString(),
+                TaskHubName = TestHelpers.GetTestTaskHubName(),
+                PartitionCount = partitionCount,
+                ControlQueueHearbeatOrchestrationInterval = TimeSpan.FromSeconds(5),
+                ControlQueueOrchHeartbeatDetectionInterval = TimeSpan.FromSeconds(5),
+                ControlQueueOrchHeartbeatDetectionThreshold = TimeSpan.FromSeconds(5),
+            };
+
+            azureStorageOrchestrationService = new AzureStorageOrchestrationService(settings);
+            controlQueueHelper = azureStorageOrchestrationService;
+
+            controlQueueNumberToNameMap = new Dictionary<string, int>();
+
+            for (int i = 0; i < partitionCount; i++)
+            {
+                var controlQueueName = AzureStorageOrchestrationService.GetControlQueueName(settings.TaskHubName, i);
+                controlQueueNumberToNameMap[controlQueueName] = i;
+            }
+        }
+
+        [TestMethod]
+        public async Task StartControlQueueHeartbeatMonitorAsync()
+        {
+            var detectionCount = new Dictionary<string, int>();
+
+            var taskHubClient = new TaskHubClient(azureStorageOrchestrationService);
+            var taskHubWorker = new Core.TaskHubWorker(azureStorageOrchestrationService);
+            var controlQueueToInstanceInfo = azureStorageOrchestrationService.GetControlQueueToInstanceIdInfo();
+
+            // Creating dictionary to calculate stuck issue detection count for each control-queue.
+            foreach (var controlQueueName in controlQueueToInstanceInfo.Keys)
+            {
+                detectionCount[controlQueueName] = 0;
+            }
+
+            var cancellationTokenSrc = new CancellationTokenSource();
+
+            var taskHandle = controlQueueHelper.StartControlQueueHeartbeatMonitorAsync(
+                taskHubClient,
+                taskHubWorker,
+                async (x, y, z, cancelationToken) => { await Task.CompletedTask; },
+                async (workerId, ownerId, isOwner, controlQueueName, instanceid, orchDetectionInfo, cancellationToken) =>
+                {
+                    detectionCount[controlQueueName]++;
+                    await Task.CompletedTask;
+                },
+                cancellationTokenSrc.Token);
+
+            await Task.Delay(this.settings.ControlQueueOrchHeartbeatDetectionInterval + this.settings.ControlQueueOrchHeartbeatDetectionThreshold);
+
+            // Scheduling of all orchestrator should happen.
+            foreach (var instanceId in controlQueueToInstanceInfo.Values)
+            {
+                var orchIsntance = await taskHubClient.GetOrchestrationStateAsync(instanceId);
+                Assert.IsNotNull(orchIsntance);
+            }
+
+            await Task.Delay(this.settings.ControlQueueOrchHeartbeatDetectionInterval + this.settings.ControlQueueOrchHeartbeatDetectionThreshold);
+
+            // Orchestrator registration completed.
+            var objectCreator = new NameValueObjectCreator<TaskOrchestration>(
+                ControlQueueHeartbeatTaskOrchestratorV1.OrchestrationName,
+                ControlQueueHeartbeatTaskOrchestratorV1.OrchestrationVersion,
+                typeof(ControlQueueHeartbeatTaskOrchestratorV1));
+
+            Assert.ThrowsException<InvalidOperationException>(() => { taskHubWorker.AddTaskOrchestrations(objectCreator); });
+
+            // Should trigger delegate for control-queue stuck.
+            foreach (var controlQueueName in controlQueueToInstanceInfo.Keys)
+            {
+                Assert.IsTrue(detectionCount[controlQueueName] > 0);
+            }
+
+        }
+
+        [TestMethod]
+        public async Task ScheduleControlQueueHeartbeatOrchestrations()
+        {
+            var utcBefore = DateTime.UtcNow;
+
+            var taskHubClient = new TaskHubClient(azureStorageOrchestrationService);
+            await controlQueueHelper.ScheduleControlQueueHeartbeatOrchestrationsAsync(taskHubClient, true);
+
+            var controlQueueToInstanceInfo = azureStorageOrchestrationService.GetControlQueueToInstanceIdInfo();
+
+            var utcNow = DateTime.UtcNow;
+
+            foreach (var instanceId in controlQueueToInstanceInfo.Values)
+            {
+                var orchIsntance = await taskHubClient.GetOrchestrationStateAsync(instanceId);
+
+                Assert.IsTrue(orchIsntance.CreatedTime >= utcBefore && orchIsntance.CreatedTime <= utcNow);
+            }
+
+            await controlQueueHelper.ScheduleControlQueueHeartbeatOrchestrationsAsync(taskHubClient, false);
+
+            foreach (var instanceId in controlQueueToInstanceInfo.Values)
+            {
+                var orchIsntance = await taskHubClient.GetOrchestrationStateAsync(instanceId);
+
+                Assert.IsTrue(orchIsntance.CreatedTime >= utcBefore && orchIsntance.CreatedTime <= utcNow);
+            }
+        }
+
+        [TestMethod]
+        public void ScheduleControlQueueHeartbeatOrchestrations_InvalidInput()
+        {
+            var settingsMod = new AzureStorageOrchestrationServiceSettings()
+            {
+                StorageConnectionString = TestHelpers.GetTestStorageAccountConnectionString(),
+                TaskHubName = TestHelpers.GetTestTaskHubName(),
+                PartitionCount = partitionCount + 1,
+            };
+
+            var azureStorageOrchestrationServiceMod = new AzureStorageOrchestrationService(settingsMod);
+
+            var taskHubClient = new TaskHubClient(azureStorageOrchestrationServiceMod);
+
+            Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+            {
+                await controlQueueHelper.ScheduleControlQueueHeartbeatOrchestrationsAsync(null);
+            });
+
+            IOrchestrationServiceClient orchestrationService = new Mock<IOrchestrationServiceClient>().Object;
+            var taskHubClientDiff = new TaskHubClient(orchestrationService);
+
+            Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
+            {
+                await controlQueueHelper.ScheduleControlQueueHeartbeatOrchestrationsAsync(taskHubClientDiff);
+            });
+
+            Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
+            {
+                await controlQueueHelper.ScheduleControlQueueHeartbeatOrchestrationsAsync(taskHubClient);
+            });
+        }
+
+        [TestMethod]
+        public void RegisterControlQueueHeartbeatOrchestration()
+        {
+            var taskHubWorker = new Core.TaskHubWorker(azureStorageOrchestrationService);
+            controlQueueHelper.RegisterControlQueueHeartbeatOrchestration(taskHubWorker, async (x, y, z, cancellationToken) => { await Task.CompletedTask; });
+
+            var objectCreator = new NameValueObjectCreator<TaskOrchestration>(
+                ControlQueueHeartbeatTaskOrchestratorV1.OrchestrationName,
+                ControlQueueHeartbeatTaskOrchestratorV1.OrchestrationVersion,
+                typeof(ControlQueueHeartbeatTaskOrchestratorV1));
+
+            Assert.ThrowsException<InvalidOperationException>(() => { taskHubWorker.AddTaskOrchestrations(objectCreator); });
+        }
+
+        [TestMethod]
+        public void RegisterControlQueueHeartbeatOrchestration_InvalidInput()
+        {
+            var settingsMod = new AzureStorageOrchestrationServiceSettings()
+            {
+                StorageConnectionString = TestHelpers.GetTestStorageAccountConnectionString(),
+                TaskHubName = TestHelpers.GetTestTaskHubName(),
+                PartitionCount = partitionCount + 1,
+            };
+
+            var azureStorageOrchestrationServiceMod = new AzureStorageOrchestrationService(settingsMod);
+
+            var taskHubWorker = new TaskHubWorker(azureStorageOrchestrationServiceMod);
+
+            Assert.ThrowsException<ArgumentNullException>(() =>
+            {
+                controlQueueHelper.RegisterControlQueueHeartbeatOrchestration(null, async (x, y, z, cancellationToken) => { await Task.CompletedTask; });
+            });
+
+            IOrchestrationService orchestrationService = new Mock<IOrchestrationService>().Object;
+            var taskHubWorkerDiff = new TaskHubWorker(orchestrationService);
+
+            Assert.ThrowsException<InvalidOperationException>(() =>
+            {
+                controlQueueHelper.RegisterControlQueueHeartbeatOrchestration(taskHubWorkerDiff, async (x, y, z, cancellationToken) => { await Task.CompletedTask; });
+            });
+
+            Assert.ThrowsException<InvalidOperationException>(() =>
+            {
+                controlQueueHelper.RegisterControlQueueHeartbeatOrchestration(taskHubWorker, async (x, y, z, cancellationToken) => { await Task.CompletedTask; });
+            });
+        }
+
+        [TestMethod]
+        [DataRow(new int[] { 0, 1, 2, 3 })]
+        [DataRow(new int[] { 2, 3 })]
+        [DataRow(new int[] { 1, 3 })]
+        [DataRow(new int[] { 0, 1 })]
+        [DataRow(new int[] { 0, 2 })]
+        [DataRow(new int[] { 0, 3 })]
+        [DataRow(new int[] { 0 })]
+        [DataRow(new int[] { 1 })]
+        [DataRow(new int[] { 3 })]
+        public async Task GetControlQueueInstanceId(int[] controlQueueNumbers)
+        {
+            Dictionary<int, List<string>> controlQueueNumberToInstanceIds = new Dictionary<int, List<string>>();
+
+            var controlQueueNumbersHashSet = new HashSet<int>();
+
+            foreach (var cQN in controlQueueNumbers)
+            {
+                controlQueueNumbersHashSet.Add(cQN);
+                controlQueueNumberToInstanceIds[cQN] = new List<string>();
+            }
+
+
+            for (int i = 0; i < 100; i++)
+            {
+                var instanceId = controlQueueHelper.GetControlQueueInstanceId(controlQueueNumbersHashSet, $"prefix{Guid.NewGuid()}_");
+
+                var controlQueue = await azureStorageOrchestrationService.GetControlQueueAsync(instanceId);
+                var controlQueueNumber = controlQueueNumberToNameMap[controlQueue.Name];
+
+                controlQueueNumberToInstanceIds[controlQueueNumber].Add(instanceId);
+
+                Assert.IsTrue(controlQueueNumbers.Any(x => x == controlQueueNumber));
+            }
+
+            foreach (var cQN in controlQueueNumbers)
+            {
+                Assert.IsTrue(controlQueueNumberToInstanceIds[cQN].Count > 0);
+            }
+        }
+
+        [TestMethod]
+        public void GetControlQueueInstanceId_InvalidInput()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => { controlQueueHelper.GetControlQueueInstanceId(null); });
+            Assert.ThrowsException<ArgumentException>(() => { controlQueueHelper.GetControlQueueInstanceId(new HashSet<int>()); });
+            Assert.ThrowsException<ArgumentException>(() => { controlQueueHelper.GetControlQueueInstanceId(new HashSet<int>() { -4 }); });
+            Assert.ThrowsException<ArgumentException>(() => { controlQueueHelper.GetControlQueueInstanceId(new HashSet<int>() { partitionCount }); });
+            Assert.ThrowsException<ArgumentException>(() => { controlQueueHelper.GetControlQueueInstanceId(new HashSet<int>() { partitionCount + 4 }); });
+        }
+
+    }
+}

--- a/samples/DurableTask.Samples/Program.cs
+++ b/samples/DurableTask.Samples/Program.cs
@@ -240,9 +240,9 @@ namespace DurableTask.Samples
                 TaskHubName = taskHubName,
                 UseTablePartitionManagement = true,
                 PartitionCount = 10,
-                ControlQueueHearbeatOrchestrationInterval = TimeSpan.FromSeconds(5),
-                ControlQueueOrchHeartbeatDetectionInterval = TimeSpan.FromSeconds(10),
-                ControlQueueOrchHeartbeatDetectionThreshold = TimeSpan.FromSeconds(10),
+                ControlQueueHearbeatOrchestrationInterval = TimeSpan.FromSeconds(10),
+                ControlQueueOrchHeartbeatDetectionInterval = TimeSpan.FromSeconds(20),
+                ControlQueueOrchHeartbeatDetectionThreshold = TimeSpan.FromSeconds(30),
                 WorkerId = workerId
             };
 

--- a/samples/DurableTask.Samples/Program.cs
+++ b/samples/DurableTask.Samples/Program.cs
@@ -44,7 +44,7 @@ namespace DurableTask.Samples
         static ObservableEventListener eventListener;
 
         [STAThread]
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
             eventListener = new ObservableEventListener();
             eventListener.LogToConsole();
@@ -133,9 +133,9 @@ namespace DurableTask.Samples
                             break;
                         case "ControlQueueHeartbeatMonitor":
                             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
-                            var taskWorker1 = TriggerTaskHubWithMonitor("workerId1", "taskHub1", cancellationTokenSource.Token);
-                            var taskWorker2 = TriggerTaskHubWithMonitor("workerId2", "taskHub1", cancellationTokenSource.Token);
-                            var taskWorker3 = TriggerTaskHubWithMonitor("WorkerId1", "taskHub1", cancellationTokenSource.Token);
+                            var taskWorker1 = await TriggerTaskHubWithMonitor("workerId1", "taskHub1", cancellationTokenSource.Token);
+                            var taskWorker2 = await TriggerTaskHubWithMonitor("workerId2", "taskHub1", cancellationTokenSource.Token);
+                            var taskWorker3 = await TriggerTaskHubWithMonitor("WorkerId1", "taskHub1", cancellationTokenSource.Token);
 
                             Task.Delay(TimeSpan.FromMinutes(5)).Wait();
 
@@ -230,7 +230,7 @@ namespace DurableTask.Samples
             }
         }
 
-        private static TaskHubWorker TriggerTaskHubWithMonitor(string workerId, string taskHubName, CancellationToken cancellationToken)
+        private static async Task<TaskHubWorker> TriggerTaskHubWithMonitor(string workerId, string taskHubName, CancellationToken cancellationToken)
         {
             string storageConnectionString = GetSetting("StorageConnectionString");
 
@@ -251,7 +251,7 @@ namespace DurableTask.Samples
             var taskHubWorker = new TaskHubWorker(orchestrationServiceAndClient);
 
             var controlQueueHealthMonitor = (IControlQueueHelper)orchestrationServiceAndClient;
-            var task = controlQueueHealthMonitor.StartControlQueueHeartbeatMonitorAsync(
+            await controlQueueHealthMonitor.StartControlQueueHeartbeatMonitorAsync(
                 taskHubClient,
                 taskHubWorker,
                 async (orchestrationInstance, controlQueueHeartbeatTaskInputContext, controlQueueHeartbeatTaskContext, cancellationToken) =>

--- a/samples/DurableTask.Samples/Program.cs
+++ b/samples/DurableTask.Samples/Program.cs
@@ -242,7 +242,7 @@ namespace DurableTask.Samples
                 PartitionCount = 10,
                 ControlQueueHearbeatOrchestrationInterval = TimeSpan.FromSeconds(10),
                 ControlQueueOrchHeartbeatDetectionInterval = TimeSpan.FromSeconds(20),
-                ControlQueueOrchHeartbeatDetectionThreshold = TimeSpan.FromSeconds(30),
+                ControlQueueOrchHeartbeatLatencyThreshold = TimeSpan.FromSeconds(30),
                 WorkerId = workerId
             };
 

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -15,12 +15,14 @@ namespace DurableTask.AzureStorage
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Diagnostics.Tracing;
     using System.Linq;
     using System.Net;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
+    using DurableTask.AzureStorage.ControlQueueHeartbeat;
     using DurableTask.AzureStorage.Messaging;
     using DurableTask.AzureStorage.Monitoring;
     using DurableTask.AzureStorage.Partitioning;
@@ -40,10 +42,11 @@ namespace DurableTask.AzureStorage
     public sealed class AzureStorageOrchestrationService :
         IOrchestrationService,
         IOrchestrationServiceClient,
-        IDisposable, 
+        IDisposable,
         IOrchestrationServiceQueryClient,
         IOrchestrationServicePurgeClient,
-        IEntityOrchestrationService
+        IEntityOrchestrationService,
+        IControlQueueHelper
     {
         static readonly HistoryEvent[] EmptyHistoryEventList = new HistoryEvent[0];
 
@@ -155,7 +158,7 @@ namespace DurableTask.AzureStorage
 
             if (this.settings.UseTablePartitionManagement && this.settings.UseLegacyPartitionManagement)
             {
-                throw new ArgumentException("Cannot use both TablePartitionManagement and LegacyPartitionManagement. For improved reliability, consider using the TablePartitionManager.");  
+                throw new ArgumentException("Cannot use both TablePartitionManagement and LegacyPartitionManagement. For improved reliability, consider using the TablePartitionManager.");
             }
             else if (this.settings.UseTablePartitionManagement)
             {
@@ -183,6 +186,8 @@ namespace DurableTask.AzureStorage
                 this.settings.TaskHubName.ToLowerInvariant() + "-applease",
                 this.settings.TaskHubName.ToLowerInvariant() + "-appleaseinfo",
                 this.settings.AppLeaseOptions);
+
+            semaphoreSlimForControlQueueMonitorCallBack = new SemaphoreSlim(this.settings.PartitionCount);
         }
 
         internal string WorkerId => this.settings.WorkerId;
@@ -239,9 +244,14 @@ namespace DurableTask.AzureStorage
                 throw new ArgumentOutOfRangeException(nameof(settings), "The number of partitions must be a positive integer and no greater than 16.");
             }
 
-            if (string.IsNullOrEmpty(settings.TaskHubName))
+            if (string.IsNullOrWhiteSpace(settings.TaskHubName))
             {
                 throw new ArgumentNullException(nameof(settings), $"A {nameof(settings.TaskHubName)} value must be configured in the settings.");
+            }
+
+            if (settings.ControlQueueHearbeatOrchestrationInterval > settings.ControlQueueOrchHeartbeatDetectionThreshold)
+            {
+                throw new ArgumentException(nameof(settings), $"{nameof(settings.ControlQueueHearbeatOrchestrationInterval)} must not be more than {nameof(settings.ControlQueueOrchHeartbeatDetectionThreshold)}");
             }
 
             // TODO: More validation.
@@ -630,7 +640,7 @@ namespace DurableTask.AzureStorage
             // Need to check for leases in Azure Table Storage. Scale Controller calls into this method.
             int partitionCount;
             Table partitionTable = azureStorageClient.GetTableReference(azureStorageClient.Settings.PartitionTableName);
-            
+
             // Check if table partition manager is used. If so, get partition count from table.
             // Else, get the partition count from the blobs.
             if (await partitionTable.ExistsAsync())
@@ -872,12 +882,12 @@ namespace DurableTask.AzureStorage
             var messages = session.CurrentMessageBatch;
             TraceContextBase parentTraceContext = null;
             bool foundEventRaised = false;
-            foreach(var message in messages)
+            foreach (var message in messages)
             {
                 if (message.SerializableTraceContext != null)
                 {
                     var traceContext = TraceContextBase.Restore(message.SerializableTraceContext);
-                    switch(message.TaskMessage.Event)
+                    switch (message.TaskMessage.Event)
                     {
                         // Dependency Execution finished.
                         case TaskCompletedEvent tc:
@@ -901,15 +911,16 @@ namespace DurableTask.AzureStorage
                             break;
                         default:
                             // When internal error happens, multiple message could come, however, it should not be prioritized.
-                            if (parentTraceContext == null || 
+                            if (parentTraceContext == null ||
                                 parentTraceContext.OrchestrationTraceContexts.Count < traceContext.OrchestrationTraceContexts.Count)
                             {
                                 parentTraceContext = traceContext;
                             }
 
                             break;
-                    }                   
-                } else
+                    }
+                }
+                else
                 {
 
                     // In this case, we set the parentTraceContext later in this method
@@ -917,7 +928,7 @@ namespace DurableTask.AzureStorage
                     {
                         foundEventRaised = true;
                     }
-                }            
+                }
             }
 
             // When EventRaisedEvent is present, it will not, out of the box, share the same operation
@@ -934,12 +945,12 @@ namespace DurableTask.AzureStorage
 
         static bool IsActivityOrOrchestrationFailedOrCompleted(IList<MessageData> messages)
         {
-            foreach(var message in messages)
+            foreach (var message in messages)
             {
                 if (message.TaskMessage.Event is DurableTask.Core.History.SubOrchestrationInstanceCompletedEvent ||
                     message.TaskMessage.Event is DurableTask.Core.History.SubOrchestrationInstanceFailedEvent ||
                     message.TaskMessage.Event is DurableTask.Core.History.TaskCompletedEvent ||
-                    message.TaskMessage.Event is DurableTask.Core.History.TaskFailedEvent  ||
+                    message.TaskMessage.Event is DurableTask.Core.History.TaskFailedEvent ||
                     message.TaskMessage.Event is DurableTask.Core.History.TimerFiredEvent)
                 {
                     return true;
@@ -1133,13 +1144,13 @@ namespace DurableTask.AzureStorage
 
             // Correlation
             CorrelationTraceClient.Propagate(() =>
+            {
+                // In case of Extended Session, Emit the Dependency Telemetry. 
+                if (workItem.IsExtendedSession)
                 {
-                    // In case of Extended Session, Emit the Dependency Telemetry. 
-                    if (workItem.IsExtendedSession)
-                    {
-                        this.TrackExtendedSessionDependencyTelemetry(session);
-                    }
-                });
+                    this.TrackExtendedSessionDependencyTelemetry(session);
+                }
+            });
 
             TraceContextBase currentTraceContextBaseOnComplete = null;
             CorrelationTraceClient.Propagate(() =>
@@ -1224,7 +1235,7 @@ namespace DurableTask.AzureStorage
             TaskMessage continuedAsNewMessage,
             OrchestrationState orchestrationState)
         {
-            return 
+            return
                 (outboundMessages.Count != 0 || orchestratorMessages.Count != 0 || timerMessages.Count != 0) &&
                 (orchestrationState.OrchestrationStatus != OrchestrationStatus.Completed) &&
                 (orchestrationState.OrchestrationStatus != OrchestrationStatus.Failed);
@@ -1266,7 +1277,7 @@ namespace DurableTask.AzureStorage
             bool dependencyTelemetryStarted)
         {
             TraceContextBase currentTraceContextBaseOnComplete = null;
-            
+
             if (dependencyTelemetryStarted)
             {
                 // DependencyTelemetry will be included on an outbound queue
@@ -1276,7 +1287,7 @@ namespace DurableTask.AzureStorage
             }
             else
             {
-                switch(orchestrationState.OrchestrationStatus)
+                switch (orchestrationState.OrchestrationStatus)
                 {
                     case OrchestrationStatus.Completed:
                     case OrchestrationStatus.Failed:
@@ -1692,7 +1703,7 @@ namespace DurableTask.AzureStorage
                 {
                     throw new InvalidOperationException($"An Orchestration instance with the status {existingInstance.State.OrchestrationStatus} already exists.");
                 }
-                
+
                 return;
             }
 
@@ -1993,7 +2004,7 @@ namespace DurableTask.AzureStorage
             while (!cancellationToken.IsCancellationRequested)
             {
                 OrchestrationState? state = await this.GetOrchestrationStateAsync(instanceId, executionId);
-                
+
                 if (state != null &&
                     state.OrchestrationStatus != OrchestrationStatus.Running &&
                     state.OrchestrationStatus != OrchestrationStatus.Suspended &&
@@ -2007,9 +2018,9 @@ namespace DurableTask.AzureStorage
                     }
                     return state;
                 }
-                
+
                 timeout -= statusPollingInterval;
-                
+
                 // For a user-provided timeout of `TimeSpan.Zero`,
                 // we want to check the status of the orchestration once and then return.
                 // Therefore, we check the timeout condition after the status check.
@@ -2045,6 +2056,417 @@ namespace DurableTask.AzureStorage
         }
 
         #endregion
+
+        #region IControlQueueHelper
+
+        /// <inheritdoc/>
+        public async Task StartControlQueueHeartbeatMonitorAsync(
+            TaskHubClient taskHubClient,
+            TaskHubWorker taskHubWorker,
+            Func<OrchestrationInstance, ControlQueueHeartbeatTaskInputContext, ControlQueueHeartbeatTaskContext, CancellationToken, Task> callBackHeartOrchAsync,
+            Func<string, string?, bool, string, string, ControlQueueHeartbeatDetectionInfo, CancellationToken, Task> callBackControlQueueValidation,
+            CancellationToken cancellationToken)
+        {
+            // Validate if taskHubClient and taskHubWorker used is of correct type and settings.
+            ValidateTaskHubClient(taskHubClient);
+            ValidateTaskHubWorker(taskHubWorker);
+
+            Stopwatch stopwatch = Stopwatch.StartNew();
+
+            // Schedule orchestrator instance for each control-queue.
+            await ScheduleControlQueueHeartbeatOrchestrations(taskHubClient, false);
+
+            // Register orchestrator for control-queue heartbeat.
+            RegisterControlQueueHeartbeatOrchestration(taskHubWorker, callBackHeartOrchAsync);
+
+            // Gets control-queue name to orchestrator instance id dictionary.
+            Dictionary<string, string> controlQueueOrchInstanceIds = GetControlQueueToInstanceIdInfo();
+
+            // Waiting for detection interval initial to give time to worker to allow some draining of messages from control-queue.
+            await Task.Delay(this.settings.ControlQueueOrchHeartbeatDetectionInterval, cancellationToken);
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var localCancellationTokenSource = new CancellationTokenSource(this.settings.ControlQueueOrchHeartbeatDetectionInterval);
+                var linkedCancelationTokenSrc = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, localCancellationTokenSource.Token);
+
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    Dictionary<string, string?> controlQueueOwnerIds = new Dictionary<string, string?>();
+
+                    try
+                    {
+                        // Gets control-queue name to owner id dictionary.
+                        controlQueueOwnerIds = await GetControlQueueOwnerIds();
+                    }
+                    catch (Exception ex)
+                    {
+                        // [Logs] Add exception details for failure at fetching owners of control-queue.
+                        FileWriter.WriteLogControlQueueMonitor($"ControlQueueOwnerIdsFetchFailed" +
+                            $"exception: {ex.ToString()}" +
+                            $"message: failed to fetch owner ids for control-queues.");
+                    }
+
+                    Parallel.ForEach(controlQueueOrchInstanceIds, async (controlQueueOrchInstanceId) =>
+                    {
+                        var controlQueueName = controlQueueOrchInstanceId.Key;
+                        var instanceId = controlQueueOrchInstanceId.Value;
+
+                        if ((controlQueueOwnerIds.Count == 0))
+                        {
+                            // If controlQueueOwnerIds was failed, run the callback with ownerId as null and ControlQueueHeartbeatDetectionInfo as ControlQueueOwnerFetchFailed.
+                            await RunCallBack(callBackControlQueueValidation, null, controlQueueName, instanceId, ControlQueueHeartbeatDetectionInfo.ControlQueueOwnerFetchFailed, linkedCancelationTokenSrc.Token);
+                        }
+                        else
+                        {
+                            var ownerId = controlQueueOwnerIds[controlQueueName];
+
+                            // Fetch orchestration instance and validate control-queue stuck.
+                            await ValidateControlQueueOrchestrationAsync(taskHubClient, callBackControlQueueValidation, ownerId, controlQueueName, instanceId, linkedCancelationTokenSrc.Token);
+                        }
+                    });
+                }
+
+                // Waiting for detection interval.
+                await Task.Delay(this.settings.ControlQueueOrchHeartbeatDetectionInterval, linkedCancelationTokenSrc.Token);
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task ScheduleControlQueueHeartbeatOrchestrations(TaskHubClient taskHubClient, bool force = false)
+        {
+            // Validate taskhubclient.
+            ValidateTaskHubClient(taskHubClient);
+
+            // Get control-queue to instance-id map.
+            Dictionary<string, string> controlQueueOrchInstanceIds = GetControlQueueToInstanceIdInfo();
+
+            foreach (var controlQueueOrchInstanceId in controlQueueOrchInstanceIds)
+            {
+                var controlQueueName = controlQueueOrchInstanceId.Key;
+                var instanceId = controlQueueOrchInstanceId.Value;
+
+                if (!force)
+                {
+                    var state = await taskHubClient.GetOrchestrationStateAsync(instanceId);
+
+                    // if the orchestration instance is not completed, then don't add orchestration instance again.
+                    if (state != null && (
+                         state.OrchestrationStatus == OrchestrationStatus.Pending
+                         || state.OrchestrationStatus == OrchestrationStatus.Running
+                         || state.OrchestrationStatus == OrchestrationStatus.ContinuedAsNew
+                         ))
+                    {
+                        // [Logs] Orchestration instance already exists with state and orchestration id. 
+                        FileWriter.WriteLogControlQueueMonitor($"ControlQueueHeartbeatOrchestrationsAlreadyQueued" +
+                            $"controlQueueName: {controlQueueName}" +
+                            $"instanceId: {instanceId}" +
+                            $"message: orchestration already present in incomplete state.");
+
+                        continue;
+                    }
+                }
+
+                // Creating input context for control queue with control-queue name, taskhub name, and partition count.
+                var orchInput = new ControlQueueHeartbeatTaskInputContext(controlQueueName, this.settings.TaskHubName, this.settings.PartitionCount);
+
+                // Creating the orchestration instance.
+                await taskHubClient.CreateOrchestrationInstanceAsync(
+                    ControlQueueHeartbeatTaskOrchestratorV1.OrchestrationName,
+                    ControlQueueHeartbeatTaskOrchestratorV1.OrchestrationVersion,
+                    controlQueueOrchInstanceId.Value,
+                    orchInput);
+            }
+        }
+
+        /// <inheritdoc/>
+        public void RegisterControlQueueHeartbeatOrchestration(TaskHubWorker taskHubWorker, Func<OrchestrationInstance, ControlQueueHeartbeatTaskInputContext, ControlQueueHeartbeatTaskContext, CancellationToken, Task> callBack)
+        {
+            ValidateTaskHubWorker(taskHubWorker);
+
+            if (!isControlQueueOrchestratorsRegistered)
+            {
+                lock (controlQueueOrchestratorsRegistrationLock)
+                {
+                    if (!isControlQueueOrchestratorsRegistered)
+                    {
+                        // Creating initial context object for orchestration. 
+                        // This context will be available for each orchestration ran of this type in the taskhubworker.
+                        ControlQueueHeartbeatTaskOrchestratorV1 controlQueueHeartbeatTaskOrchestrator = new ControlQueueHeartbeatTaskOrchestratorV1(
+                            new ControlQueueHeartbeatTaskContext(
+                                this.settings.TaskHubName,
+                                this.settings.PartitionCount),
+                            this.settings.ControlQueueHearbeatOrchestrationInterval,
+                            callBack);
+
+                        var objectCreator = new NameValueObjectCreator<TaskOrchestration>(ControlQueueHeartbeatTaskOrchestratorV1.OrchestrationName, ControlQueueHeartbeatTaskOrchestratorV1.OrchestrationVersion, controlQueueHeartbeatTaskOrchestrator);
+
+                        // Registering task orchestration. 
+                        taskHubWorker.AddTaskOrchestrations(objectCreator);
+                    }
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public string GetControlQueueInstanceId(int[] controlQueueNumbers, string instanceIdPrefix = "")
+        {
+            var instanceId = string.Empty;
+            int suffix = 0;
+            bool foundInstanceId = false;
+
+            var partitionCount = this.settings.PartitionCount;
+
+            // Validating control-queue numbers are valid.
+            foreach (var controlQueueNumber in controlQueueNumbers)
+            {
+                if (controlQueueNumber < 0 && controlQueueNumber >= partitionCount)
+                {
+                    throw new InvalidOperationException($"{nameof(controlQueueNumbers)} has at least one value which is not in range of [0,{partitionCount - 1}] with partition count = {partitionCount}.");
+                }
+            }
+
+            // Updating suffix and checking control-queue being from provided list until found one.
+            while (!foundInstanceId)
+            {
+                suffix++;
+                instanceId = $"{instanceIdPrefix}{suffix}";
+                var controlQueueNumber = (int)Fnv1aHashHelper.ComputeHash(instanceId) % partitionCount;
+
+                if (controlQueueNumbers.Any(x => x == controlQueueNumber))
+                {
+                    foundInstanceId = true;
+                }
+            }
+
+            return instanceId;
+        }
+
+        private void ValidateTaskHubWorker(TaskHubWorker taskHubWorker)
+        {
+            if (!(taskHubWorker.orchestrationService is AzureStorageOrchestrationService azureStorageOrchestrationServiceTaskHubWorker))
+            {
+                throw new InvalidOperationException($"TaskhubWorker is not using AzureStorageOrchestrationService.");
+            }
+
+            if (!(this.settings.TaskHubName.Equals(azureStorageOrchestrationServiceTaskHubWorker.settings.TaskHubName)
+                && this.settings.PartitionCount == azureStorageOrchestrationServiceTaskHubWorker.settings.PartitionCount))
+            {
+                throw new InvalidOperationException($"TaskhubWorker's AzureStorageOrchestrationService is not having either TaskHubName and/or PartitionCount mismatch.");
+            }
+        }
+
+        private void ValidateTaskHubClient(TaskHubClient taskHubClient)
+        {
+            if (!(taskHubClient.ServiceClient is AzureStorageOrchestrationService azureStorageOrchestrationService))
+            {
+                throw new InvalidOperationException($"TaskhubClient is not using AzureStorageOrchestrationService.");
+            }
+
+            if (!(this.settings.TaskHubName.Equals(azureStorageOrchestrationService.settings.TaskHubName)
+                && this.settings.PartitionCount == azureStorageOrchestrationService.settings.PartitionCount))
+            {
+                throw new InvalidOperationException($"TaskhubClient's AzureStorageOrchestrationService is not having either TaskHubName and/or PartitionCount mismatch.");
+            }
+        }
+
+        private async Task ValidateControlQueueOrchestrationAsync(
+            TaskHubClient taskHubClient,
+            Func<string, string?, bool, string, string, ControlQueueHeartbeatDetectionInfo, CancellationToken, Task> callBack,
+            string? ownerId,
+            string controlQueueName,
+            string instanceId,
+            CancellationToken cancellationToken)
+        {
+            DateTime currentTimeUTC = DateTime.UtcNow;
+
+            // Make it time boxed.
+            var timeBoxedActivity = Task.Delay(this.settings.ControlQueueOrchHeartbeatDetectionInterval, cancellationToken);
+            var orchInstanceTask = taskHubClient.GetOrchestrationStateAsync(instanceId);
+
+            await Task.WhenAny(timeBoxedActivity, orchInstanceTask);
+
+            if (!orchInstanceTask.IsCompleted)
+            {
+                // orchestrator fetch step timed out.
+                FileWriter.WriteLogControlQueueMonitor($"OrchestrationInstanceNotFound" +
+                    $"controlQueueName: {controlQueueName}" +
+                    $"instanceId: {instanceId}" +
+                    $"message: orchestration instance couldn't fetch in time.");
+
+                // Run the callback with ownerId and ControlQueueHeartbeatDetectionInfo as OrchestrationInstanceNotFound.
+                await RunCallBack(callBack, ownerId, controlQueueName, instanceId, ControlQueueHeartbeatDetectionInfo.OrchestrationInstanceNotFound, cancellationToken);
+            }
+            if (orchInstanceTask.Result == null)
+            {
+                // orchestrator instance not found in control-queue..
+                FileWriter.WriteLogControlQueueMonitor($"OrchestrationInstanceFetchTimedOut" +
+                    $"controlQueueName: {controlQueueName}" +
+                    $"instanceId: {instanceId}" +
+                    $"message: orchestration instance not found.");
+
+                // Run the callback with ownerId and ControlQueueHeartbeatDetectionInfo as OrchestrationInstanceNotFound.
+                await RunCallBack(callBack, ownerId, controlQueueName, instanceId, ControlQueueHeartbeatDetectionInfo.OrchestrationInstanceFetchTimedOut, cancellationToken);
+            }
+            else
+            {
+                var orchInstance = orchInstanceTask.Result;
+
+                var lastUpdatedTimeUTC = orchInstance.LastUpdatedTime;
+
+                var diffInSeconds = currentTimeUTC - lastUpdatedTimeUTC;
+
+                // If difference in last updated time and current time is greater than threshold, then log the 'OrchestrationInstanceStuck' and run callback.
+                if (this.settings.ControlQueueOrchHeartbeatDetectionThreshold < diffInSeconds)
+                {
+                    // orchestrator instance not found in control-queue..
+                    FileWriter.WriteLogControlQueueMonitor($"OrchestrationInstanceStuck" +
+                        $"controlQueueName: {controlQueueName}" +
+                        $"instanceId: {instanceId}" +
+                        $"lastUpdatedTimeUTC: {lastUpdatedTimeUTC.ToLongTimeString()}" +
+                        $"currentTimeUTC: {currentTimeUTC.ToLongTimeString()}" +
+                        $"message: orchestration instance is stuck.");
+
+                    await RunCallBack(callBack, ownerId, controlQueueName, instanceId, ControlQueueHeartbeatDetectionInfo.OrchestrationInstanceStuck, cancellationToken);
+                }
+            }
+        }
+
+        private async Task RunCallBack(
+            Func<string, string?, bool, string, string, ControlQueueHeartbeatDetectionInfo, CancellationToken, Task> callBack,
+            string? ownerId,
+            string controlQueueName,
+            string instanceId,
+            ControlQueueHeartbeatDetectionInfo controlQueueHeartbeatDetectionInfo,
+            CancellationToken cancellationToken)
+        {
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            bool gotSemaphore = false;
+
+            try
+            {
+                // waiting on semaphore with timeout to avoid thread hogging and starvation.
+                gotSemaphore = await semaphoreSlimForControlQueueMonitorCallBack.WaitAsync(this.settings.ControlQueueOrchHeartbeatDetectionThreshold);
+
+                var isControlQueueOwner = this.settings.WorkerId.Equals(ownerId);
+
+                if (gotSemaphore)
+                {
+                    var delayTask = Task.Delay(this.settings.ControlQueueHearbeatOrchestrationInterval, cancellationToken);
+                    var callBackTask = callBack(this.settings.WorkerId, ownerId, isControlQueueOwner, controlQueueName, instanceId, controlQueueHeartbeatDetectionInfo, cancellationToken);
+
+                    // Do not allow callBackTask to run forever.
+                    await Task.WhenAll(callBackTask, delayTask);
+
+                    if (!callBackTask.IsCompleted)
+                    {
+                        // [Logs] Add log for long running callback.
+                        FileWriter.WriteLogControlQueueMonitor($"ControlQueueMonitorCallbackTerminated" +
+                            $"controlQueueName: {controlQueueName}" +
+                            $"instanceId: {instanceId}" +
+                            $"duration: {stopwatch.ElapsedMilliseconds}" +
+                            $"message: callback is taking too long to cmplete.");
+                    }
+                }
+            }
+            // Not throwing anything beyond this.
+            catch (Exception ex)
+            {
+                FileWriter.WriteLogControlQueueMonitor($"ControlQueueMonitorCallbackFailed " +
+                    $"controlQueueName: {controlQueueName}" +
+                    $"instanceId: {instanceId}" +
+                    $"Exception: {ex.ToString()} " +
+                    $"ElapsedMilliseconds: {stopwatch.ElapsedMilliseconds} ");
+            }
+            // ensuring semaphore is released.
+            finally
+            {
+                if (gotSemaphore)
+                {
+                    semaphoreSlimForControlQueueMonitorCallBack.Release();
+                }
+            }
+        }
+
+        private async Task<Dictionary<string, string?>> GetControlQueueOwnerIds()
+        {
+            if (this.settings.UseTablePartitionManagement)
+            {
+                return GetControlQueueOwnerIdsFromTableLeases();
+            }
+            else
+            {
+                return await GetControlQueueOwnerIdsFromBlobLeasesAsync();
+            }
+        }
+
+        private Dictionary<string, string?> GetControlQueueOwnerIdsFromTableLeases()
+        {
+            // Get table leases.
+            IEnumerable<TableLease> ownershipLeases = this.ListTableLeases();
+
+            string ownershipInfo = string.Empty;
+
+            Dictionary<string, string?> controlQueueOwnerIds = new Dictionary<string, string?>();
+
+            // Tranform the table lease to control-queue name to owner-id map.
+            foreach (var ownershipLease in ownershipLeases)
+            {
+                var controlQueueName = ownershipLease.RowKey ?? string.Empty;
+                controlQueueOwnerIds[controlQueueName] = ownershipLease.CurrentOwner;
+                ownershipInfo += $"[PartitionId={ownershipLease.RowKey}, Owner={ownershipLease.CurrentOwner}, NextOwner={ownershipLease.NextOwner}, OwnedSince={ownershipLease.OwnedSince}]";
+            }
+
+            FileWriter.WriteLogControlQueueMonitor($"OwnershipInfo for all control queues: {ownershipInfo}");
+            return controlQueueOwnerIds;
+        }
+
+        private async Task<Dictionary<string, string?>> GetControlQueueOwnerIdsFromBlobLeasesAsync()
+        {
+            // Get blob leases.
+            IEnumerable<BlobLease> ownershipLeases = await this.ListBlobLeasesAsync();
+
+            string ownershipInfo = string.Empty;
+
+            Dictionary<string, string?> controlQueueOwnerIds = new Dictionary<string, string?>();
+
+            // Tranform the blob lease to control-queue name to owner-id map.
+            foreach (var ownershipLease in ownershipLeases)
+            {
+                controlQueueOwnerIds[ownershipLease.PartitionId] = ownershipLease.Owner;
+                ownershipInfo += $"[PartitionId={ownershipLease.PartitionId}, Owner={ownershipLease.Owner}, Token={ownershipLease.Token}, Epoch={ownershipLease.Epoch}]";
+            }
+
+            FileWriter.WriteLogControlQueueMonitor($"OwnershipInfo for all control queues: {ownershipInfo}");
+            return controlQueueOwnerIds;
+        }
+
+        private Dictionary<string, string> GetControlQueueToInstanceIdInfo()
+        {
+            var partitionCount = this.settings.PartitionCount;
+            var controlQueueOrchInstanceIds = new Dictionary<string, string>();
+
+            // Generate control-queue name to instance id map.
+            for (int controlQueueNumber = 0; controlQueueNumber < partitionCount; controlQueueNumber++)
+            {
+                var controlQueueName = GetControlQueueName(this.settings.TaskHubName, controlQueueNumber);
+                var instanceIdPrefix = $"DTF_PC_{partitionCount}_CQ_{controlQueueNumber}_";
+
+                string instanceId = GetControlQueueInstanceId(new int[] { controlQueueNumber }, instanceIdPrefix);
+
+                controlQueueOrchInstanceIds[controlQueueName] = instanceId;
+            }
+
+            return controlQueueOrchInstanceIds;
+        }
+
+        private SemaphoreSlim semaphoreSlimForControlQueueMonitorCallBack;
+
+        private bool isControlQueueOrchestratorsRegistered = false;
+
+        private object controlQueueOrchestratorsRegistrationLock = new object();
+
+        #endregion IControlQueueHelper
 
         // TODO: Change this to a sticky assignment so that partition count changes can
         //       be supported: https://github.com/Azure/azure-functions-durable-extension/issues/1

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -2059,6 +2059,8 @@ namespace DurableTask.AzureStorage
 
         #region IControlQueueHelper
 
+        private Task controlQueueTaskLoop;
+
         /// <inheritdoc/>
         public async Task StartControlQueueHeartbeatMonitorAsync(
             TaskHubClient taskHubClient,
@@ -2081,6 +2083,11 @@ namespace DurableTask.AzureStorage
 
             // Gets control-queue name to orchestrator instance id dictionary.
             Dictionary<string, string> controlQueueOrchInstanceIds = GetControlQueueToInstanceIdInfo();
+            controlQueueTaskLoop = StartControlQueueHeartbeatValidationLoop(taskHubClient, callBackControlQueueValidation, stopwatch, controlQueueOrchInstanceIds, cancellationToken);
+        }
+
+        private async Task StartControlQueueHeartbeatValidationLoop(TaskHubClient taskHubClient, Func<string, string?, bool, string, string, ControlQueueHeartbeatDetectionInfo, CancellationToken, Task> callBackControlQueueValidation, Stopwatch stopwatch, Dictionary<string, string> controlQueueOrchInstanceIds, CancellationToken cancellationToken)
+        {
 
             // Waiting for detection interval initial to give time to worker to allow some draining of messages from control-queue.
             await Task.Delay(this.settings.ControlQueueOrchHeartbeatDetectionInterval, cancellationToken);

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -32,6 +32,12 @@ namespace DurableTask.AzureStorage
 
         internal static readonly TimeSpan DefaultMaxQueuePollingInterval = TimeSpan.FromSeconds(30);
 
+        internal static readonly TimeSpan DefaultControlQueueHearbeatOrchestrationInterval = TimeSpan.FromSeconds(60);
+
+        internal static readonly TimeSpan DefaultControlQueueOrchHeartbeatDetectionInterval = TimeSpan.FromSeconds(600);
+
+        internal static readonly TimeSpan DefaultControlQueueOrchHeartbeatDetectionThreshold = TimeSpan.FromSeconds(600);
+
         LogHelper logHelper;
 
         /// <summary>
@@ -176,6 +182,21 @@ namespace DurableTask.AzureStorage
         /// Maximum interval for polling control and work-item queues.
         /// </summary>
         public TimeSpan MaxQueuePollingInterval { get; set; } = DefaultMaxQueuePollingInterval;
+
+        /// <summary>
+        /// Time interval between control queue heartbeat orchestration.
+        /// </summary>
+        public TimeSpan ControlQueueHearbeatOrchestrationInterval { get; set; } = DefaultControlQueueHearbeatOrchestrationInterval;
+
+        /// <summary>
+        /// Time interval between control queue heartbeat orchestration.
+        /// </summary>
+        public TimeSpan ControlQueueOrchHeartbeatDetectionInterval { get; set; } = DefaultControlQueueOrchHeartbeatDetectionInterval;
+
+        /// <summary>
+        /// Time interval between control queue heartbeat orchestration.
+        /// </summary>
+        public TimeSpan ControlQueueOrchHeartbeatDetectionThreshold { get; set; } = DefaultControlQueueOrchHeartbeatDetectionThreshold;
 
         /// <summary>
         /// If true, takes a lease on the task hub container, allowing for only one app to process messages in a task hub at a time.

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -36,7 +36,7 @@ namespace DurableTask.AzureStorage
 
         internal static readonly TimeSpan DefaultControlQueueOrchHeartbeatDetectionInterval = TimeSpan.FromSeconds(600);
 
-        internal static readonly TimeSpan DefaultControlQueueOrchHeartbeatDetectionThreshold = TimeSpan.FromSeconds(600);
+        internal static readonly TimeSpan DefaultControlQueueOrchHeartbeatLatencyThreshold = TimeSpan.FromSeconds(600);
 
         LogHelper logHelper;
 
@@ -189,14 +189,14 @@ namespace DurableTask.AzureStorage
         public TimeSpan ControlQueueHearbeatOrchestrationInterval { get; set; } = DefaultControlQueueHearbeatOrchestrationInterval;
 
         /// <summary>
-        /// Time interval between control queue heartbeat orchestration.
+        /// Time interval between control queue heartbeat detection.
         /// </summary>
         public TimeSpan ControlQueueOrchHeartbeatDetectionInterval { get; set; } = DefaultControlQueueOrchHeartbeatDetectionInterval;
 
         /// <summary>
-        /// Time interval between control queue heartbeat orchestration.
+        /// Time threshold for latency in control queue heartbeat.
         /// </summary>
-        public TimeSpan ControlQueueOrchHeartbeatDetectionThreshold { get; set; } = DefaultControlQueueOrchHeartbeatDetectionThreshold;
+        public TimeSpan ControlQueueOrchHeartbeatLatencyThreshold { get; set; } = DefaultControlQueueOrchHeartbeatLatencyThreshold;
 
         /// <summary>
         /// If true, takes a lease on the task hub container, allowing for only one app to process messages in a task hub at a time.

--- a/src/DurableTask.AzureStorage/ControlQueueHeartbeat/ControlQueueHeartbeatDetectionInfo.cs
+++ b/src/DurableTask.AzureStorage/ControlQueueHeartbeat/ControlQueueHeartbeatDetectionInfo.cs
@@ -1,0 +1,33 @@
+﻿namespace DurableTask.AzureStorage.ControlQueueHeartbeat
+{
+    /// <summary>
+    /// Control-queue heartbeat detection information.
+    /// </summary>
+    public enum ControlQueueHeartbeatDetectionInfo
+    {
+        /// <summary>
+        /// Default value.
+        /// </summary>
+        Unknown,
+
+        /// <summary>
+        /// The orchestration instance for control-queue is stuck.
+        /// </summary>
+        OrchestrationInstanceStuck,
+
+        /// <summary>
+        /// Expected orchestration instance for control-queue timed out.
+        /// </summary>
+        OrchestrationInstanceFetchTimedOut,
+
+        /// <summary>
+        /// Expected orchestration instance for control-queue not found.
+        /// </summary>
+        OrchestrationInstanceNotFound,
+
+        /// <summary>
+        /// Control-queue owner information fetch failed.
+        /// </summary>
+        ControlQueueOwnerFetchFailed
+    }
+}

--- a/src/DurableTask.AzureStorage/ControlQueueHeartbeat/ControlQueueHeartbeatTaskContext.cs
+++ b/src/DurableTask.AzureStorage/ControlQueueHeartbeat/ControlQueueHeartbeatTaskContext.cs
@@ -1,0 +1,38 @@
+﻿namespace DurableTask.AzureStorage.ControlQueueHeartbeat
+{
+    /// <summary>
+    /// Context for ControlQueueHeartbeat task orchestrator.
+    /// </summary>
+    public class ControlQueueHeartbeatTaskContext
+    {
+        /// <summary> 
+        /// Name of taskhub.    
+        /// </summary>
+        public string TaskHubName { get; private set; }
+
+        /// <summary> 
+        /// Number of partitions.
+        /// </summary>
+        public int PartitionCount { get; private set; }
+
+        /// <summary> 
+        /// ControlQueueHeartbeatTaskContext constructor.
+        /// </summary>
+        /// <param name="taskhubName">Name of taskhub.</param>
+        /// <param name="partitionCount">Number of partitions.</param>
+        public ControlQueueHeartbeatTaskContext(string taskhubName, int partitionCount)
+        {
+            this.TaskHubName = taskhubName;
+            this.PartitionCount = partitionCount;
+        }
+
+        /// <summary>
+        /// Returns a string that represents the OrchestrationInstance.
+        /// </summary>
+        /// <returns>A string that represents the current object.</returns>
+        public override string ToString()
+        {
+            return $"[TaskHubName={TaskHubName}, PartitionCount = {this.PartitionCount}]";
+        }
+    }
+}

--- a/src/DurableTask.AzureStorage/ControlQueueHeartbeat/ControlQueueHeartbeatTaskInputContext.cs
+++ b/src/DurableTask.AzureStorage/ControlQueueHeartbeat/ControlQueueHeartbeatTaskInputContext.cs
@@ -1,0 +1,32 @@
+﻿namespace DurableTask.AzureStorage.ControlQueueHeartbeat
+{
+    /// <summary>
+    /// Input for ControlQueueHeartbeat orchestration instance.
+    /// </summary>
+    public class ControlQueueHeartbeatTaskInputContext : ControlQueueHeartbeatTaskContext
+    {
+        /// <summary>
+        /// Control-queue name.
+        /// </summary>
+        public string ControlQueueName { get; private set; }
+
+        /// <summary>
+        /// ControlQueueHeartbeatTaskInputContext constructor.
+        /// </summary>
+        /// <param name="controlQueueName">Name of control queue.</param>
+        /// <param name="taskhubName">Name of taskhub.</param>
+        /// <param name="partitionCount">Name of partitionCount.</param>
+        public ControlQueueHeartbeatTaskInputContext(string controlQueueName, string taskhubName, int partitionCount)
+            : base(taskhubName, partitionCount)
+        {
+            this.ControlQueueName = controlQueueName;
+        }
+
+        /// <summary> Returns a string that represents the OrchestrationInstance.</summary>
+        /// <returns>A string that represents the current object.</returns>
+        public override string ToString()
+        {
+            return $"[ControlQueueName={ControlQueueName}, TaskHubName={TaskHubName}, PartitionCount = {this.PartitionCount}]";
+        }
+    }
+}

--- a/src/DurableTask.AzureStorage/ControlQueueHeartbeat/ControlQueueHeartbeatTaskOrchestrator.cs
+++ b/src/DurableTask.AzureStorage/ControlQueueHeartbeat/ControlQueueHeartbeatTaskOrchestrator.cs
@@ -93,6 +93,7 @@ namespace DurableTask.AzureStorage.ControlQueueHeartbeat
             if (!context.IsReplaying)
             {
                 // No wait to complete provided delegate. The current orchestrator need to be very thin and quick to run. 
+                // This is queued as independently to avoid long running callbacks and safe guard the orchestrator for its frequency and failures occur in callbacks. 
                 bool isQueued = ThreadPool.QueueUserWorkItem(async (_) =>
                 {
                     await this.callBack(context.OrchestrationInstance, controlQueueHeartbeatTaskContextInput, controlQueueHeartbeatTaskContextInit, this.cancellationTokenSrc.Token);

--- a/src/DurableTask.AzureStorage/ControlQueueHeartbeat/ControlQueueHeartbeatTaskOrchestratorV1.cs
+++ b/src/DurableTask.AzureStorage/ControlQueueHeartbeat/ControlQueueHeartbeatTaskOrchestratorV1.cs
@@ -55,6 +55,12 @@ namespace DurableTask.AzureStorage.ControlQueueHeartbeat
             if (controlQueueHeartbeatTaskContextInput == null)
             {
                 // [Logs] Add log for failure of the orchestrator.
+                // Structured logging: ControlQueueHeartbeatTaskOrchestratorFailed
+                // -> orchestrationInstance: context.OrchestrationInstance.ToString()
+                // -> initialControlQueueHeartbeatTaskContext: controlQueueHeartbeatTaskContextInit.ToString()
+                // -> inputControlQueueHeartbeatTaskContext: null
+                // -> duration: stopwatchOrch.ElapsedMilliseconds
+                // -> message : input context orchestration is null.
                 FileWriter.WriteLogControlQueueOrch($"ControlQueueHeartbeatTaskOrchestratorFailed." +
                     $"OrchestrationInstance:{context.OrchestrationInstance} " +
                     $"controlQueueHeartbeatTaskContextInit:{controlQueueHeartbeatTaskContextInit}, " +
@@ -71,6 +77,12 @@ namespace DurableTask.AzureStorage.ControlQueueHeartbeat
             if (!isOrchestratorRunningInCorrectContext)
             {
                 // [Logs] Add log for mistmatch in context.
+                // Structured logging: ControlQueueHeartbeatTaskOrchestratorFailed
+                // -> orchestrationInstance: context.OrchestrationInstance.ToString()
+                // -> initialControlQueueHeartbeatTaskContext: controlQueueHeartbeatTaskContextInit.ToString()
+                // -> inputControlQueueHeartbeatTaskContext: controlQueueHeartbeatTaskContextInit.ToString()
+                // -> duration: stopwatchOrch.ElapsedMilliseconds
+                // -> message : Input and initial context for orchestration .
                 FileWriter.WriteLogControlQueueOrch($"ControlQueueHeartbeatTaskOrchestratorContextMismatch" +
                     $"OrchestrationInstance:{context.OrchestrationInstance} " +
                     $"controlQueueHeartbeatTaskContextInit:{controlQueueHeartbeatTaskContextInit}, " +
@@ -109,6 +121,11 @@ namespace DurableTask.AzureStorage.ControlQueueHeartbeat
                             if (!callBackTask.IsCompleted)
                             {
                                 // [Logs] Add log for long running callback.
+                                // Structured logging: ControlQueueHeartbeatTaskOrchestratorCallbackTerminated
+                                // -> orchestrationInstance: context.OrchestrationInstance.ToString()
+                                // -> initialControlQueueHeartbeatTaskContext: controlQueueHeartbeatTaskContextInit.ToString()
+                                // -> inputControlQueueHeartbeatTaskContext: controlQueueHeartbeatTaskContextInit.ToString()
+                                // -> duration: stopwatchOrch.ElapsedMilliseconds
                                 FileWriter.WriteLogControlQueueOrch($"ControlQueueHeartbeatTaskOrchestratorCallbackTerminated " +
                                     $"OrchestrationInstance:{context.OrchestrationInstance} " +
                                     $"controlQueueHeartbeatTaskContextInit:{controlQueueHeartbeatTaskContextInit}, " +
@@ -122,6 +139,11 @@ namespace DurableTask.AzureStorage.ControlQueueHeartbeat
                         else
                         {
                             // [Logs] Add log for too many callbacks running. Share the semaphore-count for #callBacks allowed, and wait time for semaphore; and ask to reduce the run-time for callback.
+                            // Structured logging: ControlQueueHeartbeatTaskOrchestratorTooManyActiveCallback
+                            // -> orchestrationInstance: context.OrchestrationInstance.ToString()
+                            // -> initialControlQueueHeartbeatTaskContext: controlQueueHeartbeatTaskContextInit.ToString()
+                            // -> inputControlQueueHeartbeatTaskContext: controlQueueHeartbeatTaskContextInit.ToString()
+                            // -> duration: stopwatchOrch.ElapsedMilliseconds
                             FileWriter.WriteLogControlQueueOrch($"ControlQueueHeartbeatTaskOrchestratorTooManyActiveCallback " +
                                 $"OrchestrationInstance:{context.OrchestrationInstance} " +
                                 $"controlQueueHeartbeatTaskContextInit:{controlQueueHeartbeatTaskContextInit}, " +
@@ -134,6 +156,12 @@ namespace DurableTask.AzureStorage.ControlQueueHeartbeat
                     catch (Exception ex)
                     {
                         // [Logs] Add exception details for callback failure.
+                        // Structured logging: ControlQueueHeartbeatTaskOrchestratorCallbackFailure
+                        // -> orchestrationInstance: context.OrchestrationInstance.ToString()
+                        // -> initialControlQueueHeartbeatTaskContext: controlQueueHeartbeatTaskContextInit.ToString()
+                        // -> inputControlQueueHeartbeatTaskContext: controlQueueHeartbeatTaskContextInit.ToString()
+                        // -> duration: stopwatchOrch.ElapsedMilliseconds
+                        // -> exception : ex.ToString()
                         FileWriter.WriteLogControlQueueOrch($"ControlQueueHeartbeatTaskOrchestratorCallbackFailure " +
                             $"OrchestrationInstance:{context.OrchestrationInstance} " +
                             $"controlQueueHeartbeatTaskContextInit:{controlQueueHeartbeatTaskContextInit}, " +
@@ -157,6 +185,11 @@ namespace DurableTask.AzureStorage.ControlQueueHeartbeat
                     FileWriter.WriteLogControlQueueOrch($"ControlQueueHeartbeatTaskOrchestratorV1 Stopping OrchestrationInstance:{context.OrchestrationInstance} controlQueueHeartbeatTaskContextInit:{controlQueueHeartbeatTaskContextInit}, controlQueueHeartbeatTaskContextInput: {controlQueueHeartbeatTaskContextInput}");
 
                     // [Logs] Add log for a heartbeat message from current instance. 
+                    // Structured logging: ControlQueueHeartbeatTaskOrchestratorCallbackNotQueued
+                    // -> orchestrationInstance: context.OrchestrationInstance.ToString()
+                    // -> initialControlQueueHeartbeatTaskContext: controlQueueHeartbeatTaskContextInit.ToString()
+                    // -> inputControlQueueHeartbeatTaskContext: controlQueueHeartbeatTaskContextInit.ToString()
+                    // -> duration: stopwatchOrch.ElapsedMilliseconds
                     FileWriter.WriteLogControlQueueOrch($"ControlQueueHeartbeatTaskOrchestratorCallbackNotQueued " +
                         $"OrchestrationInstance:{context.OrchestrationInstance} " +
                         $"controlQueueHeartbeatTaskContextInit:{controlQueueHeartbeatTaskContextInit}, " +
@@ -167,6 +200,11 @@ namespace DurableTask.AzureStorage.ControlQueueHeartbeat
             }
 
             // [Logs] Add log for a heartbeat message from current instance. 
+            // Structured logging: ControlQueueHeartbeatTaskOrchestrator
+            // -> orchestrationInstance: context.OrchestrationInstance.ToString()
+            // -> initialControlQueueHeartbeatTaskContext: controlQueueHeartbeatTaskContextInit.ToString()
+            // -> inputControlQueueHeartbeatTaskContext: controlQueueHeartbeatTaskContextInit.ToString()
+            // -> duration: stopwatchOrch.ElapsedMilliseconds
             FileWriter.WriteLogControlQueueOrch($"ControlQueueHeartbeatTaskOrchestrator " +
                 $"OrchestrationInstance:{context.OrchestrationInstance} " +
                 $"controlQueueHeartbeatTaskContextInit:{controlQueueHeartbeatTaskContextInit}, " +

--- a/src/DurableTask.AzureStorage/ControlQueueHeartbeat/ControlQueueHeartbeatTaskOrchestratorV1.cs
+++ b/src/DurableTask.AzureStorage/ControlQueueHeartbeat/ControlQueueHeartbeatTaskOrchestratorV1.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using DurableTask.Core;
+
+namespace DurableTask.AzureStorage.ControlQueueHeartbeat
+{
+    /// <summary>
+    /// Control-queue heartbeat orchestrator.
+    /// This is supposed to be initialized with ControlQueueHeartbeatTaskContext informing orchestrator about configuration of taskhubworker and heartbeat interval.
+    /// </summary>
+    internal class ControlQueueHeartbeatTaskOrchestratorV1 : TaskOrchestration<string, ControlQueueHeartbeatTaskInputContext>
+    {
+        public const string OrchestrationName = "ControlQueueHeartbeatTaskOrchestrator";
+
+        public const string OrchestrationVersion = "V1";
+
+        private ControlQueueHeartbeatTaskContext controlQueueHeartbeatTaskContextInit;
+
+        private TimeSpan controlQueueHearbeatOrchestrationInterval;
+
+        private Func<OrchestrationInstance, ControlQueueHeartbeatTaskInputContext, ControlQueueHeartbeatTaskContext, CancellationToken, Task> callBack;
+
+        private SemaphoreSlim semaphoreSlim;
+
+        /// <summary>
+        /// ControlQueueHeartbeatTaskOrchestratorV1 constructor.
+        /// </summary>
+        /// <param name="controlQueueHeartbeatTaskContext">ControlQueueHeartbeatTaskContext object, informs about configuration of taskhubworker orchestrator is running in.</param>
+        /// <param name="controlQueueHearbeatOrchestrationInterval">Interval between two heartbeats.</param>
+        /// <param name="callBack">
+        ///     A callback to allow user process/emit custom metrics for heartbeat execution.
+        /// </param>
+        /// <exception cref="ArgumentNullException">Throws if provided ControlQueueHeartbeatTaskContext object is null.</exception>
+        internal ControlQueueHeartbeatTaskOrchestratorV1(
+            ControlQueueHeartbeatTaskContext controlQueueHeartbeatTaskContext,
+            TimeSpan controlQueueHearbeatOrchestrationInterval,
+            Func<OrchestrationInstance, ControlQueueHeartbeatTaskInputContext, ControlQueueHeartbeatTaskContext, CancellationToken, Task> callBack)
+        {
+            this.controlQueueHeartbeatTaskContextInit = controlQueueHeartbeatTaskContext ?? throw new ArgumentNullException(nameof(controlQueueHeartbeatTaskContext));
+            this.controlQueueHearbeatOrchestrationInterval = controlQueueHearbeatOrchestrationInterval;
+            this.callBack = callBack;
+
+            // At worst case, allowing max of 2 heartbeat of a control-queue to run callbacks. 
+            this.semaphoreSlim = new SemaphoreSlim(2 * controlQueueHeartbeatTaskContext.PartitionCount);
+        }
+
+        public override async Task<string> RunTask(OrchestrationContext context, ControlQueueHeartbeatTaskInputContext controlQueueHeartbeatTaskContextInput)
+        {
+            // Stopwatch to calculate time to complete orchestrator.
+            Stopwatch stopwatchOrch = Stopwatch.StartNew();
+
+            // Checks for input being null and complete gracefully.
+            if (controlQueueHeartbeatTaskContextInput == null)
+            {
+                // [Logs] Add log for failure of the orchestrator.
+                FileWriter.WriteLogControlQueueOrch($"ControlQueueHeartbeatTaskOrchestratorFailed." +
+                    $"OrchestrationInstance:{context.OrchestrationInstance} " +
+                    $"controlQueueHeartbeatTaskContextInit:{controlQueueHeartbeatTaskContextInit}, " +
+                    $"duration: {stopwatchOrch.ElapsedMilliseconds}" +
+                    $"message: controlQueueHeartbeatTaskContextInput is null. Completing the orchestration.");
+
+                return "Failed";
+            }
+
+            var isOrchestratorRunningInCorrectContext = controlQueueHeartbeatTaskContextInput.PartitionCount == controlQueueHeartbeatTaskContextInit.PartitionCount
+                && controlQueueHeartbeatTaskContextInit.TaskHubName.Equals(controlQueueHeartbeatTaskContextInput.TaskHubName);
+
+            // Checks if the context of orchestrator instance and orchestrator mismatch and complete gracefully.
+            if (!isOrchestratorRunningInCorrectContext)
+            {
+                // [Logs] Add log for mistmatch in context.
+                FileWriter.WriteLogControlQueueOrch($"ControlQueueHeartbeatTaskOrchestratorContextMismatch" +
+                    $"OrchestrationInstance:{context.OrchestrationInstance} " +
+                    $"controlQueueHeartbeatTaskContextInit:{controlQueueHeartbeatTaskContextInit}, " +
+                    $"controlQueueHeartbeatTaskContextInput: {controlQueueHeartbeatTaskContextInput}" +
+                    $"duration: {stopwatchOrch.ElapsedMilliseconds}" +
+                    $"message: the partition count and taskhub information are not matching.");
+
+                return "Failed";
+            }
+
+            // Waiting for heartbeat orchestration interval.
+            await context.CreateTimer(context.CurrentUtcDateTime.Add(controlQueueHearbeatOrchestrationInterval), true);
+
+            // Ensuring this section doesn't run again. 
+            // This queues the user provided callback without waiting for it to finish.
+            // This is to keep heartbeat orchestrator thin and fast.
+            if (!context.IsReplaying)
+            {
+                // No wait to complete provided delegate. The current orchestrator need to be very thin and quick to run. 
+                bool isQueued = ThreadPool.QueueUserWorkItem(async (_) =>
+                {
+                    var gotSemaphore = await semaphoreSlim.WaitAsync(controlQueueHearbeatOrchestrationInterval);
+                    Stopwatch stopwatch = Stopwatch.StartNew();
+
+                    try
+                    {
+                        if (gotSemaphore)
+                        {
+                            var cancellationTokenSrc = new CancellationTokenSource(controlQueueHearbeatOrchestrationInterval);
+                            var delayTask = Task.Delay(controlQueueHearbeatOrchestrationInterval, cancellationTokenSrc.Token);
+                            var callBackTask = this.callBack(context.OrchestrationInstance, controlQueueHeartbeatTaskContextInput, controlQueueHeartbeatTaskContextInit, cancellationTokenSrc.Token);
+
+                            // Do not allow callBackTask to run forever.
+                            await Task.WhenAll(callBackTask, delayTask);
+
+                            if (!callBackTask.IsCompleted)
+                            {
+                                // [Logs] Add log for long running callback.
+                                FileWriter.WriteLogControlQueueOrch($"ControlQueueHeartbeatTaskOrchestratorCallbackTerminated" +
+                                    $"OrchestrationInstance:{context.OrchestrationInstance} " +
+                                    $"controlQueueHeartbeatTaskContextInit:{controlQueueHeartbeatTaskContextInit}, " +
+                                    $"controlQueueHeartbeatTaskContextInput: {controlQueueHeartbeatTaskContextInput}" +
+                                    $"duration: {stopwatch.ElapsedMilliseconds}" +
+                                    $"message: callback is taking too long to cmplete.");
+                            }
+                        }
+                        else
+                        {
+                            // [Logs] Add log for too many callbacks running. Share the semaphore-count for #callBacks allowed, and wait time for semaphore; and ask to reduce the run-time for callback.
+                            FileWriter.WriteLogControlQueueOrch($"ControlQueueHeartbeatTaskOrchestratorTooManyActiveCallback" +
+                                $"OrchestrationInstance:{context.OrchestrationInstance} " +
+                                $"controlQueueHeartbeatTaskContextInit:{controlQueueHeartbeatTaskContextInit}, " +
+                                $"controlQueueHeartbeatTaskContextInput: {controlQueueHeartbeatTaskContextInput}" +
+                                $"duration: {stopwatch.ElapsedMilliseconds}" +
+                                $"message: too many active callbacks, skipping runnning this instance of callback.");
+
+                        }
+                    }
+                    // Not throwing anything beyond this.
+                    catch (Exception ex)
+                    {
+                        // [Logs] Add exception details for callback failure.
+                        FileWriter.WriteLogControlQueueOrch($"ControlQueueHeartbeatTaskOrchestratorCallbackFailure" +
+                            $"OrchestrationInstance:{context.OrchestrationInstance} " +
+                            $"controlQueueHeartbeatTaskContextInit:{controlQueueHeartbeatTaskContextInit}, " +
+                            $"controlQueueHeartbeatTaskContextInput: {controlQueueHeartbeatTaskContextInput}" +
+                            $"exception: {ex.ToString()}" +
+                            $"duration: {stopwatch.ElapsedMilliseconds}" +
+                            $"message: the partition count and taskhub information are not matching.");
+                    }
+                    // ensuring semaphore is released.
+                    finally
+                    {
+                        if (gotSemaphore)
+                        {
+                            semaphoreSlim.Release();
+                        }
+                    }
+                });
+
+                if (!isQueued)
+                {
+                    FileWriter.WriteLogControlQueueOrch($"ControlQueueHeartbeatTaskOrchestratorV1 Stopping OrchestrationInstance:{context.OrchestrationInstance} controlQueueHeartbeatTaskContextInit:{controlQueueHeartbeatTaskContextInit}, controlQueueHeartbeatTaskContextInput: {controlQueueHeartbeatTaskContextInput}");
+
+                    // [Logs] Add log for a heartbeat message from current instance. 
+                    FileWriter.WriteLogControlQueueOrch($"ControlQueueHeartbeatTaskOrchestratorCallbackNotQueued" +
+                        $"OrchestrationInstance:{context.OrchestrationInstance} " +
+                        $"controlQueueHeartbeatTaskContextInit:{controlQueueHeartbeatTaskContextInit}, " +
+                        $"controlQueueHeartbeatTaskContextInput: {controlQueueHeartbeatTaskContextInput}" +
+                        $"duration: {stopwatchOrch.ElapsedMilliseconds}" +
+                        $"message: Callback for orchestrator could not be queued.");
+                }
+            }
+
+            // [Logs] Add log for a heartbeat message from current instance. 
+            FileWriter.WriteLogControlQueueOrch($"ControlQueueHeartbeatTaskOrchestrator " +
+                $"OrchestrationInstance:{context.OrchestrationInstance} " +
+                $"controlQueueHeartbeatTaskContextInit:{controlQueueHeartbeatTaskContextInit}, " +
+                $"controlQueueHeartbeatTaskContextInput: {controlQueueHeartbeatTaskContextInput}" +
+                $"duration: {stopwatchOrch.ElapsedMilliseconds}" +
+                $"message: Sending signal for control-queue heartbeat.");
+
+            context.ContinueAsNew(controlQueueHeartbeatTaskContextInput);
+
+            return "Succeeded";
+        }
+    }
+}

--- a/src/DurableTask.AzureStorage/ControlQueueHeartbeat/ControlQueueHeartbeatTaskResult.cs
+++ b/src/DurableTask.AzureStorage/ControlQueueHeartbeat/ControlQueueHeartbeatTaskResult.cs
@@ -1,0 +1,10 @@
+﻿namespace DurableTask.AzureStorage.ControlQueueHeartbeat
+{
+    internal enum ControlQueueHeartbeatTaskResult
+    {
+        Unknown,
+        Succeeded,
+        InvalidInput,
+        InputContextMismatch
+    }
+}

--- a/src/DurableTask.AzureStorage/ControlQueueHeartbeat/ControlQueueHeartbeatTaskResult.cs
+++ b/src/DurableTask.AzureStorage/ControlQueueHeartbeat/ControlQueueHeartbeatTaskResult.cs
@@ -2,9 +2,27 @@
 {
     internal enum ControlQueueHeartbeatTaskResult
     {
+        /// <summary>
+        /// Default value of ControlQueueHeartbeatTaskResult.
+        /// </summary>
         Unknown,
+
+        /// <summary>
+        /// Orchestratoin succeeded.
+        /// </summary>
         Succeeded,
+
+        /// <summary>
+        /// Invalid input.
+        /// Happens when input is either null or not of type <see cref="ControlQueueHeartbeatTaskInputContext"/>.
+        /// </summary>
         InvalidInput,
+
+        /// <summary>
+        /// Mismatch in heartbeat orchestration context and input to orchestration instance.
+        /// This happens when the taskhubworker running with different partition count than that of orchestration instance queued with.
+        /// Usually it happens when partition-count is changed for a taskhub. 
+        /// </summary>
         InputContextMismatch
     }
 }

--- a/src/DurableTask.AzureStorage/ControlQueueHeartbeat/FileWriter.cs
+++ b/src/DurableTask.AzureStorage/ControlQueueHeartbeat/FileWriter.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace DurableTask.AzureStorage.ControlQueueHeartbeat
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class FileWriter
+    {
+        static string timeTicks = DateTime.UtcNow.Ticks.ToString();
+        static string path = @$"C:\DTF\v2.16.1\Logs_{timeTicks}.txt";
+        static string pathControlQueueMonitor = @$"C:\DTF\v2.16.1\Logs_ControlQueueMonitor_{timeTicks}.txt";
+        static string pathControlQueueOrch = @$"C:\DTF\v2.16.1\Logs_ControlQueueOrch_{timeTicks}.txt";
+        static string pathControlQueueProgram = @$"C:\DTF\v2.16.1\Logs_ControlQueueProgram_{timeTicks}.txt";
+
+        static object obj = new object();
+
+        private static void WriteLog(string path, string msg)
+        {
+            var modMsg = $"[{DateTime.UtcNow.ToLongTimeString()}] : {msg}" + Environment.NewLine;
+            Console.WriteLine(modMsg);
+
+            lock (obj)
+            {
+                File.AppendAllText(path, modMsg);
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="msg"></param>
+        public static void WriteLogControlQueueMonitor(string msg)
+        {
+            WriteLog(pathControlQueueMonitor, msg);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="msg"></param>
+        public static void WriteLogControlQueueOrch(string msg)
+        {
+            WriteLog(pathControlQueueOrch, msg);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="msg"></param>
+        public static void WriteLogControlQueueProgram(string msg)
+        {
+            WriteLog(pathControlQueueProgram, msg);
+        }
+    }
+}

--- a/src/DurableTask.AzureStorage/ControlQueueHeartbeat/IControlQueueHelper.cs
+++ b/src/DurableTask.AzureStorage/ControlQueueHeartbeat/IControlQueueHelper.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DurableTask.Core;
+
+namespace DurableTask.AzureStorage.ControlQueueHeartbeat
+{
+    /// <summary>Monitors control queue health for orchestrator's processing. Make sure to provide same <see cref="AzureStorageOrchestrationServiceSettings"/> setting for taskhubclient, taskhubworker and IControlQueueHealthMonitor.</summary>
+    public interface IControlQueueHelper
+    {
+#nullable enable
+        /// <summary>
+        /// Sets up the TaskHub client and worker for control-queue heartbeat and detects if any of heartbeat orchestration running on each control-queue is not running.
+        /// </summary>
+        /// <param name="taskHubClient">TaskHubClient object.</param>
+        /// <param name="taskHubWorker">TaskHubWorker object.</param>
+        /// <param name="callBackHeartOrchAsync">Callback to run with each execution of the orchestrator of type <see cref="ControlQueueHeartbeatTaskOrchestratorV1"/>.</param>
+        /// <param name="callBackControlQueueValidation">Callback to run with each time the detects fault of type <see cref="ControlQueueHeartbeatDetectionInfo"/>.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Task result.</returns>
+        Task StartControlQueueHeartbeatMonitorAsync(
+            TaskHubClient taskHubClient,
+            TaskHubWorker taskHubWorker,
+            Func<OrchestrationInstance, ControlQueueHeartbeatTaskInputContext, ControlQueueHeartbeatTaskContext, CancellationToken, Task> callBackHeartOrchAsync,
+            Func<string, string?, bool, string, string, ControlQueueHeartbeatDetectionInfo, CancellationToken, Task> callBackControlQueueValidation,
+            CancellationToken cancellationToken);
+#nullable disable
+
+        /// <summary>
+        /// Adds orchestrator instances of type <see cref="ControlQueueHeartbeatTaskOrchestratorV1"/> for each control queue. 
+        /// </summary>
+        /// <param name="taskHubClient">TaskHubClient object.</param>
+        /// <param name="force">If true, creates new instances of orchestrator, otherwise creates only if there is no running instance of orchestrator with same instance id..</param>
+        /// <returns>Task result.</returns>
+        Task ScheduleControlQueueHeartbeatOrchestrations(TaskHubClient taskHubClient, bool force = false);
+
+        /// <summary>
+        /// Adds orchestrator instance of type <see cref="ControlQueueHeartbeatTaskOrchestratorV1"/> to TaskHubWorkerObject.
+        /// </summary>
+        /// <param name="taskHubWorker">TaskHubWorker object.</param>
+        /// <param name="callBackHeartOrchAsync">Callback to run with each execution of the orchestrator of type <see cref="ControlQueueHeartbeatTaskOrchestratorV1"/>.</param>
+        void RegisterControlQueueHeartbeatOrchestration(
+            TaskHubWorker taskHubWorker, 
+            Func<OrchestrationInstance, ControlQueueHeartbeatTaskInputContext, ControlQueueHeartbeatTaskContext, CancellationToken, Task> callBackHeartOrchAsync);
+
+        /// <summary>
+        /// Gets instanceId which is targeted for mentioned control-queue names.
+        /// </summary>
+        /// <param name="controlQueueNumbers">Array of controlQueueNumbers.</param>
+        /// <param name="instanceIdPrefix">InstanceId prefix.</param>
+        /// <returns>InstanceId for control-queue.</returns>
+        string GetControlQueueInstanceId(int[] controlQueueNumbers, string instanceIdPrefix = "");
+    }
+}

--- a/src/DurableTask.AzureStorage/ControlQueueHeartbeat/IControlQueueHelper.cs
+++ b/src/DurableTask.AzureStorage/ControlQueueHeartbeat/IControlQueueHelper.cs
@@ -15,7 +15,7 @@ namespace DurableTask.AzureStorage.ControlQueueHeartbeat
         /// </summary>
         /// <param name="taskHubClient">TaskHubClient object.</param>
         /// <param name="taskHubWorker">TaskHubWorker object.</param>
-        /// <param name="callBackHeartOrchAsync">Callback to run with each execution of the orchestrator of type <see cref="ControlQueueHeartbeatTaskOrchestratorV1"/>.</param>
+        /// <param name="callBackHeartOrchAsync">Callback to run with each execution of the orchestrator of type <see cref="ControlQueueHeartbeatTaskOrchestrator"/>.</param>
         /// <param name="callBackControlQueueValidation">Callback to run with each time the detects fault of type <see cref="ControlQueueHeartbeatDetectionInfo"/>.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Task result.</returns>
@@ -28,18 +28,19 @@ namespace DurableTask.AzureStorage.ControlQueueHeartbeat
 #nullable disable
 
         /// <summary>
-        /// Adds orchestrator instances of type <see cref="ControlQueueHeartbeatTaskOrchestratorV1"/> for each control queue. 
+        /// Adds orchestrator instances of type <see cref="ControlQueueHeartbeatTaskOrchestrator"/> for each control queue. 
         /// </summary>
         /// <param name="taskHubClient">TaskHubClient object.</param>
+        /// <param name="cancellationToken">CancellationToken.</param>
         /// <param name="force">If true, creates new instances of orchestrator, otherwise creates only if there is no running instance of orchestrator with same instance id..</param>
         /// <returns>Task result.</returns>
-        Task ScheduleControlQueueHeartbeatOrchestrationsAsync(TaskHubClient taskHubClient, bool force = false);
+        Task ScheduleControlQueueHeartbeatOrchestrationsAsync(TaskHubClient taskHubClient, CancellationToken cancellationToken, bool force = false);
 
         /// <summary>
-        /// Adds orchestrator instance of type <see cref="ControlQueueHeartbeatTaskOrchestratorV1"/> to TaskHubWorkerObject.
+        /// Adds orchestrator instance of type <see cref="ControlQueueHeartbeatTaskOrchestrator"/> to TaskHubWorkerObject.
         /// </summary>
         /// <param name="taskHubWorker">TaskHubWorker object.</param>
-        /// <param name="callBackHeartOrchAsync">Callback to run with each execution of the orchestrator of type <see cref="ControlQueueHeartbeatTaskOrchestratorV1"/>.</param>
+        /// <param name="callBackHeartOrchAsync">Callback to run with each execution of the orchestrator of type <see cref="ControlQueueHeartbeatTaskOrchestrator"/>.</param>
         void RegisterControlQueueHeartbeatOrchestration(
             TaskHubWorker taskHubWorker, 
             Func<OrchestrationInstance, ControlQueueHeartbeatTaskInputContext, ControlQueueHeartbeatTaskContext, CancellationToken, Task> callBackHeartOrchAsync);

--- a/src/DurableTask.AzureStorage/ControlQueueHeartbeat/IControlQueueHelper.cs
+++ b/src/DurableTask.AzureStorage/ControlQueueHeartbeat/IControlQueueHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using DurableTask.Core;
@@ -32,7 +33,7 @@ namespace DurableTask.AzureStorage.ControlQueueHeartbeat
         /// <param name="taskHubClient">TaskHubClient object.</param>
         /// <param name="force">If true, creates new instances of orchestrator, otherwise creates only if there is no running instance of orchestrator with same instance id..</param>
         /// <returns>Task result.</returns>
-        Task ScheduleControlQueueHeartbeatOrchestrations(TaskHubClient taskHubClient, bool force = false);
+        Task ScheduleControlQueueHeartbeatOrchestrationsAsync(TaskHubClient taskHubClient, bool force = false);
 
         /// <summary>
         /// Adds orchestrator instance of type <see cref="ControlQueueHeartbeatTaskOrchestratorV1"/> to TaskHubWorkerObject.
@@ -46,9 +47,9 @@ namespace DurableTask.AzureStorage.ControlQueueHeartbeat
         /// <summary>
         /// Gets instanceId which is targeted for mentioned control-queue names.
         /// </summary>
-        /// <param name="controlQueueNumbers">Array of controlQueueNumbers.</param>
+        /// <param name="controlQueueNumbers">Collection of controlQueueNumbers.</param>
         /// <param name="instanceIdPrefix">InstanceId prefix.</param>
         /// <returns>InstanceId for control-queue.</returns>
-        string GetControlQueueInstanceId(int[] controlQueueNumbers, string instanceIdPrefix = "");
+        string GetControlQueueInstanceId(HashSet<int>  controlQueueNumbers, string instanceIdPrefix = "");
     }
 }


### PR DESCRIPTION
# Motivation: 
Issue: Unpredictable time to detect (TTD) for any orchestration being stuck in control-queue.
- We have been facing issues where DTF orchestration used to get stuck at random. Given that customer load is not very regular in our service, it was challenging to understand upfront if the orchestration would be processed or will be stuck. 
- More often customers used to reach out with incidents complaining their request not completing for long time.
Motivation: motivation was to reduce the TTD for finding if orchestration can be stuck/waiting-forever in a control-queue irrespective of the cause.
- This is where heartbeat orchestration comes into picture, which evaluates the control-queue siting outside the system (let's say system is completely down and cannot emit any metric or emitting false/partial metrics).
- We built this system locally in our service, and it has been detecting the issue with 100% accuracy. We build monitors around it to raise ICM and mitigate the situation manually using TSGs.

Issue: Manual efforts in identifying the impacted worker and mitigation steps.
- Post having heartbeat orchestrations, next issue was it used to take manual steps and active engineering cycles to identify the impacted worker and trigger mitigation.
Motivation: motivation was to make detection of impacted worker and perform mitigation steps automatically.
- This is where monitor for these heartbeat orchestration and owner of control-queue arrives.
- We built this system locally in our service, and it has been identifying the impacted worker predictably and auto-mitigates the issue.

> With both these systems in place, we are able to run DTF with no orchestrations stuck, without any manual steps for detection and mitigation. To bring this capability to all users of DTF users, proposing below change.

# Proposals:
Adding control-queue monitor with dedicated orchestrator to each control-queue.

This change consists of 2 main portions:
1. Addition of orchestration and its instances exactly one for each control-queue. 
- This orchestrator (aka ControlQueueHeartbeatTaskOrchestrator) is very simple and quick to run.
- It just waits for some interval (configurable) and logs a heartbeat message and continue itself as new.
- It validates if the context is correct, just in case partition count changes (it assumes partition count doesn't change, otherwise it may result in closing off the orchestrators). 
- It provides a way for user to provide a delegate (callback) to run with each heartbeat.
- This one gets the partition-count information and creates instance-ids such that one is allotted to each control-queue.

2. Addition of a monitoring of these orchestrations from last processed time. 
- Now, with the instance id for each control-queue, it checks for last updated time of orchestration instance and uses it measuring against threshold.
- If orchestration found stuck, appropriate message is logged. 
- This one does a bit more to find point in time owners of each control-queue, to pin the impacted taskhubworker owning the control-queue. 
- It also provides a way for user to provide delegate (callback) to run when it detect any anomaly, like stuck orchestration, fetching owner fails, fetching orchestration instance fails, or any of these times out).