### PR TITLE
Remove Wrong Core Entities Error Handling

### DIFF
--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -18,7 +18,7 @@
   <PropertyGroup>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>17</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <FileVersion>$(VersionPrefix).0</FileVersion>
     <!-- FileVersionRevision is expected to be set by the CI. This is useful for distinguishing between multiple builds of the same version. -->

--- a/src/DurableTask.Core/TaskEntityDispatcher.cs
+++ b/src/DurableTask.Core/TaskEntityDispatcher.cs
@@ -564,8 +564,6 @@ namespace DurableTask.Core
 
                         break;
 
-                    default:
-                        throw new EntitySchedulerException($"The entity with instanceId '{instanceId}' received an unexpected event type of type '{e.EventType}'. This is not a valid entity message. This is a framework-internal error, please report this issue in the GitHub repo: 'https://github.com/Azure/durabletask/'");
                 }
             }
 


### PR DESCRIPTION
Whenever core entities start, they will generate both `OrchestratorStarted` and `OrchestratorCompleted` events. The DetermineWork function checks all events of entities' runtime status. Therefore, the default error handling is not appropriate, as it should at least exclude these two events from being caught.

Fixes #1095 