### PR TITLE
[For internal investigation][Do note merge] Add logs around semaphore waitasync and release.

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -124,6 +124,11 @@ namespace DurableTask.AzureStorage
         public int MaxStorageOperationConcurrency { get; set; } = Environment.ProcessorCount * 25;
 
         /// <summary>
+        /// Max wait time to wait for semaphore to process after which log should be added.
+        /// </summary>
+        public int MaxWaitForSemaphoreLoggingInSeconds { get; set; } = 20;
+
+        /// <summary>
         /// Gets the maximum number of orchestrator actions to checkpoint at a time.
         /// </summary>
         public int MaxCheckpointBatchSize { get; set; }

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -24,7 +24,7 @@
     <PatchVersion>1</PatchVersion>
 
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
-    <FileVersion>$(VersionPrefix).0</FileVersion>
+    <FileVersion>$(VersionPrefix)-semaphorelogs.4</FileVersion>
     <!-- FileVersionRevision is expected to be set by the CI. This is useful for distinguishing between multiple builds of the same version. -->
     <FileVersion Condition="'$(FileVersionRevision)' != ''">$(VersionPrefix).$(FileVersionRevision)</FileVersion>
     <!-- The assembly version is only the major/minor pair, making it easier to do in-place upgrades -->


### PR DESCRIPTION
Added logs around AzureStorageClient semaphore waitasync and release to understand which all threads took longer than usual. 

**@davidmrdavid edit:** David here - this is a known internal collaborator, he's asking for these logs to be added to an private package to help diagnose some issues they're running into. Not for real review, just for CI convenience.