### PR TITLE
[durabletask-core-v2] Various fixes to public build for DTFx.Core v2

### DIFF
--- a/Test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
+++ b/Test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
@@ -89,7 +89,7 @@ namespace DurableTask.Core.Tests
             }
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public async Task FailureDetailsOnHandled()
         {
             // The error propagation mode must be set before the worker is started
@@ -149,7 +149,7 @@ namespace DurableTask.Core.Tests
             }
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public void TaskFailureOnNullContextTaskActivity()
         {
             TaskActivity activity = new ThrowInvalidOperationExceptionAsync();

--- a/Test/DurableTask.Core.Tests/MessageSorterTests.cs
+++ b/Test/DurableTask.Core.Tests/MessageSorterTests.cs
@@ -18,7 +18,7 @@ namespace DurableTask.Core.Tests
     {
         private static readonly TimeSpan ReorderWindow = TimeSpan.FromMinutes(30);
 
-        [TestMethod]
+        [DataTestMethod]
         public void SimpleInOrder()
         {
             var senderId = "A";
@@ -44,7 +44,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual(0, receiverSorter.NumberBufferedRequests);
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public void WackySystemClock()
         {
             var senderId = "A";
@@ -71,7 +71,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual(0, receiverSorter.NumberBufferedRequests);
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public void DelayedElement()
         {
             var senderId = "A";
@@ -102,7 +102,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual(0, receiverSorter.NumberBufferedRequests);
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public void NoFilteringOrSortingPastReorderWindow()
         {
             var senderId = "A";
@@ -137,7 +137,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual(0, receiverSorter.NumberBufferedRequests);
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public void DuplicatedElements()
         {
             var senderId = "A";
@@ -179,7 +179,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual(0, receiverSorter.NumberBufferedRequests);
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public void RandomShuffleAndDuplication()
         {
             var senderId = "A";
@@ -233,7 +233,7 @@ namespace DurableTask.Core.Tests
         /// Tests that if messages get reordered beyond the supported reorder window,
         /// we still deliver them all but they may now be out of order.
         /// </summary>
-        [TestMethod]
+        [DataTestMethod]
         public void RandomCollection()
         {
             var senderId = "A";

--- a/Test/DurableTask.Core.Tests/RetryInterceptorTests.cs
+++ b/Test/DurableTask.Core.Tests/RetryInterceptorTests.cs
@@ -31,7 +31,7 @@ namespace DurableTask.Core.Tests
             await Assert.ThrowsExceptionAsync<IOException>(Invoke, "Interceptor should throw the original exception after exceeding max retry attempts.");
         }
 
-        [TestMethod]
+        [DataTestMethod]
         [DataRow(1)]
         [DataRow(2)]
         [DataRow(3)]
@@ -59,7 +59,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual(maxAttempts, callCount, 0, $"There should be {maxAttempts} function calls for {maxAttempts} max attempts.");
         }
 
-        [TestMethod]
+        [DataTestMethod]
         [DataRow(1)]
         [DataRow(2)]
         [DataRow(3)]

--- a/Test/DurableTask.Core.Tests/RetryInterceptorTests.cs
+++ b/Test/DurableTask.Core.Tests/RetryInterceptorTests.cs
@@ -22,7 +22,7 @@ namespace DurableTask.Core.Tests
             this.context = new MockOrchestrationContext(new OrchestrationInstance(), TaskScheduler.Default);
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public async Task Invoke_WithFailingRetryCall_ShouldThrowCorrectException()
         {
             var interceptor = new RetryInterceptor<object>(this.context, new RetryOptions(TimeSpan.FromMilliseconds(100), 1), () => throw new IOException());

--- a/Test/DurableTask.Core.Tests/TaskHubClientTests.cs
+++ b/Test/DurableTask.Core.Tests/TaskHubClientTests.cs
@@ -44,7 +44,7 @@ namespace DurableTask.Core.Tests
         /// <summary>
         /// Tests that scheduled orchestrations can be created.
         /// </summary>
-        [TestMethod]
+        [DataTestMethod]
         public async Task CanCreateScheduledOrchestrations()
         {
             // create test orchestration service that allows us to inspect the generated HistoryEvents

--- a/Test/DurableTask.Core.Tests/TestTaskEntityDispatcher.cs
+++ b/Test/DurableTask.Core.Tests/TestTaskEntityDispatcher.cs
@@ -43,7 +43,7 @@ namespace DurableTask.Core.Tests
         /// they did not know how to handle. Eventually, this led to them deleting
         /// their own state. This test checks against that case.
         /// </summary>
-        [TestMethod]
+        [DataTestMethod]
         public void TestEntityDoesNotSetFireAndForgetTags()
         {
             TaskEntityDispatcher dispatcher = GetTaskEntityDispatcher();

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -55,8 +55,6 @@ extends:
     - stage: DTFxCoreValidate
       jobs:
       - job: Validate
-        # strategy:
-        #   parallel: 1
         steps:
         # Build the code and the tests
         - template: /eng/templates/build-steps.yml@self
@@ -70,41 +68,41 @@ extends:
         - template: /eng/templates/test.yml@self
           parameters:
             testAssembly: '**\bin\**\DurableTask.Core.Tests.dll'
-    # - stage: DTFxASValidate
-    #   dependsOn: []
-    #   jobs:
-    #   - job: Validate
-    #     strategy:
-    #       parallel: 13
-    #     steps:
-    #     # Build the code and the tests
-    #     - template: /eng/templates/build-steps.yml@self
-    #       parameters:
-    #         # The tests only build in the 'Debug' configuration.
-    #         # In the release configuration, the packages don't expose their internals
-    #         # to the test projects.
-    #         buildConfiguration: 'Debug'
-    #         buildTests: true 
-    #     # Run tests
-    #     - template: /eng/templates/test.yml@self
-    #       parameters:
-    #         testAssembly: '**\bin\**\DurableTask.AzureStorage.Tests.dll'
-    # - stage: DTFxEmulatorValidate
-    #   dependsOn: []
-    #   jobs:
-    #   - job: Validate
-    #     strategy:
-    #       parallel: 13
-    #     steps:
-    #     # Build the code and the tests
-    #     - template: /eng/templates/build-steps.yml@self
-    #       parameters:
-    #         # The tests only build in the 'Debug' configuration.
-    #         # In the release configuration, the packages don't expose their internals
-    #         # to the test projects.
-    #         buildConfiguration: 'Debug'
-    #         buildTests: true 
-    #     # Run tests
-    #     - template: /eng/templates/test.yml@self
-    #       parameters:
-    #         testAssembly: '**\bin\**\DurableTask.Emulator.Tests.dll'
+    - stage: DTFxASValidate
+      dependsOn: []
+      jobs:
+      - job: Validate
+        strategy:
+          parallel: 13
+        steps:
+        # Build the code and the tests
+        - template: /eng/templates/build-steps.yml@self
+          parameters:
+            # The tests only build in the 'Debug' configuration.
+            # In the release configuration, the packages don't expose their internals
+            # to the test projects.
+            buildConfiguration: 'Debug'
+            buildTests: true 
+        # Run tests
+        - template: /eng/templates/test.yml@self
+          parameters:
+            testAssembly: '**\bin\**\DurableTask.AzureStorage.Tests.dll'
+    - stage: DTFxEmulatorValidate
+      dependsOn: []
+      jobs:
+      - job: Validate
+        strategy:
+          parallel: 13
+        steps:
+        # Build the code and the tests
+        - template: /eng/templates/build-steps.yml@self
+          parameters:
+            # The tests only build in the 'Debug' configuration.
+            # In the release configuration, the packages don't expose their internals
+            # to the test projects.
+            buildConfiguration: 'Debug'
+            buildTests: true 
+        # Run tests
+        - template: /eng/templates/test.yml@self
+          parameters:
+            testAssembly: '**\bin\**\DurableTask.Emulator.Tests.dll'

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -55,8 +55,8 @@ extends:
     - stage: DTFxCoreValidate
       jobs:
       - job: Validate
-        strategy:
-          parallel: 13
+        # strategy:
+        #   parallel: 1
         steps:
         # Build the code and the tests
         - template: /eng/templates/build-steps.yml@self
@@ -70,41 +70,41 @@ extends:
         - template: /eng/templates/test.yml@self
           parameters:
             testAssembly: '**\bin\**\DurableTask.Core.Tests.dll'
-    - stage: DTFxASValidate
-      dependsOn: []
-      jobs:
-      - job: Validate
-        strategy:
-          parallel: 13
-        steps:
-        # Build the code and the tests
-        - template: /eng/templates/build-steps.yml@self
-          parameters:
-            # The tests only build in the 'Debug' configuration.
-            # In the release configuration, the packages don't expose their internals
-            # to the test projects.
-            buildConfiguration: 'Debug'
-            buildTests: true 
-        # Run tests
-        - template: /eng/templates/test.yml@self
-          parameters:
-            testAssembly: '**\bin\**\DurableTask.AzureStorage.Tests.dll'
-    - stage: DTFxEmulatorValidate
-      dependsOn: []
-      jobs:
-      - job: Validate
-        strategy:
-          parallel: 13
-        steps:
-        # Build the code and the tests
-        - template: /eng/templates/build-steps.yml@self
-          parameters:
-            # The tests only build in the 'Debug' configuration.
-            # In the release configuration, the packages don't expose their internals
-            # to the test projects.
-            buildConfiguration: 'Debug'
-            buildTests: true 
-        # Run tests
-        - template: /eng/templates/test.yml@self
-          parameters:
-            testAssembly: '**\bin\**\DurableTask.Emulator.Tests.dll'
+    # - stage: DTFxASValidate
+    #   dependsOn: []
+    #   jobs:
+    #   - job: Validate
+    #     strategy:
+    #       parallel: 13
+    #     steps:
+    #     # Build the code and the tests
+    #     - template: /eng/templates/build-steps.yml@self
+    #       parameters:
+    #         # The tests only build in the 'Debug' configuration.
+    #         # In the release configuration, the packages don't expose their internals
+    #         # to the test projects.
+    #         buildConfiguration: 'Debug'
+    #         buildTests: true 
+    #     # Run tests
+    #     - template: /eng/templates/test.yml@self
+    #       parameters:
+    #         testAssembly: '**\bin\**\DurableTask.AzureStorage.Tests.dll'
+    # - stage: DTFxEmulatorValidate
+    #   dependsOn: []
+    #   jobs:
+    #   - job: Validate
+    #     strategy:
+    #       parallel: 13
+    #     steps:
+    #     # Build the code and the tests
+    #     - template: /eng/templates/build-steps.yml@self
+    #       parameters:
+    #         # The tests only build in the 'Debug' configuration.
+    #         # In the release configuration, the packages don't expose their internals
+    #         # to the test projects.
+    #         buildConfiguration: 'Debug'
+    #         buildTests: true 
+    #     # Run tests
+    #     - template: /eng/templates/test.yml@self
+    #       parameters:
+    #         testAssembly: '**\bin\**\DurableTask.Emulator.Tests.dll'

--- a/eng/templates/build-steps.yml
+++ b/eng/templates/build-steps.yml
@@ -1,0 +1,107 @@
+parameters:
+- name: buildConfiguration
+  type: string
+  default: 'Release'
+
+- name: buildTests
+  type: boolean
+  default: false
+
+steps:
+# Start by restoring all the dependencies. This needs to be its own task
+# from what I can tell. We specifically only target DurableTask.AzureStorage
+# and its direct dependencies.
+# Configure all the .NET SDK versions we need
+- task: UseDotNet@2
+  displayName: 'Use the .NET Core 2.1 SDK (required for build signing)'
+  inputs:
+    packageType: 'sdk'
+    version: '2.1.x'
+
+- task: UseDotNet@2
+  displayName: 'Use the .NET Core 3.1 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '3.1.x'
+
+- task: UseDotNet@2
+  displayName: 'Use the .NET 6 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '6.0.x'
+
+- task: DotNetCoreCLI@2
+  displayName: 'Restore nuget dependencies'
+  inputs:
+      command: restore
+      verbosityRestore: Minimal
+      projects: |
+          src/DurableTask.AzureStorage/DurableTask.AzureStorage.sln
+          src/DurableTask.Emulator/DurableTask.Emulator.csproj
+          src/DurableTask.ApplicationInsights/DurableTask.ApplicationInsights.csproj
+
+# Build the filtered solution in release mode, specifying the continuous integration flag.
+- task: VSBuild@1
+  displayName: 'Build (AzureStorage)'
+  inputs:
+    solution: 'src/DurableTask.AzureStorage/DurableTask.AzureStorage.sln'
+    vsVersion: '17.0'
+    logFileVerbosity: minimal
+    configuration: ${{ parameters.buildConfiguration }}
+    msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
+
+- task: VSBuild@1
+  displayName: 'Build (ApplicationInsights)'
+  inputs:
+    solution: 'src/DurableTask.ApplicationInsights/DurableTask.ApplicationInsights.csproj'
+    vsVersion: '17.0'
+    logFileVerbosity: minimal
+    configuration: ${{ parameters.buildConfiguration }}
+    msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
+
+- task: VSBuild@1
+  displayName: 'Build (Emulator)'
+  inputs:
+    solution: 'src/DurableTask.Emulator/DurableTask.Emulator.csproj'
+    vsVersion: '17.0'
+    logFileVerbosity: minimal
+    configuration: ${{ parameters.buildConfiguration }}
+    msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
+
+- ${{ if eq(parameters.buildTests, true) }}:
+  - task: DotNetCoreCLI@2
+    displayName: 'Restore nuget dependencies'
+    inputs:
+        command: restore
+        verbosityRestore: Minimal
+        projects: |
+            .\Test\DurableTask.Core.Tests\DurableTask.Core.Tests.csproj
+            .\Test\DurableTask.AzureStorage.Tests\DurableTask.AzureStorage.Tests.csproj
+            .\Test\DurableTask.Emulator.Tests\DurableTask.Emulator.Tests.csproj
+
+  - task: VSBuild@1
+    displayName: 'Build (Core Tests)'
+    inputs:
+      solution: '.\Test\DurableTask.Core.Tests\DurableTask.Core.Tests.csproj'
+      vsVersion: '17.0'
+      logFileVerbosity: minimal
+      configuration: ${{ parameters.buildConfiguration }}
+      msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
+
+  - task: VSBuild@1
+    displayName: 'Build (AzureStorage Tests)'
+    inputs:
+      solution: '.\Test\DurableTask.AzureStorage.Tests\DurableTask.AzureStorage.Tests.csproj'
+      vsVersion: '17.0'
+      logFileVerbosity: minimal
+      configuration: ${{ parameters.buildConfiguration }}
+      msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
+
+  - task: VSBuild@1
+    displayName: 'Build (Emulator Tests)'
+    inputs:
+      solution: '.\Test\DurableTask.Emulator.Tests\DurableTask.Emulator.Tests.csproj'
+      vsVersion: '17.0'
+      logFileVerbosity: minimal
+      configuration: ${{ parameters.buildConfiguration }}
+      msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true

--- a/eng/templates/test.yml
+++ b/eng/templates/test.yml
@@ -31,18 +31,18 @@ steps:
       "%ProgramFiles(x86)%\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe" init /server "(localdb)\MsSqlLocalDb"
       "%ProgramFiles(x86)%\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe" start
 
-  # Run tests
-  - task: VSTest@2
-    displayName: 'Run tests'
-    inputs:
-      testAssemblyVer2: ${{ parameters.testAssembly }}
-      testFiltercriteria: 'TestCategory!=DisabledInCI'
-      vsTestVersion: 17.0
-      distributionBatchType: basedOnExecutionTime
-      platform: 'any cpu'
-      configuration: 'Debug'
-      diagnosticsEnabled: True
-      collectDumpOn: always
-      rerunFailedTests: true
-      rerunFailedThreshold: 30
-      rerunMaxAttempts: 3
+# Run tests
+- task: VSTest@2
+  displayName: 'Run tests'
+  inputs:
+    testAssemblyVer2: ${{ parameters.testAssembly }}
+    testFiltercriteria: 'TestCategory!=DisabledInCI'
+    vsTestVersion: 17.0
+    distributionBatchType: basedOnExecutionTime
+    platform: 'any cpu'
+    configuration: 'Debug'
+    diagnosticsEnabled: True
+    collectDumpOn: always
+    rerunFailedTests: true
+    rerunFailedThreshold: 30
+    rerunMaxAttempts: 3

--- a/eng/templates/test.yml
+++ b/eng/templates/test.yml
@@ -5,12 +5,31 @@ parameters:
 
 
 steps:
-  - task: CmdLine@2
-    displayName: 'Run Azure Storage Emulator'
-    inputs:
-      script: |
-        "%ProgramFiles(x86)%\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe" init /server "(localdb)\MsSqlLocalDb"
-        "%ProgramFiles(x86)%\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe" start
+# Install Azure Storage Emulator (Azurite does not work with DTFx.AS v1 tests)
+- task: PowerShell@2
+  inputs:
+    targetType: 'inline'
+    script: |
+      Write-Host "Downloading Azure Storage emulator installer"
+      $downloadLink = "https://go.microsoft.com/fwlink/?linkid=717179&clcid=0x409"
+      $installer = "installer.msi"
+      Invoke-WebRequest -Uri $downloadLink -OutFile $installer
+      Write-Host "Downloaded Azure Storage emulator installer"
+      
+      Write-Host "Executing installer"
+      $logFile = "installer.log"
+      Start-Process msiexec.exe -ArgumentList "/i `"$installer`" /qn /norestart /log `"$logFile`"" -Wait -NoNewWindow
+      Write-Host "Executed installer"
+      Get-Content -Path $logFile
+  displayName: 'Download and install Azure Storage emulator'
+
+# Start Azure Storage emulator
+- task: CmdLine@2
+  displayName: 'Run Azure Storage Emulator'
+  inputs:
+    script: |
+      "%ProgramFiles(x86)%\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe" init /server "(localdb)\MsSqlLocalDb"
+      "%ProgramFiles(x86)%\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe" start
 
   # Run tests
   - task: VSTest@2

--- a/eng/templates/test.yml
+++ b/eng/templates/test.yml
@@ -5,16 +5,12 @@ parameters:
 
 
 steps:
-  # Install Azurite
-  - bash: |
-      echo "Installing azurite"
-      npm install -g azurite
-      mkdir azurite1
-      echo "azurite installed"
-      azurite --silent --location azurite1 --debug azurite1\debug.txt --queuePort 10001 &
-      echo "azurite started"
-      sleep 5
-    displayName: 'Install and Run Azurite'
+  - task: CmdLine@2
+    displayName: 'Run Azure Storage Emulator'
+    inputs:
+      script: |
+        "%ProgramFiles(x86)%\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe" init /server "(localdb)\MsSqlLocalDb"
+        "%ProgramFiles(x86)%\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe" start
 
   # Run tests
   - task: VSTest@2

--- a/eng/templates/test.yml
+++ b/eng/templates/test.yml
@@ -1,0 +1,33 @@
+parameters:
+- name: testAssembly
+  type: string
+  default: ''
+
+
+steps:
+  # Install Azurite
+  - bash: |
+      echo "Installing azurite"
+      npm install -g azurite
+      mkdir azurite1
+      echo "azurite installed"
+      azurite --silent --location azurite1 --debug azurite1\debug.txt --queuePort 10001 &
+      echo "azurite started"
+      sleep 5
+    displayName: 'Install and Run Azurite'
+
+  # Run tests
+  - task: VSTest@2
+    displayName: 'Run tests'
+    inputs:
+      testAssemblyVer2: ${{ parameters.testAssembly }}
+      testFiltercriteria: 'TestCategory!=DisabledInCI'
+      vsTestVersion: 17.0
+      distributionBatchType: basedOnExecutionTime
+      platform: 'any cpu'
+      configuration: 'Debug'
+      diagnosticsEnabled: True
+      collectDumpOn: always
+      rerunFailedTests: true
+      rerunFailedThreshold: 30
+      rerunMaxAttempts: 3

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -2312,6 +2312,7 @@ namespace DurableTask.AzureStorage.Tests
         /// End-to-end test which validates a simple orchestrator function that calls an activity function
         /// and checks the OpenTelemetry trace information
         /// </summary>
+        [TestCategory("DisabledInCI")]
         [DataTestMethod]
         [DataRow(true)]
         [DataRow(false)]
@@ -2404,6 +2405,7 @@ namespace DurableTask.AzureStorage.Tests
         /// End-to-end test which validates a simple orchestrator function that waits for an external event
         /// raised through the RaiseEvent API and checks the OpenTelemetry trace information
         /// </summary>
+        [TestCategory("DisabledInCI")]
         [DataTestMethod]
         [DataRow(true)]
         [DataRow(false)]
@@ -2505,6 +2507,7 @@ namespace DurableTask.AzureStorage.Tests
         /// End-to-end test which validates a simple orchestrator function that waits for an external event
         /// raised by calling SendEvent and checks the OpenTelemetry trace information
         /// </summary>
+        [TestCategory("DisabledInCI")]
         [DataTestMethod]
         [DataRow(true)]
         [DataRow(false)]

--- a/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
+++ b/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
@@ -7,13 +7,15 @@
 
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+	<PackageReference Include="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer" Version="2.0.1406.1" />
+	<PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" />
     <PackageReference Include="WindowsAzure.Storage" version="7.2.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
+	<PackageReference Include="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer.NetCore" Version="2.0.1406.4" />
+	<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.6" />
     <PackageReference Include="WindowsAzure.Storage" version="9.3.3" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.0.0-beta.3" />
@@ -31,7 +33,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\DurableTask.Core\DurableTask.Core.csproj" />
     <ProjectReference Include="..\..\src\DurableTask.AzureStorage\DurableTask.AzureStorage.csproj" />
-    <!--<ProjectReference Include="..\DurableTask.Core.Tests\DurableTask.Core.Tests.csproj" />-->
     <ProjectReference Include="..\DurableTask.Test.Orchestrations\DurableTask.Test.Orchestrations.csproj" />
   </ItemGroup>
 

--- a/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
+++ b/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
@@ -31,7 +31,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\DurableTask.Core\DurableTask.Core.csproj" />
     <ProjectReference Include="..\..\src\DurableTask.AzureStorage\DurableTask.AzureStorage.csproj" />
-    <ProjectReference Include="..\DurableTask.Core.Tests\DurableTask.Core.Tests.csproj" />
+    <!--<ProjectReference Include="..\DurableTask.Core.Tests\DurableTask.Core.Tests.csproj" />-->
     <ProjectReference Include="..\DurableTask.Test.Orchestrations\DurableTask.Test.Orchestrations.csproj" />
   </ItemGroup>
 

--- a/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
+++ b/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
@@ -7,15 +7,15 @@
 
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-	<PackageReference Include="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer" Version="2.0.1406.1" />
-	<PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+    <PackageReference Include="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer" Version="2.0.1406.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" />
     <PackageReference Include="WindowsAzure.Storage" version="7.2.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
-	<PackageReference Include="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer.NetCore" Version="2.0.1406.4" />
-	<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
+    <PackageReference Include="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer.NetCore" Version="2.0.1406.4" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.6" />
     <PackageReference Include="WindowsAzure.Storage" version="9.3.3" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.0.0-beta.3" />

--- a/test/DurableTask.Core.Tests/CommonTests.cs
+++ b/test/DurableTask.Core.Tests/CommonTests.cs
@@ -24,7 +24,7 @@ namespace DurableTask.Core.Tests
     [TestClass]
     public class CommonTests
     {
-        [TestMethod]
+        [DataTestMethod]
         public void DateTimeExtensionsIsSetTest()
         {
             Assert.IsTrue(DateTime.Now.IsSet());
@@ -42,7 +42,7 @@ namespace DurableTask.Core.Tests
         /// Test that the SerializeToJson utility ignores the default/global serialization config.
         /// This ensures that users may not influence our own serialization by setting modifying global settings.
         /// </summary>
-        [TestMethod]
+        [DataTestMethod]
         public void DefaultJsonConvertSettingsAreIgnored()
         {
             // set default Newtonsoft.JSON settings to drop default values (i.e 0 for numbers)
@@ -76,7 +76,7 @@ namespace DurableTask.Core.Tests
 
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public void ShouldValidateEventSource()
         {
             EventSourceAnalyzer.InspectAll(DefaultEventSource.Log);
@@ -86,7 +86,7 @@ namespace DurableTask.Core.Tests
         /// Ignores the action since number of attempts is zero
         /// </summary>
         /// <returns></returns>
-        [TestMethod]
+        [DataTestMethod]
         public async Task ExecuteWithRetryIsNoOpBecauseNoAttemptsWereMade()
         {
             const int NumberOfAttempts = 0;
@@ -113,7 +113,7 @@ namespace DurableTask.Core.Tests
         /// Executes the action with retry and rethrows the exception.
         /// </summary>
         /// <returns></returns>
-        [TestMethod]
+        [DataTestMethod]
         public async Task ExecuteWithRetryThrowsByRetryCountLimit()
         {
             const int NumberOfAttempts = 3;
@@ -163,7 +163,7 @@ namespace DurableTask.Core.Tests
         /// Executes the action with retry until it succeeds.
         /// </summary>
         /// <returns></returns>
-        [TestMethod]
+        [DataTestMethod]
         public async Task ExecuteWithRetrySucceedsAfterXAttemptsMinus1()
         {
             const int NumberOfAttempts = 5;

--- a/test/DurableTask.Core.Tests/CustomExceptionsTests.cs
+++ b/test/DurableTask.Core.Tests/CustomExceptionsTests.cs
@@ -39,7 +39,7 @@ namespace DurableTask.Core.Tests
             this.customExceptions = typeof(TaskHubWorker).Assembly.GetTypes().Where(_ => typeof(Exception).IsAssignableFrom(_) && _.IsPublic).ToList();
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public void CustomExceptionNamespace()
         {
             this.customExceptions.ForEach(_ =>
@@ -48,7 +48,7 @@ namespace DurableTask.Core.Tests
             });
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public void CustomExceptionDefaultConstructors()
         {
             this.customExceptions.ForEach(_ =>
@@ -79,7 +79,7 @@ namespace DurableTask.Core.Tests
             });
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public void CustomExceptionSerialization()
         {
             var ignoredProperties = new Dictionary<string, Type>

--- a/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
+++ b/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
@@ -55,7 +55,7 @@ namespace DurableTask.Core.Tests
             await this.worker!.StopAsync(true);
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public async Task DispatchMiddlewareContextBuiltInProperties()
         {
             TaskOrchestration? orchestration = null;
@@ -107,7 +107,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual(instance1!.InstanceId, instance2!.InstanceId);
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public async Task OrchestrationDispatcherMiddlewareContextFlow()
         {
             StringBuilder? output = null;
@@ -144,7 +144,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual("01234567899876543210", output?.ToString());
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public async Task ActivityDispatcherMiddlewareContextFlow()
         {
             StringBuilder? output = null;
@@ -181,7 +181,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual("01234567899876543210", output?.ToString());
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public async Task EnsureOrchestrationDispatcherMiddlewareHasAccessToRuntimeState()
         {
             OrchestrationExecutionContext? executionContext = null;
@@ -218,7 +218,7 @@ namespace DurableTask.Core.Tests
         /// <summary>
         /// Test to ensure <see cref="OrchestrationExecutionContext"/> supports DataContract serialization.
         /// </summary>
-        [TestMethod]
+        [DataTestMethod]
         public void EnsureOrchestrationExecutionContextSupportsDataContractSerialization()
         {
             OrchestrationExecutionContext orchestrationExecutionContext = new OrchestrationExecutionContext
@@ -247,7 +247,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual("Value", deserializedContext.OrchestrationTags["Key"]);
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public async Task EnsureSubOrchestrationDispatcherMiddlewareHasAccessToRuntimeState()
         {
             ConcurrentBag<OrchestrationExecutionContext> capturedContexts = new ConcurrentBag<OrchestrationExecutionContext>(); 
@@ -282,7 +282,7 @@ namespace DurableTask.Core.Tests
             }
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public async Task EnsureActivityDispatcherMiddlewareHasAccessToRuntimeState()
         {
             OrchestrationExecutionContext? executionContext = null;
@@ -361,7 +361,7 @@ namespace DurableTask.Core.Tests
             Assert.IsNull(orchestration, "Expected a null orchestration object in the middleware");
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public async Task MockActivityOrchestration()
         {
             // Orchestrator middleware mocks an orchestration that calls one activity

--- a/test/DurableTask.Core.Tests/HttpCorrelationProtocolTraceContextTest.cs
+++ b/test/DurableTask.Core.Tests/HttpCorrelationProtocolTraceContextTest.cs
@@ -25,7 +25,7 @@ namespace DurableTask.Core.Tests
     [TestClass]
     public class HttpCorrelationProtocolTraceContextTest
     {
-        [TestMethod]
+        [DataTestMethod]
         public void GetRootIdNormalCase()
         {
             var id = "|ea55fd0a-45699198bc3873c3.ea55fd0b_";
@@ -37,7 +37,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual(expected,traceContext.GetRootId(childId));
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public void GetRootIdWithNull()
         {
             string id = null;
@@ -45,7 +45,7 @@ namespace DurableTask.Core.Tests
             Assert.IsNull(traceContext.GetRootId(id));
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public void GetRootIdWithMalformed()
         {
             // Currently it doesn't fail and doesn't throw exception.
@@ -54,7 +54,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual("ea55fd0a-45699198bc3873c3", traceContext.GetRootId(id));
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public void SetParentAndStartWithNullObject()
         {
             var traceContext = new HttpCorrelationProtocolTraceContext();

--- a/test/DurableTask.Core.Tests/StackExtensionsTest.cs
+++ b/test/DurableTask.Core.Tests/StackExtensionsTest.cs
@@ -24,7 +24,7 @@ namespace DurableTask.Core.Tests
     [TestClass]
     public class StackExtensionsTest
     {
-        [TestMethod]
+        [DataTestMethod]
         public void CloneStack()
         {
             var input = new Stack<string>(); 

--- a/test/DurableTask.Core.Tests/TraceContextBaseTest.cs
+++ b/test/DurableTask.Core.Tests/TraceContextBaseTest.cs
@@ -24,105 +24,105 @@ namespace DurableTask.Core.Tests
     [TestClass]
     public class TraceContextBaseTest
     {
-        [DataTestMethod]
-        public void SerializeTraceContextBase()
-        {
-            Foo context = new Foo();
-            context.StartAsNew();
-            var expectedStartTime = context.StartTime;
-            context.Comment = "hello";
-            var json = context.SerializableTraceContext;
-            var result = TraceContextBase.Restore(json);
-            Assert.AreEqual(expectedStartTime, result.StartTime);
-            Assert.AreEqual(context.Comment, ((Foo)result).Comment);
-        }
+        // [DataTestMethod]
+        // public void SerializeTraceContextBase()
+        // {
+        //     Foo context = new Foo();
+        //     context.StartAsNew();
+        //     var expectedStartTime = context.StartTime;
+        //     context.Comment = "hello";
+        //     var json = context.SerializableTraceContext;
+        //     var result = TraceContextBase.Restore(json);
+        //     Assert.AreEqual(expectedStartTime, result.StartTime);
+        //     Assert.AreEqual(context.Comment, ((Foo)result).Comment);
+        // }
 
-        [DataTestMethod]
-        public void SerializeAndDeserializeTraceContextWithParent()
-        {
-            TraceContextBase context = new Foo();
-            context.StartAsNew();
-            var expectedStartTime = context.StartTime;
-            context.OrchestrationTraceContexts.Push(context); // Adding Orchestration Context it might include $type 
-            var json = context.SerializableTraceContext;
-            var result = TraceContextBase.Restore(json);
-            Assert.AreEqual(expectedStartTime, result.StartTime);
-        }
+        // [DataTestMethod]
+        // public void SerializeAndDeserializeTraceContextWithParent()
+        // {
+        //     TraceContextBase context = new Foo();
+        //     context.StartAsNew();
+        //     var expectedStartTime = context.StartTime;
+        //     context.OrchestrationTraceContexts.Push(context); // Adding Orchestration Context it might include $type 
+        //     var json = context.SerializableTraceContext;
+        //     var result = TraceContextBase.Restore(json);
+        //     Assert.AreEqual(expectedStartTime, result.StartTime);
+        // }
 
-        [DataTestMethod]
-        public void SerializeAndDeserializeTraceContextWithMultipleOrchestrationTraceContexts()
-        {
-            TraceContextBase one = new Foo() { Comment = "one" };
-            TraceContextBase two = new Foo() { Comment = "two" };
-            TraceContextBase three = new Foo() { Comment = "three" };
-            one.OrchestrationTraceContexts.Push(one);
-            one.OrchestrationTraceContexts.Push(two);
-            one.OrchestrationTraceContexts.Push(three);
-            var json = one.SerializableTraceContext;
-            var restored = TraceContextBase.Restore(json);
-            Assert.AreEqual("three", ((Foo)restored.OrchestrationTraceContexts.Pop()).Comment);
-            Assert.AreEqual("two", ((Foo)restored.OrchestrationTraceContexts.Pop()).Comment);
-            Assert.AreEqual("one", ((Foo)restored.OrchestrationTraceContexts.Pop()).Comment);
-        }
+        // [DataTestMethod]
+        // public void SerializeAndDeserializeTraceContextWithMultipleOrchestrationTraceContexts()
+        // {
+        //     TraceContextBase one = new Foo() { Comment = "one" };
+        //     TraceContextBase two = new Foo() { Comment = "two" };
+        //     TraceContextBase three = new Foo() { Comment = "three" };
+        //     one.OrchestrationTraceContexts.Push(one);
+        //     one.OrchestrationTraceContexts.Push(two);
+        //     one.OrchestrationTraceContexts.Push(three);
+        //     var json = one.SerializableTraceContext;
+        //     var restored = TraceContextBase.Restore(json);
+        //     Assert.AreEqual("three", ((Foo)restored.OrchestrationTraceContexts.Pop()).Comment);
+        //     Assert.AreEqual("two", ((Foo)restored.OrchestrationTraceContexts.Pop()).Comment);
+        //     Assert.AreEqual("one", ((Foo)restored.OrchestrationTraceContexts.Pop()).Comment);
+        // }
 
-        [DataTestMethod]
-        public void DeserializeScenario()
-        {
-            var json  = "{ \"$id\":\"1\",\"$type\":\"DurableTask.Core.W3CTraceContext, DurableTask.Core\",\"Traceparent\":\"00-a422532de19d3e4f8f67af06f8f880c7-81354b086ec6fb41-02\",\"Tracestate\":null,\"ParentSpanId\":\"b69bc0f95af84240\",\"StartTime\":\"2019-05-03T23:43:27.6728211+00:00\",\"OrchestrationTraceContexts\":[{\"$id\":\"2\",\"$type\":\"DurableTask.Core.W3CTraceContext, DurableTask.Core\",\"Traceparent\":\"00-a422532de19d3e4f8f67af06f8f880c7-f86a8711d7226d42-02\",\"Tracestate\":null,\"ParentSpanId\":\"2ec2a64f22dbb143\",\"StartTime\":\"2019-05-03T23:43:12.7553182+00:00\",\"OrchestrationTraceContexts\":[{\"$ref\":\"2\"}]}]}";
-            TraceContextBase context = TraceContextBase.Restore(json);
-            Assert.AreEqual(DateTimeOffset.Parse("2019-05-03T23:43:27.6728211+00:00"), context.StartTime);
-        }
+        // [DataTestMethod]
+        // public void DeserializeScenario()
+        // {
+        //     var json  = "{ \"$id\":\"1\",\"$type\":\"DurableTask.Core.W3CTraceContext, DurableTask.Core\",\"Traceparent\":\"00-a422532de19d3e4f8f67af06f8f880c7-81354b086ec6fb41-02\",\"Tracestate\":null,\"ParentSpanId\":\"b69bc0f95af84240\",\"StartTime\":\"2019-05-03T23:43:27.6728211+00:00\",\"OrchestrationTraceContexts\":[{\"$id\":\"2\",\"$type\":\"DurableTask.Core.W3CTraceContext, DurableTask.Core\",\"Traceparent\":\"00-a422532de19d3e4f8f67af06f8f880c7-f86a8711d7226d42-02\",\"Tracestate\":null,\"ParentSpanId\":\"2ec2a64f22dbb143\",\"StartTime\":\"2019-05-03T23:43:12.7553182+00:00\",\"OrchestrationTraceContexts\":[{\"$ref\":\"2\"}]}]}";
+        //     TraceContextBase context = TraceContextBase.Restore(json);
+        //     Assert.AreEqual(DateTimeOffset.Parse("2019-05-03T23:43:27.6728211+00:00"), context.StartTime);
+        // }
 
-        [DataTestMethod]
-        public void DeserializeNullScenario()
-        {
-            TraceContextBase context = TraceContextBase.Restore(null);
-            Assert.AreEqual(typeof(NullObjectTraceContext), context.GetType());
-        }
+        // [DataTestMethod]
+        // public void DeserializeNullScenario()
+        // {
+        //     TraceContextBase context = TraceContextBase.Restore(null);
+        //     Assert.AreEqual(typeof(NullObjectTraceContext), context.GetType());
+        // }
 
-        [DataTestMethod]
-        public void DeserializeEmptyScenario()
-        {
-            TraceContextBase context = TraceContextBase.Restore("");
-            Assert.AreEqual(typeof(NullObjectTraceContext), context.GetType());
-        }
+        // [DataTestMethod]
+        // public void DeserializeEmptyScenario()
+        // {
+        //     TraceContextBase context = TraceContextBase.Restore("");
+        //     Assert.AreEqual(typeof(NullObjectTraceContext), context.GetType());
+        // }
 
-        [DataTestMethod]
-        public void GetCurrentOrchestrationRequestTraceContextScenario()
-        {
-            TraceContextBase currentContext = new Foo();
+        // [DataTestMethod]
+        // public void GetCurrentOrchestrationRequestTraceContextScenario()
+        // {
+        //     TraceContextBase currentContext = new Foo();
             
-            currentContext.OrchestrationTraceContexts.Push(GetNewRequestContext("foo"));
-            currentContext.OrchestrationTraceContexts.Push(GetNewDependencyContext("bar"));
+        //     currentContext.OrchestrationTraceContexts.Push(GetNewRequestContext("foo"));
+        //     currentContext.OrchestrationTraceContexts.Push(GetNewDependencyContext("bar"));
 
-            var currentRequestContext = currentContext.GetCurrentOrchestrationRequestTraceContext();
+        //     var currentRequestContext = currentContext.GetCurrentOrchestrationRequestTraceContext();
 
-            Assert.AreEqual(TelemetryType.Request, currentRequestContext.TelemetryType);
-            Assert.AreEqual("foo", ((Foo)currentRequestContext).Comment);
-        }
+        //     Assert.AreEqual(TelemetryType.Request, currentRequestContext.TelemetryType);
+        //     Assert.AreEqual("foo", ((Foo)currentRequestContext).Comment);
+        // }
 
-        [DataTestMethod]
-        public void GetCurrentOrchestrationRequestTraceContextMultiOrchestratorScenario()
-        {
-            TraceContextBase currentContext = new Foo();
+        // [DataTestMethod]
+        // public void GetCurrentOrchestrationRequestTraceContextMultiOrchestratorScenario()
+        // {
+        //     TraceContextBase currentContext = new Foo();
 
-            currentContext.OrchestrationTraceContexts.Push(GetNewRequestContext("foo"));
-            currentContext.OrchestrationTraceContexts.Push(GetNewDependencyContext("bar"));
-            currentContext.OrchestrationTraceContexts.Push(GetNewRequestContext("baz"));
-            currentContext.OrchestrationTraceContexts.Push(GetNewDependencyContext("qux"));
+        //     currentContext.OrchestrationTraceContexts.Push(GetNewRequestContext("foo"));
+        //     currentContext.OrchestrationTraceContexts.Push(GetNewDependencyContext("bar"));
+        //     currentContext.OrchestrationTraceContexts.Push(GetNewRequestContext("baz"));
+        //     currentContext.OrchestrationTraceContexts.Push(GetNewDependencyContext("qux"));
 
-            var currentRequestContext = currentContext.GetCurrentOrchestrationRequestTraceContext();
+        //     var currentRequestContext = currentContext.GetCurrentOrchestrationRequestTraceContext();
 
-            Assert.AreEqual(TelemetryType.Request, currentRequestContext.TelemetryType);
-            Assert.AreEqual("baz", ((Foo)currentRequestContext).Comment);
-        }
+        //     Assert.AreEqual(TelemetryType.Request, currentRequestContext.TelemetryType);
+        //     Assert.AreEqual("baz", ((Foo)currentRequestContext).Comment);
+        // }
 
-        [DataTestMethod]
-        public void GetCurrentOrchestrationRequestTraceContextWithNoRequestTraceContextScenario()
-        {
-            TraceContextBase currentContext = new Foo();
-            Assert.ThrowsException<InvalidOperationException>(() => currentContext.GetCurrentOrchestrationRequestTraceContext());
-        }
+        // [DataTestMethod]
+        // public void GetCurrentOrchestrationRequestTraceContextWithNoRequestTraceContextScenario()
+        // {
+        //     TraceContextBase currentContext = new Foo();
+        //     Assert.ThrowsException<InvalidOperationException>(() => currentContext.GetCurrentOrchestrationRequestTraceContext());
+        // }
 
         private static Foo GetNewRequestContext(string comment)
         {

--- a/test/DurableTask.Core.Tests/TraceContextBaseTest.cs
+++ b/test/DurableTask.Core.Tests/TraceContextBaseTest.cs
@@ -24,7 +24,7 @@ namespace DurableTask.Core.Tests
     [TestClass]
     public class TraceContextBaseTest
     {
-        [TestMethod]
+        [DataTestMethod]
         public void SerializeTraceContextBase()
         {
             Foo context = new Foo();
@@ -37,7 +37,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual(context.Comment, ((Foo)result).Comment);
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public void SerializeAndDeserializeTraceContextWithParent()
         {
             TraceContextBase context = new Foo();
@@ -49,7 +49,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual(expectedStartTime, result.StartTime);
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public void SerializeAndDeserializeTraceContextWithMultipleOrchestrationTraceContexts()
         {
             TraceContextBase one = new Foo() { Comment = "one" };
@@ -65,7 +65,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual("one", ((Foo)restored.OrchestrationTraceContexts.Pop()).Comment);
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public void DeserializeScenario()
         {
             var json  = "{ \"$id\":\"1\",\"$type\":\"DurableTask.Core.W3CTraceContext, DurableTask.Core\",\"Traceparent\":\"00-a422532de19d3e4f8f67af06f8f880c7-81354b086ec6fb41-02\",\"Tracestate\":null,\"ParentSpanId\":\"b69bc0f95af84240\",\"StartTime\":\"2019-05-03T23:43:27.6728211+00:00\",\"OrchestrationTraceContexts\":[{\"$id\":\"2\",\"$type\":\"DurableTask.Core.W3CTraceContext, DurableTask.Core\",\"Traceparent\":\"00-a422532de19d3e4f8f67af06f8f880c7-f86a8711d7226d42-02\",\"Tracestate\":null,\"ParentSpanId\":\"2ec2a64f22dbb143\",\"StartTime\":\"2019-05-03T23:43:12.7553182+00:00\",\"OrchestrationTraceContexts\":[{\"$ref\":\"2\"}]}]}";
@@ -73,21 +73,21 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual(DateTimeOffset.Parse("2019-05-03T23:43:27.6728211+00:00"), context.StartTime);
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public void DeserializeNullScenario()
         {
             TraceContextBase context = TraceContextBase.Restore(null);
             Assert.AreEqual(typeof(NullObjectTraceContext), context.GetType());
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public void DeserializeEmptyScenario()
         {
             TraceContextBase context = TraceContextBase.Restore("");
             Assert.AreEqual(typeof(NullObjectTraceContext), context.GetType());
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public void GetCurrentOrchestrationRequestTraceContextScenario()
         {
             TraceContextBase currentContext = new Foo();
@@ -101,7 +101,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual("foo", ((Foo)currentRequestContext).Comment);
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public void GetCurrentOrchestrationRequestTraceContextMultiOrchestratorScenario()
         {
             TraceContextBase currentContext = new Foo();
@@ -117,7 +117,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual("baz", ((Foo)currentRequestContext).Comment);
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public void GetCurrentOrchestrationRequestTraceContextWithNoRequestTraceContextScenario()
         {
             TraceContextBase currentContext = new Foo();

--- a/test/DurableTask.Core.Tests/TraceContextBaseTest.cs
+++ b/test/DurableTask.Core.Tests/TraceContextBaseTest.cs
@@ -24,105 +24,105 @@ namespace DurableTask.Core.Tests
     [TestClass]
     public class TraceContextBaseTest
     {
-        // [DataTestMethod]
-        // public void SerializeTraceContextBase()
-        // {
-        //     Foo context = new Foo();
-        //     context.StartAsNew();
-        //     var expectedStartTime = context.StartTime;
-        //     context.Comment = "hello";
-        //     var json = context.SerializableTraceContext;
-        //     var result = TraceContextBase.Restore(json);
-        //     Assert.AreEqual(expectedStartTime, result.StartTime);
-        //     Assert.AreEqual(context.Comment, ((Foo)result).Comment);
-        // }
+        [DataTestMethod]
+        public void SerializeTraceContextBase()
+        {
+            Foo context = new Foo();
+            context.StartAsNew();
+            var expectedStartTime = context.StartTime;
+            context.Comment = "hello";
+            var json = context.SerializableTraceContext;
+            var result = TraceContextBase.Restore(json);
+            Assert.AreEqual(expectedStartTime, result.StartTime);
+            Assert.AreEqual(context.Comment, ((Foo)result).Comment);
+        }
 
-        // [DataTestMethod]
-        // public void SerializeAndDeserializeTraceContextWithParent()
-        // {
-        //     TraceContextBase context = new Foo();
-        //     context.StartAsNew();
-        //     var expectedStartTime = context.StartTime;
-        //     context.OrchestrationTraceContexts.Push(context); // Adding Orchestration Context it might include $type 
-        //     var json = context.SerializableTraceContext;
-        //     var result = TraceContextBase.Restore(json);
-        //     Assert.AreEqual(expectedStartTime, result.StartTime);
-        // }
+        [DataTestMethod]
+        public void SerializeAndDeserializeTraceContextWithParent()
+        {
+            TraceContextBase context = new Foo();
+            context.StartAsNew();
+            var expectedStartTime = context.StartTime;
+            context.OrchestrationTraceContexts.Push(context); // Adding Orchestration Context it might include $type 
+            var json = context.SerializableTraceContext;
+            var result = TraceContextBase.Restore(json);
+            Assert.AreEqual(expectedStartTime, result.StartTime);
+        }
 
-        // [DataTestMethod]
-        // public void SerializeAndDeserializeTraceContextWithMultipleOrchestrationTraceContexts()
-        // {
-        //     TraceContextBase one = new Foo() { Comment = "one" };
-        //     TraceContextBase two = new Foo() { Comment = "two" };
-        //     TraceContextBase three = new Foo() { Comment = "three" };
-        //     one.OrchestrationTraceContexts.Push(one);
-        //     one.OrchestrationTraceContexts.Push(two);
-        //     one.OrchestrationTraceContexts.Push(three);
-        //     var json = one.SerializableTraceContext;
-        //     var restored = TraceContextBase.Restore(json);
-        //     Assert.AreEqual("three", ((Foo)restored.OrchestrationTraceContexts.Pop()).Comment);
-        //     Assert.AreEqual("two", ((Foo)restored.OrchestrationTraceContexts.Pop()).Comment);
-        //     Assert.AreEqual("one", ((Foo)restored.OrchestrationTraceContexts.Pop()).Comment);
-        // }
+        [DataTestMethod]
+        public void SerializeAndDeserializeTraceContextWithMultipleOrchestrationTraceContexts()
+        {
+            TraceContextBase one = new Foo() { Comment = "one" };
+            TraceContextBase two = new Foo() { Comment = "two" };
+            TraceContextBase three = new Foo() { Comment = "three" };
+            one.OrchestrationTraceContexts.Push(one);
+            one.OrchestrationTraceContexts.Push(two);
+            one.OrchestrationTraceContexts.Push(three);
+            var json = one.SerializableTraceContext;
+            var restored = TraceContextBase.Restore(json);
+            Assert.AreEqual("three", ((Foo)restored.OrchestrationTraceContexts.Pop()).Comment);
+            Assert.AreEqual("two", ((Foo)restored.OrchestrationTraceContexts.Pop()).Comment);
+            Assert.AreEqual("one", ((Foo)restored.OrchestrationTraceContexts.Pop()).Comment);
+        }
 
-        // [DataTestMethod]
-        // public void DeserializeScenario()
-        // {
-        //     var json  = "{ \"$id\":\"1\",\"$type\":\"DurableTask.Core.W3CTraceContext, DurableTask.Core\",\"Traceparent\":\"00-a422532de19d3e4f8f67af06f8f880c7-81354b086ec6fb41-02\",\"Tracestate\":null,\"ParentSpanId\":\"b69bc0f95af84240\",\"StartTime\":\"2019-05-03T23:43:27.6728211+00:00\",\"OrchestrationTraceContexts\":[{\"$id\":\"2\",\"$type\":\"DurableTask.Core.W3CTraceContext, DurableTask.Core\",\"Traceparent\":\"00-a422532de19d3e4f8f67af06f8f880c7-f86a8711d7226d42-02\",\"Tracestate\":null,\"ParentSpanId\":\"2ec2a64f22dbb143\",\"StartTime\":\"2019-05-03T23:43:12.7553182+00:00\",\"OrchestrationTraceContexts\":[{\"$ref\":\"2\"}]}]}";
-        //     TraceContextBase context = TraceContextBase.Restore(json);
-        //     Assert.AreEqual(DateTimeOffset.Parse("2019-05-03T23:43:27.6728211+00:00"), context.StartTime);
-        // }
+        [DataTestMethod]
+        public void DeserializeScenario()
+        {
+            var json  = "{ \"$id\":\"1\",\"$type\":\"DurableTask.Core.W3CTraceContext, DurableTask.Core\",\"Traceparent\":\"00-a422532de19d3e4f8f67af06f8f880c7-81354b086ec6fb41-02\",\"Tracestate\":null,\"ParentSpanId\":\"b69bc0f95af84240\",\"StartTime\":\"2019-05-03T23:43:27.6728211+00:00\",\"OrchestrationTraceContexts\":[{\"$id\":\"2\",\"$type\":\"DurableTask.Core.W3CTraceContext, DurableTask.Core\",\"Traceparent\":\"00-a422532de19d3e4f8f67af06f8f880c7-f86a8711d7226d42-02\",\"Tracestate\":null,\"ParentSpanId\":\"2ec2a64f22dbb143\",\"StartTime\":\"2019-05-03T23:43:12.7553182+00:00\",\"OrchestrationTraceContexts\":[{\"$ref\":\"2\"}]}]}";
+            TraceContextBase context = TraceContextBase.Restore(json);
+            Assert.AreEqual(DateTimeOffset.Parse("2019-05-03T23:43:27.6728211+00:00"), context.StartTime);
+        }
 
-        // [DataTestMethod]
-        // public void DeserializeNullScenario()
-        // {
-        //     TraceContextBase context = TraceContextBase.Restore(null);
-        //     Assert.AreEqual(typeof(NullObjectTraceContext), context.GetType());
-        // }
+        [DataTestMethod]
+        public void DeserializeNullScenario()
+        {
+            TraceContextBase context = TraceContextBase.Restore(null);
+            Assert.AreEqual(typeof(NullObjectTraceContext), context.GetType());
+        }
 
-        // [DataTestMethod]
-        // public void DeserializeEmptyScenario()
-        // {
-        //     TraceContextBase context = TraceContextBase.Restore("");
-        //     Assert.AreEqual(typeof(NullObjectTraceContext), context.GetType());
-        // }
+        [DataTestMethod]
+        public void DeserializeEmptyScenario()
+        {
+            TraceContextBase context = TraceContextBase.Restore("");
+            Assert.AreEqual(typeof(NullObjectTraceContext), context.GetType());
+        }
 
-        // [DataTestMethod]
-        // public void GetCurrentOrchestrationRequestTraceContextScenario()
-        // {
-        //     TraceContextBase currentContext = new Foo();
+        [DataTestMethod]
+        public void GetCurrentOrchestrationRequestTraceContextScenario()
+        {
+            TraceContextBase currentContext = new Foo();
             
-        //     currentContext.OrchestrationTraceContexts.Push(GetNewRequestContext("foo"));
-        //     currentContext.OrchestrationTraceContexts.Push(GetNewDependencyContext("bar"));
+            currentContext.OrchestrationTraceContexts.Push(GetNewRequestContext("foo"));
+            currentContext.OrchestrationTraceContexts.Push(GetNewDependencyContext("bar"));
 
-        //     var currentRequestContext = currentContext.GetCurrentOrchestrationRequestTraceContext();
+            var currentRequestContext = currentContext.GetCurrentOrchestrationRequestTraceContext();
 
-        //     Assert.AreEqual(TelemetryType.Request, currentRequestContext.TelemetryType);
-        //     Assert.AreEqual("foo", ((Foo)currentRequestContext).Comment);
-        // }
+            Assert.AreEqual(TelemetryType.Request, currentRequestContext.TelemetryType);
+            Assert.AreEqual("foo", ((Foo)currentRequestContext).Comment);
+        }
 
-        // [DataTestMethod]
-        // public void GetCurrentOrchestrationRequestTraceContextMultiOrchestratorScenario()
-        // {
-        //     TraceContextBase currentContext = new Foo();
+        [DataTestMethod]
+        public void GetCurrentOrchestrationRequestTraceContextMultiOrchestratorScenario()
+        {
+            TraceContextBase currentContext = new Foo();
 
-        //     currentContext.OrchestrationTraceContexts.Push(GetNewRequestContext("foo"));
-        //     currentContext.OrchestrationTraceContexts.Push(GetNewDependencyContext("bar"));
-        //     currentContext.OrchestrationTraceContexts.Push(GetNewRequestContext("baz"));
-        //     currentContext.OrchestrationTraceContexts.Push(GetNewDependencyContext("qux"));
+            currentContext.OrchestrationTraceContexts.Push(GetNewRequestContext("foo"));
+            currentContext.OrchestrationTraceContexts.Push(GetNewDependencyContext("bar"));
+            currentContext.OrchestrationTraceContexts.Push(GetNewRequestContext("baz"));
+            currentContext.OrchestrationTraceContexts.Push(GetNewDependencyContext("qux"));
 
-        //     var currentRequestContext = currentContext.GetCurrentOrchestrationRequestTraceContext();
+            var currentRequestContext = currentContext.GetCurrentOrchestrationRequestTraceContext();
 
-        //     Assert.AreEqual(TelemetryType.Request, currentRequestContext.TelemetryType);
-        //     Assert.AreEqual("baz", ((Foo)currentRequestContext).Comment);
-        // }
+            Assert.AreEqual(TelemetryType.Request, currentRequestContext.TelemetryType);
+            Assert.AreEqual("baz", ((Foo)currentRequestContext).Comment);
+        }
 
-        // [DataTestMethod]
-        // public void GetCurrentOrchestrationRequestTraceContextWithNoRequestTraceContextScenario()
-        // {
-        //     TraceContextBase currentContext = new Foo();
-        //     Assert.ThrowsException<InvalidOperationException>(() => currentContext.GetCurrentOrchestrationRequestTraceContext());
-        // }
+        [DataTestMethod]
+        public void GetCurrentOrchestrationRequestTraceContextWithNoRequestTraceContextScenario()
+        {
+            TraceContextBase currentContext = new Foo();
+            Assert.ThrowsException<InvalidOperationException>(() => currentContext.GetCurrentOrchestrationRequestTraceContext());
+        }
 
         private static Foo GetNewRequestContext(string comment)
         {

--- a/test/DurableTask.Core.Tests/W3CTraceContextTest.cs
+++ b/test/DurableTask.Core.Tests/W3CTraceContextTest.cs
@@ -25,7 +25,7 @@ namespace DurableTask.Core.Tests
     [TestClass]
     public class W3CTraceContextTest
     {
-        [TestMethod]
+        [DataTestMethod]
         public void SetParentNormalCase()
         {
             var ExpectedTraceState = "congo=t61rcWkgMzE";
@@ -54,7 +54,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual(parentContext.CurrentActivity.SpanId.ToHexString(), childContext.TelemetryContextOperationParentId);
         }
 
-        [TestMethod]
+        [DataTestMethod]
         public void RestoredSoThatNoCurrentActivity()
         {
             var ExpectedTraceState = "congo=t61rcWkgMzE";
@@ -78,7 +78,7 @@ namespace DurableTask.Core.Tests
         }
 
         // SetParent sometimes accept NullObject 
-        [TestMethod]
+        [DataTestMethod]
         public void SetParentWithNullObject()
         {
             var traceContext = new W3CTraceContext();


### PR DESCRIPTION
This PR contains various fixes to make the public build CI pass in the `durabletask-core-v2` branch. These changes are listed below:
1. It changes various `[TestMethod]` declarations to `DataTestMethod` in the DTFx.Core test project. For some reason I can't explain, the ADO testing infrastructure was unable to _discover_ these tests if they were marked as `[TestMethod]`. This fix is a **hack**, but it works for now and I think it's worth unblocking us. To my knowledge, these two annotations are almost equivalent, except that a `[DataTestMethod]` can be parametrized (as in the test method can take  a parameter such as `extendedSessionsEnabled`), but a `[TestMethod]` cannot. Other than that, they both declare tests.

2. It remove the parallelism of the DTFx.Core unit testing task (previously had 13 parallel jobs). There aren't that many DTFx.Core tests to run, so the parallel tasks were just adding noisy. The tests run in about a minute anyways.

3. It adds missing files under "eng/templates" that are already in the main branch and we forgot the port them to this "frozen" branch. These are needed for the public build yml to work as it references them.

4. It disables the open telemetry tests, just like they're already disabled in the main branch! (we also forgot to port this change)

That's all. After this, we should have a running public CI for all main branches of this repo.