### PR TITLE
Allow TaskHubClient's CreateOrchestrationInstanceAsync to schedule orchestrators

### DIFF
--- a/Test/DurableTask.Core.Tests/TaskHubClientTests.cs
+++ b/Test/DurableTask.Core.Tests/TaskHubClientTests.cs
@@ -1,0 +1,73 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+#nullable enable
+namespace DurableTask.Core.Tests
+{
+    using DurableTask.Core.History;
+    using DurableTask.Emulator;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// A test implementation of <see cref="LocalOrchestrationService"/> that captures messages for later inspection.
+    /// </summary>
+    public class TestLocalOrchestrationService : LocalOrchestrationService
+    {
+        public List<TaskMessage> Messages { get; } = new List<TaskMessage>();
+
+        public override Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, OrchestrationStatus[] dedupeStatuses)
+        {
+            // capture message for later inspection
+            this.Messages.Add(creationMessage);
+
+            // call base implementation
+            return base.CreateTaskOrchestrationAsync(creationMessage, dedupeStatuses);
+        }
+    }
+
+    [TestClass]
+    public class TaskHubClientTests
+    {
+        /// <summary>
+        /// Tests that scheduled orchestrations can be created.
+        /// </summary>
+        [TestMethod]
+        public async Task CanCreateScheduledOrchestrations()
+        {
+            // create test orchestration service that allows us to inspect the generated HistoryEvents
+            TestLocalOrchestrationService service = new TestLocalOrchestrationService();
+            TaskHubClient client = new TaskHubClient(service);
+
+            // orchestrator should fire in 5 minutes
+            DateTime fireAt = DateTime.UtcNow.AddMinutes(5);
+
+            // invoke client method
+            await client.CreateOrchestrationInstanceAsync(
+                name: "TestOrchestration", version: "", instanceId: null, input: null, tags: null, dedupeStatuses: null, startAt: fireAt);
+
+            var messages = service.Messages;
+            Assert.IsTrue(messages.Count == 1);
+            
+            TaskMessage startMessage = messages[0];
+            HistoryEvent durableEvent = startMessage.Event;
+            Assert.IsInstanceOfType(durableEvent, typeof(ExecutionStartedEvent));
+
+            // we expect the generated history event to have a populated ScheduledStartTime with value provided to the client.
+            ExecutionStartedEvent startEvent = (ExecutionStartedEvent)durableEvent;
+            Assert.IsTrue(startEvent.ScheduledStartTime == fireAt);
+        }
+    }
+}

--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -82,7 +82,7 @@ namespace DurableTask.Core
         /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
         public Task<OrchestrationInstance> CreateScheduledOrchestrationInstanceAsync(
             Type orchestrationType,
-            object input,
+            object? input,
             DateTime startAt)
         {
             return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
@@ -107,8 +107,8 @@ namespace DurableTask.Core
         /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
         public Task<OrchestrationInstance> CreateScheduledOrchestrationInstanceAsync(
             Type orchestrationType,
-            string instanceId,
-            object input,
+            string? instanceId,
+            object? input,
             DateTime startAt)
         {
             return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
@@ -132,7 +132,7 @@ namespace DurableTask.Core
         /// <param name="input">Input parameter to the specified TaskOrchestration</param>
         /// <param name="startAt">Orchestration start time</param>
         /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
-        public Task<OrchestrationInstance> CreateScheduledOrchestrationInstanceAsync(string name, string version, string instanceId, object input, DateTime startAt)
+        public Task<OrchestrationInstance> CreateScheduledOrchestrationInstanceAsync(string name, string version, string? instanceId, object? input, DateTime startAt)
         {
             return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 name,
@@ -172,7 +172,7 @@ namespace DurableTask.Core
         /// <param name="input">Input parameter to the specified TaskOrchestration</param>
         /// <param name="startAt">Orchestration start time</param>
         /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
-        public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(Type orchestrationType, object input, DateTime startAt)
+        public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(Type orchestrationType, object? input, DateTime startAt)
         {
             return InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 NameVersionHelper.GetDefaultName(orchestrationType),
@@ -194,8 +194,8 @@ namespace DurableTask.Core
         /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
         public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(
             Type orchestrationType,
-            string instanceId,
-            object input)
+            string? instanceId,
+            object? input)
         {
             return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 NameVersionHelper.GetDefaultName(orchestrationType),
@@ -218,8 +218,8 @@ namespace DurableTask.Core
         /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
         public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(
             Type orchestrationType,
-            string instanceId,
-            object input,
+            string? instanceId,
+            object? input,
             OrchestrationStatus[] dedupeStatuses)
         {
             return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
@@ -240,7 +240,7 @@ namespace DurableTask.Core
         /// <param name="version">Version of the TaskOrchestration</param>
         /// <param name="input">Input parameter to the specified TaskOrchestration</param>
         /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
-        public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(string name, string version, object input)
+        public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(string name, string version, object? input)
         {
             return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 name,
@@ -261,7 +261,7 @@ namespace DurableTask.Core
         /// <param name="instanceId">Instance id for the orchestration to be created, must be unique across the Task Hub</param>
         /// <param name="input">Input parameter to the specified TaskOrchestration</param>
         /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
-        public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(string name, string version, string instanceId, object input)
+        public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(string name, string version, string? instanceId, object? input)
         {
             return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 name,
@@ -286,8 +286,8 @@ namespace DurableTask.Core
         public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(
             string name,
             string version,
-            string instanceId,
-            object input,
+            string? instanceId,
+            object? input,
             IDictionary<string, string> tags)
         {
             return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
@@ -314,8 +314,8 @@ namespace DurableTask.Core
         public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(
             string name,
             string version,
-            string instanceId,
-            object input,
+            string? instanceId,
+            object? input,
             IDictionary<string, string> tags,
             OrchestrationStatus[] dedupeStatuses)
         {
@@ -344,8 +344,8 @@ namespace DurableTask.Core
         public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(
             string name,
             string version,
-            string instanceId,
-            object input,
+            string? instanceId,
+            object? input,
             IDictionary<string, string> tags,
             OrchestrationStatus[] dedupeStatuses,
             DateTime startAt)
@@ -400,8 +400,8 @@ namespace DurableTask.Core
         /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
         public Task<OrchestrationInstance> CreateOrchestrationInstanceWithRaisedEventAsync(
             Type orchestrationType,
-            string instanceId,
-            object orchestrationInput,
+            string? instanceId,
+            object? orchestrationInput,
             string eventName,
             object eventData)
         {
@@ -429,8 +429,8 @@ namespace DurableTask.Core
         /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
         public Task<OrchestrationInstance> CreateOrchestrationInstanceWithRaisedEventAsync(
             Type orchestrationType,
-            string instanceId,
-            object orchestrationInput,
+            string? instanceId,
+            object? orchestrationInput,
             OrchestrationStatus[] dedupeStatuses,
             string eventName,
             object eventData)
@@ -484,7 +484,7 @@ namespace DurableTask.Core
         public Task<OrchestrationInstance> CreateOrchestrationInstanceWithRaisedEventAsync(
             string orchestrationName,
             string orchestrationVersion,
-            object orchestrationInput,
+            object? orchestrationInput,
             string eventName,
             object eventData)
         {
@@ -513,8 +513,8 @@ namespace DurableTask.Core
         public Task<OrchestrationInstance> CreateOrchestrationInstanceWithRaisedEventAsync(
             string orchestrationName,
             string orchestrationVersion,
-            string instanceId,
-            object orchestrationInput,
+            string? instanceId,
+            object? orchestrationInput,
             string eventName,
             object eventData)
         {
@@ -544,8 +544,8 @@ namespace DurableTask.Core
         public Task<OrchestrationInstance> CreateOrchestrationInstanceWithRaisedEventAsync(
             string orchestrationName,
             string orchestrationVersion,
-            string instanceId,
-            object orchestrationInput,
+            string? instanceId,
+            object? orchestrationInput,
             IDictionary<string, string> orchestrationTags,
             string eventName,
             object eventData)
@@ -577,8 +577,8 @@ namespace DurableTask.Core
         public Task<OrchestrationInstance> CreateOrchestrationInstanceWithRaisedEventAsync(
             string orchestrationName,
             string orchestrationVersion,
-            string instanceId,
-            object orchestrationInput,
+            string? instanceId,
+            object? orchestrationInput,
             IDictionary<string, string> orchestrationTags,
             OrchestrationStatus[] dedupeStatuses,
             string eventName,
@@ -607,7 +607,7 @@ namespace DurableTask.Core
         public Task<OrchestrationInstance> CreateOrchestrationInstanceWithRaisedEventAsync(
             string orchestrationName,
             string orchestrationVersion,
-            string instanceId,
+            string? instanceId,
             string eventName,
             object eventData)
         {

--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -10,7 +10,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
-
+#nullable enable
 namespace DurableTask.Core
 {
     using System;
@@ -66,7 +66,7 @@ namespace DurableTask.Core
         /// <param name="serviceClient">Object implementing the <see cref="IOrchestrationServiceClient"/> interface </param>
         /// <param name="dataConverter">The <see cref="DataConverter"/> to use for message serialization.</param>
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging.</param>
-        public TaskHubClient(IOrchestrationServiceClient serviceClient, DataConverter dataConverter = null, ILoggerFactory loggerFactory = null)
+        public TaskHubClient(IOrchestrationServiceClient serviceClient, DataConverter? dataConverter = null, ILoggerFactory? loggerFactory = null)
         {
             this.ServiceClient = serviceClient ?? throw new ArgumentNullException(nameof(serviceClient));
             this.defaultConverter = dataConverter ?? JsonDataConverter.Default;
@@ -152,7 +152,7 @@ namespace DurableTask.Core
         /// <param name="orchestrationType">Type that derives from TaskOrchestration</param>
         /// <param name="input">Input parameter to the specified TaskOrchestration</param>
         /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
-        public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(Type orchestrationType, object input)
+        public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(Type orchestrationType, object? input)
         {
             return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 NameVersionHelper.GetDefaultName(orchestrationType),
@@ -328,6 +328,38 @@ namespace DurableTask.Core
                 dedupeStatuses,
                 eventName: null,
                 eventData: null);
+        }
+
+        /// <summary>
+        ///     Create a new orchestration of the specified name and version
+        /// </summary>
+        /// <param name="name">Name of the orchestration as specified by the ObjectCreator</param>
+        /// <param name="version">Name of the orchestration as specified by the ObjectCreator</param>
+        /// <param name="instanceId">Instance id for the orchestration to be created, must be unique across the Task Hub</param>
+        /// <param name="input">Input parameter to the specified TaskOrchestration</param>
+        /// <param name="tags">Dictionary of key/value tags associated with this instance</param>
+        /// <param name="dedupeStatuses">States of previous orchestration executions to be considered while de-duping new orchestrations on the client</param>
+        /// <param name="startAt">Orchestration start time</param>
+        /// <returns>OrchestrationInstance that represents the orchestration that was created</returns>
+        public Task<OrchestrationInstance> CreateOrchestrationInstanceAsync(
+            string name,
+            string version,
+            string instanceId,
+            object input,
+            IDictionary<string, string> tags,
+            OrchestrationStatus[] dedupeStatuses,
+            DateTime startAt)
+        {
+            return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
+                name,
+                version,
+                instanceId,
+                input,
+                tags,
+                dedupeStatuses,
+                eventName: null,
+                eventData: null,
+                startAt: startAt);
         }
 
         /// <summary>
@@ -593,15 +625,15 @@ namespace DurableTask.Core
         async Task<OrchestrationInstance> InternalCreateOrchestrationInstanceWithRaisedEventAsync(
             string orchestrationName,
             string orchestrationVersion,
-            string orchestrationInstanceId,
-            object orchestrationInput,
-            IDictionary<string, string> orchestrationTags,
-            OrchestrationStatus[] dedupeStatuses,
-            string eventName,
-            object eventData,
+            string? orchestrationInstanceId,
+            object? orchestrationInput,
+            IDictionary<string, string>? orchestrationTags,
+            OrchestrationStatus[]? dedupeStatuses,
+            string? eventName,
+            object? eventData,
             DateTime? startAt = null)
         {
-            TraceContextBase requestTraceContext = null;
+            TraceContextBase? requestTraceContext = null;
 
             // correlation 
             CorrelationTraceClient.Propagate(()=> { requestTraceContext = CreateOrExtractRequestTraceContext(eventName); });
@@ -618,7 +650,7 @@ namespace DurableTask.Core
             };
 
             string serializedOrchestrationData = this.defaultConverter.SerializeInternal(orchestrationInput);
-            var startedEvent = new ExecutionStartedEvent(-1, serializedOrchestrationData)
+            ExecutionStartedEvent startedEvent = new ExecutionStartedEvent(-1, serializedOrchestrationData)
             {
                 Tags = orchestrationTags,
                 Name = orchestrationName,
@@ -627,7 +659,7 @@ namespace DurableTask.Core
                 ScheduledStartTime = startAt
             };
 
-            var startMessage = new TaskMessage
+            TaskMessage startMessage = new TaskMessage
             {
                 OrchestrationInstance = orchestrationInstance,
                 Event = startedEvent
@@ -635,7 +667,7 @@ namespace DurableTask.Core
 
             this.logHelper.SchedulingOrchestration(startedEvent);
 
-            using Activity newActivity = TraceHelper.StartActivityForNewOrchestration(startedEvent);
+            using Activity? newActivity = TraceHelper.StartActivityForNewOrchestration(startedEvent);
 
             CorrelationTraceClient.Propagate(() => CreateAndTrackDependencyTelemetry(requestTraceContext));
 
@@ -679,9 +711,9 @@ namespace DurableTask.Core
             return orchestrationInstance;
         }
 
-        TraceContextBase CreateOrExtractRequestTraceContext(string eventName)
+        TraceContextBase CreateOrExtractRequestTraceContext(string? eventName)
         {
-            TraceContextBase requestTraceContext = null;
+            TraceContextBase? requestTraceContext = null;
             if (Activity.Current == null) // It is possible that the caller already has an activity.
             {
                 requestTraceContext = TraceContextFactory.Create($"{TraceConstants.Client}: {eventName}");
@@ -695,7 +727,7 @@ namespace DurableTask.Core
             return requestTraceContext;
         }
 
-        void CreateAndTrackDependencyTelemetry(TraceContextBase requestTraceContext)
+        void CreateAndTrackDependencyTelemetry(TraceContextBase? requestTraceContext)
         {
             TraceContextBase dependencyTraceContext = TraceContextFactory.Create(TraceConstants.Client);
             dependencyTraceContext.TelemetryType = TelemetryType.Dependency;
@@ -715,7 +747,8 @@ namespace DurableTask.Core
         /// <param name="eventData">Data for the event</param>
         public async Task RaiseEventAsync(OrchestrationInstance orchestrationInstance, string eventName, object eventData)
         {
-            if (string.IsNullOrWhiteSpace(orchestrationInstance?.InstanceId))
+
+            if (string.IsNullOrWhiteSpace(orchestrationInstance.InstanceId))
             {
                 throw new ArgumentException(nameof(orchestrationInstance));
             }
@@ -724,7 +757,7 @@ namespace DurableTask.Core
             
             // Distributed Tracing
             EventRaisedEvent eventRaisedEvent = new EventRaisedEvent(-1, serializedInput) { Name = eventName };
-            using Activity traceActivity = TraceHelper.StartActivityForNewEventRaisedFromClient(eventRaisedEvent, orchestrationInstance);
+            using Activity? traceActivity = TraceHelper.StartActivityForNewEventRaisedFromClient(eventRaisedEvent, orchestrationInstance);
 
             var taskMessage = new TaskMessage
             {
@@ -761,7 +794,12 @@ namespace DurableTask.Core
         /// <param name="reason">Reason for terminating the instance</param>
         public async Task TerminateInstanceAsync(OrchestrationInstance orchestrationInstance, string reason)
         {
-            if (string.IsNullOrWhiteSpace(orchestrationInstance?.InstanceId))
+            if (orchestrationInstance == null)
+            {
+                throw new ArgumentNullException(nameof(orchestrationInstance));
+            }
+
+            if (string.IsNullOrWhiteSpace(orchestrationInstance.InstanceId))
             {
                 throw new ArgumentException("orchestrationInstance");
             }
@@ -775,14 +813,19 @@ namespace DurableTask.Core
         /// </summary>
         /// <param name="orchestrationInstance">Instance to suspend</param>
         /// <param name="reason">Reason for suspending the instance</param>
-        public async Task SuspendInstanceAsync(OrchestrationInstance orchestrationInstance, string reason = null)
+        public async Task SuspendInstanceAsync(OrchestrationInstance orchestrationInstance, string? reason = null)
         {
-            if (string.IsNullOrWhiteSpace(orchestrationInstance?.InstanceId))
+            if (orchestrationInstance == null)
+            {
+                throw new ArgumentNullException(nameof(orchestrationInstance));
+            }
+
+            if (string.IsNullOrWhiteSpace(orchestrationInstance.InstanceId))
             {
                 throw new ArgumentException("orchestrationInstance");
             }
 
-            this.logHelper.SuspendingInstance(orchestrationInstance, reason);
+            this.logHelper.SuspendingInstance(orchestrationInstance, reason ?? string.Empty);
 
             var taskMessage = new TaskMessage
             {
@@ -798,14 +841,19 @@ namespace DurableTask.Core
         /// </summary>
         /// <param name="orchestrationInstance">Instance to resume</param>
         /// <param name="reason">Reason for resuming the instance</param>
-        public async Task ResumeInstanceAsync(OrchestrationInstance orchestrationInstance, string reason = null)
+        public async Task ResumeInstanceAsync(OrchestrationInstance orchestrationInstance, string? reason = null)
         {
-            if (string.IsNullOrWhiteSpace(orchestrationInstance?.InstanceId))
+            if (orchestrationInstance == null)
+            {
+                throw new ArgumentNullException(nameof(orchestrationInstance));
+            }
+
+            if (string.IsNullOrWhiteSpace(orchestrationInstance.InstanceId))
             {
                 throw new ArgumentException("orchestrationInstance");
             }
 
-            this.logHelper.ResumingInstance(orchestrationInstance, reason);
+            this.logHelper.ResumingInstance(orchestrationInstance, reason ?? string.Empty);
 
             var taskMessage = new TaskMessage
             {
@@ -825,7 +873,12 @@ namespace DurableTask.Core
             OrchestrationInstance orchestrationInstance,
             TimeSpan timeout)
         {
-            if (string.IsNullOrWhiteSpace(orchestrationInstance?.InstanceId))
+            if (orchestrationInstance == null)
+            {
+                throw new ArgumentException(nameof(orchestrationInstance));
+            }
+
+            if (string.IsNullOrWhiteSpace(orchestrationInstance.InstanceId))
             {
                 throw new ArgumentException(nameof(orchestrationInstance));
             }
@@ -849,7 +902,12 @@ namespace DurableTask.Core
             TimeSpan timeout,
             CancellationToken cancellationToken)
         {
-            if (string.IsNullOrWhiteSpace(orchestrationInstance?.InstanceId))
+            if (orchestrationInstance == null)
+            {
+                throw new ArgumentException(nameof(orchestrationInstance));
+            }
+
+            if (string.IsNullOrWhiteSpace(orchestrationInstance.InstanceId))
             {
                 throw new ArgumentException(nameof(orchestrationInstance));
             }
@@ -871,7 +929,7 @@ namespace DurableTask.Core
         /// <param name="instanceId">Instance id</param>
         /// <returns>The OrchestrationState of the specified instanceId or null if not found</returns>
         /// <exception cref="InvalidOperationException">Thrown if instance store not configured</exception>
-        public async Task<OrchestrationState> GetOrchestrationStateAsync(string instanceId)
+        public async Task<OrchestrationState?> GetOrchestrationStateAsync(string instanceId)
         {
             IList<OrchestrationState> state = await this.GetOrchestrationStateAsync(instanceId, false);
             return state?.FirstOrDefault();
@@ -934,7 +992,12 @@ namespace DurableTask.Core
         /// <exception cref="InvalidOperationException">Thrown if instance store not configured</exception>
         public Task<string> GetOrchestrationHistoryAsync(OrchestrationInstance instance)
         {
-            if (string.IsNullOrWhiteSpace(instance?.InstanceId) ||
+            if (instance == null)
+            {
+                throw new ArgumentNullException(nameof(instance));
+            }
+
+            if (string.IsNullOrWhiteSpace(instance.InstanceId) ||
                 string.IsNullOrWhiteSpace(instance.ExecutionId))
             {
                 throw new ArgumentException("instance, instanceId and/or ExecutionId cannot be null or empty", nameof(instance));

--- a/src/DurableTask.Core/TaskHubClient.cs
+++ b/src/DurableTask.Core/TaskHubClient.cs
@@ -220,7 +220,7 @@ namespace DurableTask.Core
             Type orchestrationType,
             string? instanceId,
             object? input,
-            OrchestrationStatus[] dedupeStatuses)
+            OrchestrationStatus[]? dedupeStatuses)
         {
             return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 NameVersionHelper.GetDefaultName(orchestrationType),
@@ -316,8 +316,8 @@ namespace DurableTask.Core
             string version,
             string? instanceId,
             object? input,
-            IDictionary<string, string> tags,
-            OrchestrationStatus[] dedupeStatuses)
+            IDictionary<string, string>? tags,
+            OrchestrationStatus[]? dedupeStatuses)
         {
             return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(
                 name,
@@ -346,8 +346,8 @@ namespace DurableTask.Core
             string version,
             string? instanceId,
             object? input,
-            IDictionary<string, string> tags,
-            OrchestrationStatus[] dedupeStatuses,
+            IDictionary<string, string>? tags,
+            OrchestrationStatus[]? dedupeStatuses,
             DateTime startAt)
         {
             return this.InternalCreateOrchestrationInstanceWithRaisedEventAsync(

--- a/src/DurableTask.Emulator/LocalOrchestrationService.cs
+++ b/src/DurableTask.Emulator/LocalOrchestrationService.cs
@@ -175,7 +175,7 @@ namespace DurableTask.Emulator
         }
 
         /// <inheritdoc />
-        public Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, OrchestrationStatus[] dedupeStatuses)
+        public virtual Task CreateTaskOrchestrationAsync(TaskMessage creationMessage, OrchestrationStatus[] dedupeStatuses)
         {
             var ee = creationMessage.Event as ExecutionStartedEvent;
 


### PR DESCRIPTION
Related: https://github.com/Azure/azure-functions-durable-extension/pull/2805

In the PR above, we learned if a user wants to _schedule_ an orchestrator to start a particular time, they need to use the `CreateScheduledOrchestrationInstanceAsync` instead of using the more commonly used `CreateOrchestrationInstanceAsync` API. 

Allowing `CreateOrchestrationInstanceAsync` to also schedule orchestrators by accepting a new `fireAt` would simplify things downstream (in durabletask-dotnet, it would simplify the PR linked above^) so this PR adds that "missing" parameter. This does create some repetition (there are now two APIs that allow users to schedule orchestrators) but I think it makes the orchestrator-scheduling feature more discoverable while also helping simplify downstream code.

This PR also include 2 additional minor contributions:
1) It enables nullable analysis in TaskHubClient, and performs the minimal edits needed to get the analysis to pass.
2) It adds a simple TaskHubClient test validating that the class is able to schedule orchestrators to fire at a given time.