### PR TITLE
Run public build on all PRs, add DTFx.Core v2 branch to public build triggers

### DIFF
--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -6,6 +6,7 @@ trigger:
   branches:
     include:
     - main
+    - durabletask-core-v2
 
 # Run nightly to catch new CVEs and to report SDL often.
 schedules:
@@ -14,12 +15,14 @@ schedules:
     branches:
       include:
       - main
+      - durabletask-core-v2
     always: true # Run pipeline irrespective of no code changes since last successful run
 
 # Run on all PRs
 pr:
-- main
-- '*' # run on all PRs
+  branches:
+    include:
+    - '*'
 
 # This allows us to reference 1ES templates, our pipelines extend a pre-existing template
 resources:


### PR DESCRIPTION
The public 1ES build is not automatically running on PRs, as it should. This PR attempts to fix that by trying alternative syntax to the `pr:` block of our public 1ES build definition.

It also adds `durabletask-core-v2` to the list of branches we run our nightly CI on.