### PR TITLE
Allow user to specify MaxHistoryEvents and constraint history loading to include the latest generation only

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -318,5 +318,12 @@ namespace DurableTask.AzureStorage
         /// Consumers that require separate dispatch (such as the new out-of-proc v2 SDKs) must set this to true.
         /// </summary>
         public bool UseSeparateQueueForEntityWorkItems { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets the maximum number of history events for a single orchestration instance.
+        /// An orchestrator that goes beyond this limit is automatically terminated.
+        /// By default, this is null, which means there is no limit.
+        /// </summary>
+        public int? MaxHistoryEvents { get; set; } = null;
     }
 }

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -20,7 +20,7 @@
   <!-- Version Info -->
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
-    <MinorVersion>17</MinorVersion>
+    <MinorVersion>18</MinorVersion>
     <PatchVersion>3</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <FileVersion>$(VersionPrefix).0</FileVersion>
@@ -28,6 +28,7 @@
     <FileVersion Condition="'$(FileVersionRevision)' != ''">$(VersionPrefix).$(FileVersionRevision)</FileVersion>
     <!-- The assembly version is only the major/minor pair, making it easier to do in-place upgrades -->
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
+    <VersionSuffix>preview.1</VersionSuffix>
   </PropertyGroup>
 
    <!-- This version is used as the nuget package version -->


### PR DESCRIPTION
This PR makes two small (diff-wise) but significant changes to the Azure Storage provider.

### New MaxHistoryEvents configuration

First - it introduces a new `MaxHistoryEvents` configuration. It allows the user to specify the maximum number of events they want to allow an orchestration to have before it is automatically terminated. Many incidents, and sometimes outages, result from orchestrators having too large of a history, creating application instability. This configuration should give users peace of mind so that, even if they accidentally generate a large history, the framework will _protect itself_ and terminate offending orchestrations. This is an opt-in feature.

### ContinueAsNew bug fix

It also fixes a longstanding bug that was only recently discovered - it appears that, in many cases, an orchestrator that was "continued as new" will still load fragments of it's old history (those that were not already overridden by the new history). This is because we don't always know the latest executionID of an orchestrator (which allows us to distinguish between **generations**), meaning that we loaded more data than necessary. The end result was this: if an orchestrator _instanceID_ ever generated a history of 10k records, it did not matter that later generations only generated 1k records, we would always load 10k (the 1k of the current generation, and 9k stale records that haven't been overridden yet).

The fix for this bug is simple: we need to get the latest instanceID by first reading _only_ sentinel row of the History table, which reports the latest executionID. Then, using that executionID as an extra filter, we read the history as normal. This extra table read will be a new cost to our users, but it is necessary for correctness. I'm hoping the cost is low enough to be 'ok'.

I did try to make this work without the extra table read, by a _paginated_ query and read the history table "in parts" and stopped as soon as the executionID of the results changed, which tells us that now we're reading a stale history. However, if we did this, we would stop before reading the sentinel row (the sentinel row is the last row of the table), which DTFx needs for it's  `CheckpointCompletedTimestamp` which it uses to determine out of order messages. In the end, I found it simpler and safer to make that extra request, but this is up for debate.

 

