### PR TITLE
Change CreateTaskOrchestrationAsync tp throw OrchestrationAlreadyExistsException

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1690,7 +1690,7 @@ namespace DurableTask.AzureStorage
                 // An instance in this state already exists.
                 if (this.settings.ThrowExceptionOnInvalidDedupeStatus)
                 {
-                    throw new InvalidOperationException($"An Orchestration instance with the status {existingInstance.State.OrchestrationStatus} already exists.");
+                    throw new OrchestrationAlreadyExistsException($"An Orchestration instance with the status {existingInstance.State.OrchestrationStatus} already exists.");
                 }
                 
                 return;


### PR DESCRIPTION
This is to allow exception handling code to catch a more specific exception and differentiate between unexpected errors and expected errors.

This is largely non-breaking because `OrchestrationAlreadyExistsException` already derives from `InvalidOperationException`.

Note that the `IOrchestrationServiceClient` interface already documents that the `CreateTaskOrchestrationAsync` methods should be throwing `OrchestrationAlreadyExistsException`, so this change fixes the AzureStorageOrchestrationService's implementation to follow the existing spec.