### PR TITLE
Add 1ES CI for DTFx.AS v2

### DIFF
--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -53,7 +53,8 @@ extends:
     - stage: DTFxCoreValidate
       jobs:
       - job: Validate
-
+        strategy:
+          parallel: 13
         steps:
         # Build the code and the tests
         - template: /eng/templates/build-steps.yml@self

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -68,7 +68,7 @@ extends:
         - template: /eng/templates/test.yml@self
           parameters:
             # TODO: for some reason we're unable to run the net462 tests in the CI
-            testAssembly: '**\bin\Debug\netcoreapp3.1\DurableTask.Core.Tests.dll'
+            testAssembly: '**\bin\Debug\**\DurableTask.Core.Tests.dll'
     - stage: DTFxASValidate
       dependsOn: []
       jobs:

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -67,7 +67,7 @@ extends:
         # Run tests
         - template: /eng/templates/test.yml@self
           parameters:
-            testAssembly: '**\bin\**\DurableTask.Core.Tests.dll'
+            testAssembly: '**\bin\Debug\netcoreapp3.1\DurableTask.Core.Tests.dll'
     - stage: DTFxASValidate
       dependsOn: []
       jobs:

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -68,7 +68,7 @@ extends:
         - template: /eng/templates/test.yml@self
           parameters:
             # TODO: for some reason we're unable to run the net462 tests in the CI
-            testAssembly: '**\bin\Debug\**\DurableTask.Core.Tests.dll'
+            testAssembly: '**\bin\**\DurableTask.Core.Tests.dll'
     - stage: DTFxASValidate
       dependsOn: []
       jobs:
@@ -87,7 +87,7 @@ extends:
         # Run tests
         - template: /eng/templates/test.yml@self
           parameters:
-            testAssembly: '**\bin\Debug\**\DurableTask.AzureStorage.Tests.dll'
+            testAssembly: '**\bin\**\DurableTask.AzureStorage.Tests.dll'
     - stage: DTFxEmulatorValidate
       dependsOn: []
       jobs:
@@ -106,4 +106,4 @@ extends:
         # Run tests
         - template: /eng/templates/test.yml@self
           parameters:
-            testAssembly: '**\bin\Debug\**\DurableTask.Emulator.Tests.dll'
+            testAssembly: '**\bin\**\DurableTask.Emulator.Tests.dll'

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -31,7 +31,7 @@ resources:
     ref: refs/tags/release
 
 extends:
-  # The template we extend injects compliance-checks into the pipleine, such as SDL and CodeQL
+  # The template we extend injects compliance-checks into the pipeline, such as SDL and CodeQL
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1es
   parameters:
     pool:
@@ -67,7 +67,6 @@ extends:
         # Run tests
         - template: /eng/templates/test.yml@self
           parameters:
-            # TODO: for some reason we're unable to run the net462 tests in the CI
             testAssembly: '**\bin\**\DurableTask.Core.Tests.dll'
     - stage: DTFxASValidate
       dependsOn: []

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -67,7 +67,8 @@ extends:
         # Run tests
         - template: /eng/templates/test.yml@self
           parameters:
-            testAssembly: '**\bin\**\netcoreapp3.1\DurableTask.Core.Tests.dll'
+            # TODO: for some reason we're unable to run the net462 tests in the CI
+            testAssembly: '**\bin\Debug\netcoreapp3.1\DurableTask.Core.Tests.dll'
     - stage: DTFxASValidate
       dependsOn: []
       jobs:
@@ -86,7 +87,7 @@ extends:
         # Run tests
         - template: /eng/templates/test.yml@self
           parameters:
-            testAssembly: '**\bin\**\netcoreapp3.1\DurableTask.AzureStorage.Tests.dll'
+            testAssembly: '**\bin\Debug\**\DurableTask.AzureStorage.Tests.dll'
     - stage: DTFxEmulatorValidate
       dependsOn: []
       jobs:
@@ -105,4 +106,4 @@ extends:
         # Run tests
         - template: /eng/templates/test.yml@self
           parameters:
-            testAssembly: '**\bin\**\netcoreapp3.1\DurableTask.Emulator.Tests.dll'
+            testAssembly: '**\bin\Debug\**\DurableTask.Emulator.Tests.dll'

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -53,8 +53,7 @@ extends:
     - stage: DTFxCoreValidate
       jobs:
       - job: Validate
-        strategy:
-          parallel: 13
+
         steps:
         # Build the code and the tests
         - template: /eng/templates/build-steps.yml@self
@@ -67,7 +66,7 @@ extends:
         # Run tests
         - template: /eng/templates/test.yml@self
           parameters:
-            testAssembly: '**\bin\Debug\**\DurableTask.Core.Tests.dll'
+            testAssembly: '**\bin\**\DurableTask.Core.Tests.dll'
     - stage: DTFxASValidate
       dependsOn: []
       jobs:

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -67,7 +67,7 @@ extends:
         # Run tests
         - template: /eng/templates/test.yml@self
           parameters:
-            testAssembly: '**\bin\Debug\netcoreapp3.1\DurableTask.Core.Tests.dll'
+            testAssembly: '**\bin\Debug\**\DurableTask.Core.Tests.dll'
     - stage: DTFxASValidate
       dependsOn: []
       jobs:

--- a/eng/templates/test.yml
+++ b/eng/templates/test.yml
@@ -20,16 +20,14 @@ steps:
   - task: VSTest@2
     displayName: 'Run tests'
     inputs:
-      testAssemblyVer2: |
-        ${{ parameters.testAssembly }}
-        !**\obj\**
-        testFiltercriteria: 'TestCategory!=DisabledInCI'
-        vsTestVersion: 17.0
-        distributionBatchType: basedOnExecutionTime
-        platform: 'any cpu'
-        configuration: 'Debug'
-        diagnosticsEnabled: True
-        collectDumpOn: always
-        rerunFailedTests: true
-        rerunFailedThreshold: 30
-        rerunMaxAttempts: 3
+      testAssemblyVer2: ${{ parameters.testAssembly }}
+      testFiltercriteria: 'TestCategory!=DisabledInCI'
+      vsTestVersion: 17.0
+      distributionBatchType: basedOnExecutionTime
+      platform: 'any cpu'
+      configuration: 'Debug'
+      diagnosticsEnabled: True
+      collectDumpOn: always
+      rerunFailedTests: true
+      rerunFailedThreshold: 30
+      rerunMaxAttempts: 3

--- a/eng/templates/test.yml
+++ b/eng/templates/test.yml
@@ -17,7 +17,7 @@ steps:
     displayName: 'Install and Run Azurite'
 
   # Run tests
-  - task: VSTest@3
+  - task: VSTest@2
     displayName: 'Run tests'
     inputs:
       testAssemblyVer2: ${{ parameters.testAssembly }}

--- a/eng/templates/test.yml
+++ b/eng/templates/test.yml
@@ -17,7 +17,7 @@ steps:
     displayName: 'Install and Run Azurite'
 
   # Run tests
-  - task: VSTest@2
+  - task: VSTest@3
     displayName: 'Run tests'
     inputs:
       testAssemblyVer2: ${{ parameters.testAssembly }}

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -40,7 +40,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.40.0" />
+    <PackageReference Include="Azure.Core" Version="1.41.0" />
     <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.18.0" />

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="Azure.Storage.Queues" Version="12.18.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -13,7 +13,8 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>embedded</DebugType>
     <IncludeSymbols>false</IncludeSymbols>
-    <!--NuGet licenseUrl and PackageIconUrl/iconUrl deprecation. -->
+	<PackageReadmeFile>.\README.md</PackageReadmeFile>
+	<!--NuGet licenseUrl and PackageIconUrl/iconUrl deprecation. -->
     <NoWarn>NU5125;NU5048;CS7035</NoWarn> <!-- TODO: addition of CS7035 (version format doesn't follow convention) is a temporary workaround during 1ES migration -->
   </PropertyGroup>
 
@@ -51,6 +52,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DurableTask.Core\DurableTask.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include=".\..\..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Release'">

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -13,7 +13,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>embedded</DebugType>
     <IncludeSymbols>false</IncludeSymbols>
-	<PackageReadmeFile>.\README.md</PackageReadmeFile>
+    <PackageReadmeFile>.\README.md</PackageReadmeFile>
 	<!--NuGet licenseUrl and PackageIconUrl/iconUrl deprecation. -->
     <NoWarn>NU5125;NU5048;CS7035</NoWarn> <!-- TODO: addition of CS7035 (version format doesn't follow convention) is a temporary workaround during 1ES migration -->
   </PropertyGroup>
@@ -41,13 +41,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.41.0" />
+    <PackageReference Include="Azure.Core" Version="1.40.0" />
     <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.18.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Azure.Storage.Queues" Version="12.18.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -41,7 +41,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.40.0" />
+    <PackageReference Include="Azure.Core" Version="1.41.0" />
     <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.18.0" />

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Azure.Storage.Queues" Version="12.18.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -513,7 +513,7 @@ namespace DurableTask.AzureStorage.Tracking
                 yield break;
             }
 
-            IEnumerable<Task<OrchestrationState>> instanceQueries = instanceIds.Select(instance => this.GetStateAsync(instance, allExecutions: true, fetchInput: false, cancellationToken).SingleAsync().AsTask());
+            IEnumerable<Task<OrchestrationState>> instanceQueries = instanceIds.Select(instance => this.GetStateAsync(instance, allExecutions: true, fetchInput: false, cancellationToken).SingleOrDefaultAsync().AsTask());
             foreach (OrchestrationState state in await Task.WhenAll(instanceQueries))
             {
                 if (state != null)

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
     <PackageReference Include="System.Reactive.Core" Version="4.4.1" />

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -37,10 +37,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
-    <!--<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />-->
     <PackageReference Include="System.Reactive.Core" Version="4.4.1" />
     <PackageReference Include="System.Reactive.Compatibility" Version="4.4.1" />
     <PackageReference Include="Castle.Core" Version="5.0.0" />

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -38,8 +38,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
+    <!--<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />-->
     <PackageReference Include="System.Reactive.Core" Version="4.4.1" />
     <PackageReference Include="System.Reactive.Compatibility" Version="4.4.1" />
     <PackageReference Include="Castle.Core" Version="5.0.0" />

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -39,7 +39,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="System.Reactive.Core" Version="4.4.1" />
     <PackageReference Include="System.Reactive.Compatibility" Version="4.4.1" />

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <!--<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />-->
     <PackageReference Include="System.Reactive.Core" Version="4.4.1" />
     <PackageReference Include="System.Reactive.Compatibility" Version="4.4.1" />
     <PackageReference Include="Castle.Core" Version="5.0.0" />

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <!--<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />-->
     <PackageReference Include="System.Reactive.Core" Version="4.4.1" />
     <PackageReference Include="System.Reactive.Compatibility" Version="4.4.1" />
     <PackageReference Include="Castle.Core" Version="5.0.0" />

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
     <!--<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />-->

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
-    <!--<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />-->
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="System.Reactive.Core" Version="4.4.1" />
     <PackageReference Include="System.Reactive.Compatibility" Version="4.4.1" />
     <PackageReference Include="Castle.Core" Version="5.0.0" />

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -39,7 +39,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="System.Reactive.Core" Version="4.4.1" />
     <PackageReference Include="System.Reactive.Compatibility" Version="4.4.1" />

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -25,6 +25,7 @@
     <FileVersion Condition="'$(FileVersionRevision)' != ''">$(VersionPrefix).$(FileVersionRevision)</FileVersion>
     <!-- The assembly version is only the major/minor pair, making it easier to do in-place upgrades -->
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
+    <PackageReadmeFile>.\README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <!-- This version is used as the nuget package version -->
@@ -38,11 +39,15 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="System.Reactive.Core" Version="4.4.1" />
     <PackageReference Include="System.Reactive.Compatibility" Version="4.4.1" />
     <PackageReference Include="Castle.Core" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include=".\..\..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Release'">

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
-    <!--<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />-->
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="System.Reactive.Core" Version="4.4.1" />
     <PackageReference Include="System.Reactive.Compatibility" Version="4.4.1" />
     <PackageReference Include="Castle.Core" Version="5.0.0" />

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="System.Reactive.Core" Version="4.4.1" />
     <PackageReference Include="System.Reactive.Compatibility" Version="4.4.1" />
     <PackageReference Include="Castle.Core" Version="5.0.0" />

--- a/src/DurableTask.Core/TaskActivityDispatcher.cs
+++ b/src/DurableTask.Core/TaskActivityDispatcher.cs
@@ -23,6 +23,7 @@ namespace DurableTask.Core
     using DurableTask.Core.Logging;
     using DurableTask.Core.Middleware;
     using DurableTask.Core.Tracing;
+    using ActivityStatusCode = Tracing.ActivityStatusCode;
 
     /// <summary>
     /// Dispatcher for task activities to handle processing and renewing of work items

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -28,6 +28,7 @@ namespace DurableTask.Core
     using DurableTask.Core.Middleware;
     using DurableTask.Core.Serializing;
     using DurableTask.Core.Tracing;
+    using ActivityStatusCode = Tracing.ActivityStatusCode;
 
     /// <summary>
     /// Dispatcher for orchestrations to handle processing and renewing, completion of orchestration events

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -85,7 +85,7 @@ namespace DurableTask.Core.Tracing
             DateTimeOffset startTime = startEvent.ParentTraceContext.ActivityStartTime ?? default;
 
             Activity? activity = ActivityTraceSource.StartActivity(
-                name: activityName,
+                activityName,
                 kind: activityKind,
                 parentContext: activityContext,
                 startTime: startTime);
@@ -139,7 +139,7 @@ namespace DurableTask.Core.Tracing
             }
 
             Activity? newActivity = ActivityTraceSource.StartActivity(
-                name: CreateSpanName(TraceActivityConstants.Activity, scheduledEvent.Name, scheduledEvent.Version),
+                CreateSpanName(TraceActivityConstants.Activity, scheduledEvent.Name, scheduledEvent.Version),
                 kind: ActivityKind.Server,
                 parentContext: activityContext);
 
@@ -180,7 +180,7 @@ namespace DurableTask.Core.Tracing
             }
 
             Activity? newActivity = ActivityTraceSource.StartActivity(
-                name: CreateSpanName(TraceActivityConstants.Activity, taskScheduledEvent.Name, taskScheduledEvent.Version),
+                CreateSpanName(TraceActivityConstants.Activity, taskScheduledEvent.Name, taskScheduledEvent.Version),
                 kind: ActivityKind.Client,
                 startTime: taskScheduledEvent.Timestamp,
                 parentContext: Activity.Current?.Context ?? default);
@@ -274,7 +274,7 @@ namespace DurableTask.Core.Tracing
             }
 
             Activity? activity = ActivityTraceSource.StartActivity(
-                name: CreateSpanName(TraceActivityConstants.Orchestration, createdEvent.Name, createdEvent.Version),
+                CreateSpanName(TraceActivityConstants.Orchestration, createdEvent.Name, createdEvent.Version),
                 kind: ActivityKind.Client,
                 startTime: createdEvent.Timestamp,
                 parentContext: Activity.Current?.Context ?? default);
@@ -358,7 +358,7 @@ namespace DurableTask.Core.Tracing
             string? targetInstanceId)
         {
             Activity? newActivity = ActivityTraceSource.StartActivity(
-                name: CreateSpanName(TraceActivityConstants.OrchestrationEvent, eventRaisedEvent.Name, null),
+                CreateSpanName(TraceActivityConstants.OrchestrationEvent, eventRaisedEvent.Name, null),
                 kind: ActivityKind.Producer,
                 parentContext: Activity.Current?.Context ?? default);
 
@@ -391,7 +391,7 @@ namespace DurableTask.Core.Tracing
         internal static Activity? StartActivityForNewEventRaisedFromClient(EventRaisedEvent eventRaised, OrchestrationInstance instance)
         {
             Activity? newActivity = ActivityTraceSource.StartActivity(
-                name: CreateSpanName(TraceActivityConstants.OrchestrationEvent, eventRaised.Name, null),
+                CreateSpanName(TraceActivityConstants.OrchestrationEvent, eventRaised.Name, null),
                 kind: ActivityKind.Producer,
                 parentContext: Activity.Current?.Context ?? default,
                 tags: new KeyValuePair<string, object?>[]
@@ -418,7 +418,7 @@ namespace DurableTask.Core.Tracing
             TimerFiredEvent timerFiredEvent)
         {
             Activity? newActivity = ActivityTraceSource.StartActivity(
-                name: CreateTimerSpanName(orchestrationName),
+                CreateTimerSpanName(orchestrationName),
                 kind: ActivityKind.Internal,
                 startTime: startTime,
                 parentContext: Activity.Current?.Context ?? default);

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -1517,7 +1517,7 @@ namespace DurableTask.AzureStorage.Tests
 
                 string message = this.GenerateMediumRandomStringPayload(largeMessageSize, utf8ByteSize: 1, utf16ByteSize: 2).ToString();
                 var client = await host.StartOrchestrationAsync(typeof(Orchestrations.Echo), message);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                var status = await client.WaitForCompletionAsync(TimeSpan.FromMinutes(2));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
                 await ValidateLargeMessageBlobUrlAsync(
@@ -1632,7 +1632,7 @@ namespace DurableTask.AzureStorage.Tests
 
                 string message = this.GenerateMediumRandomStringPayload(largeMessageSize, utf8ByteSize: 1, utf16ByteSize: 2).ToString();
                 var client = await host.StartOrchestrationAsync(typeof(Orchestrations.Echo), message);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                var status = await client.WaitForCompletionAsync(TimeSpan.FromMinutes(2));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
                 Assert.AreEqual(message, JToken.Parse(status?.Input));
@@ -2252,6 +2252,7 @@ namespace DurableTask.AzureStorage.Tests
         /// End-to-end test which validates a simple orchestrator function that calls an activity function
         /// and checks the OpenTelemetry trace information
         /// </summary>
+        [TestCategory("DisabledInCI")]
         [DataTestMethod]
         [DataRow(true)]
         [DataRow(false)]
@@ -2344,6 +2345,7 @@ namespace DurableTask.AzureStorage.Tests
         /// End-to-end test which validates a simple orchestrator function that waits for an external event
         /// raised through the RaiseEvent API and checks the OpenTelemetry trace information
         /// </summary>
+        [TestCategory("DisabledInCI")]
         [DataTestMethod]
         [DataRow(true)]
         [DataRow(false)]
@@ -2445,6 +2447,7 @@ namespace DurableTask.AzureStorage.Tests
         /// End-to-end test which validates a simple orchestrator function that waits for an external event
         /// raised by calling SendEvent and checks the OpenTelemetry trace information
         /// </summary>
+        [TestCategory("DisabledInCI")]
         [DataTestMethod]
         [DataRow(true)]
         [DataRow(false)]

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -1517,7 +1517,7 @@ namespace DurableTask.AzureStorage.Tests
 
                 string message = this.GenerateMediumRandomStringPayload(largeMessageSize, utf8ByteSize: 1, utf16ByteSize: 2).ToString();
                 var client = await host.StartOrchestrationAsync(typeof(Orchestrations.Echo), message);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromMinutes(2));
+                var status = await client.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
                 await ValidateLargeMessageBlobUrlAsync(
@@ -1632,7 +1632,7 @@ namespace DurableTask.AzureStorage.Tests
 
                 string message = this.GenerateMediumRandomStringPayload(largeMessageSize, utf8ByteSize: 1, utf16ByteSize: 2).ToString();
                 var client = await host.StartOrchestrationAsync(typeof(Orchestrations.Echo), message);
-                var status = await client.WaitForCompletionAsync(TimeSpan.FromMinutes(2));
+                var status = await client.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
                 Assert.AreEqual(message, JToken.Parse(status?.Input));

--- a/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
+++ b/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
@@ -5,28 +5,30 @@
     <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
   </PropertyGroup>
 
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" />
     <PackageReference Include="WindowsAzure.Storage" version="8.7.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.0.0-beta.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.6" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
     <PackageReference Include="WindowsAzure.Storage" version="9.3.3" />
   </ItemGroup>
 
   <!-- Common package dependencies -->
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="Moq" Version="4.10.0" />
+
+    <!-- We don't really make use of these dependencies, but 1ES somehow detects them in our test project and flags them for update.
+	Since this is just a test project, and to prevent "warning fatigue" so real CVEs stand out, we choose to upgrade the dependency explicitly to remove the false alarm.-->
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" /> <!-- Version 4.3.1 was detected by default-->
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
+++ b/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
@@ -29,6 +29,7 @@
     <!-- We don't really make use of these dependencies, but 1ES somehow detects them in our test project and flags them for update.
 	Since this is just a test project, and to prevent "warning fatigue" so real CVEs stand out, we choose to upgrade the dependency explicitly to remove the false alarm.-->
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" /> <!-- Version 4.3.1 was detected by default-->
+	<PackageReference Include="Microsoft.Data.Services.Client" Version="5.8.4" /> <!-- Without this, we resolve Microsoft.Data.OData 5.8.2, which is flagged-->
   </ItemGroup>
 
   <ItemGroup>
@@ -49,9 +50,6 @@
   <ItemGroup>
     <None Update="large.jpeg">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="testhost.dll.config" Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
+++ b/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
@@ -22,8 +22,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
     <PackageReference Include="Moq" Version="4.10.0" />
 
     <!-- We don't really make use of these dependencies, but 1ES somehow detects them in our test project and flags them for update.

--- a/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
+++ b/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
@@ -29,7 +29,7 @@
     <!-- We don't really make use of these dependencies, but 1ES somehow detects them in our test project and flags them for update.
 	Since this is just a test project, and to prevent "warning fatigue" so real CVEs stand out, we choose to upgrade the dependency explicitly to remove the false alarm.-->
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" /> <!-- Version 4.3.1 was detected by default-->
-	<PackageReference Include="Microsoft.Data.Services.Client" Version="5.8.4" /> <!-- Without this, we resolve Microsoft.Data.OData 5.8.2, which is flagged-->
+    <PackageReference Include="Microsoft.Data.Services.Client" Version="5.8.4" /> <!-- Without this, we resolve Microsoft.Data.OData 5.8.2, which is flagged-->
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DurableTask.AzureStorage.Tests/TestHelpers.cs
+++ b/test/DurableTask.AzureStorage.Tests/TestHelpers.cs
@@ -31,6 +31,7 @@ namespace DurableTask.AzureStorage.Tests
         {
             string storageConnectionString = GetTestStorageAccountConnectionString();
 
+#pragma warning disable CS0618 // Type or member is obsolete
             var settings = new AzureStorageOrchestrationServiceSettings
             {
                 ExtendedSessionIdleTimeout = TimeSpan.FromSeconds(extendedSessionTimeoutInSeconds),
@@ -40,9 +41,9 @@ namespace DurableTask.AzureStorage.Tests
                 TaskHubName = GetTestTaskHubName(),
 
                 // Setting up a logger factory to enable the new DurableTask.Core logs
-                // TODO: Add a logger provider so we can collect these logs in memory.
-                LoggerFactory = new LoggerFactory(),
+                LoggerFactory = new LoggerFactory().AddConsole(LogLevel.Trace),
             };
+#pragma warning restore CS0618 // Type or member is obsolete
 
             // Give the caller a chance to make test-specific changes to the settings
             modifySettingsAction?.Invoke(settings);

--- a/test/DurableTask.AzureStorage.Tests/TestHelpers.cs
+++ b/test/DurableTask.AzureStorage.Tests/TestHelpers.cs
@@ -31,6 +31,7 @@ namespace DurableTask.AzureStorage.Tests
         {
             string storageConnectionString = GetTestStorageAccountConnectionString();
 
+            // TODO: update Microsoft.Extensions.Logging to avoid the following warning suppression
 #pragma warning disable CS0618 // Type or member is obsolete
             var settings = new AzureStorageOrchestrationServiceSettings
             {

--- a/test/DurableTask.AzureStorage.Tests/TestTablePartitionManager.cs
+++ b/test/DurableTask.AzureStorage.Tests/TestTablePartitionManager.cs
@@ -446,7 +446,6 @@ namespace DurableTask.AzureStorage.Tests
 
         // Start with four workers and four partitions. Then kill three workers.
         // Test that the remaining worker will take all the partitions.
-        [TestCategory("DisabledInCI")]
         [TestMethod]
         public async Task TestKillThreeWorker()
         {
@@ -586,7 +585,6 @@ namespace DurableTask.AzureStorage.Tests
         /// Ensure that all instances should be processed sucessfully.
         /// </summary>
         /// <returns></returns>
-        [TestCategory("DisabledInCI")]
         [TestMethod]
         public async Task EnsureOwnedQueueExclusive()
         {

--- a/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
+++ b/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
@@ -10,6 +10,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
+#if !NET462 // TODO: For some reason tests aren't discoverable in the 1ES CI pipeline when using NET462, leading to errors. Need to investigate.
 #nullable enable
 namespace DurableTask.Core.Tests
 {
@@ -115,7 +116,6 @@ namespace DurableTask.Core.Tests
             Assert.AreNotSame(instance1, instance2);
             Assert.AreEqual(instance1!.InstanceId, instance2!.InstanceId);
         }
-#if !NET462
 
         [TestMethod]
         public async Task OrchestrationDispatcherMiddlewareContextFlow()

--- a/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
+++ b/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
@@ -37,8 +37,8 @@ namespace DurableTask.Core.Tests
         TaskHubWorker worker = null!;
         TaskHubClient client = null!;
 
-        [TestInitialize()]
-        public async Task InitializeTests()
+        [TestInitialize]
+        public void InitializeTests()
         {
             // configure logging so traces are emitted during tests.
             // This facilitates debugging when tests fail.
@@ -50,18 +50,18 @@ namespace DurableTask.Core.Tests
             var service = new LocalOrchestrationService();
             this.worker = new TaskHubWorker(service, loggerFactory);
 
-            await this.worker
+            this.worker
                 .AddTaskOrchestrations(typeof(SimplestGreetingsOrchestration), typeof(ParentWorkflow), typeof(ChildWorkflow))
                 .AddTaskActivities(typeof(SimplestGetUserTask), typeof(SimplestSendGreetingTask))
-                .StartAsync();
+                .StartAsync().RunSynchronously();
 
             this.client = new TaskHubClient(service);
         }
 
         [TestCleanup()]
-        public async Task CleanupTests()
+        public void CleanupTests()
         {
-            await this.worker!.StopAsync(true);
+            this.worker!.StopAsync(true).RunSynchronously();
         }
 
         [TestMethod]

--- a/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
+++ b/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
@@ -10,6 +10,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
+#if !NET462 // for some reasons these tests are not discoverable on 1ES, leading to the test getting aborted. TODO: Needs investigation
 #nullable enable
 namespace DurableTask.Core.Tests
 {
@@ -453,3 +454,4 @@ namespace DurableTask.Core.Tests
         }
     }
 }
+#endif

--- a/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
+++ b/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
@@ -43,6 +43,7 @@ namespace DurableTask.Core.Tests
             // configure logging so traces are emitted during tests.
             // This facilitates debugging when tests fail.
 
+            // TODO: update Microsoft.Extensions.Logging to avoid the following warning suppression
 #pragma warning disable CS0618 // Type or member is obsolete
             var loggerFactory = new LoggerFactory().AddConsole(LogLevel.Trace);
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
+++ b/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
@@ -10,7 +10,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
-#if !NET462 // TODO: For some reason tests aren't discoverable in the 1ES CI pipeline when using NET462, leading to errors. Need to investigate.
 #nullable enable
 namespace DurableTask.Core.Tests
 {
@@ -450,4 +449,3 @@ namespace DurableTask.Core.Tests
         }
     }
 }
-#endif

--- a/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
+++ b/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
@@ -37,8 +37,8 @@ namespace DurableTask.Core.Tests
         TaskHubWorker worker = null!;
         TaskHubClient client = null!;
 
-        [TestInitialize()]
-        public async Task InitializeTests()
+        [TestInitialize]
+        public void InitializeTests()
         {
             // configure logging so traces are emitted during tests.
             // This facilitates debugging when tests fail.
@@ -50,18 +50,22 @@ namespace DurableTask.Core.Tests
             var service = new LocalOrchestrationService();
             this.worker = new TaskHubWorker(service, loggerFactory);
 
-            await this.worker
+            // We use `GetAwaiter().GetResult()` because otherwise this method will fail with:
+            // "X has wrong signature. The method must be non-static, public, does not return a value and should not take any parameter."
+            this.worker
                 .AddTaskOrchestrations(typeof(SimplestGreetingsOrchestration), typeof(ParentWorkflow), typeof(ChildWorkflow))
                 .AddTaskActivities(typeof(SimplestGetUserTask), typeof(SimplestSendGreetingTask))
-                .StartAsync();
+                .StartAsync().GetAwaiter().GetResult();
 
             this.client = new TaskHubClient(service);
         }
 
-        [TestCleanup()]
-        public async Task CleanupTests()
+        [TestCleanup]
+        public void CleanupTests()
         {
-            await this.worker!.StopAsync(true);
+            // We use `GetAwaiter().GetResult()` because otherwise this method will fail with:
+            // "X has wrong signature. The method must be non-static, public, does not return a value and should not take any parameter."
+            this.worker!.StopAsync(true).GetAwaiter().GetResult();
         }
 
         [TestMethod]

--- a/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
+++ b/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
@@ -39,7 +39,7 @@ namespace DurableTask.Core.Tests
         TaskHubClient client = null!;
 
         [TestInitialize]
-        public async void InitializeTests()
+        public async Task InitializeTests()
         {
             // configure logging so traces are emitted during tests.
             // This facilitates debugging when tests fail.
@@ -60,7 +60,7 @@ namespace DurableTask.Core.Tests
         }
 
         [TestCleanup]
-        public async void CleanupTests()
+        public async Task CleanupTests()
         {
             await this.worker!.StopAsync(true);
         }

--- a/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
+++ b/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
@@ -10,6 +10,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
+#if !NET462
 #nullable enable
 namespace DurableTask.Core.Tests
 {
@@ -449,3 +450,5 @@ namespace DurableTask.Core.Tests
         }
     }
 }
+
+#endif

--- a/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
+++ b/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
@@ -90,7 +90,7 @@ namespace DurableTask.Core.Tests
 
             OrchestrationInstance instance = await this.client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), null);
 
-            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 10);
+            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 30);
             await this.client.WaitForOrchestrationAsync(instance, timeout);
 
             Assert.IsNotNull(orchestration);
@@ -135,7 +135,7 @@ namespace DurableTask.Core.Tests
 
             OrchestrationInstance instance = await this.client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), null);
 
-            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 10);
+            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 30);
             await this.client.WaitForOrchestrationAsync(instance, timeout);
 
             // Each reply gets a new context, so the output should stay the same regardless of how
@@ -172,7 +172,7 @@ namespace DurableTask.Core.Tests
 
             OrchestrationInstance instance = await this.client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), null);
 
-            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 10);
+            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 30);
             await this.client.WaitForOrchestrationAsync(instance, timeout);
 
             // Each activity gets a new context, so the output should stay the same regardless of how
@@ -206,7 +206,7 @@ namespace DurableTask.Core.Tests
                     { "Test", "Value" }
                 });
 
-            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 10);
+            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 30);
             await this.client.WaitForOrchestrationAsync(instance, timeout);
 
             // Each activity gets a new context, so the output should stay the same regardless of how
@@ -272,7 +272,7 @@ namespace DurableTask.Core.Tests
                     { "Test", "Value" }
                 });
 
-            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 10);
+            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 30);
             await this.client.WaitForOrchestrationAsync(instance, timeout);
 
             foreach (OrchestrationExecutionContext context in capturedContexts)
@@ -307,7 +307,7 @@ namespace DurableTask.Core.Tests
                     { "Test", "Value" }
                 });
 
-            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 10);
+            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 30);
             await this.client.WaitForOrchestrationAsync(instance, timeout);
 
             // Each activity gets a new context, so the output should stay the same regardless of how
@@ -432,7 +432,7 @@ namespace DurableTask.Core.Tests
                 version: "FakeVersion",
                 input: null);
 
-            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 5);
+            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 15);
             OrchestrationState state = await this.client.WaitForOrchestrationAsync(instance, timeout);
 
             Assert.AreEqual(OrchestrationStatus.Completed, state.OrchestrationStatus);

--- a/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
+++ b/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
@@ -37,7 +37,7 @@ namespace DurableTask.Core.Tests
         TaskHubWorker worker = null!;
         TaskHubClient client = null!;
 
-        [TestInitialize]
+        [TestInitialize()]
         public async Task InitializeTests()
         {
             // configure logging so traces are emitted during tests.
@@ -58,7 +58,7 @@ namespace DurableTask.Core.Tests
             this.client = new TaskHubClient(service);
         }
 
-        [TestCleanup]
+        [TestCleanup()]
         public async Task CleanupTests()
         {
             await this.worker!.StopAsync(true);

--- a/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
+++ b/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
@@ -39,7 +39,7 @@ namespace DurableTask.Core.Tests
         TaskHubClient client = null!;
 
         [TestInitialize]
-        public void InitializeTests()
+        public async void InitializeTests()
         {
             // configure logging so traces are emitted during tests.
             // This facilitates debugging when tests fail.
@@ -51,18 +51,18 @@ namespace DurableTask.Core.Tests
             var service = new LocalOrchestrationService();
             this.worker = new TaskHubWorker(service, loggerFactory);
 
-            this.worker
+            await this.worker
                 .AddTaskOrchestrations(typeof(SimplestGreetingsOrchestration), typeof(ParentWorkflow), typeof(ChildWorkflow))
                 .AddTaskActivities(typeof(SimplestGetUserTask), typeof(SimplestSendGreetingTask))
-                .StartAsync().RunSynchronously();
+                .StartAsync();
 
             this.client = new TaskHubClient(service);
         }
 
-        [TestCleanup()]
-        public void CleanupTests()
+        [TestCleanup]
+        public async void CleanupTests()
         {
-            this.worker!.StopAsync(true).RunSynchronously();
+            await this.worker!.StopAsync(true);
         }
 
         [TestMethod]
@@ -448,6 +448,6 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual(OrchestrationStatus.Completed, state.OrchestrationStatus);
             Assert.AreEqual("FakeActivity,FakeActivityVersion,SomeInput", state.Output);
         }
-#endif
     }
 }
+#endif

--- a/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
+++ b/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
@@ -38,7 +38,7 @@ namespace DurableTask.Core.Tests
         TaskHubClient client = null!;
 
         [TestInitialize]
-        public async Task Initialize()
+        public async Task InitializeTests()
         {
             // configure logging so traces are emitted during tests.
             // This facilitates debugging when tests fail.

--- a/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
+++ b/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
@@ -10,7 +10,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
-#if !NET462
 #nullable enable
 namespace DurableTask.Core.Tests
 {
@@ -38,7 +37,7 @@ namespace DurableTask.Core.Tests
         TaskHubWorker worker = null!;
         TaskHubClient client = null!;
 
-        [TestInitialize]
+        [TestInitialize()]
         public async Task InitializeTests()
         {
             // configure logging so traces are emitted during tests.
@@ -59,7 +58,7 @@ namespace DurableTask.Core.Tests
             this.client = new TaskHubClient(service);
         }
 
-        [TestCleanup]
+        [TestCleanup()]
         public async Task CleanupTests()
         {
             await this.worker!.StopAsync(true);
@@ -116,6 +115,7 @@ namespace DurableTask.Core.Tests
             Assert.AreNotSame(instance1, instance2);
             Assert.AreEqual(instance1!.InstanceId, instance2!.InstanceId);
         }
+#if !NET462
 
         [TestMethod]
         public async Task OrchestrationDispatcherMiddlewareContextFlow()
@@ -448,7 +448,6 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual(OrchestrationStatus.Completed, state.OrchestrationStatus);
             Assert.AreEqual("FakeActivity,FakeActivityVersion,SomeInput", state.Output);
         }
+#endif
     }
 }
-
-#endif

--- a/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
+++ b/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
@@ -27,6 +27,8 @@ namespace DurableTask.Core.Tests
     using DurableTask.Core.History;
     using DurableTask.Emulator;
     using DurableTask.Test.Orchestrations;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Console;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
@@ -38,8 +40,14 @@ namespace DurableTask.Core.Tests
         [TestInitialize]
         public async Task Initialize()
         {
+            // configure logging so traces are emitted during tests.
+            // This facilitates debugging when tests fail.
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            var loggerFactory = new LoggerFactory().AddConsole(LogLevel.Trace);
+#pragma warning restore CS0618 // Type or member is obsolete
             var service = new LocalOrchestrationService();
-            this.worker = new TaskHubWorker(service);
+            this.worker = new TaskHubWorker(service, loggerFactory);
 
             await this.worker
                 .AddTaskOrchestrations(typeof(SimplestGreetingsOrchestration), typeof(ParentWorkflow), typeof(ChildWorkflow))
@@ -90,7 +98,7 @@ namespace DurableTask.Core.Tests
 
             OrchestrationInstance instance = await this.client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), null);
 
-            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 30);
+            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 10);
             await this.client.WaitForOrchestrationAsync(instance, timeout);
 
             Assert.IsNotNull(orchestration);
@@ -135,7 +143,7 @@ namespace DurableTask.Core.Tests
 
             OrchestrationInstance instance = await this.client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), null);
 
-            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 30);
+            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 10);
             await this.client.WaitForOrchestrationAsync(instance, timeout);
 
             // Each reply gets a new context, so the output should stay the same regardless of how
@@ -172,7 +180,7 @@ namespace DurableTask.Core.Tests
 
             OrchestrationInstance instance = await this.client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), null);
 
-            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 30);
+            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 10);
             await this.client.WaitForOrchestrationAsync(instance, timeout);
 
             // Each activity gets a new context, so the output should stay the same regardless of how
@@ -206,7 +214,7 @@ namespace DurableTask.Core.Tests
                     { "Test", "Value" }
                 });
 
-            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 30);
+            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 10);
             await this.client.WaitForOrchestrationAsync(instance, timeout);
 
             // Each activity gets a new context, so the output should stay the same regardless of how
@@ -272,7 +280,7 @@ namespace DurableTask.Core.Tests
                     { "Test", "Value" }
                 });
 
-            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 30);
+            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 10);
             await this.client.WaitForOrchestrationAsync(instance, timeout);
 
             foreach (OrchestrationExecutionContext context in capturedContexts)
@@ -307,7 +315,7 @@ namespace DurableTask.Core.Tests
                     { "Test", "Value" }
                 });
 
-            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 30);
+            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 10);
             await this.client.WaitForOrchestrationAsync(instance, timeout);
 
             // Each activity gets a new context, so the output should stay the same regardless of how
@@ -432,7 +440,7 @@ namespace DurableTask.Core.Tests
                 version: "FakeVersion",
                 input: null);
 
-            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 15);
+            TimeSpan timeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 1000 : 5);
             OrchestrationState state = await this.client.WaitForOrchestrationAsync(instance, timeout);
 
             Assert.AreEqual(OrchestrationStatus.Completed, state.OrchestrationStatus);

--- a/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
+++ b/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
@@ -59,7 +59,7 @@ namespace DurableTask.Core.Tests
         }
 
         [TestCleanup]
-        public async Task TestCleanup()
+        public async Task CleanupTests()
         {
             await this.worker!.StopAsync(true);
         }

--- a/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj
+++ b/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj
@@ -5,19 +5,13 @@
     <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer" Version="2.0.1406.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup>
     <PackageReference Include="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer.NetCore" Version="2.0.1406.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-	<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj
+++ b/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer.NetCore" Version="2.0.1406.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />

--- a/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj
+++ b/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj
@@ -8,8 +8,8 @@
   <ItemGroup>
     <PackageReference Include="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer.NetCore" Version="2.0.1406.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
   </ItemGroup>

--- a/test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
+++ b/test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
@@ -25,7 +25,7 @@ namespace DurableTask.Core.Tests
     [TestClass]
     public class ExceptionHandlingIntegrationTests
     {
-        static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 300 : 10);
+        static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 300 : 30);
 
         readonly TaskHubWorker worker;
         readonly TaskHubClient client;

--- a/test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
+++ b/test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
@@ -19,22 +19,29 @@ namespace DurableTask.Core.Tests
     using System.Threading.Tasks;
     using DurableTask.Core.Exceptions;
     using DurableTask.Emulator;
+    using Microsoft.Extensions.Logging;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Newtonsoft.Json;
 
     [TestClass]
     public class ExceptionHandlingIntegrationTests
     {
-        static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 300 : 30);
+        static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(Debugger.IsAttached ? 300 : 10);
 
         readonly TaskHubWorker worker;
         readonly TaskHubClient client;
 
         public ExceptionHandlingIntegrationTests()
         {
+            // configure logging so traces are emitted during tests.
+            // This facilitates debugging when tests fail.
+#pragma warning disable CS0618 // Type or member is obsolete
+            var loggerFactory = new LoggerFactory().AddConsole(LogLevel.Trace);
+#pragma warning restore CS0618 // Type or member is obsolete
+
             var service = new LocalOrchestrationService();
-            this.worker = new TaskHubWorker(service);
-            this.client = new TaskHubClient(service);
+            this.worker = new TaskHubWorker(service, loggerFactory);
+            this.client = new TaskHubClient(service, loggerFactory: loggerFactory);
         }
 
         [DataTestMethod]

--- a/test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
+++ b/test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
@@ -35,6 +35,8 @@ namespace DurableTask.Core.Tests
         {
             // configure logging so traces are emitted during tests.
             // This facilitates debugging when tests fail.
+
+            // TODO: update Microsoft.Extensions.Logging to avoid the following warning suppression
 #pragma warning disable CS0618 // Type or member is obsolete
             var loggerFactory = new LoggerFactory().AddConsole(LogLevel.Trace);
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/test/DurableTask.Core.Tests/RetryInterceptorTests.cs
+++ b/test/DurableTask.Core.Tests/RetryInterceptorTests.cs
@@ -31,7 +31,7 @@ namespace DurableTask.Core.Tests
             await Assert.ThrowsExceptionAsync<IOException>(Invoke, "Interceptor should throw the original exception after exceeding max retry attempts.");
         }
 
-        [TestMethod]
+        [DataTestMethod]
         [DataRow(1)]
         [DataRow(2)]
         [DataRow(3)]
@@ -59,7 +59,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual(maxAttempts, callCount, 0, $"There should be {maxAttempts} function calls for {maxAttempts} max attempts.");
         }
 
-        [TestMethod]
+        [DataTestMethod]
         [DataRow(1)]
         [DataRow(2)]
         [DataRow(3)]

--- a/test/DurableTask.Core.Tests/app.config
+++ b/test/DurableTask.Core.Tests/app.config
@@ -6,11 +6,5 @@
     <add key="TaskHubName" value="test" />
   </appSettings>
   <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
   </runtime>
 </configuration>

--- a/test/DurableTask.Emulator.Tests/DurableTask.Emulator.Tests.csproj
+++ b/test/DurableTask.Emulator.Tests/DurableTask.Emulator.Tests.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DurableTask.Emulator.Tests/DurableTask.Emulator.Tests.csproj
+++ b/test/DurableTask.Emulator.Tests/DurableTask.Emulator.Tests.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DurableTask.Test.Orchestrations/SimpleOrchestrations.cs
+++ b/test/DurableTask.Test.Orchestrations/SimpleOrchestrations.cs
@@ -409,6 +409,11 @@ namespace DurableTask.Test.Orchestrations
                 responderOrchestration = Task.FromResult("Herkimer is done");
             }
 
+            // before sending the event, wait a few seconds to ensure the sub-orchestrator exists
+            // otherwise, we risk a race condition where the event is dicarded because the instances table
+            // does not yet have the sub-orchestrator instance in it.
+            await context.CreateTimer<object>(context.CurrentUtcDateTime.AddSeconds(10), state: null);
+
             // send the id of this orchestration to the responder
             var responderInstance = new OrchestrationInstance() { InstanceId = responderId };
             context.SendEvent(responderInstance, channelName, context.OrchestrationInstance.InstanceId);


### PR DESCRIPTION
The primary goal of this PR is to add a public 1ES ADO testing CI for DTFx.AS v2. This pipeline's results (and a messy development history) can be found here: https://dev.azure.com/azfunc/public/_build?definitionId=881&_a=summary

While migrating our CI pipeline, I encountered previously stable tests becoming flaky, as well as the fact that some tests were previously not running (and were failing once enabled) plus other 1ES-specific idiosyncrasies. This PR aims to resolve them all. 

To help with reviews, I'll add comments throughout the diff to clarify why some part of the code had to be changed. I feel comfortable about most changes except for one: the addition of  `System.Runtime.CompilerServices.Unsafe  v6.0.0` as an explicit dependency in DTFx.Core.

Without this change, some DTFx.Core would fail with the following exception trace:

```
Could not load file or assembly 'System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. Could not find or load a specific file. (0x80131621)
File name: 'System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
at System.Diagnostics.ActivityTraceId.SetToRandomBytes(Span1 outBytes)    at System.Diagnostics.ActivitySpanId.CreateRandom()    at DurableTask.Core.TaskOrchestrationDispatcher.ProcessScheduleTaskDecision(ScheduleTaskOrchestratorAction scheduleTaskOrchestratorAction, OrchestrationRuntimeState runtimeState, Boolean includeParameters, Activity parentTraceActivity) in /_/src/DurableTask.Core/TaskOrchestrationDispatcher.cs:line 1016    at DurableTask.Core.TaskOrchestrationDispatcher.OnProcessWorkItemAsync(TaskOrchestrationWorkItem workItem) in /_/src/DurableTask.Core/TaskOrchestrationDispatcher.cs:line 412    at DurableTask.Core.TaskOrchestrationDispatcher.OnProcessWorkItemAsync(TaskOrchestrationWorkItem workItem) in /_/src/DurableTask.Core/TaskOrchestrationDispatcher.cs:line 598    at DurableTask.Core.TaskOrchestrationDispatcher.OnProcessWorkItemSessionAsync(TaskOrchestrationWorkItem workItem) in /_/src/DurableTask.Core/TaskOrchestrationDispatcher.cs:line 211    at DurableTask.Core.WorkItemDispatcher1.ProcessWorkItemAsync(WorkItemDispatcherContext context, Object workItemObj) in /_/src/DurableTask.Core/WorkItemDispatcher.cs:line 374
```

This exception occurs in the Distributed Tracing path, as you can see by the mention of `System.Diagnostics.ActivitySpanId` in the stack, which is a type we get from our `System.Diagnostics.DiagnosticSource` dependency.

I tried researching this, and found this [GH thread](https://github.com/dotnet/runtime/issues/67196#issuecomment-1081657399) with the following excerpt:

> Unsafe package isn't referenced anymore on netstandard2.0 or net462 which means that consumers of this package now get the transitive Unsafe dependency of System.Memory which is super old (4.5.3 vs 6.0.0).

Since we recently changed DTFx.Core to use only netstandard2.0 (as per https://github.com/Azure/durabletask/pull/1125/files), it's possible this is the reason why this error is only showing up now. Unfortunately, I'm unable to reproduce this locally, but this reproduces pretty consistently on the 1ES CI. 

**As a relevant aside:** Durable Functions v2 has been incompatible with Azure Functions v1 for a while now. We never got to the bottom of that investigation, but I have a rough recollection that the reason for it was an exception _like this_ being thrown in Functions V1. Perhaps that's worth revisiting.

In any case - I need some .NET expertise to help me validate what's the problem here and if the right solution is indeed to add the explicit dependency to `CompilerServices.Unsafe v6.x`.

Other than that, I'll annotate the PR below. Thanks

_See the CI passing for the latest commit here: https://dev.azure.com/azfunc/public/_build/results?buildId=172877&view=results_