### PR TITLE
Honor DataConverter when creating JsonConverters

### DIFF
--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -60,12 +60,16 @@ namespace DurableTask.AzureStorage
                 Binder = new TypeNameSerializationBinder(settings.CustomMessageTypeBinder),
 #endif
             };
-            this.serializer = JsonSerializer.Create(taskMessageSerializerSettings);
 
             if (this.settings.UseDataContractSerialization)
             {
                 this.taskMessageSerializerSettings.Converters.Add(new DataContractJsonConverter());
             }
+
+            // We _need_ to create the Json serializer after providing the data converter,
+            // otherwise the converters will be ignored.
+            this.serializer = JsonSerializer.Create(taskMessageSerializerSettings);
+
         }
 
         public async Task<bool> EnsureContainerAsync()


### PR DESCRIPTION
In this PR (https://github.com/Azure/durabletask/pull/503) we introduced the ability to use a DataContractConverter when de-/serializing to Json. However, in this PR (https://github.com/Azure/durabletask/pull/775) we moved the instantiation of the JsonConverter to occur _before_ the DataConverter is specified, which means the converter is ignored at de-/serialization time.

This PR fixes that by moving the JsonConverter instantiation to _after_ the DataConverter is provided.

**Open question: why did the unit tests in (https://github.com/Azure/durabletask/pull/503) not catch this regression?**