### PR TITLE
Fix DurableTaskStorageException Constructor Null Handling

### DIFF
--- a/Test/DurableTask.AzureStorage.Tests/Storage/DurableTaskStorageExceptionTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/Storage/DurableTaskStorageExceptionTests.cs
@@ -1,0 +1,44 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+#nullable enable
+namespace DurableTask.AzureStorage.Tests.Storage
+{
+    using Azure;
+    using Azure.Storage.Blobs.Models;
+    using DurableTask.AzureStorage.Storage;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System.Net;
+
+    [TestClass]
+    public class DurableTaskStorageExceptionTests
+    {
+        [TestMethod]
+        public void MissingRequestFailedException()
+        {
+            DurableTaskStorageException exception = new((RequestFailedException)null!);
+            Assert.AreEqual(0, exception.HttpStatusCode);
+            Assert.IsFalse(exception.LeaseLost);
+        }
+
+        [DataTestMethod]
+        [DataRow(true, HttpStatusCode.Conflict, nameof(BlobErrorCode.LeaseLost))]
+        [DataRow(false, HttpStatusCode.Conflict, nameof(BlobErrorCode.LeaseNotPresentWithBlobOperation))]
+        [DataRow(false, HttpStatusCode.NotFound, nameof(BlobErrorCode.BlobNotFound))]
+        public void ValidRequestFailedException(bool expectedLease, HttpStatusCode statusCode, string errorCode)
+        {
+            DurableTaskStorageException exception = new(new RequestFailedException((int)statusCode, "Error!", errorCode, innerException: null));
+            Assert.AreEqual((int)statusCode, exception.HttpStatusCode);
+            Assert.AreEqual(expectedLease, exception.LeaseLost);
+        }
+    }
+}

--- a/Test/DurableTask.AzureStorage.Tests/Storage/DurableTaskStorageExceptionTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/Storage/DurableTaskStorageExceptionTests.cs
@@ -13,11 +13,11 @@
 #nullable enable
 namespace DurableTask.AzureStorage.Tests.Storage
 {
+    using System.Net;
     using Azure;
     using Azure.Storage.Blobs.Models;
     using DurableTask.AzureStorage.Storage;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using System.Net;
 
     [TestClass]
     public class DurableTaskStorageExceptionTests

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -40,10 +40,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.40.0" />
+    <PackageReference Include="Azure.Core" Version="1.41.0" />
     <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.18.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.21.0" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.19.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -42,8 +42,8 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.41.0" />
     <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.21.0" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.19.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.18.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />

--- a/src/DurableTask.AzureStorage/Storage/DurableTaskStorageException.cs
+++ b/src/DurableTask.AzureStorage/Storage/DurableTaskStorageException.cs
@@ -35,12 +35,12 @@ namespace DurableTask.AzureStorage.Storage
         }
 
         public DurableTaskStorageException(RequestFailedException requestFailedException)
-            : base(requestFailedException.Message, requestFailedException)
+            : base("An error occurred while communicating with Azure Storage", requestFailedException)
         {
-            this.HttpStatusCode = requestFailedException.Status;
-            if (requestFailedException?.ErrorCode == BlobErrorCode.LeaseLost)
+            if (requestFailedException != null)
             {
-                LeaseLost = true;
+                this.HttpStatusCode = requestFailedException.Status;
+                this.LeaseLost = requestFailedException.ErrorCode != null && requestFailedException.ErrorCode == BlobErrorCode.LeaseLost;
             }
         }
 

--- a/src/DurableTask.AzureStorage/Storage/DurableTaskStorageException.cs
+++ b/src/DurableTask.AzureStorage/Storage/DurableTaskStorageException.cs
@@ -24,17 +24,17 @@ namespace DurableTask.AzureStorage.Storage
         {
         }
 
-        public DurableTaskStorageException(string message)
+        public DurableTaskStorageException(string? message)
             : base(message)
         {
         }
 
-        public DurableTaskStorageException(string message, Exception inner)
+        public DurableTaskStorageException(string? message, Exception? inner)
             : base(message, inner)
         {
         }
 
-        public DurableTaskStorageException(RequestFailedException requestFailedException)
+        public DurableTaskStorageException(RequestFailedException? requestFailedException)
             : base("An error occurred while communicating with Azure Storage", requestFailedException)
         {
             if (requestFailedException != null)


### PR DESCRIPTION
The ctor for `DurableTaskStorageException` will throw an exception if the given `RequestFailedException` is `null` or the `ErrorCode` property is `null`. Both cases should be handled gracefully, and this change involves some refactoring to the class.

Included in this change is also an update to libraries including `Azure.Core` which had a vulnerability.