### PR TITLE
add public build to durabletask-core-v2

### DIFF
--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -1,0 +1,110 @@
+# This pipeline is used for public PR and CI builds.
+
+# Run on changes in main
+trigger:
+  batch: true
+  branches:
+    include:
+    - main
+    - durabletask-core-v2
+
+# Run nightly to catch new CVEs and to report SDL often.
+schedules:
+  - cron: "0 0 * * *"
+    displayName: Nightly Run
+    branches:
+      include:
+      - main
+      - durabletask-core-v2
+    always: true # Run pipeline irrespective of no code changes since last successful run
+
+# Run on all PRs
+pr:
+  branches:
+    include:
+    - '*'
+
+# This allows us to reference 1ES templates, our pipelines extend a pre-existing template
+resources:
+  repositories:
+  - repository: 1es
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  # The template we extend injects compliance-checks into the pipeline, such as SDL and CodeQL
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1es
+  parameters:
+    pool:
+      name: 1es-pool-azfunc-public
+      image: 1es-windows-2022
+      os: windows
+
+    sdl:
+      codeql:
+        compiled:
+          enabled: true
+        runSourceLanguagesInSourceAnalysis: true
+
+    settings:
+      # PR's from forks should not have permissions to set tags.
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
+    stages:
+    - stage: DTFxCoreValidate
+      jobs:
+      - job: Validate
+        strategy:
+          parallel: 13
+        steps:
+        # Build the code and the tests
+        - template: /eng/templates/build-steps.yml@self
+          parameters:
+            # The tests only build in the 'Debug' configuration.
+            # In the release configuration, the packages don't expose their internals
+            # to the test projects.
+            buildConfiguration: 'Debug'
+            buildTests: true 
+        # Run tests
+        - template: /eng/templates/test.yml@self
+          parameters:
+            testAssembly: '**\bin\**\DurableTask.Core.Tests.dll'
+    - stage: DTFxASValidate
+      dependsOn: []
+      jobs:
+      - job: Validate
+        strategy:
+          parallel: 13
+        steps:
+        # Build the code and the tests
+        - template: /eng/templates/build-steps.yml@self
+          parameters:
+            # The tests only build in the 'Debug' configuration.
+            # In the release configuration, the packages don't expose their internals
+            # to the test projects.
+            buildConfiguration: 'Debug'
+            buildTests: true 
+        # Run tests
+        - template: /eng/templates/test.yml@self
+          parameters:
+            testAssembly: '**\bin\**\DurableTask.AzureStorage.Tests.dll'
+    - stage: DTFxEmulatorValidate
+      dependsOn: []
+      jobs:
+      - job: Validate
+        strategy:
+          parallel: 13
+        steps:
+        # Build the code and the tests
+        - template: /eng/templates/build-steps.yml@self
+          parameters:
+            # The tests only build in the 'Debug' configuration.
+            # In the release configuration, the packages don't expose their internals
+            # to the test projects.
+            buildConfiguration: 'Debug'
+            buildTests: true 
+        # Run tests
+        - template: /eng/templates/test.yml@self
+          parameters:
+            testAssembly: '**\bin\**\DurableTask.Emulator.Tests.dll'


### PR DESCRIPTION
As in title, just adding the public build CI to the `durabletask-core-v2`. With this, all PRs to `durabletask-core-v2` will get a CI build running the tests.