### PR TITLE
[Proposal] Detect and fail fast for dangerous to deserialize types in task activity and task orchestration.

### DIFF
--- a/Test/DurableTask.Core.Tests/ReflectionBasedTaskActivityTests.cs
+++ b/Test/DurableTask.Core.Tests/ReflectionBasedTaskActivityTests.cs
@@ -1,0 +1,146 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core.Tests
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+    using System.Runtime.Serialization;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Xml;
+    using DurableTask.Core.Command;
+    using DurableTask.Core.History;
+    using DurableTask.Emulator;
+    using DurableTask.Test.Orchestrations;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class ReflectionBasedTaskActivityTests
+    {
+        public TaskHubWorker worker { get; private set; }
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            var service = new LocalOrchestrationService();
+            this.worker = new TaskHubWorker(service);
+        }
+
+        [TestMethod]
+        public void Test_AddTaskActivitiesFromInterface()
+        {
+            IReflectionBasedTaskActivityTest reflectionBasedTaskActivityTest = new ReflectionBasedTaskActivityTest();
+
+            worker.AddTaskActivitiesFromInterface(reflectionBasedTaskActivityTest);
+            worker.AddTaskActivitiesFromInterface(reflectionBasedTaskActivityTest, useFullyQualifiedMethodNames: true);
+        }
+
+        [TestMethod]
+        public void Test_ReflectionBasedTaskActivity()
+        {
+            IReflectionBasedTaskActivityTest reflectionBasedTaskActivityTest = new ReflectionBasedTaskActivityTest();
+
+            worker.AddTaskActivitiesFromInterface(reflectionBasedTaskActivityTest);
+            worker.AddTaskActivitiesFromInterface(reflectionBasedTaskActivityTest, useFullyQualifiedMethodNames: true);
+        }
+
+        [TestMethod]
+        public void Test_ReflectionBasedTaskActivityWithGeneric()
+        {
+            IReflectionBasedTaskActivityWithGenericTest reflectionBasedTaskActivityTest = new ReflectionBasedTaskActivityTest();
+
+            worker.AddTaskActivitiesFromInterface(reflectionBasedTaskActivityTest);
+            worker.AddTaskActivitiesFromInterface(reflectionBasedTaskActivityTest, useFullyQualifiedMethodNames: true);
+        }
+
+        [TestMethod]
+        public void Test_AddTaskActivitiesFromInterfaceWithCancellationToken()
+        {
+            IReflectionBasedTaskActivityWithCancellationTokenTest reflectionBasedTaskActivityTest = new ReflectionBasedTaskActivityTest();
+            Action action = () =>
+            {
+                worker.AddTaskActivitiesFromInterface(reflectionBasedTaskActivityTest);
+            };
+
+            Assert.ThrowsException<InvalidOperationException>(action);
+
+            action = () =>
+            {
+                worker.AddTaskActivitiesFromInterface(reflectionBasedTaskActivityTest, useFullyQualifiedMethodNames: true);
+            };
+
+            Assert.ThrowsException<InvalidOperationException>(action);
+        }
+
+        [TestMethod]
+        public void Test_ReflectionBasedTaskActivityWithCancellationToken()
+        {
+            IReflectionBasedTaskActivityWithCancellationTokenTest reflectionBasedTaskActivityTest = new ReflectionBasedTaskActivityTest();
+            Action action = () =>
+            {
+                worker.AddTaskActivitiesFromInterface(reflectionBasedTaskActivityTest);
+            };
+
+            Assert.ThrowsException<InvalidOperationException>(action);
+
+            action = () =>
+            {
+                worker.AddTaskActivitiesFromInterface(reflectionBasedTaskActivityTest, useFullyQualifiedMethodNames: true);
+            };
+
+            Assert.ThrowsException<InvalidOperationException>(action);
+        }
+
+        public interface IReflectionBasedTaskActivityTest
+        {
+            void TestMethod1();
+            void TestMethod2(int n1, int n2);
+        }
+
+        public interface IReflectionBasedTaskActivityWithGenericTest
+        {
+            void TestMethodG3<T>(T obj);
+        }
+
+        public interface IReflectionBasedTaskActivityWithCancellationTokenTest : IReflectionBasedTaskActivityTest
+        {
+            void TestMethod3(int n, CancellationToken cancellationToken);
+        }
+
+        public class ReflectionBasedTaskActivityTest : IReflectionBasedTaskActivityWithCancellationTokenTest, IReflectionBasedTaskActivityWithGenericTest
+        {
+            public void TestMethod1()
+            {
+            }
+
+            public void TestMethod2(int n1, int n2)
+            {
+            }
+
+            public void TestMethod3(int n, CancellationToken cancellationToken)
+            {
+            }
+
+            public void TestMethodG3<T>(T obj)
+            {
+            }
+        }
+    }
+}

--- a/Test/DurableTask.Core.Tests/TaskRegistrationTests.cs
+++ b/Test/DurableTask.Core.Tests/TaskRegistrationTests.cs
@@ -1,0 +1,144 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core.Tests
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
+    using System.Runtime.Serialization;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Xml;
+    using DurableTask.Core.Command;
+    using DurableTask.Core.History;
+    using DurableTask.Emulator;
+    using DurableTask.Test.Orchestrations;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class TaskRegistrationTests
+    {
+        public TaskHubWorker worker { get; private set; }
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            var service = new LocalOrchestrationService();
+            this.worker = new TaskHubWorker(service);
+        }
+
+        [TestMethod]
+        [DataRow(typeof(TaskOrchInValid))]
+        [DataRow(typeof(TaskOrchInValidGeneric<CancellationToken>))]
+        [DataRow(typeof(TaskOrchInValidGeneric<string>))]
+        [DataRow(typeof(TaskOrchGeneric<CancellationToken, string>))]
+        [DataRow(typeof(TaskOrchGeneric<int, CancellationToken>))]
+        [DataRow(typeof(TaskOrchGeneric<CancellationToken, CancellationToken>))]
+        public void Test_RegistrationOfInValidTaskOrchestration(Type type)
+        {
+            Action action = () =>
+            {
+                this.worker.AddTaskOrchestrations(new[] { type });
+            };
+
+            Assert.ThrowsException<InvalidOperationException>(action);
+        }
+
+        [TestMethod]
+        [DataRow(typeof(TaskOrchValid))]
+        [DataRow(typeof(TaskOrchValidGeneric<CancellationToken>))]
+        [DataRow(typeof(TaskOrchValidGeneric<string>))]
+        [DataRow(typeof(TaskOrchGeneric<string, string>))]
+        [DataRow(typeof(TaskOrchGeneric<int, bool>))]
+        public void Test_RegistrationOfValidTaskOrchestration(Type type)
+        {
+            this.worker.AddTaskOrchestrations(new[] { type });
+        }
+
+        [TestMethod]
+        [DataRow(typeof(SampleTaskActivity<CancellationToken, CancellationToken, CancellationToken>))]
+        [DataRow(typeof(SampleTaskActivity<string, CancellationToken, string>))]
+        [DataRow(typeof(SampleTaskActivity<CancellationToken, string, int>))]
+        public void Test_RegistrationOfInValidTaskActivities(Type type)
+        {
+            Action action = () =>
+            {
+                this.worker.AddTaskActivities(new[] { type });
+            };
+
+            Assert.ThrowsException<InvalidOperationException>(action);
+        }
+
+        [TestMethod]
+        [DataRow(typeof(SampleTaskActivity<string, int, CancellationToken>))]
+        [DataRow(typeof(SampleTaskActivity<string, double, string>))]
+        [DataRow(typeof(SampleTaskActivity<string, string, int>))]
+        public void Test_RegistrationOfValidTaskActivities(Type type)
+        {
+            this.worker.AddTaskActivities(new[] { type });
+        }
+
+        public class TaskOrchValid : TaskOrchestration<string, string>
+        {
+            public override Task<string> RunTask(OrchestrationContext context, string input)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public class TaskOrchValidGeneric<T> : TaskOrchestration<string, string>
+        {
+            public override Task<string> RunTask(OrchestrationContext context, string input)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public class TaskOrchInValid : TaskOrchestration<string, CancellationToken>
+        {
+            public override Task<string> RunTask(OrchestrationContext context, CancellationToken input)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public class TaskOrchInValidGeneric<T> : TaskOrchestration<string, CancellationToken>
+        {
+            public override Task<string> RunTask(OrchestrationContext context, CancellationToken input)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public class TaskOrchGeneric<TOut, Tin> : TaskOrchestration<TOut, Tin>
+        {
+            public override Task<TOut> RunTask(OrchestrationContext context, Tin input)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public class SampleTaskActivity<Tin, Tout, T> : TaskActivity<Tin, Tout>
+        {
+            protected override Tout Execute(TaskContext context, Tin input)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/Test/DurableTask.Core.Tests/TypeExtensionsTests.cs
+++ b/Test/DurableTask.Core.Tests/TypeExtensionsTests.cs
@@ -1,0 +1,94 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core.Tests
+{
+    using DurableTask.Core.Common;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System;
+    using System.Threading.Tasks;
+    using System.Threading;
+
+    [TestClass]
+    public class TypeExtensionsTests
+    {
+        [TestMethod]
+        [DataRow(typeof(Task<TestClass1>), true)]
+        [DataRow(typeof(CancellationToken), true)]
+        [DataRow(typeof(Semaphore), true)]
+        [DataRow(typeof(Task<(bool, string)>), true)]
+        [DataRow(typeof(TestClass1), false)]
+        [DataRow(typeof(TestClass2), false)]
+        [DataRow(typeof(string), false)]
+        public void IsEqualOrContainsCancellationTokenType(Type typeContaining, bool isTrue)
+        {
+            if (isTrue)
+            {
+                Assert.IsTrue(typeContaining.IsEqualOrContainsNativeType());
+            }
+            else
+            {
+                Assert.IsFalse(typeContaining.IsEqualOrContainsNativeType());
+            }
+        }
+
+        [TestMethod]
+        [DataRow(typeof(Task<TestClass1>), typeof(CancellationToken), true)]
+        [DataRow(typeof(CancellationToken), typeof(CancellationToken), true)]
+        [DataRow(typeof(Task<TestClass1>), typeof(TestClass1), true)]
+        [DataRow(typeof(Task<(bool, string)>), typeof(string), true)]
+        [DataRow(typeof(Task<(bool, string)>), typeof(bool), true)]
+        [DataRow(typeof(TestClass1), typeof(TestClass1), true)]
+        [DataRow(typeof(TestClass1), typeof(string), true)]
+        [DataRow(typeof(TestClass1), typeof(double), true)]
+        [DataRow(typeof(TestClass1), typeof(TestClass2), true)]
+        [DataRow(typeof(TestClass2), typeof(double), true)]
+        [DataRow(typeof(TestClass2), typeof(string), false)]
+        public void Test_ContainsType(Type typeContaining, Type typeContained, bool isTrue)
+        {
+            if (isTrue)
+            {
+                Assert.IsTrue(typeContaining.IsEqualOrContainsType(typeContained));
+            }
+            else
+            {
+                Assert.IsFalse(typeContaining.IsEqualOrContainsType(typeContained));
+            }
+        }
+
+        internal class TestClass1
+        {
+            public string abc;
+
+            public TestClass2 t2;
+
+            public TestClass2 NewT2 { get; set; }
+
+            public TestClass1()
+            {
+                abc = string.Empty;
+                t2 = new TestClass2();
+            }
+        }
+
+        internal class TestClass2
+        {
+            public double def;
+
+            public TestClass2()
+            {
+                def = 1.0;
+            }
+        }
+    }
+}

--- a/src/DurableTask.Core/Common/TypeExtension.cs
+++ b/src/DurableTask.Core/Common/TypeExtension.cs
@@ -22,6 +22,16 @@ namespace DurableTask.Core.Common
 
     internal static class TypeExtension
     {
+        internal static void HandleTypeValidationError(string metadataInfo)
+        {
+            var isCancellationTokenWarningOnly = true;
+
+            if (isCancellationTokenWarningOnly)
+            {
+                throw new InvalidOperationException($"Dangerous type deserialization found while converting method to task-activity for {metadataInfo}.");
+            }
+        }
+
         /// <summary>
         /// Checks if a type has any dangerous object which can conflict with native OS event handle.
         /// E.g., CancellationToken, etc.

--- a/src/DurableTask.Core/Common/TypeExtension.cs
+++ b/src/DurableTask.Core/Common/TypeExtension.cs
@@ -1,0 +1,85 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core.Common
+{
+    using Microsoft.Win32.SafeHandles;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Threading;
+
+    internal static class TypeExtension
+    {
+        /// <summary>
+        /// Checks if a type has any dangerous object which can conflict with native OS event handle.
+        /// E.g., CancellationToken, etc.
+        /// </summary>
+        /// <param name="typeContaining"></param>
+        /// <returns></returns>
+        public static bool IsEqualOrContainsNativeType(this Type typeContaining)
+        {
+            return typeContaining.IsEqualOrContainsType(typeof(WaitHandle))
+                || typeContaining.IsEqualOrContainsType(typeof(SafeWaitHandle));
+        }
+
+        public static bool IsEqualOrContainsType(this Type typeContaining, Type typeContained)
+        {
+            if (typeContaining == typeContained)
+            {
+                return true;
+            }
+
+            List<Type> processedTypes = new List<Type>();
+            return typeContaining.ContainsType(typeContained, processedTypes);
+        }
+
+        private static bool ContainsType(this Type typeContaining, Type typeContained, List<Type> processedTypes)
+        {
+            if (processedTypes.Any(x => x == typeContaining))
+            {
+                // Self-reference, no point processing it again.
+                return false;
+            }
+            else
+            {
+                processedTypes.Add(typeContaining);
+            }
+
+            // Get all properties and fields of typeT
+            PropertyInfo[] properties = typeContaining.GetProperties();
+            FieldInfo[] fields = typeContaining.GetFields();
+
+            // Check properties
+            foreach (var property in properties)
+            {
+                if (property.PropertyType == typeContained)
+                    return true;
+                else if (!property.PropertyType.IsPrimitive && property.PropertyType.ContainsType(typeContained, processedTypes))
+                    return true;
+            }
+
+            // Check fields
+            foreach (var field in fields)
+            {
+                if (field.FieldType == typeContained)
+                    return true;
+                else if (!field.FieldType.IsPrimitive && field.FieldType.ContainsType(typeContained, processedTypes))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
# Motivation
Regarding issue: #903 Stuck orchestrations at random on control-queue
The investigation surfaced that in task-activities via interface were calling method with cancellation token in their parameters.
Since, it becomes scheduling and running a task-activity with serialization and deserialization of parameters and return types, cancellation token was also getting deserialized. 
Deserializing a cancellation token, or any object with safehandle, is dangerous as it can corrupt the native objects and result in undesirable outcomes. 
E.g., for us, semaphore's locking handle got corrupt and both waitasync and release got stuck making DTF not to proceed.

Since DTF TaskOrchestration and TaskActivities do serialize and deserialize its input(parameters) and output(return type), we had fixed this in our local repo by adding guards around such task-activities and orchestration to avoid objects having safehandle as parameters or return types. Post this check, we are not hitting this issue anymore. 

Since, DTF's inherent nature is such it has to serialize and deserialize input and output of task-activity and task-orchestration, it becomes important that DTF upfront understands such dangerous usage and throw to restrict bad practices.
This was the motivation behind making this change in DTF core library. 


# Proposal
Proposal is to add an extension to validate any type for dangerous deserialization and use it to check task-orchestration and task-activity's input and output. 
- Add an extension for type to detect any such types or contained types which are dangerous for deserialization.
- Validating the task orchestration and task activity registration to fail fast.
- For interface to task activity: Fail fast at task registration, and for generic type task-activities from interface, fail fast before deserializing parameters while executing task.