### PR TITLE
Run DTFx.Core tests in GitHub action

### DIFF
--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -31,13 +31,13 @@ jobs:
       run: dotnet restore $solution
 
     - name: Build
-      run: dotnet build $solution --configuration $config #--no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=true
+      run: dotnet build $solution #--configuration $config #--no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=true
 
     - name: Test
-      run: dotnet test $solution --configuration $config --no-build --verbosity normal
+      run: dotnet test $solution #--configuration $config --no-build --verbosity normal
 
     - name: Pack
-      run: dotnet pack $solution --configuration $config --no-build
+      run: dotnet pack $solution #--configuration $config --no-build
 
     - name: Upload
       uses: actions/upload-artifact@v3

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -15,6 +15,14 @@ env:
   solution: DurableTask.sln
   config: Release
 
+services:
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite
+    ports:
+      - 10000:10000
+      - 10001:10001
+      - 10002:10002
+
 jobs:
   build:
     runs-on: windows-latest
@@ -33,8 +41,8 @@ jobs:
     - name: Build
       run: dotnet build $solution #--configuration $config #--no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=true
 
-    - name: Test
-      run: dotnet test $solution #--configuration $config --no-build --verbosity normal
+    - name: Test DTx.Core
+      run: dotnet test Azure/durabletask/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj #--configuration $config --no-build --verbosity normal
 
     - name: Pack
       run: dotnet pack $solution #--configuration $config --no-build

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -27,6 +27,16 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
 
+    - name: Set up .NET Core 2.1
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '2.1.x'
+
+    - name: Set up .NET Core 3.1
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '3.1.x'
+
     - name: Restore dependencies
       run: dotnet restore $solution
 

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - 'dajusto/add-tests-as-gh-action'
     paths-ignore: [ '**.md' ]
   pull_request:
     branches:

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -15,17 +15,18 @@ env:
   solution: DurableTask.sln
   config: Release
 
-services:
-  azurite:
-    image: mcr.microsoft.com/azure-storage/azurite
-    ports:
-      - 10000:10000
-      - 10001:10001
-      - 10002:10002
-
 jobs:
   build:
     runs-on: windows-latest
+
+    services:
+      azurite:
+        image: mcr.microsoft.com/azure-storage/azurite
+        ports:
+          - 10000:10000
+          - 10001:10001
+          - 10002:10002
+
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -45,7 +45,7 @@ jobs:
       run: azurite --silent &
 
     - name: Test DTx.Core
-      run: dotnet test Azure/durabletask/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj #--configuration $config --no-build --verbosity normal
+      run: dotnet test ./test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj #--configuration $config --no-build --verbosity normal
 
     - name: Pack
       run: dotnet pack $solution #--configuration $config --no-build

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -51,14 +51,11 @@ jobs:
     - name: Install Azurite
       run: npm install -g azurite
 
-    - name: Start Azurite
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
-
     - name: Test DTFx.Core
-      run: dotnet test ./test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj #--configuration $config --no-build --verbosity normal
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj #--configuration $config --no-build --verbosity normal
 
     - name: Test DTFx.AzureStorage
-      run: dotnet test ./test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj #--configuration $config --no-build --verbosity normal
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj #--configuration $config --no-build --verbosity normal
 
     # - name: Pack
     #   run: dotnet pack $solution #--configuration $config --no-build

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -1,0 +1,48 @@
+name: Validate Build
+
+on:
+  push:
+    branches:
+      - main
+      - 'dajusto/add-tests-as-gh-action'
+    paths-ignore: [ '**.md' ]
+  pull_request:
+    branches:
+      - main
+    paths-ignore: [ '**.md' ]
+
+env:
+  solution: DurableTask.sln
+  config: Release
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        global-json-file: global.json
+
+    - name: Restore dependencies
+      run: dotnet restore $solution
+
+    - name: Build
+      run: dotnet build $solution --configuration $config --no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=true
+
+    - name: Test
+      run: dotnet test $solution --configuration $config --no-build --verbosity normal
+
+    - name: Pack
+      run: dotnet pack $solution --configuration $config --no-build
+
+    - name: Upload
+      uses: actions/upload-artifact@v3
+      with:
+        name: pkg
+        path: out/pkg

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -52,7 +52,7 @@ jobs:
       run: npm install -g azurite
 
     - name: Start Azurite
-      run: azurite --silent &
+      run: azurite --silent --queuePort 10001 &
 
     - name: Test DTFx.Core
       run: dotnet test ./test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -54,14 +54,17 @@ jobs:
     - name: Start Azurite
       run: azurite --silent &
 
-    - name: Test DTx.Core
+    - name: Test DTFx.Core
       run: dotnet test ./test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj #--configuration $config --no-build --verbosity normal
 
-    - name: Pack
-      run: dotnet pack $solution #--configuration $config --no-build
+    - name: Test DTFx.AzureStorage
+      run: dotnet test ./test/DurableTask.Core.Tests/DurableTask.AzureStorage.Tests.csproj #--configuration $config --no-build --verbosity normal
 
-    - name: Upload
-      uses: actions/upload-artifact@v3
-      with:
-        name: pkg
-        path: out/pkg
+    # - name: Pack
+    #   run: dotnet pack $solution #--configuration $config --no-build
+
+    # - name: Upload
+    #   uses: actions/upload-artifact@v3
+    #   with:
+    #     name: pkg
+    #     path: out/pkg

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -52,7 +52,7 @@ jobs:
       run: npm install -g azurite
 
     - name: Start Azurite
-      run: azurite --silent --queuePort 10001 &
+      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 &
 
     - name: Test DTFx.Core
       run: dotnet test ./test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -26,8 +26,6 @@ jobs:
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
-      with:
-        global-json-file: global.json
 
     - name: Restore dependencies
       run: dotnet restore $solution

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -1,4 +1,4 @@
-name: Validate Build
+name: Validate Build (DTFx.Core)
 
 on:
   push:
@@ -54,14 +54,7 @@ jobs:
     - name: Test DTFx.Core
       run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj #--configuration $config --no-build --verbosity normal
 
-    - name: Test DTFx.AzureStorage
-      run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj #--configuration $config --no-build --verbosity normal
+    # Azure Storage is commented out until DTFx.AS v2 is enabled, where Azurite can be used to run unit tests
+    # - name: Test DTFx.AzureStorage
+    #   run: azurite --silent --blobPort 10000 --queuePort 10001 --tablePort 10002 & dotnet test ./test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj #--configuration $config --no-build --verbosity normal
 
-    # - name: Pack
-    #   run: dotnet pack $solution #--configuration $config --no-build
-
-    # - name: Upload
-    #   uses: actions/upload-artifact@v3
-    #   with:
-    #     name: pkg
-    #     path: out/pkg

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -58,7 +58,7 @@ jobs:
       run: dotnet test ./test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj #--configuration $config --no-build --verbosity normal
 
     - name: Test DTFx.AzureStorage
-      run: dotnet test ./test/DurableTask.Core.Tests/DurableTask.AzureStorage.Tests.csproj #--configuration $config --no-build --verbosity normal
+      run: dotnet test ./test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj #--configuration $config --no-build --verbosity normal
 
     # - name: Pack
     #   run: dotnet pack $solution #--configuration $config --no-build

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -19,15 +19,6 @@ jobs:
   build:
     runs-on: windows-latest
 
-    services:
-      azurite:
-        image: mcr.microsoft.com/azure-storage/azurite
-        ports:
-          - 10000:10000
-          - 10001:10001
-          - 10002:10002
-
-
     steps:
     - uses: actions/checkout@v3
       with:
@@ -41,6 +32,11 @@ jobs:
 
     - name: Build
       run: dotnet build $solution #--configuration $config #--no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=true
+
+    - name: Run Azurite
+      run: |
+        docker pull mcr.microsoft.com/azure-storage/azurite
+        docker run -d -p 10000:10000 -p 10001:10001 -p 10002:10002 --name azurite mcr.microsoft.com/azure-storage/azurite
 
     - name: Test DTx.Core
       run: dotnet test Azure/durabletask/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj #--configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -31,7 +31,7 @@ jobs:
       run: dotnet restore $solution
 
     - name: Build
-      run: dotnet build $solution --configuration $config --no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=true
+      run: dotnet build $solution --configuration $config #--no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=true
 
     - name: Test
       run: dotnet test $solution --configuration $config --no-build --verbosity normal

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -33,10 +33,16 @@ jobs:
     - name: Build
       run: dotnet build $solution #--configuration $config #--no-restore -p:FileVersionRevision=$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=true
 
-    - name: Run Azurite
-      run: |
-        docker pull mcr.microsoft.com/azure-storage/azurite
-        docker run -d -p 10000:10000 -p 10001:10001 -p 10002:10002 --name azurite mcr.microsoft.com/azure-storage/azurite
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16.x'
+
+    - name: Install Azurite
+      run: npm install -g azurite
+
+    - name: Start Azurite
+      run: azurite --silent &
 
     - name: Test DTx.Core
       run: dotnet test Azure/durabletask/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj #--configuration $config --no-build --verbosity normal


### PR DESCRIPTION
As part of 1ES migration - replaces part of the "DTFx Build & Run tests" pipeline with a GitHub action, in particular, the DTFx.Core tests are replaced here. DTFx.AzureStorage cannot be replaced with a GH action until DTFx.AS v2 is released, where Azurite will be compatible with the tests - the current tests depend on the old Azure Storage emulator and that is not compatible with GitHub pipelines (because they run on ARM64)