### PR TITLE
Update code-mirror pipeline in durabletask-core-v2 branch

### DIFF
--- a/eng/ci/code-mirror.yml
+++ b/eng/ci/code-mirror.yml
@@ -4,6 +4,7 @@ trigger:
     # These are the branches we'll mirror to our internal ADO instance
     # Keep this set limited as appropriate (don't mirror individual user branches).
     - main
+    - durabletask-core-v2
 
 resources:
   repositories:

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -3,6 +3,7 @@ trigger:
     branches:
         include:
             - main
+            - durabletask-core-v2
 
 # CI only, does not trigger on PRs.
 pr: none


### PR DESCRIPTION
As in title, to allow this branch to be code-mirror in 1ES