### PR TITLE
Add automatic push to ADO step when signing

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -219,10 +219,6 @@ steps:
 
 # Next, we push directly to ADO
 steps:
-- task: NuGetToolInstaller@1
-  displayName: 'Use NuGet '
-
-steps:
 - task: NuGetCommand@2
   displayName: 'Push to durabletask ADO feed'
   inputs:

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -217,6 +217,16 @@ steps:
   displayName: 'Publish nuget packages to Artifacts'
   artifact: PackageOutput
 
+- task: PowerShell@2
+  inputs:
+    targetType: 'inline'
+    script: ls $(build.artifactStagingDirectory)
+
+- task: PowerShell@2
+  inputs:
+    targetType: 'inline'
+    script: ls $(build.artifactStagingDirectory)/PackageOutput
+
 # Next, push the payload to the ADO feed
 - task: NuGetToolInstaller@1
   displayName: 'Use NuGet '

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -216,3 +216,18 @@ steps:
 - publish: $(build.artifactStagingDirectory)
   displayName: 'Publish nuget packages to Artifacts'
   artifact: PackageOutput
+
+# Next, we push directly to ADO
+steps:
+- task: NuGetToolInstaller@1
+  displayName: 'Use NuGet '
+
+steps:
+- task: NuGetCommand@2
+  displayName: 'Push to durabletask ADO feed'
+  inputs:
+    command: push
+    feedsToUse: config
+    packagesToPush: '$(System.DefaultWorkingDirectory)/drop/PackageOutput/*.nupkg'
+    publishVstsFeed: '734e7913-2fab-4624-a174-bc57fe96f95d/d55248c1-5b53-411f-bfe7-73efc9e540d1'
+    allowPackageConflicts: true

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -217,8 +217,10 @@ steps:
   displayName: 'Publish nuget packages to Artifacts'
   artifact: PackageOutput
 
-# Next, we push directly to ADO
-steps:
+# Next, push the payload to the ADO feed
+- task: NuGetToolInstaller@1
+  displayName: 'Use NuGet '
+
 - task: NuGetCommand@2
   displayName: 'Push to durabletask ADO feed'
   inputs:

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -226,6 +226,6 @@ steps:
   inputs:
     command: push
     feedsToUse: config
-    packagesToPush: '$(System.DefaultWorkingDirectory)/drop/PackageOutput/*.nupkg'
+    packagesToPush: '$(build.artifactStagingDirectory)/PackageOutput/*.nupkg'
     publishVstsFeed: '734e7913-2fab-4624-a174-bc57fe96f95d/d55248c1-5b53-411f-bfe7-73efc9e540d1'
     allowPackageConflicts: true

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -217,16 +217,6 @@ steps:
   displayName: 'Publish nuget packages to Artifacts'
   artifact: PackageOutput
 
-- task: PowerShell@2
-  inputs:
-    targetType: 'inline'
-    script: ls $(build.artifactStagingDirectory)
-
-- task: PowerShell@2
-  inputs:
-    targetType: 'inline'
-    script: ls $(build.artifactStagingDirectory)/PackageOutput
-
 # Next, push the payload to the ADO feed
 - task: NuGetToolInstaller@1
   displayName: 'Use NuGet '
@@ -236,6 +226,6 @@ steps:
   inputs:
     command: push
     feedsToUse: config
-    packagesToPush: '$(build.artifactStagingDirectory)/PackageOutput/*.nupkg'
+    packagesToPush: '$(build.artifactStagingDirectory)/*.nupkg'
     publishVstsFeed: '734e7913-2fab-4624-a174-bc57fe96f95d/d55248c1-5b53-411f-bfe7-73efc9e540d1'
     allowPackageConflicts: true


### PR DESCRIPTION
Another step in the effort to minimize our release burden. This PR makes it so that every time a package is signed, it is also pushed to ADO. In most scenarios, if we sign a package, we want to share them with another user, in which case ADO is the preferred mechanism. This prevents us from having to manually kick off the "release to ADO" feed, it will run automatically instead.