### PR TITLE
Update ExecuteWithTimeout() to reduce "A task was canceled" exceptions

### DIFF
--- a/src/DurableTask.AzureStorage/TimeoutHandler.cs
+++ b/src/DurableTask.AzureStorage/TimeoutHandler.cs
@@ -128,9 +128,11 @@ namespace DurableTask.AzureStorage
 
                     }
 
+                    T result = await operationTask;
+
                     cts.Cancel();
 
-                    return await operationTask;
+                    return result;
                 }
             }
         }


### PR DESCRIPTION
This PR updates the `ExecuteWithTimeout` method to call `await operationTask` before calling `cts.Cancel()` since we are seeing `DurableTaskStorageException: A task was canceled.` exceptions in logs.