### PR TITLE
Migrate to 1ES (first draft)

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -1,0 +1,33 @@
+trigger:
+    batch: true
+    branches:
+        include:
+            - main
+
+# CI only, does not trigger on PRs.
+pr: none
+
+resources:
+    repositories:
+        - repository: 1es
+          type: git
+          name: 1ESPipelineTemplates/1ESPipelineTemplates
+          ref: refs/tags/release
+        - repository: eng
+          type: git
+          name: engineering
+          ref: refs/tags/release
+
+extends:
+    template: v1/1ES.Official.PipelineTemplate.yml@1es
+    parameters:
+        pool:
+            name: 1es-pool-azfunc
+            image: 1es-windows-2022
+            os: windows
+
+        stages:
+            - stage: BuildAndSign
+              dependsOn: []
+              jobs:
+                  - template: /eng/templates/build.yml@self

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -1,0 +1,116 @@
+jobs:
+    - job: Build
+
+      templateContext:
+          outputs:
+              - output: pipelineArtifact
+                path: $(build.artifactStagingDirectory)
+                artifact: drop
+                sbomBuildDropPath: $(build.artifactStagingDirectory)
+                sbomPackageName: 'DurableTask SBOM'
+
+      steps:
+      # Start by restoring all the dependencies. This needs to be its own task
+      # from what I can tell. We specifically only target DurableTask.AzureStorage
+      # and its direct dependencies.
+      
+      - task: DotNetCoreCLI@2
+        displayName: 'Restore nuget dependencies'
+        inputs:
+            command: restore
+            verbosityRestore: Minimal
+            projects: |
+                src/DurableTask.AzureStorage/DurableTask.AzureStorage.sln
+                src/DurableTask.Emulator/DurableTask.Emulator.csproj
+                src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
+                src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
+                src/DurableTask.ApplicationInsights/DurableTask.ApplicationInsights.csproj
+
+
+      # Build the filtered solution in release mode, specifying the continuous integration flag.
+      - task: VSBuild@1
+        displayName: 'Build (AzureStorage)'
+        inputs:
+          solution: 'src/DurableTask.AzureStorage/DurableTask.AzureStorage.sln'
+          vsVersion: '16.0'
+          logFileVerbosity: minimal
+          configuration: Release
+          msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
+
+      - task: VSBuild@1
+        displayName: 'Build (ApplicationInsights)'
+        inputs:
+          solution: 'src/DurableTask.ApplicationInsights/DurableTask.ApplicationInsights.csproj'
+          vsVersion: '16.0'
+          logFileVerbosity: minimal
+          configuration: Release
+          msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
+
+      - task: VSBuild@1
+        displayName: 'Build (Emulator)'
+        inputs:
+          solution: 'src/DurableTask.Emulator/DurableTask.Emulator.csproj'
+          vsVersion: '16.0'
+          logFileVerbosity: minimal
+          configuration: Release
+          msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
+
+      # - task: VSBuild@1
+      #   displayName: 'Build (ServiceBus)'
+      #   inputs:
+      #     solution: 'src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj'
+      #     vsVersion: '16.0'
+      #     logFileVerbosity: minimal
+      #     configuration: Release
+      #     msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
+
+      # - task: VSBuild@1
+      #   displayName: 'Build (AzureServiceFabric)'
+      #   inputs:
+      #     solution: 'src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj'
+      #     vsVersion: '16.0'
+      #     logFileVerbosity: minimal
+      #     configuration: Release
+      #     platform: x64
+      #     msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
+
+      #- task: UseDotNet@2
+      #  displayName: 'Use the .NET Core 6 SDK (required for build signing)'
+      #  inputs:
+      #    packageType: 'sdk'
+      #    version: '6.x.x'
+      
+      - template: ci/sign-files.yml@eng
+        parameters:
+          displayName: Sign assemblies
+          folderPath: src
+          pattern: DurableTask.*.dll
+          signType: dll
+      
+      # need to add all the code-signing stuff + SBOM
+      - task: DotNetCoreCLI@2
+        displayName: Generate nuget packages
+        inputs:
+          command: pack
+          verbosityPack: Minimal
+          configuration: Release
+          nobuild: true
+          packDirectory: $(build.artifactStagingDirectory)
+          packagesToPack: 'src/DurableTask.AzureStorage/DurableTask.AzureStorage.sln'
+
+      - task: DotNetCoreCLI@2
+        displayName: Generate nuget packages
+        inputs:
+          command: pack
+          verbosityPack: Minimal
+          configuration: Release
+          nobuild: true
+          packDirectory: $(build.artifactStagingDirectory)
+          packagesToPack: 'src/DurableTask.ApplicationInsights/DurableTask.ApplicationInsights.csproj'
+
+      - template: ci/sign-files.yml@eng
+        parameters:
+          displayName: Sign NugetPackages
+          folderPath: $(build.artifactStagingDirectory)
+          pattern: '*.nupkg'
+          signType: nuget

--- a/src/DurableTask.ApplicationInsights/DurableTask.ApplicationInsights.csproj
+++ b/src/DurableTask.ApplicationInsights/DurableTask.ApplicationInsights.csproj
@@ -5,7 +5,7 @@
         <TargetFrameworks>netstandard2.0</TargetFrameworks>
         <PackageId>Microsoft.Azure.DurableTask.ApplicationInsights</PackageId>
         <!-- NuGet licenseUrl and PackageIconUrl/iconUrl deprecation. -->
-        <NoWarn>NU5125;NU5048</NoWarn>
+        <NoWarn>NU5125;NU5048;CS7035</NoWarn>  <!-- TODO: addition of CS7035 (version format doesn't follow convention) is a temporary workaround during 1ES migration -->
     </PropertyGroup>
 
     <!-- Version Info -->

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -14,7 +14,7 @@
     <DebugType>embedded</DebugType> 
     <IncludeSymbols>false</IncludeSymbols> 
     <!--NuGet licenseUrl and PackageIconUrl/iconUrl deprecation. -->
-    <NoWarn>NU5125;NU5048</NoWarn>
+    <NoWarn>NU5125;NU5048;CS7035</NoWarn> <!-- TODO: addition of CS7035 (version format doesn't follow convention) is a temporary workaround during 1ES migration -->
   </PropertyGroup>
 
   <!-- Version Info -->

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!--NuGet licenseUrl and PackageIconUrl/iconUrl deprecation. -->
-    <NoWarn>NU5125;NU5048</NoWarn>
+    <NoWarn>NU5125;NU5048;CS7035</NoWarn> <!-- TODO: addition of CS7035 (version format doesn't follow convention) is a temporary workaround during 1ES migration -->
   </PropertyGroup>
   
   <!-- General Package Info -->


### PR DESCRIPTION
This PR adds the basic "build and sign" pipeline to migrate DTFx.Core, DTFx.AS, and DTFx.AI to 1ES.

A few cut corners to address in a future follow-up:
* the SBOM parameters need further scrutiny, it's possible it is not analyzing the right data
* The build pipeline isn't building ServiceBus and ServiceFabric (it's commented out in the yml for that reason). It's unclear if we want to do that in the Azure Functions-managed 1ES pipeline
* warning CS7035 is being suppressed, which calls out that our assembly version format doesn't follow conventions. Example: ": Error CS7035: The specified version string '2.17.1.167958' does not conform to the recommended format - major.minor.build.revision". 
* Integration tests aren't included yet. This is just building and signing the code.
* CodeQL integration still missing
* Still a few warnings in the pipeline that deserve scrutiny