### PR TITLE
New APIs and updates related to failure details propagation

### DIFF
--- a/Test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
+++ b/Test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
@@ -15,6 +15,7 @@ namespace DurableTask.Core.Tests
 {
     using System;
     using System.Diagnostics;
+    using System.Runtime.Serialization;
     using System.Threading.Tasks;
     using DurableTask.Core.Exceptions;
     using DurableTask.Emulator;
@@ -203,7 +204,10 @@ namespace DurableTask.Core.Tests
                                     tfe.FailureDetails.ErrorMessage == "This is a test exception" &&
                                     tfe.FailureDetails.StackTrace!.Contains(typeof(ThrowInvalidOperationException).Name) &&
                                     tfe.FailureDetails.IsCausedBy<InvalidOperationException>() &&
-                                    tfe.FailureDetails.IsCausedBy<Exception>()) // check that base types work too
+                                    tfe.FailureDetails.IsCausedBy<Exception>() &&
+                                    tfe.FailureDetails.InnerFailure != null &&
+                                    tfe.FailureDetails.InnerFailure.IsCausedBy<CustomException>() &&
+                                    tfe.FailureDetails.InnerFailure.ErrorMessage == "And this is its custom inner exception") 
                                 {
                                     // Stop retrying
                                     return false;
@@ -235,7 +239,8 @@ namespace DurableTask.Core.Tests
         {
             protected override string Execute(TaskContext context, string input)
             {
-                throw new InvalidOperationException("This is a test exception");
+                throw new InvalidOperationException("This is a test exception",
+                    new CustomException("And this is its custom inner exception"));
             }
         }
 
@@ -243,7 +248,22 @@ namespace DurableTask.Core.Tests
         {
             protected override Task<string> ExecuteAsync(TaskContext context, string input)
             {
-                throw new InvalidOperationException("This is a test exception");
+                throw new InvalidOperationException("This is a test exception",
+                    new CustomException("And this is its custom inner exception"));
+            }
+        }
+
+        [Serializable]
+        class CustomException : Exception
+        {
+            public CustomException(string message)
+                : base(message)
+            {
+            }
+
+            protected CustomException(SerializationInfo info, StreamingContext context)
+                : base(info, context)
+            {
             }
         }
     }

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -17,8 +17,8 @@
   <!-- Version Info -->
   <PropertyGroup>
     <MajorVersion>2</MajorVersion>
-    <MinorVersion>16</MinorVersion>
-    <PatchVersion>2</PatchVersion>
+    <MinorVersion>17</MinorVersion>
+    <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <FileVersion>$(VersionPrefix).0</FileVersion>
     <!-- FileVersionRevision is expected to be set by the CI. This is useful for distinguishing between multiple builds of the same version. -->

--- a/src/DurableTask.Core/Exceptions/OrchestrationException.cs
+++ b/src/DurableTask.Core/Exceptions/OrchestrationException.cs
@@ -88,8 +88,8 @@ namespace DurableTask.Core.Exceptions
         public int EventId { get; set; }
 
         /// <summary>
-        /// Gets additional details about the failure. May be <c>null</c> if the failure details collection is not enabled.
+        /// Gets or sets additional details about the failure. May be <c>null</c> if the failure details collection is not enabled.
         /// </summary>
-        public FailureDetails? FailureDetails { get; internal set; }
+        public FailureDetails? FailureDetails { get; set; }
     }
 }

--- a/src/DurableTask.Core/FailureDetails.cs
+++ b/src/DurableTask.Core/FailureDetails.cs
@@ -21,6 +21,9 @@ namespace DurableTask.Core
     using DurableTask.Core.Exceptions;
     using Newtonsoft.Json;
 
+    // NOTE: This class is very similar to https://github.com/microsoft/durabletask-dotnet/blob/main/src/Abstractions/TaskFailureDetails.cs.
+    //       Any functional changes to this class should be mirrored in that class and vice versa.
+
     /// <summary>
     /// Details of an activity, orchestration, or entity operation failure.
     /// </summary>
@@ -129,11 +132,6 @@ namespace DurableTask.Core
         /// <returns>Returns <c>true</c> if the <see cref="ErrorType"/> value matches <typeparamref name="T"/>; <c>false</c> otherwise.</returns>
         public bool IsCausedBy<T>() where T : Exception
         {
-            if (string.IsNullOrEmpty(this.ErrorType))
-            {
-                return false;
-            }
-
             // This check works for .NET exception types defined in System.Core.PrivateLib (aka mscorelib.dll)
             Type? exceptionType = Type.GetType(this.ErrorType, throwOnError: false);
 

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -638,10 +638,11 @@ namespace DurableTask.Core
                     details = orchestrationFailureException.Details;
                 }
             }
-            else if (failure is TaskFailedException tfe && this.ErrorPropagationMode == ErrorPropagationMode.UseFailureDetails)
+            else if (failure is TaskFailedException taskFailedException &&
+                this.ErrorPropagationMode == ErrorPropagationMode.UseFailureDetails)
             {
                 // Propagate the original FailureDetails
-                failureDetails = tfe.FailureDetails;
+                failureDetails = taskFailedException.FailureDetails;
             }
             else
             {

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -638,6 +638,11 @@ namespace DurableTask.Core
                     details = orchestrationFailureException.Details;
                 }
             }
+            else if (failure is TaskFailedException tfe && this.ErrorPropagationMode == ErrorPropagationMode.UseFailureDetails)
+            {
+                // Propagate the original FailureDetails
+                failureDetails = tfe.FailureDetails;
+            }
             else
             {
                 if (this.ErrorPropagationMode == ErrorPropagationMode.UseFailureDetails)


### PR DESCRIPTION
First step towards properly fixing https://github.com/Azure/azure-functions-durable-extension/issues/2476.

This PR fixes a couple things:

1. The `IsCausedBy<T>()` API doesn't correctly handle exceptions defined outside of mscorlib. This PR fixes that.
2. Exception details aren't propagating correctly from a sub-orchestration to the parent orchestration. This PR also fixes the propagation.
3. Minor public API changes to make some of the failure details primitives usable by other SDKs

I also went ahead and bumped the minor version number of DurableTask.Core since these changes impact the public API surface area.