### PR TITLE
Ensure queue is listened to on a sudden PMv3 restart

### DIFF
--- a/eng/ci/code-mirror.yml
+++ b/eng/ci/code-mirror.yml
@@ -4,6 +4,7 @@ trigger:
     # These are the branches we'll mirror to our internal ADO instance
     # Keep this set limited as appropriate (don't mirror individual user branches).
     - main
+    - durabletask-core-v2
 
 resources:
   repositories:

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -3,6 +3,7 @@ trigger:
     branches:
         include:
             - main
+            - durabletask-core-v2
 
 # CI only, does not trigger on PRs.
 pr: none

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -17,10 +17,7 @@ schedules:
     always: true # Run pipeline irrespective of no code changes since last successful run
 
 # Run on all PRs
-pr:
-  branches:
-    include:
-    - '*'
+pr: '*' # run on all PRs
 
 # This allows us to reference 1ES templates, our pipelines extend a pre-existing template
 resources:

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -17,7 +17,9 @@ schedules:
     always: true # Run pipeline irrespective of no code changes since last successful run
 
 # Run on all PRs
-pr: '*' # run on all PRs
+pr:
+- main
+- '*' # run on all PRs
 
 # This allows us to reference 1ES templates, our pipelines extend a pre-existing template
 resources:

--- a/src/DurableTask.AzureStorage/Partitioning/TablePartitionManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/TablePartitionManager.cs
@@ -407,7 +407,11 @@ namespace DurableTask.AzureStorage.Partitioning
                             throw;
                         }
 
-                        if (claimedLease)
+                        // Ensure worker is listening to the control queue iff either:
+                        // 1) worker just claimed the lease,
+                        // 2) worker was already the owner in the partitions table and is not actively draining the queue. Note that during draining, we renew the lease but do not want to listen to new messages. Otherwise, we'll never finish draining our in-memory messages.
+                        bool isRenewingToDrainQueue = renewedLease & response.IsDrainingPartition
+                        if (claimedLease || !isRenewingToDrainQueue)
                         {
                             // Notify the orchestration session manager that we acquired a lease for one of the partitions.
                             // This will cause it to start reading control queue messages for that partition.

--- a/src/DurableTask.AzureStorage/Partitioning/TablePartitionManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/TablePartitionManager.cs
@@ -410,7 +410,7 @@ namespace DurableTask.AzureStorage.Partitioning
                         // Ensure worker is listening to the control queue iff either:
                         // 1) worker just claimed the lease,
                         // 2) worker was already the owner in the partitions table and is not actively draining the queue. Note that during draining, we renew the lease but do not want to listen to new messages. Otherwise, we'll never finish draining our in-memory messages.
-                        bool isRenewingToDrainQueue = renewedLease & response.IsDrainingPartition
+                        bool isRenewingToDrainQueue = renewedLease & response.IsDrainingPartition;
                         if (claimedLease || !isRenewingToDrainQueue)
                         {
                             // Notify the orchestration session manager that we acquired a lease for one of the partitions.

--- a/test/DurableTask.AzureStorage.Tests/TestTablePartitionManager.cs
+++ b/test/DurableTask.AzureStorage.Tests/TestTablePartitionManager.cs
@@ -726,7 +726,6 @@ namespace DurableTask.AzureStorage.Tests
                 Assert.IsTrue(
                     Array.TrueForAll(states, s => s?.OrchestrationStatus == OrchestrationStatus.Completed),
                     "Not all orchestrations completed successfully!");
-                nytian marked this conversation as resolved.
             }
         }
 

--- a/test/DurableTask.AzureStorage.Tests/TestTablePartitionManager.cs
+++ b/test/DurableTask.AzureStorage.Tests/TestTablePartitionManager.cs
@@ -657,6 +657,79 @@ namespace DurableTask.AzureStorage.Tests
             await Task.WhenAll(stopServiceTasks);
         }
 
+        /// <summary>
+        /// End to end test to simulate one worker with one partition.
+        /// Simulate that one worker becomes unhealthy, and then back to a healthy again before the owned lease expires.
+        /// Make sure the worker can still listen to owned control queue without claiming the lease.
+        /// </summary>
+        [TestMethod]
+        public async Task TestWorkerRestartBeforeLeaseExpired()
+        {
+            const int WorkerCount = 2;
+            const int InstanceCount = 50;
+            var services = new AzureStorageOrchestrationService[WorkerCount];
+            var taskHubWorkers = new TaskHubWorker[WorkerCount];
+
+            var settings = new AzureStorageOrchestrationServiceSettings()
+            {
+                StorageAccountClientProvider = new StorageAccountClientProvider(this.connection),
+                TaskHubName = "WorkerRestartBeforeLeaseExpired",
+                PartitionCount = 1,
+                // Set a long lease interval to make sure the lease won't expire during the test.
+                LeaseInterval = TimeSpan.FromMinutes(5),
+                WorkerId = "0",
+                UseTablePartitionManagement = true,
+            };
+
+            for (int i = 0; i < WorkerCount; i++)
+            {
+                services[i] = new AzureStorageOrchestrationService(settings);
+                // Two workers share the same worker id since here we want to simulate a worker restart.
+                taskHubWorkers[i] = new TaskHubWorker(services[i]);
+                taskHubWorkers[i].AddTaskOrchestrations(typeof(LongRunningOrchestrator));
+            }
+
+            // Create orchestration instances.
+            var client = new TaskHubClient(services[0]);
+            var createInstanceTasks = new Task<OrchestrationInstance>[InstanceCount];
+            for (int i = 0; i < InstanceCount; i++)
+            {
+                createInstanceTasks[i] = client.CreateOrchestrationInstanceAsync(typeof(LongRunningOrchestrator), input: null);
+            }
+            OrchestrationInstance[] instances = await Task.WhenAll(createInstanceTasks);
+
+            await taskHubWorkers[0].StartAsync();
+
+            // Ensure worker acquired the partition.
+            await WaitForConditionAsync(
+                timeout: TimeSpan.FromSeconds(2),
+                condition: async t =>
+                {
+                    TablePartitionLease lease = await services[0].ListTableLeasesAsync(t).SingleAsync(t);
+                    return lease.CurrentOwner == "0";
+                });
+
+            using var cts = new CancellationTokenSource();
+            {
+                // Simulate a worker crashed and back to healthy again before the lease expires.
+                // To achieve this, we stop worker[0] table partition management loop and start worker[1].
+                services[0].KillPartitionManagerLoop();
+                await taskHubWorkers[1].StartAsync();
+
+                // Worker[1] that shares name "0" should owned the partition without cliaming the lease. 
+                await Task.Delay(1000);
+                Assert.AreEqual(1, services[1].OwnedControlQueues.Count());
+
+                // Check all the instances could be processed successfully. 
+                OrchestrationState[] states = await Task.WhenAll(
+                    instances.Select(i => client.WaitForOrchestrationAsync(i, TimeSpan.FromSeconds(30))));
+                Assert.IsTrue(
+                    Array.TrueForAll(states, s => s?.OrchestrationStatus == OrchestrationStatus.Completed),
+                    "Not all orchestrations completed successfully!");
+                nytian marked this conversation as resolved.
+            }
+        }
+
         [KnownType(typeof(Hello))]
         internal class HelloOrchestrator : TaskOrchestration<string, string>
         {


### PR DESCRIPTION
Replaces: https://github.com/Azure/durabletask/pull/1136/files, which targets `azure-storage-v12` which got _squashed_ when it got merged to main (on @cgillum's recommendation for a clean history on main). I figured that re-creating the PR was the easier path forward, as the other PR's history would need to be rebased and squashed as well.

Also made some minor edits to our pipeline config so the pipelines run on the DTFx.ASv1 "frozen" branch.