### PR TITLE
Add Check for Lease Ownership Bug in Table Partition Manager

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -574,12 +574,6 @@ namespace DurableTask.AzureStorage
             }
         }
 
-        internal bool CheckIfListeningToOwnedQueue(TablePartitionLease partition)
-        {
-            return this.allControlQueues.TryGetValue(partition.RowKey, out ControlQueue controlQueue) &&
-                this.OwnedControlQueues.Contains(controlQueue);
-        }
-
         internal Task OnOwnershipLeaseReleasedAsync(BlobPartitionLease lease, CloseReason reason)
         {
             this.orchestrationSessionManager.RemoveQueue(lease.PartitionId, reason, "Ownership LeaseCollectionBalancer");
@@ -588,6 +582,14 @@ namespace DurableTask.AzureStorage
 
         internal async Task OnTableLeaseAcquiredAsync(TablePartitionLease lease)
         {
+            // Check if the worker is already listening to the control queue.
+            if(this.allControlQueues.TryGetValue(lease.RowKey, out ControlQueue queue) &&
+                this.OwnedControlQueues.Contains(queue))
+            {
+                return;
+            }
+
+            // If the worker hasn't listened to the queue yet, then add it.
             var controlQueue = new ControlQueue(this.azureStorageClient, lease.RowKey, this.messageManager);
             await controlQueue.CreateIfNotExistsAsync();
             this.orchestrationSessionManager.AddQueue(lease.RowKey, controlQueue, this.shutdownSource.Token);

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -18,7 +18,6 @@ namespace DurableTask.AzureStorage
     using System.Diagnostics.Tracing;
     using System.Linq;
     using System.Net;
-    using System.Runtime.CompilerServices;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -18,6 +18,7 @@ namespace DurableTask.AzureStorage
     using System.Diagnostics.Tracing;
     using System.Linq;
     using System.Net;
+    using System.Runtime.CompilerServices;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
@@ -572,6 +573,12 @@ namespace DurableTask.AzureStorage
             {
                 this.orchestrationSessionManager.RemoveQueue(partition.RowKey, CloseReason.LeaseLost, nameof(DropLostControlQueue));
             }
+        }
+
+        internal bool CheckIfListeningToOwnedQueue(TablePartitionLease partition)
+        {
+            return this.allControlQueues.TryGetValue(partition.RowKey, out ControlQueue controlQueue) &&
+                this.OwnedControlQueues.Contains(controlQueue);
         }
 
         internal Task OnOwnershipLeaseReleasedAsync(BlobPartitionLease lease, CloseReason reason)

--- a/src/DurableTask.AzureStorage/Partitioning/TablePartitionManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/TablePartitionManager.cs
@@ -352,10 +352,17 @@ namespace DurableTask.AzureStorage.Partitioning
                     bool renewedLease = false;
                     bool drainedLease = false;
                     bool releasedLease = false;
+                    bool isListeningToOwnedQueue = false;
                     ETag etag = partition.ETag;
 
                     // String previousOwner is for the steal process logs. Only used for stealing leases of any worker which is in shutdown process in this loop.
                     string previousOwner = partition.CurrentOwner ?? this.workerName;
+
+                    // If the partition is owned by this worker, check if the worker is listening to the owned control queue.
+                    if(partition.CurrentOwner == this.workerName)
+                    {
+                        isListeningToOwnedQueue = this.service.CheckIfListeningToOwnedQueue(partition);
+                    }
 
                     if (!isShuttingDown)
                     {
@@ -407,7 +414,9 @@ namespace DurableTask.AzureStorage.Partitioning
                             throw;
                         }
 
-                        if (claimedLease)
+                        // Worker should listen to the control queue if 1) worker just claimed the lease,
+                        // or 2) worker is already the lease owner but hasn't listened to the queue yet for some reason.
+                        if (claimedLease || !isListeningToOwnedQueue)
                         {
                             // Notify the orchestration session manager that we acquired a lease for one of the partitions.
                             // This will cause it to start reading control queue messages for that partition.

--- a/src/DurableTask.AzureStorage/Partitioning/TablePartitionManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/TablePartitionManager.cs
@@ -352,7 +352,7 @@ namespace DurableTask.AzureStorage.Partitioning
                     bool renewedLease = false;
                     bool drainedLease = false;
                     bool releasedLease = false;
-                    bool isListeningToOwnedQueue = false;
+                    bool isListeningToOwnedQueue = true;
                     ETag etag = partition.ETag;
 
                     // String previousOwner is for the steal process logs. Only used for stealing leases of any worker which is in shutdown process in this loop.

--- a/test/DurableTask.AzureStorage.Tests/TestTablePartitionManager.cs
+++ b/test/DurableTask.AzureStorage.Tests/TestTablePartitionManager.cs
@@ -659,6 +659,78 @@ namespace DurableTask.AzureStorage.Tests
             await Task.WhenAll(stopServiceTasks);
         }
 
+        /// <summary>
+        /// End to end test to simulate one worker with one partition.
+        /// Simulate that one worker becomes unhealthy, and then back to a healthy again before the owned lease expires.
+        /// Make sure the worker can still listen to owned control queue without claiming the lease.
+        /// </summary>
+        [TestMethod]
+        public async Task TestWorkerRestartBeforeLeaseExpired()
+        {
+            const int WorkerCount = 2;
+            const int InstanceCount = 50;
+            var services = new AzureStorageOrchestrationService[WorkerCount];
+            var taskHubWorkers = new TaskHubWorker[WorkerCount];
+
+            var settings = new AzureStorageOrchestrationServiceSettings()
+            {
+                StorageAccountClientProvider = new StorageAccountClientProvider(this.connection),
+                TaskHubName = "WorkerRestartBeforeLeaseExpired",
+                PartitionCount = 1,
+                // Set a long lease interval to make sure the lease won't expire during the test.
+                LeaseInterval = TimeSpan.FromMinutes(5),
+                WorkerId = "0",
+                UseTablePartitionManagement = true,
+            };
+
+            for (int i = 0; i < WorkerCount; i++)
+            {
+                services[i] = new AzureStorageOrchestrationService(settings);
+                // Two workers share the same worker id since here we want to simulate a worker restart.
+                taskHubWorkers[i] = new TaskHubWorker(services[i]);
+                taskHubWorkers[i].AddTaskOrchestrations(typeof(LongRunningOrchestrator));
+            }
+
+            // Create orchestration instances.
+            var client = new TaskHubClient(services[0]);
+            var createInstanceTasks = new Task<OrchestrationInstance>[InstanceCount];
+            for (int i = 0; i < InstanceCount; i++)
+            {
+                createInstanceTasks[i] = client.CreateOrchestrationInstanceAsync(typeof(LongRunningOrchestrator), input: null);
+            }
+            OrchestrationInstance[] instances = await Task.WhenAll(createInstanceTasks);
+
+            await taskHubWorkers[0].StartAsync();
+            
+            // Ensure worker acquired the partition.
+            await WaitForConditionAsync(
+                timeout: TimeSpan.FromSeconds(2),
+                condition: async t =>
+                {
+                    TablePartitionLease lease = await services[0].ListTableLeasesAsync(t).SingleAsync(t);
+                    return lease.CurrentOwner == "0";
+                });
+
+            using var cts = new CancellationTokenSource();
+            {
+                // Simulate a worker crashed and back to healthy again before the lease expires.
+                // To achieve this, we stop worker[0] table partition management loop and start worker[1].
+                services[0].KillPartitionManagerLoop();
+                await taskHubWorkers[1].StartAsync();
+
+                // Worker[1] that shares name "0" should owned the partition without cliaming the lease. 
+                await Task.Delay(1000);
+                Assert.AreEqual(1, services[1].OwnedControlQueues.Count());
+
+                // Check all the instances could be processed successfully. 
+                OrchestrationState[] states = await Task.WhenAll(
+                    instances.Select(i => client.WaitForOrchestrationAsync(i, TimeSpan.FromSeconds(30))));
+                Assert.IsTrue(
+                    Array.TrueForAll(states, s => s?.OrchestrationStatus == OrchestrationStatus.Completed),
+                    "Not all orchestrations completed successfully!");
+            }
+        }
+
         [KnownType(typeof(Hello))]
         internal class HelloOrchestrator : TaskOrchestration<string, string>
         {


### PR DESCRIPTION
This PR addresses a bug reported by customers involving the table partition manager. The issue occurs when a worker is the owner of a partition without claiming the lease. This can happen when a worker restarts or crashes and returns to a healthy state before the lease expires, thus it remains the owner of the partition. In our current logic, the worker only listens to a control queue when it has claimed a lease. Therefore, in the above scenario worker will continue to renew the lease without listening to queue messages.

To resolve this, the PR adds a check to ensure that when a worker reads the partition table and identifies itself as the current lease owner, it verifies if it is actively listening to the queue. If it is not, the worker should initiate the process to start listening to the queue. This ensures that the lease renewal logic only applies when the worker is actively managing the partition.