### PR TITLE
Remove duplicate activity starting log message

### DIFF
--- a/src/DurableTask.Core/TaskActivityDispatcher.cs
+++ b/src/DurableTask.Core/TaskActivityDispatcher.cs
@@ -130,8 +130,6 @@ namespace DurableTask.Core
                 // Distributed tracing: start a new trace activity derived from the orchestration's trace context.
                 Activity? traceActivity = TraceHelper.StartTraceActivityForTaskExecution(scheduledEvent, orchestrationInstance);
 
-                this.logHelper.TaskActivityStarting(orchestrationInstance, scheduledEvent);
-
                 if (scheduledEvent.Name == null)
                 {
                     string message = $"The activity worker received a {nameof(EventType.TaskScheduled)} event that does not specify an activity name.";


### PR DESCRIPTION
Looks like this log somehow got duplicated. Removing the first instance, since it occurs before a null-check and therefore seems at risk compared to the second instance (which is just a few lines below).