### PR TITLE
Add setting to allow replaying terminal orchestrators in DTFx.AS

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -790,7 +790,7 @@ namespace DurableTask.AzureStorage
                         TraceContext = currentRequestTraceContext,
                     };
 
-                    if (!this.IsExecutableInstance(session.RuntimeState, orchestrationWorkItem.NewMessages, out string warningMessage))
+                    if (!this.IsExecutableInstance(session.RuntimeState, orchestrationWorkItem.NewMessages, settings.AllowReplayingTerminalInstances, out string warningMessage))
                     {
                         // If all messages belong to the same execution ID, then all of them need to be discarded.
                         // However, it's also possible to have messages for *any* execution ID batched together with messages
@@ -1046,7 +1046,7 @@ namespace DurableTask.AzureStorage
                 data.Episode.GetValueOrDefault(-1));
         }
 
-        bool IsExecutableInstance(OrchestrationRuntimeState runtimeState, IList<TaskMessage> newMessages, out string message)
+        bool IsExecutableInstance(OrchestrationRuntimeState runtimeState, IList<TaskMessage> newMessages, bool allowReplayingTerminalInstances, out string message)
         {
             if (runtimeState.ExecutionStartedEvent == null && !newMessages.Any(msg => msg.Event is ExecutionStartedEvent))
             {
@@ -1072,6 +1072,7 @@ namespace DurableTask.AzureStorage
             }
 
             if (runtimeState.ExecutionStartedEvent != null &&
+                !allowReplayingTerminalInstances &&
                 runtimeState.OrchestrationStatus != OrchestrationStatus.Running &&
                 runtimeState.OrchestrationStatus != OrchestrationStatus.Pending &&
                 runtimeState.OrchestrationStatus != OrchestrationStatus.Suspended)

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -157,6 +157,20 @@ namespace DurableTask.AzureStorage
         public bool UseAppLease { get; set; } = true;
 
         /// <summary>
+        /// When false, when an orchestrator is in a terminal state (e.g. Completed, Failed, Terminated), events for that orchestrator are discarded.
+        /// Otherwise, events for a terminal orchestrator induce a replay. This may be used to recompute the state of the orchestrator in the "Instances Table".
+        /// </summary>
+        /// <remarks>
+        /// Transactions across Azure Tables are not possible, so we independently update the "History table" and then the "Instances table"
+        /// to set the state of the orchestrator.
+        /// If a crash were to occur between these two updates, the state of the orchestrator in the "Instances table" would be incorrect.
+        /// By setting this configuration to true, you can recover from these inconsistencies by forcing a replay of the orchestrator in response
+        /// to a client event like a termination request or an external event, which gives the framework another opportunity to update the state of
+        /// the orchestrator in the "Instances table". To force a replay after enabling this configuration, just send any external event to the affected instanceId.
+        /// </remarks>
+        public bool AllowReplayingTerminalInstances { get; set; } = false;
+
+        /// <summary>
         /// If UseAppLease is true, gets or sets the AppLeaseOptions used for acquiring the lease to start the application.
         /// </summary>
         public AppLeaseOptions AppLeaseOptions { get; set; } = AppLeaseOptions.DefaultOptions;

--- a/test/DurableTask.AzureStorage.Tests/TestHelpers.cs
+++ b/test/DurableTask.AzureStorage.Tests/TestHelpers.cs
@@ -27,7 +27,25 @@ namespace DurableTask.AzureStorage.Tests
             bool enableExtendedSessions,
             int extendedSessionTimeoutInSeconds = 30,
             bool fetchLargeMessages = true,
+            bool allowReplayingTerminalInstances = false,
             Action<AzureStorageOrchestrationServiceSettings>? modifySettingsAction = null)
+        {
+            AzureStorageOrchestrationServiceSettings settings = GetTestAzureStorageOrchestrationServiceSettings(
+                enableExtendedSessions,
+                extendedSessionTimeoutInSeconds,
+                fetchLargeMessages,
+                allowReplayingTerminalInstances);
+            // Give the caller a chance to make test-specific changes to the settings
+            modifySettingsAction?.Invoke(settings);
+
+            return new TestOrchestrationHost(settings);
+        }
+
+        public static AzureStorageOrchestrationServiceSettings GetTestAzureStorageOrchestrationServiceSettings(
+            bool enableExtendedSessions,
+            int extendedSessionTimeoutInSeconds = 30,
+            bool fetchLargeMessages = true,
+            bool allowReplayingTerminalInstances = false)
         {
             string storageConnectionString = GetTestStorageAccountConnectionString();
 
@@ -43,15 +61,13 @@ namespace DurableTask.AzureStorage.Tests
                 FetchLargeMessageDataEnabled = fetchLargeMessages,
                 StorageAccountClientProvider = new StorageAccountClientProvider(storageConnectionString),
                 TaskHubName = GetTestTaskHubName(),
+                AllowReplayingTerminalInstances = allowReplayingTerminalInstances,
 
                 // Setting up a logger factory to enable the new DurableTask.Core logs
                 LoggerFactory = loggerFactory,
             };
 
-            // Give the caller a chance to make test-specific changes to the settings
-            modifySettingsAction?.Invoke(settings);
-
-            return new TestOrchestrationHost(settings);
+            return settings;
         }
 
         public static string GetTestStorageAccountConnectionString()


### PR DESCRIPTION
## Problem
In DTFx.AS, we track an orchestration state in the History and Instance tables, which we update independently in a non-transactional way (there are not transactions in Azure Storage tables). Therefore, there exists a race condition where if DTFx.AS crashes after updating the orchestrator state in the History table but before updating the Instance table, the two tables will be out of sync.

In many cases, this is fine: the next orchestrator replay will update the Instance table and bring the two data stores back in sync. **However**, if the orchestrator is in a terminal state as per the History table (e.g. Completed, Failed, Terminated), then we will not get another opportunity to update the Instances table because we will discard any new events for that instanceID (including "Terminate" requests) based solely on the fact that the History table claims the orchestrator is completed. For proof, see the `IsExecutableInstance` method, where we ensure an orchestrator that is terminal (according to the history table) cannot be replayed again:

https://github.com/Azure/durabletask/blob/4f82f628e20b764ce7621b446d0cd121d0dce51e/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs#L1049-L1085

In the end, this situation necessary manuals editing of storage resources to recover from, which is dangerous.

## Impact
This is rare, but I've seen it a handful of times in servicing cases, including yesterday.

## This PR
This PR introduces a new setting for the Azure Storage backend, called `AllowReplayingTerminalInstances`. When set, we will **not** discard events for orchestrator in terminal instances, like we do today in `IsExecutableInstance` (embedded snippet above). This means we can force the orchestrator to replay, causing the instance table to get updated and thus brought back into sync. 

I imagine the user story to be:
(1) the user identifies the state of instanceID X is inconsistent between the History and Instance table: the former claims the orchestrator is completed/terminal, but the latter says it's running.
(2) They set to `AllowReplayingTerminalInstances` to `true`.
(3) They send an arbitrary external event to the orchestrator, which will force a replay and update the instace table.
(4) The orchestrator state in storage is now correct :-)

In step (3) they may also decide to just terminate the orchestrator, either works. What matters is that we can once again update the Instance table in response to an event.

## Ideal solution (not this PR), in my opinion. Just some musings.
It would be great if Azure Storage provided transactions across Azure Storage tables. In the absence of that, this race condition will always exist. I think it's worth considering if a new major version of DTFx.AS could work with only a singular Azure Storage table, perhaps by making use of another "sentinel"-type row in the History table to replace the Instance table altogether. This remove the possibility of an incomplete update like this. Just something I've been considering in the back of my mind.