### PR TITLE
Enable DTFx.AzureStorage v1.x backward compatibility support

### DIFF
--- a/src/DurableTask.AzureStorage/Storage/QueueMessage.cs
+++ b/src/DurableTask.AzureStorage/Storage/QueueMessage.cs
@@ -14,7 +14,6 @@
 namespace DurableTask.AzureStorage.Storage
 {
     using System;
-    using System.Text;
     using Microsoft.WindowsAzure.Storage.Queue;
 
     class QueueMessage
@@ -28,12 +27,15 @@ namespace DurableTask.AzureStorage.Storage
             }
             catch (FormatException)
             {
+                // This try-catch block ensures backward compatibility with DTFx.AzureStorage v1.x.
+                // It should only be executed in scenarios requiring this compatibility.
                 try
                 {
+                    // RawString is an internal property of CloudQueueMessage.
                     System.Reflection.PropertyInfo rawStringProperty = typeof(CloudQueueMessage).GetProperty("RawString", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
                     this.Message = (string)rawStringProperty.GetValue(this.CloudQueueMessage);
                 }
-                catch (Exception)
+                catch (Exception) // If failed to read the RawString property, throw an exception.
                 {
                     throw new InvalidOperationException("Failed to read the cloud queue message.");
                 }

--- a/src/DurableTask.AzureStorage/Storage/QueueMessage.cs
+++ b/src/DurableTask.AzureStorage/Storage/QueueMessage.cs
@@ -27,18 +27,11 @@ namespace DurableTask.AzureStorage.Storage
             }
             catch (FormatException)
             {
-                // This try-catch block ensures backward compatibility with DTFx.AzureStorage v1.x.
-                // It should only be executed in scenarios requiring this compatibility.
-                try
-                {
-                    // RawString is an internal property of CloudQueueMessage.
-                    System.Reflection.PropertyInfo rawStringProperty = typeof(CloudQueueMessage).GetProperty("RawString", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-                    this.Message = (string)rawStringProperty.GetValue(this.CloudQueueMessage);
-                }
-                catch (Exception) // If failed to read the RawString property, throw an exception.
-                {
-                    throw new InvalidOperationException("Failed to read the cloud queue message.");
-                }
+                // This try-catch block ensures forwards compatibility with DTFx.AzureStorage v2.x, which does not guarantee base64 encoding of messages (messages not encoded at all).
+                // Therefore, if we try to decode those messages as base64, we will have a format exception that will yield a poison message
+                // RawString is an internal property of CloudQueueMessage, so we need to obtain it via reflection.
+                System.Reflection.PropertyInfo rawStringProperty = typeof(CloudQueueMessage).GetProperty("RawString", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                this.Message = (string)rawStringProperty.GetValue(this.CloudQueueMessage);
             }
             this.Id = this.CloudQueueMessage.Id;
         }

--- a/src/DurableTask.AzureStorage/Storage/QueueMessage.cs
+++ b/src/DurableTask.AzureStorage/Storage/QueueMessage.cs
@@ -14,6 +14,7 @@
 namespace DurableTask.AzureStorage.Storage
 {
     using System;
+    using System.Text;
     using Microsoft.WindowsAzure.Storage.Queue;
 
     class QueueMessage
@@ -21,7 +22,22 @@ namespace DurableTask.AzureStorage.Storage
         public QueueMessage(CloudQueueMessage cloudQueueMessage)
         {
             this.CloudQueueMessage = cloudQueueMessage;
-            this.Message = this.CloudQueueMessage.AsString;
+            try
+            {
+                this.Message = this.CloudQueueMessage.AsString;
+            }
+            catch (FormatException)
+            {
+                try
+                {
+                    System.Reflection.PropertyInfo rawStringProperty = typeof(CloudQueueMessage).GetProperty("RawString", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                    this.Message = (string)rawStringProperty.GetValue(this.CloudQueueMessage);
+                }
+                catch (Exception)
+                {
+                    throw new InvalidOperationException("Failed to read the cloud queue message.");
+                }
+            }
             this.Id = this.CloudQueueMessage.Id;
         }
 


### PR DESCRIPTION
DTFx.AzureStorage v1.x and v2.x use different Azure Storage SDK versions, each with its own encoding method. This PR adds backward compatibility to DTFx.AzureStorage v1.x, ensuring that queue messages created with DTFx.AS v2 remain readable after downgrading to DTFx.AS v1.

The `RawProperty` is an internal attribute of `CloudQueueMessage`, and we use System.Reflection to access it. The included catch block should only be triggered in the scenario described above.

End-to-End tests have been done. 
