### PR TITLE
Log current backoff in WaitingForMoreMessages

### DIFF
--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -14,6 +14,7 @@
 namespace DurableTask.AzureStorage
 {
     using System;
+    using System.Collections.Specialized;
     using System.Diagnostics.Tracing;
     using System.Runtime.CompilerServices;
     using DurableTask.AzureStorage.Logging;
@@ -507,11 +508,12 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(EventIds.WaitingForMoreMessages, Level = EventLevel.Informational, Version = 2)]
+        [Event(EventIds.WaitingForMoreMessages, Level = EventLevel.Informational, Version = 3)]
         public void WaitingForMoreMessages(
             string Account,
             string TaskHub,
             string PartitionId,
+            string Details,
             string AppName,
             string ExtensionVersion)
         {
@@ -520,6 +522,7 @@ namespace DurableTask.AzureStorage
                 Account,
                 TaskHub,
                 PartitionId,
+                Details,
                 AppName,
                 ExtensionVersion);
         }

--- a/src/DurableTask.AzureStorage/BackoffPollingHelper.cs
+++ b/src/DurableTask.AzureStorage/BackoffPollingHelper.cs
@@ -36,6 +36,11 @@ namespace DurableTask.AzureStorage
             this.resetEvent.Set();
         }
 
+        public TimeSpan GetCurrentDelay()
+        {
+            return this.backoffStrategy.CurrentInterval;
+        }
+
         public async Task<bool> WaitAsync(CancellationToken hostCancellationToken)
         {
             bool signaled = await this.resetEvent.WaitAsync(this.backoffStrategy.CurrentInterval, hostCancellationToken);

--- a/src/DurableTask.AzureStorage/Logging/LogEvents.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogEvents.cs
@@ -1266,11 +1266,13 @@ namespace DurableTask.AzureStorage.Logging
             public WaitingForMoreMessages(
                 string account,
                 string taskHub,
-                string partitionId)
+                string partitionId,
+                string details)
             {
                 this.Account = account;
                 this.TaskHub = taskHub;
                 this.PartitionId = partitionId;
+                this.Details = details;
             }
 
             [StructuredLogField]
@@ -1282,6 +1284,9 @@ namespace DurableTask.AzureStorage.Logging
             [StructuredLogField]
             public string PartitionId { get; }
 
+            [StructuredLogField]
+            public string Details { get; }
+
             public override EventId EventId => new EventId(
                 EventIds.WaitingForMoreMessages,
                 nameof(EventIds.WaitingForMoreMessages));
@@ -1289,12 +1294,13 @@ namespace DurableTask.AzureStorage.Logging
             public override LogLevel Level => LogLevel.Information;
 
             protected override string CreateLogMessage() => 
-                $"{this.PartitionId}: No new messages were found - backing off";
+                $"{this.PartitionId}: No new messages were found - backing off. Details: ${this.Details}";
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.WaitingForMoreMessages(
                 this.Account,
                 this.TaskHub,
                 this.PartitionId,
+                this.Details,
                 Utils.AppName,
                 Utils.ExtensionVersion);
         }

--- a/src/DurableTask.AzureStorage/Logging/LogHelper.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogHelper.cs
@@ -420,12 +420,14 @@ namespace DurableTask.AzureStorage.Logging
         internal void WaitingForMoreMessages(
             string account,
             string taskHub,
-            string partitionId)
+            string partitionId,
+            string details)
         {
             var logEvent = new LogEvents.WaitingForMoreMessages(
                 account,
                 taskHub,
-                partitionId);
+                partitionId,
+                details);
             this.WriteStructuredLog(logEvent);
         }
 

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -90,7 +90,8 @@ namespace DurableTask.AzureStorage.Messaging
                                 this.settings.Logger.WaitingForMoreMessages(
                                     this.storageAccountName,
                                     this.settings.TaskHubName,
-                                    this.storageQueue.Name);
+                                    this.storageQueue.Name,
+                                    $"Backoff is {this.backoffHelper.GetCurrentDelay().TotalMilliseconds} ms");
                             }
 
                             await this.backoffHelper.WaitAsync(linkedCts.Token);


### PR DESCRIPTION
In some recent performance-sensitive investigations, I've found it challenging not to have access to the current queue-polling backOff whenever a `WaitingForMoreMessages` delay takes place. I think it would be nice to include this in our logs, so that we're armed with precise data on how much latency is expected between `MessageReceived` operations (assuming the queue is populated).