### PR TITLE
Remove netcoreapp3.1 from tests

### DIFF
--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -3229,7 +3229,7 @@ namespace DurableTask.AzureStorage.Tests
             internal class AutoStartOrchestration : TaskOrchestration<string, string>
             {
                 private readonly TaskCompletionSource<string> tcs
-                    = new TaskCompletionSource<string>(TaskContinuationOptions.ExecuteSynchronously);
+                    = new TaskCompletionSource<string>();
 
                 // HACK: This is just a hack to communicate result of orchestration back to test
                 public static bool OkResult;
@@ -3273,7 +3273,7 @@ namespace DurableTask.AzureStorage.Tests
                 public class Responder : TaskOrchestration<string, string, RequestInformation, string>
                 {
                     private readonly TaskCompletionSource<string> tcs
-                        = new TaskCompletionSource<string>(TaskContinuationOptions.ExecuteSynchronously);
+                        = new TaskCompletionSource<string>();
 
                     public async override Task<string> RunTask(OrchestrationContext context, string input)
                     {

--- a/test/DurableTask.AzureStorage.Tests/Correlation/DurableTaskCorrelationTelemetryInitializer.cs
+++ b/test/DurableTask.AzureStorage.Tests/Correlation/DurableTaskCorrelationTelemetryInitializer.cs
@@ -311,10 +311,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
             if (initializeFromCurrent)
             {
                 opTelemetry.Id = activity.SpanId.ToHexString();
-                if (activity.ParentSpanId != null)
-                {
-                    opTelemetry.Context.Operation.ParentId = activity.ParentSpanId.ToHexString();
-                }
+                opTelemetry.Context.Operation.ParentId = activity.ParentSpanId.ToHexString();
             }
             else
             {

--- a/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
+++ b/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
+++ b/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
@@ -255,7 +255,7 @@ namespace DurableTask.Core.Tests
             StringReader stringReader = new StringReader(writtenString);
             XmlReader xmlReader = XmlReader.Create(stringReader);
 
-            OrchestrationExecutionContext deserializedContext = (OrchestrationExecutionContext)dataContractSerializer.ReadObject(xmlReader);
+            OrchestrationExecutionContext deserializedContext = (OrchestrationExecutionContext)dataContractSerializer.ReadObject(xmlReader)!;
 
             Assert.AreEqual("Value", deserializedContext.OrchestrationTags["Key"]);
         }

--- a/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj
+++ b/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/DurableTask.Emulator.Tests/DurableTask.Emulator.Tests.csproj
+++ b/test/DurableTask.Emulator.Tests/DurableTask.Emulator.Tests.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/DurableTask.Stress.Tests/DurableTask.Stress.Tests.csproj
+++ b/test/DurableTask.Stress.Tests/DurableTask.Stress.Tests.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
     <StartupObject>DurableTask.Stress.Tests.Program</StartupObject>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
@@ -12,16 +12,16 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
     <None Remove="eventFlowConfig.json" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
     <Content Include="eventFlowConfig.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
     <PackageReference Include="CommandLineParser" Version="2.4.3" />
     <PackageReference Include="Microsoft.Diagnostics.EventFlow.Core" Version="1.5.6" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
@@ -39,7 +39,7 @@
     <ProjectReference Include="..\DurableTask.Test.Orchestrations\DurableTask.Test.Orchestrations.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
     <None Update="DurableTask.Stress.Tests.dll.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Given our recent TFM changes, and that `netcoreapp3.1` is out of support and will _soon_ no longer be the used in Azure Functions' extension bundles, this PR changes our test project to use `.net6.0` as it's TFM over `netcoreapp3.1`. This removes some warnings from our solution, which should help with compliance and reduce "warning fatigue".

