### PR TITLE
HotFixes: Enable Support for Forward Compatibility  between DTFx.AzureStorage 1.x to 2.x

### DIFF
--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -161,9 +161,9 @@ namespace DurableTask.AzureStorage
             {
                 envelope = this.DeserializeMessageData(Encoding.UTF8.GetString(body));
             }
-            catch
+            catch(JsonReaderException)
             {
-                // This catch block is a hotfix for sev1 and better implementation might be needed in future. 
+                // This catch block is a hotfix and better implementation might be needed in future. 
                 // DTFx.AzureStorage 1.x and 2.x use different encoding methods. Adding this line to enable forward compatibility.
                 envelope = this.DeserializeMessageData(Encoding.UTF8.GetString(Convert.FromBase64String(Encoding.UTF8.GetString(body))));
             }

--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -156,7 +156,17 @@ namespace DurableTask.AzureStorage
         {
             // TODO: Deserialize with Stream?
             byte[] body = queueMessage.Body.ToArray();
-            MessageData envelope = this.DeserializeMessageData(Encoding.UTF8.GetString(body));
+            MessageData envelope;
+            try
+            {
+                envelope = this.DeserializeMessageData(Encoding.UTF8.GetString(body));
+            }
+            catch
+            {
+                // This catch block is a hotfix for sev1 and better implementation might be needed in future. 
+                // DTFx.AzureStorage 1.x and 2.x use different encoding methods. Adding this line to enable forward compatibility.
+                envelope = this.DeserializeMessageData(Encoding.UTF8.GetString(Convert.FromBase64String(Encoding.UTF8.GetString(body))));
+            }
 
             if (!string.IsNullOrEmpty(envelope.CompressedBlobName))
             {


### PR DESCRIPTION
DurableTask.AzureStorage v1.x and v2.x use different version of Azure Storage SDK which use different encoding methods. Consequently, when upgrading from v1 to v2, the app may be stuck with queue processing because workers loaded with DTFx.AS v2 cannot successfully read messages encoded with DTFx.AS v1. This PR introduces a hotfix to ensure forward compatibility.

End-to-end test has been made. 