### PR TITLE
Migrate DurableTask.ServiceBus Table and Blob store SDK from WindowsAzure.Storage to Azure.Data.Tables and Azure.Storage.Blobs

### DIFF
--- a/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
+++ b/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
@@ -8,7 +8,7 @@
 
     <!-- Version Info -->
   <PropertyGroup>
-    <MajorVersion>3</MajorVersion>
+    <MajorVersion>4</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
 

--- a/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
+++ b/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
 	<PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
+	<PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
     <PackageReference Include="ImpromptuInterface" version="6.2.2" />
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" version="1.0.0" />
     <PackageReference Include="Microsoft.Data.Edm" version="5.8.5" />
@@ -32,14 +33,13 @@
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" />
     <PackageReference Include="System.Spatial" version="5.8.5" />
     <PackageReference Include="WindowsAzure.ServiceBus" version="4.1.3" />
-    <PackageReference Include="WindowsAzure.Storage" version="7.0.0" />
     <Reference Include="System.Transactions" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
 	<PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
+	<PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.0" />
-    <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
+++ b/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
@@ -23,6 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+	<PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
     <PackageReference Include="ImpromptuInterface" version="6.2.2" />
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" version="1.0.0" />
     <PackageReference Include="Microsoft.Data.Edm" version="5.8.5" />
@@ -36,6 +37,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+	<PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.0" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
   </ItemGroup>

--- a/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
+++ b/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
@@ -23,8 +23,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-	<PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
-	<PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
     <PackageReference Include="ImpromptuInterface" version="6.2.2" />
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" version="1.0.0" />
     <PackageReference Include="Microsoft.Data.Edm" version="5.8.5" />
@@ -37,8 +37,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-	<PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
-	<PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.0" />
   </ItemGroup>
 

--- a/src/DurableTask.ServiceBus/Tracking/AzureStorageBlobStore.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureStorageBlobStore.cs
@@ -41,7 +41,7 @@ namespace DurableTask.ServiceBus.Tracking
         }
 
         /// <summary>
-        /// Construct a blob storage client instance with hub name and cloud storage account
+        /// Creates a new AzureStorageBlobStore using the supplied hub name, endpoint and token credential
         /// </summary>
         /// <param name="hubName">The hub name</param>
         /// <param name="endpoint">Uri Endpoint for the blob store</param>

--- a/src/DurableTask.ServiceBus/Tracking/AzureStorageBlobStore.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureStorageBlobStore.cs
@@ -16,9 +16,9 @@ namespace DurableTask.ServiceBus.Tracking
     using System;
     using System.IO;
     using System.Threading.Tasks;
+    using Azure.Core;
     using DurableTask.Core;
     using DurableTask.Core.Tracking;
-    using Microsoft.WindowsAzure.Storage;
 
     /// <summary>
     /// Azure blob storage to allow save and load large blobs, such as message and session, as a stream using Azure blob container.
@@ -41,13 +41,14 @@ namespace DurableTask.ServiceBus.Tracking
         }
 
         /// <summary>
-        /// Creates a new AzureStorageBlobStore using the supplied hub name and cloud storage account
+        /// Construct a blob storage client instance with hub name and cloud storage account
         /// </summary>
-        /// <param name="hubName">The hub name for this store</param>
-        /// <param name="cloudStorageAccount">Azure Cloud Storage Account</param>
-        public AzureStorageBlobStore(string hubName, CloudStorageAccount cloudStorageAccount)
+        /// <param name="hubName">The hub name</param>
+        /// <param name="endpoint">Uri Endpoint for the blob store</param>
+        /// <param name="credential">Token Credentials required for accessing the blob store</param>
+        public AzureStorageBlobStore(string hubName, Uri endpoint, TokenCredential credential)
         {
-            this.blobClient = new BlobStorageClient(hubName, cloudStorageAccount);
+            this.blobClient = new BlobStorageClient(hubName, endpoint, credential);
         }
 
         /// <summary>

--- a/src/DurableTask.ServiceBus/Tracking/AzureTableClient.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureTableClient.cs
@@ -59,6 +59,8 @@ namespace DurableTask.ServiceBus.Tracking
 
             this.tableClient = new TableServiceClient(tableConnectionString);
             this.hubName = hubName;
+            this.jumpStartTableClient = tableClient.GetTableClient(JumpStartTableName);
+            this.historyTableClient = tableClient.GetTableClient(TableName);
         }
 
         public AzureTableClient(string hubName, Uri endpoint, TokenCredential credential)
@@ -80,6 +82,8 @@ namespace DurableTask.ServiceBus.Tracking
 
             this.tableClient = new TableServiceClient(endpoint, credential);
             this.hubName = hubName;
+            this.jumpStartTableClient = tableClient.GetTableClient(JumpStartTableName);
+            this.historyTableClient = tableClient.GetTableClient(TableName);
         }
 
         public string TableName => AzureTableConstants.InstanceHistoryTableNamePrefix + "00" + this.hubName;
@@ -88,14 +92,14 @@ namespace DurableTask.ServiceBus.Tracking
 
         internal async Task CreateTableIfNotExistsAsync()
         {
-            await this.tableClient.CreateTableIfNotExistsAsync(TableName);
             this.historyTableClient = tableClient.GetTableClient(TableName);
+            await this.tableClient.CreateTableIfNotExistsAsync(TableName);
         }
 
         internal async Task CreateJumpStartTableIfNotExistsAsync()
         {
-            await this.tableClient.CreateTableIfNotExistsAsync(JumpStartTableName);
             this.jumpStartTableClient = tableClient.GetTableClient(JumpStartTableName);
+            await this.tableClient.CreateTableIfNotExistsAsync(JumpStartTableName);
         }
 
         internal async Task DeleteTableIfExistsAsync()
@@ -392,7 +396,7 @@ namespace DurableTask.ServiceBus.Tracking
             where T : class, ITableEntity
         {
             var pageableResults = tableClient.QueryAsync<T>(filter: filter, 
-                maxPerPage: count > 0? count: default);
+                maxPerPage: count > 0? count: null);
 
             var results = new List<T>();
 

--- a/src/DurableTask.ServiceBus/Tracking/AzureTableClient.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureTableClient.cs
@@ -121,7 +121,7 @@ namespace DurableTask.ServiceBus.Tracking
         public Task<IEnumerable<AzureTableOrchestrationStateEntity>> QueryOrchestrationStatesAsync(
             OrchestrationStateQuery stateQuery)
         {
-            var query = CreateQueryInternal(stateQuery,false);
+            var query = CreateQueryInternal(stateQuery, false);
             return ReadAllEntitiesAsync<AzureTableOrchestrationStateEntity>(query, this.historyTableClient);
         }
 
@@ -267,13 +267,13 @@ namespace DurableTask.ServiceBus.Tracking
 
         string GetSecondaryFilterExpression(OrchestrationStateQueryFilter filter)
         {
-            string filterExpression;
+            string query;
 
             if (filter is OrchestrationStateInstanceFilter orchestrationStateInstanceFilter)
             {
                 if (orchestrationStateInstanceFilter.StartsWith)
                 {
-                    filterExpression = string.Format(CultureInfo.InvariantCulture,
+                    query = string.Format(CultureInfo.InvariantCulture,
                         AzureTableConstants.InstanceQuerySecondaryFilterRangeTemplate,
                         orchestrationStateInstanceFilter.InstanceId, ComputeNextKeyInRange(orchestrationStateInstanceFilter.InstanceId));
                 }
@@ -281,12 +281,12 @@ namespace DurableTask.ServiceBus.Tracking
                 {
                     if (string.IsNullOrWhiteSpace(orchestrationStateInstanceFilter.ExecutionId))
                     {
-                        filterExpression = string.Format(CultureInfo.InvariantCulture,
+                        query = string.Format(CultureInfo.InvariantCulture,
                             AzureTableConstants.InstanceQuerySecondaryFilterTemplate, orchestrationStateInstanceFilter.InstanceId);
                     }
                     else
                     {
-                        filterExpression = string.Format(CultureInfo.InvariantCulture,
+                        query = string.Format(CultureInfo.InvariantCulture,
                             AzureTableConstants.InstanceQuerySecondaryFilterExactTemplate, orchestrationStateInstanceFilter.InstanceId,
                             orchestrationStateInstanceFilter.ExecutionId);
                     }
@@ -296,12 +296,12 @@ namespace DurableTask.ServiceBus.Tracking
             {
                 if (orchestrationStateNameVersionFilter.Version == null)
                 {
-                    filterExpression = string.Format(CultureInfo.InvariantCulture,
+                    query = string.Format(CultureInfo.InvariantCulture,
                         AzureTableConstants.NameVersionQuerySecondaryFilterTemplate, orchestrationStateNameVersionFilter.Name);
                 }
                 else
                 {
-                    filterExpression = string.Format(CultureInfo.InvariantCulture,
+                    query = string.Format(CultureInfo.InvariantCulture,
                         AzureTableConstants.NameVersionQuerySecondaryFilterExactTemplate, orchestrationStateNameVersionFilter.Name,
                         orchestrationStateNameVersionFilter.Version);
                 }
@@ -309,7 +309,7 @@ namespace DurableTask.ServiceBus.Tracking
             else if (filter is OrchestrationStateStatusFilter orchestrationStateStatusFilter)
             {
                 string template = AzureTableConstants.StatusQuerySecondaryFilterTemplate;
-                filterExpression = string.Format(CultureInfo.InvariantCulture,
+                query = string.Format(CultureInfo.InvariantCulture,
                     template, ComparisonOperatorMap[orchestrationStateStatusFilter.ComparisonType], orchestrationStateStatusFilter.Status);
             }
             else if (filter is OrchestrationStateTimeRangeFilter orchestrationStateTimeRangeFilter)
@@ -323,15 +323,15 @@ namespace DurableTask.ServiceBus.Tracking
                 switch (orchestrationStateTimeRangeFilter.FilterType)
                 {
                     case OrchestrationStateTimeRangeFilterType.OrchestrationCreatedTimeFilter:
-                        filterExpression = string.Format(CultureInfo.InvariantCulture,
+                        query = string.Format(CultureInfo.InvariantCulture,
                             AzureTableConstants.CreatedTimeRangeQuerySecondaryFilterTemplate, startTime, endTime);
                         break;
                     case OrchestrationStateTimeRangeFilterType.OrchestrationCompletedTimeFilter:
-                        filterExpression = string.Format(CultureInfo.InvariantCulture,
+                        query = string.Format(CultureInfo.InvariantCulture,
                             AzureTableConstants.CompletedTimeRangeQuerySecondaryFilterTemplate, startTime, endTime);
                         break;
                     case OrchestrationStateTimeRangeFilterType.OrchestrationLastUpdatedTimeFilter:
-                        filterExpression = string.Format(CultureInfo.InvariantCulture,
+                        query = string.Format(CultureInfo.InvariantCulture,
                             AzureTableConstants.LastUpdatedTimeRangeQuerySecondaryFilterTemplate, startTime, endTime);
                         break;
                     default:
@@ -343,7 +343,7 @@ namespace DurableTask.ServiceBus.Tracking
                 throw new InvalidOperationException("Unsupported filter type: " + filter.GetType());
             }
 
-            return filterExpression;
+            return query;
         }
 
         private static readonly DateTimeOffset MinDateTime = new DateTimeOffset(1601, 1, 1, 0, 0, 0, TimeSpan.Zero);

--- a/src/DurableTask.ServiceBus/Tracking/AzureTableClient.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureTableClient.cs
@@ -184,15 +184,15 @@ namespace DurableTask.ServiceBus.Tracking
                 secondaryFilters = filters.Item2;
             }
 
-            string filterExpression = GetPrimaryFilterExpression(primaryFilter, useTimeRangePrimaryFilter);
-            if (string.IsNullOrWhiteSpace(filterExpression))
+            string query = GetPrimaryFilterExpression(primaryFilter, useTimeRangePrimaryFilter);
+            if (string.IsNullOrWhiteSpace(query))
             {
                 throw new InvalidOperationException("Invalid primary filter");
             }
 
             if (secondaryFilters != null)
             {
-                filterExpression = secondaryFilters.Aggregate(filterExpression,
+                query = secondaryFilters.Aggregate(query,
                     (current, filter) =>
                     {
                         string newFilter = current;
@@ -206,7 +206,7 @@ namespace DurableTask.ServiceBus.Tracking
                     });
             }
 
-            return filterExpression;
+            return query;
         }
 
         string GetPrimaryFilterExpression(OrchestrationStateQueryFilter filter, bool isJumpStartTable)

--- a/src/DurableTask.ServiceBus/Tracking/AzureTableClient.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureTableClient.cs
@@ -95,7 +95,7 @@ namespace DurableTask.ServiceBus.Tracking
         internal async Task CreateJumpStartTableIfNotExistsAsync()
         {
             await this.tableClient.CreateTableIfNotExistsAsync(JumpStartTableName);
-            this.historyTableClient = tableClient.GetTableClient(JumpStartTableName);
+            this.jumpStartTableClient = tableClient.GetTableClient(JumpStartTableName);
         }
 
         internal async Task DeleteTableIfExistsAsync()

--- a/src/DurableTask.ServiceBus/Tracking/AzureTableCompositeTableEntity.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureTableCompositeTableEntity.cs
@@ -15,8 +15,8 @@ namespace DurableTask.ServiceBus.Tracking
 {
     using System;
     using System.Collections.Generic;
-    using Microsoft.WindowsAzure.Storage;
-    using Microsoft.WindowsAzure.Storage.Table;
+    using Azure;
+    using Azure.Data.Tables;
 
     /// <summary>
     /// Abstract class for composite entities for Azure table
@@ -41,40 +41,13 @@ namespace DurableTask.ServiceBus.Tracking
         /// <summary>
         /// Gets or sets the row timestamp
         /// </summary>
-        public DateTimeOffset Timestamp { get; set; } = DateTimeOffset.Now;
+        public DateTimeOffset? Timestamp { get; set; } = DateTimeOffset.Now;
 
         /// <summary>
         /// Gets or sets the entity etag
         /// </summary>
-        public string ETag { get; set; }
-
-        /// <summary>
-        /// Read an entity properties based on the supplied dictionary or entity properties
-        /// </summary>
-        /// <param name="properties">Dictionary of properties to read for the entity</param>
-        /// <param name="operationContext">The operation context</param>
-        public abstract void ReadEntity(IDictionary<string, EntityProperty> properties, OperationContext operationContext);
-
-        /// <summary>
-        /// Write an entity to a dictionary of entity properties
-        /// </summary>
-        /// <param name="operationContext">The operation context</param>
-        public abstract IDictionary<string, EntityProperty> WriteEntity(OperationContext operationContext);
+        public ETag ETag { get; set; }
 
         internal abstract IEnumerable<ITableEntity> BuildDenormalizedEntities();
-
-        /// <summary>
-        /// 
-        /// </summary>
-        protected T GetValue<T>(string key, IDictionary<string, EntityProperty> properties,
-            Func<EntityProperty, T> extract)
-        {
-            if (!properties.TryGetValue(key, out EntityProperty ep))
-            {
-                return default(T);
-            }
-
-            return extract(ep);
-        }
     }
 }

--- a/src/DurableTask.ServiceBus/Tracking/AzureTableInstanceStore.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureTableInstanceStore.cs
@@ -17,14 +17,15 @@ namespace DurableTask.ServiceBus.Tracking
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Net;
     using System.Text;
     using System.Threading.Tasks;
+    using Azure;
+    using Azure.Core;
     using DurableTask.Core;
     using DurableTask.Core.Common;
     using DurableTask.Core.Serializing;
     using DurableTask.Core.Tracking;
-    using Microsoft.WindowsAzure.Storage;
-    using Microsoft.WindowsAzure.Storage.Table;
 
     /// <summary>
     /// Azure Table Instance store provider to allow storage and lookup for orchestration state event history with query support
@@ -61,15 +62,21 @@ namespace DurableTask.ServiceBus.Tracking
         }
 
         /// <summary>
-        /// Creates a new AzureTableInstanceStore using the supplied hub name and cloud storage account
+        /// Creates a new AzureTableInstanceStore using the supplied hub name, Uri endpoint, and Token Crednetial
         /// </summary>
         /// <param name="hubName">The hub name for this instance store</param>
-        /// <param name="cloudStorageAccount">Cloud Storage Account</param>
-        public AzureTableInstanceStore(string hubName, CloudStorageAccount cloudStorageAccount)
+        /// <param name="endpoint">Uri Endpoint for the instance store</param>
+        /// <param name="credential">Token Credentials required for accessing the instance store</param>
+        public AzureTableInstanceStore(string hubName, Uri endpoint, TokenCredential credential)
         {
-            if (cloudStorageAccount == null)
+            if (endpoint == null)
             {
-                throw new ArgumentException("Invalid Cloud Storage Account", nameof(cloudStorageAccount));
+                throw new ArgumentException("Invalid Uri Endpoint", nameof(endpoint));
+            }
+
+            if (credential == null)
+            {
+                throw new ArgumentException("Invalid Token Credential", nameof(credential));
             }
 
             if (string.IsNullOrWhiteSpace(hubName))
@@ -77,7 +84,7 @@ namespace DurableTask.ServiceBus.Tracking
                 throw new ArgumentException("Invalid hub name", nameof(hubName));
             }
 
-            this.tableClient = new AzureTableClient(hubName, cloudStorageAccount);
+            this.tableClient = new AzureTableClient(hubName, endpoint, credential);
 
             // Workaround an issue with Storage that throws exceptions for any date < 1600 so DateTime.Min cannot be used
             DateTimeUtils.SetMinDateTimeForStorageEmulator();
@@ -287,23 +294,14 @@ namespace DurableTask.ServiceBus.Tracking
         public async Task<OrchestrationStateQuerySegment> QueryOrchestrationStatesSegmentedAsync(
             OrchestrationStateQuery stateQuery, string continuationToken, int count)
         {
-            TableContinuationToken tokenObj = null;
-
-            if (continuationToken != null)
-            {
-                tokenObj = DeserializeTableContinuationToken(continuationToken);
-            }
-
-            TableQuerySegment<AzureTableOrchestrationStateEntity> results =
-                await this.tableClient.QueryOrchestrationStatesSegmentedAsync(stateQuery, tokenObj, count)
+            Page<AzureTableOrchestrationStateEntity> results =
+                await this.tableClient.QueryOrchestrationStatesSegmentedAsync(stateQuery, continuationToken, count)
                         .ConfigureAwait(false);
 
             return new OrchestrationStateQuerySegment
             {
-                Results = results.Results.Select(s => s.State),
-                ContinuationToken = results.ContinuationToken == null
-                    ? null
-                    : SerializeTableContinuationToken(results.ContinuationToken)
+                Results = results.Values.Select(s => s.State),
+                ContinuationToken = results.ContinuationToken
             };
         }
 
@@ -315,12 +313,12 @@ namespace DurableTask.ServiceBus.Tracking
         /// <returns>The number of history events purged.</returns>
         public async Task<int> PurgeOrchestrationHistoryEventsAsync(DateTime thresholdDateTimeUtc, OrchestrationStateTimeRangeFilterType timeRangeFilterType)
         {
-            TableContinuationToken continuationToken = null;
+            string continuationToken = null;
 
             var purgeCount = 0;
             do
             {
-                TableQuerySegment<AzureTableOrchestrationStateEntity> resultSegment =
+                Page<AzureTableOrchestrationStateEntity> resultSegment =
                     (await this.tableClient.QueryOrchestrationStatesSegmentedAsync(
                         new OrchestrationStateQuery()
                             .AddTimeRangeFilter(DateTimeUtils.MinDateTime, thresholdDateTimeUtc, timeRangeFilterType),
@@ -329,10 +327,10 @@ namespace DurableTask.ServiceBus.Tracking
 
                 continuationToken = resultSegment.ContinuationToken;
 
-                if (resultSegment.Results != null)
+                if (resultSegment.Values != null)
                 {
                     await PurgeOrchestrationHistorySegmentAsync(resultSegment).ConfigureAwait(false);
-                    purgeCount += resultSegment.Results.Count;
+                    purgeCount += resultSegment.Values.Count;
                 }
             } while (continuationToken != null);
 
@@ -340,12 +338,12 @@ namespace DurableTask.ServiceBus.Tracking
         }
 
         async Task PurgeOrchestrationHistorySegmentAsync(
-            TableQuerySegment<AzureTableOrchestrationStateEntity> orchestrationStateEntitySegment)
+            Page<AzureTableOrchestrationStateEntity> orchestrationStateEntitySegment)
         {
-            var stateEntitiesToDelete = new List<AzureTableOrchestrationStateEntity>(orchestrationStateEntitySegment.Results);
+            var stateEntitiesToDelete = new List<AzureTableOrchestrationStateEntity>(orchestrationStateEntitySegment.Values);
 
             var historyEntitiesToDelete = new ConcurrentBag<IEnumerable<AzureTableOrchestrationHistoryEventEntity>>();
-            await Task.WhenAll(orchestrationStateEntitySegment.Results.Select(
+            await Task.WhenAll(orchestrationStateEntitySegment.Values.Select(
                 entity => Task.Run(async () =>
                 {
                     IEnumerable<AzureTableOrchestrationHistoryEventEntity> historyEntities =
@@ -462,29 +460,6 @@ namespace DurableTask.ServiceBus.Tracking
                 EventTimestamp = entity.TaskTimeStamp,
                 HistoryEvent = entity.HistoryEvent
             };
-        }
-
-        string SerializeTableContinuationToken(TableContinuationToken continuationToken)
-        {
-            if (continuationToken == null)
-            {
-                throw new ArgumentNullException(nameof(continuationToken));
-            }
-
-            string serializedToken = JsonDataConverter.Default.Serialize(continuationToken);
-            return Convert.ToBase64String(Encoding.Unicode.GetBytes(serializedToken));
-        }
-
-        TableContinuationToken DeserializeTableContinuationToken(string serializedContinuationToken)
-        {
-            if (string.IsNullOrWhiteSpace(serializedContinuationToken))
-            {
-                throw new ArgumentException("Invalid serializedContinuationToken");
-            }
-
-            byte[] tokenBytes = Convert.FromBase64String(serializedContinuationToken);
-
-            return JsonDataConverter.Default.Deserialize<TableContinuationToken>(Encoding.Unicode.GetString(tokenBytes));
         }
     }
 }

--- a/src/DurableTask.ServiceBus/Tracking/AzureTableInstanceStore.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureTableInstanceStore.cs
@@ -62,7 +62,7 @@ namespace DurableTask.ServiceBus.Tracking
         }
 
         /// <summary>
-        /// Creates a new AzureTableInstanceStore using the supplied hub name, Uri endpoint, and Token Crednetial
+        /// Creates a new AzureTableInstanceStore using the supplied hub name, Uri endpoint, and Token Credential
         /// </summary>
         /// <param name="hubName">The hub name for this instance store</param>
         /// <param name="endpoint">Uri Endpoint for the instance store</param>

--- a/src/DurableTask.ServiceBus/Tracking/AzureTableOrchestrationHistoryEventEntity.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureTableOrchestrationHistoryEventEntity.cs
@@ -93,7 +93,7 @@ namespace DurableTask.ServiceBus.Tracking
         /// <summary>
         /// Gets or set the history event detail for the tracking entity
         /// </summary>
-        [IgnoreDataMember]
+        [IgnoreDataMember] // see HistoryEventJson
         public HistoryEvent HistoryEvent { get; set; }
 
 #pragma warning disable 1591

--- a/src/DurableTask.ServiceBus/Tracking/AzureTableOrchestrationHistoryEventEntity.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureTableOrchestrationHistoryEventEntity.cs
@@ -122,7 +122,7 @@ namespace DurableTask.ServiceBus.Tracking
             return $"Instance Id: {InstanceId} Execution Id: {ExecutionId} Seq: {SequenceNumber.ToString()} Time: {TaskTimeStamp} HistoryEvent: {HistoryEvent.EventType.ToString()}";
         }
 
-        #region
+        #region AzureStorageHelpers
         // This public accessor is only used to safely interact with the Azure Table Storage SDK, which reads and writes using reflection.
         // This is an artifact of updating from and SDK that did not use reflection.
         [DataMember(Name = "HistoryEvent")]

--- a/src/DurableTask.ServiceBus/Tracking/AzureTableOrchestrationJumpStartEntity.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureTableOrchestrationJumpStartEntity.cs
@@ -16,8 +16,7 @@ namespace DurableTask.ServiceBus.Tracking
     using System;
     using System.Collections.Generic;
     using System.Globalization;
-    using Microsoft.WindowsAzure.Storage;
-    using Microsoft.WindowsAzure.Storage.Table;
+    using Azure.Data.Tables;
     using DurableTask.Core.Tracking;
 
     /// <summary>
@@ -65,32 +64,6 @@ namespace DurableTask.ServiceBus.Tracking
                              AzureTableConstants.JoinDelimiter + State.OrchestrationInstance.InstanceId +
                              AzureTableConstants.JoinDelimiter + State.OrchestrationInstance.ExecutionId;
             return new [] { entity1 };
-        }
-
-        /// <summary>
-        /// Write an entity to a dictionary of entity properties
-        /// </summary>
-        /// <param name="operationContext">The operation context</param>
-        public override IDictionary<string, EntityProperty> WriteEntity(OperationContext operationContext)
-        {
-            IDictionary<string, EntityProperty> returnValues = base.WriteEntity(operationContext);
-            returnValues.Add("JumpStartTime", new EntityProperty(JumpStartTime));
-            return returnValues;
-        }
-
-        /// <summary>
-        /// Read an entity properties based on the supplied dictionary or entity properties
-        /// </summary>
-        /// <param name="properties">Dictionary of properties to read for the entity</param>
-        /// <param name="operationContext">The operation context</param>
-        public override void ReadEntity(IDictionary<string, EntityProperty> properties,
-            OperationContext operationContext)
-        {
-            base.ReadEntity(properties, operationContext);
-            JumpStartTime =
-                GetValue("JumpStartTime", properties, property => property.DateTimeOffsetValue)
-                    .GetValueOrDefault()
-                    .DateTime;
         }
 
         /// <summary>

--- a/src/DurableTask.ServiceBus/Tracking/AzureTableOrchestrationJumpStartEntity.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureTableOrchestrationJumpStartEntity.cs
@@ -23,7 +23,7 @@ namespace DurableTask.ServiceBus.Tracking
     /// <summary>
     /// History Tracking Entity for orchestration jump start event
     /// </summary>
-    public class AzureTableOrchestrationJumpStartEntity : AzureTableOrchestrationStateEntity
+    internal class AzureTableOrchestrationJumpStartEntity : AzureTableOrchestrationStateEntity
     {
         /// <summary>
         /// Gets or sets the date and time for the jump start event

--- a/src/DurableTask.ServiceBus/Tracking/AzureTableOrchestrationJumpStartEntity.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureTableOrchestrationJumpStartEntity.cs
@@ -16,6 +16,7 @@ namespace DurableTask.ServiceBus.Tracking
     using System;
     using System.Collections.Generic;
     using System.Globalization;
+    using System.Runtime.Serialization;
     using Azure.Data.Tables;
     using DurableTask.Core.Tracking;
 
@@ -49,6 +50,7 @@ namespace DurableTask.ServiceBus.Tracking
         /// <summary>
         /// Gets a OrchestrationJumpStartInstanceEntity
         /// </summary>
+        [IgnoreDataMember]
         public OrchestrationJumpStartInstanceEntity OrchestrationJumpStartInstanceEntity => new OrchestrationJumpStartInstanceEntity
         {
             State = State,

--- a/src/DurableTask.ServiceBus/Tracking/AzureTableOrchestrationJumpStartEntity.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureTableOrchestrationJumpStartEntity.cs
@@ -50,7 +50,7 @@ namespace DurableTask.ServiceBus.Tracking
         /// <summary>
         /// Gets a OrchestrationJumpStartInstanceEntity
         /// </summary>
-        [IgnoreDataMember]
+        [IgnoreDataMember] //This data is accessed by JumpStartTime above, and the AzureStoreHelpers region in AzureTableOrchestrationStateEntity.cs
         public OrchestrationJumpStartInstanceEntity OrchestrationJumpStartInstanceEntity => new OrchestrationJumpStartInstanceEntity
         {
             State = State,

--- a/src/DurableTask.ServiceBus/Tracking/AzureTableOrchestrationStateEntity.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureTableOrchestrationStateEntity.cs
@@ -26,6 +26,7 @@ namespace DurableTask.ServiceBus.Tracking
     /// </summary>
     public class AzureTableOrchestrationStateEntity : AzureTableCompositeTableEntity
     {
+        [IgnoreDataMember]
         readonly DataConverter dataConverter;
 
         /// <summary>

--- a/src/DurableTask.ServiceBus/Tracking/AzureTableOrchestrationStateEntity.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureTableOrchestrationStateEntity.cs
@@ -26,7 +26,7 @@ namespace DurableTask.ServiceBus.Tracking
     /// </summary>
     internal class AzureTableOrchestrationStateEntity : AzureTableCompositeTableEntity
     {
-        [IgnoreDataMember]
+        [IgnoreDataMember] // This property needs to be ignored to safely be skipped by the Azure Storage SDK
         readonly DataConverter dataConverter;
 
         /// <summary>
@@ -51,7 +51,7 @@ namespace DurableTask.ServiceBus.Tracking
         /// <summary>
         /// Gets or sets the orchestration state for the entity
         /// </summary>
-        [IgnoreDataMember]
+        [IgnoreDataMember] // See AzureStorageHelpers Region
         public OrchestrationState State { get; set; }
 
 
@@ -87,10 +87,11 @@ namespace DurableTask.ServiceBus.Tracking
                 State.CompressedSize);
         }
 
-        #region
+        #region AzureStorageHelpers
         // Public Accessors with the Sate prefix are equivalent to those in the already existing State Property.
         // These are used only to safely interact with the Azure Table Storage SDK which reads and writes using reflection.
-        // This is an artifact of updating from and SDK that did not use reflection.
+        // This is an artifact of updating from an SDK that did not use reflection.
+
         [DataMember(Name = "InstanceId")]
         public string StateInstanceId
         {

--- a/src/DurableTask.ServiceBus/Tracking/AzureTableOrchestrationStateEntity.cs
+++ b/src/DurableTask.ServiceBus/Tracking/AzureTableOrchestrationStateEntity.cs
@@ -60,14 +60,22 @@ namespace DurableTask.ServiceBus.Tracking
         public string StateInstanceId
         {
             get => State.OrchestrationInstance.InstanceId;
-            set => State.OrchestrationInstance.InstanceId = value;
+            set
+            {
+                CreateStateIfNotExists();
+                State.OrchestrationInstance.InstanceId = value;
+            }
         }
 
         [DataMember(Name = "ExecutionId")]
         public string StateExecutionId
         {
             get => State.OrchestrationInstance.ExecutionId;
-            set => State.OrchestrationInstance.ExecutionId = value;
+            set
+            {
+                CreateStateIfNotExists();
+                State.OrchestrationInstance.ExecutionId = value;
+            }
         }
 
         [DataMember(Name = "ParentInstanceId")]
@@ -76,10 +84,8 @@ namespace DurableTask.ServiceBus.Tracking
             get => State.ParentInstance?.OrchestrationInstance.InstanceId;
             set
             {
-                if (State.ParentInstance != null)
-                {
-                    State.ParentInstance.OrchestrationInstance.InstanceId = value;
-                }
+                CreateStateIfNotExists();
+                State.ParentInstance.OrchestrationInstance.InstanceId = value;
             }
         }
 
@@ -89,10 +95,8 @@ namespace DurableTask.ServiceBus.Tracking
             get => State.ParentInstance?.OrchestrationInstance.ExecutionId;
             set
             {
-                if (State.ParentInstance != null)
-                {
-                    State.ParentInstance.OrchestrationInstance.ExecutionId = value;
-                }
+                CreateStateIfNotExists();
+                State.ParentInstance.OrchestrationInstance.ExecutionId = value;
             }
         }
 
@@ -100,21 +104,33 @@ namespace DurableTask.ServiceBus.Tracking
         public string StateName
         {
             get => State.Name;
-            set => State.Name = value;
+            set
+            {
+                CreateStateIfNotExists();
+                State.Name = value;
+            }
         }
 
         [DataMember(Name = "Version")]
         public string StateVersion
         {
             get => State.Version;
-            set => State.Version = value;
+            set
+            {
+                CreateStateIfNotExists();
+                State.Version = value;
+            }
         }
 
         [DataMember(Name = "Status")]
         public string StateStatus
         {
             get => State.Status;
-            set => State.Status = value;
+            set
+            {
+                CreateStateIfNotExists();
+                State.Status = value;
+            }
         }
 
         [DataMember(Name = "Tags")]
@@ -123,6 +139,7 @@ namespace DurableTask.ServiceBus.Tracking
             get => State.Tags != null ? this.dataConverter.Serialize(State.Tags) : null;
             set
             {
+                CreateStateIfNotExists();
                 if (string.IsNullOrWhiteSpace(value))
                 {
                     State.Tags = null;
@@ -138,6 +155,7 @@ namespace DurableTask.ServiceBus.Tracking
             get => State.OrchestrationStatus.ToString();
             set
             {
+                CreateStateIfNotExists();
                 if (!Enum.TryParse(value, out State.OrchestrationStatus))
                 {
                     throw new InvalidOperationException("Invalid status string in state " + value);
@@ -149,42 +167,66 @@ namespace DurableTask.ServiceBus.Tracking
         public DateTime StateCreatedTime
         {
             get => State.CreatedTime;
-            set => State.CreatedTime = value;
+            set
+            {
+                CreateStateIfNotExists();
+                State.CreatedTime = value;
+            }
         }
 
         [DataMember(Name = "CompletedTime")]
         public DateTime StateCompletedTime
         {
             get => State.CompletedTime;
-            set => State.CompletedTime = value;
+            set
+            {
+                CreateStateIfNotExists();
+                State.CompletedTime = value;
+            }
         }
 
         [DataMember(Name = "LastUpdatedTime")]
         public DateTime StateLastUpdatedTime
         {
             get => State.LastUpdatedTime;
-            set => State.LastUpdatedTime = value;
+            set
+            {
+                CreateStateIfNotExists();
+                State.LastUpdatedTime = value;
+            }
         }
 
         [DataMember(Name = "Size")]
         public long StateSize
         {
             get => State.Size;
-            set => State.Size = value;
+            set
+            {
+                CreateStateIfNotExists();
+                State.Size = value;
+            }
         }
 
         [DataMember(Name = "CompressedSize")]
         public long StateCompressedSize
         {
             get => State.CompressedSize;
-            set => State.CompressedSize = value;
+            set
+            {
+                CreateStateIfNotExists();
+                State.CompressedSize = value;
+            }
         }
 
         [DataMember(Name = "Input")]
         public string StateInput
         {
             get => State.Input.Truncate(ServiceBusConstants.MaxStringLengthForAzureTableColumn);
-            set => State.Input = value;
+            set
+            {
+                CreateStateIfNotExists();
+                State.Input = value;
+            }
 
         }
 
@@ -192,14 +234,54 @@ namespace DurableTask.ServiceBus.Tracking
         public string StateOutput
         {
             get => State.Output.Truncate(ServiceBusConstants.MaxStringLengthForAzureTableColumn);
-            set => State.Output = value;
+            set
+            {
+                CreateStateIfNotExists();
+                State.Output = value;
+            }
         }
 
         [DataMember(Name = "ScheduledStartTime")]
         public DateTime? StateScheduledStartTime
         {
             get => State.ScheduledStartTime;
-            set => State.ScheduledStartTime = value;
+            set
+            {
+                CreateStateIfNotExists();
+                State.ScheduledStartTime = value;
+            }
+        }
+
+        private void CreateStateIfNotExists()
+        {
+            if (this.State == null)
+            {
+                this.State = new OrchestrationState
+                {
+                    OrchestrationInstance = new OrchestrationInstance(),
+                    ParentInstance = new ParentInstance
+                    {
+                        Name = null,
+                        TaskScheduleId = -1,
+                        Version = null,
+                        OrchestrationInstance = new OrchestrationInstance(),
+                    }
+                };
+            }
+            if (this.State.OrchestrationInstance == null)
+            {
+                this.State.OrchestrationInstance = new OrchestrationInstance();
+            }
+            if (this.State.ParentInstance == null)
+            {
+                this.State.ParentInstance = new ParentInstance
+                {
+                    Name = null,
+                    TaskScheduleId = -1,
+                    Version = null,
+                    OrchestrationInstance = new OrchestrationInstance(),
+                };
+            }
         }
 #pragma warning restore 1591
 

--- a/src/DurableTask.ServiceBus/Tracking/BlobStorageClient.cs
+++ b/src/DurableTask.ServiceBus/Tracking/BlobStorageClient.cs
@@ -67,7 +67,7 @@ namespace DurableTask.ServiceBus.Tracking
         }
 
         /// <summary>
-        /// Construct a blob storage client instance with hub name and cloud storage account
+        /// Construct a blob storage client instance with hub name uri endpoint and a token credential
         /// </summary>
         /// <param name="hubName">The hub name</param>
         /// <param name="endpoint">Uri Endpoint for the blob store</param>

--- a/src/DurableTask.ServiceBus/Tracking/BlobStorageClient.cs
+++ b/src/DurableTask.ServiceBus/Tracking/BlobStorageClient.cs
@@ -22,10 +22,6 @@ namespace DurableTask.ServiceBus.Tracking
     using Azure.Storage.Blobs;
     using Azure.Storage.Blobs.Models;
 
-    //using Microsoft.WindowsAzure.Storage;
-    //using Microsoft.WindowsAzure.Storage.Blob;
-    //using Microsoft.WindowsAzure.Storage.RetryPolicies;
-
     /// <summary>
     /// A client to access the Azure blob storage.
     /// </summary>
@@ -171,5 +167,5 @@ namespace DurableTask.ServiceBus.Tracking
             var tasks = containers.ToList().Select(container => this.blobServiceClient.DeleteBlobContainerAsync(container.Name));
             await Task.WhenAll(tasks);
         }
-            }
+    }
 }

--- a/test/DurableTask.ServiceBus.Tests/AzureTableClientTest.cs
+++ b/test/DurableTask.ServiceBus.Tests/AzureTableClientTest.cs
@@ -15,6 +15,7 @@ namespace DurableTask.ServiceBus.Tests
 {
     using DurableTask.Core;
     using DurableTask.ServiceBus.Tracking;
+    using Azure.Data.Tables;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Microsoft.WindowsAzure.Storage.Table;
 
@@ -29,9 +30,9 @@ namespace DurableTask.ServiceBus.Tests
             var tableClient = new AzureTableClient("myHub", ConnectionString);
             var stateQuery = new OrchestrationStateQuery();
 
-            TableQuery<AzureTableOrchestrationStateEntity> query = tableClient.CreateQueryInternal(stateQuery, 1, false);
+           var query = tableClient.CreateQueryInternal(stateQuery, false);
 
-            Assert.AreEqual("(PartitionKey eq 'IS')", query.FilterString);
+            Assert.AreEqual("(PartitionKey eq 'IS')", query);
         }
 
         [TestMethod]
@@ -41,9 +42,9 @@ namespace DurableTask.ServiceBus.Tests
             var stateQuery = new OrchestrationStateQuery();
             stateQuery.AddInstanceFilter("myInstance");
 
-            TableQuery<AzureTableOrchestrationStateEntity> query = tableClient.CreateQueryInternal(stateQuery, 1, false);
+            var query = tableClient.CreateQueryInternal(stateQuery, false);
 
-            Assert.AreEqual("(PartitionKey eq 'IS') and (RowKey ge 'ID_EID_myInstance') and (RowKey lt 'ID_EID_myInstancf')", query.FilterString);
+            Assert.AreEqual("(PartitionKey eq 'IS') and (RowKey ge 'ID_EID_myInstance') and (RowKey lt 'ID_EID_myInstancf')", query);
         }
 
         [TestMethod]
@@ -54,9 +55,9 @@ namespace DurableTask.ServiceBus.Tests
             stateQuery.AddInstanceFilter("myInstance");
             stateQuery.AddNameVersionFilter("myName");
 
-            TableQuery<AzureTableOrchestrationStateEntity> query = tableClient.CreateQueryInternal(stateQuery, 1, false);
+            var query = tableClient.CreateQueryInternal(stateQuery, false);
 
-            Assert.AreEqual("(PartitionKey eq 'IS') and (RowKey ge 'ID_EID_myInstance') and (RowKey lt 'ID_EID_myInstancf') and (InstanceId eq 'myInstance') and (Name eq 'myName')", query.FilterString);
+            Assert.AreEqual("(PartitionKey eq 'IS') and (RowKey ge 'ID_EID_myInstance') and (RowKey lt 'ID_EID_myInstancf') and (InstanceId eq 'myInstance') and (Name eq 'myName')", query);
         }
     }
 }

--- a/test/DurableTask.ServiceBus.Tests/AzureTableClientTest.cs
+++ b/test/DurableTask.ServiceBus.Tests/AzureTableClientTest.cs
@@ -17,7 +17,6 @@ namespace DurableTask.ServiceBus.Tests
     using DurableTask.ServiceBus.Tracking;
     using Azure.Data.Tables;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Microsoft.WindowsAzure.Storage.Table;
 
     [TestClass]
     public class AzureTableClientTest

--- a/test/DurableTask.ServiceBus.Tests/BlobStorageClientTest.cs
+++ b/test/DurableTask.ServiceBus.Tests/BlobStorageClientTest.cs
@@ -81,8 +81,11 @@ namespace DurableTask.ServiceBus.Tests
 
             Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(testContent));
             await this.blobStorageClient.UploadStreamBlobAsync(key1, stream);
+            stream.Position = 0;
             await this.blobStorageClient.UploadStreamBlobAsync(key2, stream);
+            stream.Position = 0;
             await this.blobStorageClient.UploadStreamBlobAsync(key3, stream);
+            stream.Position = 0;
 
             var dateTime = new DateTime(2015, 05, 17);
             await this.blobStorageClient.DeleteExpiredContainersAsync(dateTime);

--- a/test/DurableTask.ServiceBus.Tests/BlobStorageClientTest.cs
+++ b/test/DurableTask.ServiceBus.Tests/BlobStorageClientTest.cs
@@ -23,7 +23,6 @@ namespace DurableTask.ServiceBus.Tests
     using Azure.Storage.Blobs;
     using Azure.Storage.Blobs.Models;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Microsoft.WindowsAzure.Storage.Blob;
     using DurableTask.ServiceBus.Tracking;
 
     [TestClass]

--- a/test/DurableTask.ServiceBus.Tests/DurableTask.ServiceBus.Tests.csproj
+++ b/test/DurableTask.ServiceBus.Tests/DurableTask.ServiceBus.Tests.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-	<PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
-	<PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
     <PackageReference Include="CommandLineParser" version="1.9.71" />
     <PackageReference Include="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" />
     <PackageReference Include="ImpromptuInterface" version="6.2.2" />
@@ -29,8 +29,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-	<PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
-	<PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
     <PackageReference Include="EnterpriseLibrary.SemanticLogging.NetCore" Version="2.0.1406.4" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />

--- a/test/DurableTask.ServiceBus.Tests/DurableTask.ServiceBus.Tests.csproj
+++ b/test/DurableTask.ServiceBus.Tests/DurableTask.ServiceBus.Tests.csproj
@@ -10,6 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+	<PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
+	<PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
     <PackageReference Include="CommandLineParser" version="1.9.71" />
     <PackageReference Include="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" />
     <PackageReference Include="ImpromptuInterface" version="6.2.2" />
@@ -24,17 +26,17 @@
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="System.Spatial" version="5.8.5" />
     <PackageReference Include="WindowsAzure.ServiceBus" version="4.1.3" />
-    <PackageReference Include="WindowsAzure.Storage" version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+	<PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
+	<PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
     <PackageReference Include="EnterpriseLibrary.SemanticLogging.NetCore" Version="2.0.1406.4" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DurableTask.ServiceBus.Tests/OrchestrationHubTableClientTests.cs
+++ b/test/DurableTask.ServiceBus.Tests/OrchestrationHubTableClientTests.cs
@@ -306,7 +306,7 @@ namespace DurableTask.ServiceBus.Tests
             {
                 var eeStartedEvent = new ExecutionStartedEvent(-1, "EVENT_" + instanceId + "_" + genId + "_" + i);
 
-                historyEntities.Add(new AzureTableOrchestrationHistoryEventEntity(instanceId, genId, i, DateTime.Now,
+                historyEntities.Add(new AzureTableOrchestrationHistoryEventEntity(instanceId, genId, i, DateTime.UtcNow,
                     eeStartedEvent));
             }
 


### PR DESCRIPTION
### Notable Changes

- The class CloudStorageAccount no longer exists in the new libraries. Therefore, any constructors that leverage it were replaced with new constructors that take an endpoint to the store and a TokenCredentials object
- TableStore entities were able to implement a method that allowed the code to "unpack" complex types to save and load from tables. These methods are no longer available. Instead, a series of public accessors with custom getters and setters are now used to get the same behavior.

### Validation

- Running DurableTask.ServiceBus.Tests project: Test runs are green via both the pipeline and running tests against a live storage account