### PR TITLE
[WIP] Ensure popReceipt is updated between RenewMessage operations

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -17,10 +17,6 @@ steps:
     verbosityRestore: Minimal
     projects: |
       src/DurableTask.AzureStorage/DurableTask.AzureStorage.sln
-      src/DurableTask.Emulator/DurableTask.Emulator.csproj
-      src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
-      src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
-      src/DurableTask.ApplicationInsights/DurableTask.ApplicationInsights.csproj
 
 # Build the filtered solution in release mode, specifying the continuous integration flag.
 - task: VSBuild@1
@@ -30,43 +26,6 @@ steps:
     vsVersion: '16.0'
     logFileVerbosity: minimal
     configuration: Release
-    msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
-
-- task: VSBuild@1
-  displayName: 'Build (ApplicationInsights)'
-  inputs:
-    solution: 'src/DurableTask.ApplicationInsights/DurableTask.ApplicationInsights.csproj'
-    vsVersion: '16.0'
-    logFileVerbosity: minimal
-    configuration: Release
-    msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
-
-- task: VSBuild@1
-  displayName: 'Build (Emulator)'
-  inputs:
-    solution: 'src/DurableTask.Emulator/DurableTask.Emulator.csproj'
-    vsVersion: '16.0'
-    logFileVerbosity: minimal
-    configuration: Release
-    msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
-
-- task: VSBuild@1
-  displayName: 'Build (ServiceBus)'
-  inputs:
-    solution: 'src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj'
-    vsVersion: '16.0'
-    logFileVerbosity: minimal
-    configuration: Release
-    msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
-
-- task: VSBuild@1
-  displayName: 'Build (AzureServiceFabric)'
-  inputs:
-    solution: 'src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj'
-    vsVersion: '16.0'
-    logFileVerbosity: minimal
-    configuration: Release
-    platform: x64
     msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
 
 - task: UseDotNet@2
@@ -126,74 +85,6 @@ steps:
     nobuild: true
     packDirectory: $(build.artifactStagingDirectory)
     packagesToPack: 'src/DurableTask.AzureStorage/DurableTask.AzureStorage.sln'
-
-- task: DotNetCoreCLI@2
-  displayName: Generate nuget packages
-  inputs:
-    command: pack
-    verbosityPack: Minimal
-    configuration: Release
-    nobuild: true
-    packDirectory: $(build.artifactStagingDirectory)
-    packagesToPack: 'src/DurableTask.ApplicationInsights/DurableTask.ApplicationInsights.csproj'
-
-- task: DotNetCoreCLI@2
-  displayName: Generate nuget packages
-  inputs:
-    command: pack
-    verbosityPack: Minimal
-    configuration: Release
-    nobuild: true
-    packDirectory: $(build.artifactStagingDirectory)
-    packagesToPack: 'src/DurableTask.Emulator/DurableTask.Emulator.csproj'
-
-- task: DotNetCoreCLI@2
-  displayName: Generate nuget packages
-  inputs:
-    command: pack
-    verbosityPack: Minimal
-    configuration: Release
-    nobuild: true
-    packDirectory: $(build.artifactStagingDirectory)
-    packagesToPack: 'src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj'
-
-- task: DotNetCoreCLI@2
-  displayName: Generate nuget packages
-  inputs:
-    command: pack
-    verbosityPack: Minimal
-    configuration: Release
-    nobuild: true
-    packDirectory: $(build.artifactStagingDirectory)
-    packagesToPack: 'src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj'
-    buildProperties: 'Platform=x64'
-
-# Digitally sign all the nuget packages with the Microsoft certificate.
-# This appears to be an in-place signing job, which is convenient.
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-  displayName: 'ESRP CodeSigning: Nupkg'
-  inputs:
-    ConnectedServiceName: 'ESRP Service'
-    FolderPath: $(build.artifactStagingDirectory)
-    Pattern: '*.nupkg'
-    signConfigType: inlineSignParams
-    inlineOperation: |
-     [    
-        {
-            "KeyCode": "CP-401405",
-            "OperationCode": "NuGetSign",
-            "Parameters": {},
-            "ToolName": "sign",
-            "ToolVersion": "1.0"
-        },
-        {
-            "KeyCode": "CP-401405",
-            "OperationCode": "NuGetVerify",
-            "Parameters": {},
-            "ToolName": "sign",
-            "ToolVersion": "1.0"
-        }
-     ]
 
 # Make the nuget packages available for download in the ADO portal UI
 - publish: $(build.artifactStagingDirectory)

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -45,7 +45,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -24,7 +24,7 @@
     <PatchVersion>0</PatchVersion>
 
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
-    <VersionSuffix>preview.5</VersionSuffix>
+    <VersionSuffix>preview.5.popReceiptfix.1</VersionSuffix>
     <FileVersion>$(VersionPrefix).0</FileVersion>
     <!-- FileVersionRevision is expected to be set by the CI. This is useful for distinguishing between multiple builds of the same version. -->
     <FileVersion Condition="'$(FileVersionRevision)' != ''">$(VersionPrefix).$(FileVersionRevision)</FileVersion>

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -32,7 +32,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="7.0.1" NoWarn="NU1903"/>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
In order to update messages on Azure Storage, we need to provide an up-to-date "popReceipt" to the Azure Storage SDK. Otherwise, the request will fail with "404"-type errors. After every message update operation, the popReceipt for a message is updated.

From recent reports, we learned that in the new Azure Storage SDK, the popReceipt of an `queueMessage` object is not automatically updated in-place when the update API is called. Instead, the update API now returns an `updateReceipt` object containing the new popRecepit, and leaves the `popReceipt` in the `queueMessage` object intact, making it stale.
 
This suggests that we cannot simply access `queueMessage.popReceipt` to obtain the latest receipt, instead we'll need to maintain an extra mapping between messageIds and their latest popReceipts. This PR implements a rather naive mapping, but further refinement may be needed.

_work in progress_