### PR TITLE
Modifies WorkItem renew logic to start running after item is fetched.

### DIFF
--- a/UpgradeLog.htm
+++ b/UpgradeLog.htm
@@ -1,0 +1,268 @@
+﻿<!DOCTYPE html>
+<!-- saved from url=(0014)about:internet -->
+ <html xmlns:msxsl="urn:schemas-microsoft-com:xslt"><head><meta content="en-us" http-equiv="Content-Language" /><meta content="text/html; charset=utf-16" http-equiv="Content-Type" /><title _locID="ConversionReport0">
+          Migration Report
+        </title><style> 
+                    /* Body style, for the entire document */
+                    body
+                    {
+                        background: #F3F3F4;
+                        color: #1E1E1F;
+                        font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+                        padding: 0;
+                        margin: 0;
+                    }
+
+                    /* Header1 style, used for the main title */
+                    h1
+                    {
+                        padding: 10px 0px 10px 10px;
+                        font-size: 21pt;
+                        background-color: #E2E2E2;
+                        border-bottom: 1px #C1C1C2 solid; 
+                        color: #201F20;
+                        margin: 0;
+                        font-weight: normal;
+                    }
+
+                    /* Header2 style, used for "Overview" and other sections */
+                    h2
+                    {
+                        font-size: 18pt;
+                        font-weight: normal;
+                        padding: 15px 0 5px 0;
+                        margin: 0;
+                    }
+
+                    /* Header3 style, used for sub-sections, such as project name */
+                    h3
+                    {
+                        font-weight: normal;
+                        font-size: 15pt;
+                        margin: 0;
+                        padding: 15px 0 5px 0;
+                        background-color: transparent;
+                    }
+
+                    /* Color all hyperlinks one color */
+                    a
+                    {
+                        color: #1382CE;
+                    }
+
+                    /* Table styles */ 
+                    table
+                    {
+                        border-spacing: 0 0;
+                        border-collapse: collapse;
+                        font-size: 10pt;
+                    }
+
+                    table th
+                    {
+                        background: #E7E7E8;
+                        text-align: left;
+                        text-decoration: none;
+                        font-weight: normal;
+                        padding: 3px 6px 3px 6px;
+                    }
+
+                    table td
+                    {
+                        vertical-align: top;
+                        padding: 3px 6px 5px 5px;
+                        margin: 0px;
+                        border: 1px solid #E7E7E8;
+                        background: #F7F7F8;
+                    }
+
+                    /* Local link is a style for hyperlinks that link to file:/// content, there are lots so color them as 'normal' text until the user mouse overs */
+                    .localLink
+                    {
+                        color: #1E1E1F;
+                        background: #EEEEED;
+                        text-decoration: none;
+                    }
+
+                    .localLink:hover
+                    {
+                        color: #1382CE;
+                        background: #FFFF99;
+                        text-decoration: none;
+                    }
+
+                    /* Center text, used in the over views cells that contain message level counts */ 
+                    .textCentered
+                    {
+                        text-align: center;
+                    }
+
+                    /* The message cells in message tables should take up all avaliable space */
+                    .messageCell
+                    {
+                        width: 100%;
+                    }
+
+                    /* Padding around the content after the h1 */ 
+                    #content 
+                    {
+	                    padding: 0px 12px 12px 12px; 
+                    }
+
+                    /* The overview table expands to width, with a max width of 97% */ 
+                    #overview table
+                    {
+                        width: auto;
+                        max-width: 75%; 
+                    }
+
+                    /* The messages tables are always 97% width */
+                    #messages table
+                    {
+                        width: 97%;
+                    }
+
+                    /* All Icons */
+                    .IconSuccessEncoded, .IconInfoEncoded, .IconWarningEncoded, .IconErrorEncoded
+                    {
+                        min-width:18px;
+                        min-height:18px; 
+                        background-repeat:no-repeat;
+                        background-position:center;
+                    }
+
+                    /* Success icon encoded */
+                    .IconSuccessEncoded
+                    {
+                        /* Note: Do not delete the comment below. It is used to verify the correctness of the encoded image resource below before the product is released */
+                        /* [---XsltValidateInternal-Base64EncodedImage:IconSuccess#Begin#background-image: url(data:image/png;base64,#Separator#);#End#] */
+                        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAA7EAAAOxAGVKw4bAAABcElEQVR4Xq2TsUsCURzHv15g8ZJcBWlyiYYgCIWcb9DFRRwMW5TA2c0/QEFwFkxxUQdxVlBwCYWOi6IhWgQhBLHJUCkhLr/BW8S7gvrAg+N+v8/v+x68Z8MGy+XSCyABQAXgBgHGALoASkIIDWSLeLBetdHryMjd5IxQPWT4rn1c/P7+xxp72Cs9m5SZ0Bq2vPnbPFafK2zDvmNHypdC0BPkLlQhxJsCAhQoZwdZU5mwxh720qGo8MzTxTTKZDPCx2HoVzp6lz0Q9tKhyx0kGs8Ny+TkWRKk8lCROwEduhyg9l/6lunOPSfmH3NUH6uQ0KHLAe7JYvJjevm+DAMGJHToKtigE+vwvIidxLamb8IBY9e+C5LiXREkfho3TSd06HJA13/oh6T51MTsfQbHrsMynQ5dDihFjiK8JJAU9AKIWTp76dCVN7HWHrajmUEGvyF9nkbAE6gLIS7kTUyuf2gscLoJrElZo/Mvj+nPz/kLTmfnEwP3tB0AAAAASUVORK5CYII=);
+                    }
+
+                    /* Information icon encoded */
+                    .IconInfoEncoded
+                    {
+                        /* Note: Do not delete the comment below. It is used to verify the correctness of the encoded image resource below before the product is released */
+                        /* [---XsltValidateInternal-Base64EncodedImage:IconInformation#Begin#background-image: url(data:image/png;base64,#Separator#);#End#] */
+                        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABHElEQVR4Xs2TsUoDQRRF7wwoziokjZUKadInhdhukR9YP8DMX1hYW+QvdsXa/QHBbcXC7W0CamWTQnclFutceIQJwwaWNLlwm5k5d94M76mmaeCrrmsLYOocY12FcxZFUeozCqKqqgYA8uevv1H6VuPxcwlfk5N92KHBxfFeCSAxxswlYAW/Xr989x/mv9gkhtyMDhcAxgzRsp7flj8B/HF1RsMXq+NZMkopaHe7lbKxQUEIGbKsYNoGn969060hZBkQex/W8oRQwsQaW2o3Ago2SVcJUzAgY3N0lTCZZm+zPS8HB51gMmS1DEYyOz9acKO1D8JWTlafKIMxdhvlfdyT94Vv5h7P8Ky7nQzACmhvKq3zk3PjW9asz9D/1oigecsioooAAAAASUVORK5CYII=);
+                    }
+
+                    /* Warning icon encoded */
+                    .IconWarningEncoded
+                    {
+                        /* Note: Do not delete the comment below. It is used to verify the correctness of the encoded image resource below before the product is released */
+                        /* [---XsltValidateInternal-Base64EncodedImage:IconWarning#Begin#background-image: url(data:image/png;base64,#Separator#);#End#] */
+                        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAx0lEQVR4XpWSMQ7CMAxFf4xAyBMLCxMrO8dhaBcuwdCJS3RJBw7SA/QGTCxdWJgiQYWKXJWKIXHIlyw5lqr34tQgEOdcBsCOx5yZK3hCCKdYXneQkh4pEfqzLfu+wVDSyyzFoJjfz9NB+pAF+eizx2Vruts0k15mPgvS6GYvpVtQhB61IB/dk6AF6fS4Ben0uIX5odtFe8Q/eW1KvFeH4e8khT6+gm5B+t3juyDt7n0jpe+CANTd+oTUjN/U3yVaABnSUjFz/gFq44JaVSCXeQAAAABJRU5ErkJggg==);
+                    }
+
+                    /* Error icon encoded */
+                    .IconErrorEncoded
+                    {
+                        /* Note: Do not delete the comment below. It is used to verify the correctness of the encoded image resource below before the product is released */
+                        /* [---XsltValidateInternal-Base64EncodedImage:IconError#Begin#background-image: url(data:image/png;base64,#Separator#);#End#] */
+                        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABQElEQVR4XqWTvUoEQRCE6wYPZUA80AfwAQz23uCMjA7MDRQEIzPBVEyNTQUFIw00vcQTTMzuAh/AxEQQT8HF/3G/oGGnEUGuoNnd6qoZuqltyKEsyzVJq5I6rnUp6SjGeGhESikzzlc1eL7opfuVbrqbU1Zw9NCgtQMaZpY0eNnaaL2fHusvTK5vKu7sjSS1Y4y3QUA6K3e3Mau5UFDyMP7tYF9o8cAHZv68vipoIJg971PZIZ5HiwdvYGGvFVFHmGmZ2MxwmQYPXubPl9Up0tfoMQGetXd6mRbvhBw+boZ6WF7Mbv1+GsHRk0fQmPAH1GfmZirbCfDJ61tw3Px8/8pZsPAG4jlVhcPgZ7adwNWBB68lkRQWFiTgFlbnLY3DGGM7izIJIyT/jjIvEJw6fdJTc6krDzh6aMwMP9bvDH4ADSsa9uSWVJkAAAAASUVORK5CYII=);
+                    }
+                 </style><script type="text/javascript" language="javascript"> 
+          
+            // Startup 
+            // Hook up the the loaded event for the document/window, to linkify the document content
+            var startupFunction = function() { linkifyElement("messages"); };
+            
+            if(window.attachEvent)
+            {
+              window.attachEvent('onload', startupFunction);
+            }
+            else if (window.addEventListener) 
+            {
+              window.addEventListener('load', startupFunction, false);
+            }
+            else 
+            {
+              document.addEventListener('load', startupFunction, false);
+            } 
+            
+            // Toggles the visibility of table rows with the specified name 
+            function toggleTableRowsByName(name)
+            {
+               var allRows = document.getElementsByTagName('tr');
+               for (i=0; i < allRows.length; i++)
+               {
+                  var currentName = allRows[i].getAttribute('name');
+                  if(!!currentName && currentName.indexOf(name) == 0)
+                  {
+                      var isVisible = allRows[i].style.display == ''; 
+                      isVisible ? allRows[i].style.display = 'none' : allRows[i].style.display = '';
+                  }
+               }
+            }
+            
+            function scrollToFirstVisibleRow(name) 
+            {
+               var allRows = document.getElementsByTagName('tr');
+               for (i=0; i < allRows.length; i++)
+               {
+                  var currentName = allRows[i].getAttribute('name');
+                  var isVisible = allRows[i].style.display == ''; 
+                  if(!!currentName && currentName.indexOf(name) == 0 && isVisible)
+                  {
+                     allRows[i].scrollIntoView(true); 
+                     return true; 
+                  }
+               }
+               
+               return false;
+            }
+            
+            // Linkifies the specified text content, replaces candidate links with html links 
+            function linkify(text)
+            {
+                 if(!text || 0 === text.length)
+                 {
+                     return text; 
+                 }
+
+                 // Find http, https and ftp links and replace them with hyper links 
+                 var urlLink = /(http|https|ftp)\:\/\/[a-zA-Z0-9\-\.]+(:[a-zA-Z0-9]*)?\/?([a-zA-Z0-9\-\._\?\,\/\\\+&%\$#\=~;\{\}])*/gi;
+                 
+                 return text.replace(urlLink, '<a href="$&">$&</a>') ;
+            }
+            
+            // Linkifies the specified element by ID
+            function linkifyElement(id)
+            {
+                var element = document.getElementById(id);
+                if(!!element)
+                {
+                  element.innerHTML = linkify(element.innerHTML); 
+                }
+            }
+            
+            function ToggleMessageVisibility(projectName)
+            {
+              if(!projectName || 0 === projectName.length)
+              {
+                return; 
+              }
+              
+              toggleTableRowsByName("MessageRowClass" + projectName);
+              toggleTableRowsByName('MessageRowHeaderShow' + projectName);
+              toggleTableRowsByName('MessageRowHeaderHide' + projectName); 
+            }
+            
+            function ScrollToFirstVisibleMessage(projectName)
+            {
+              if(!projectName || 0 === projectName.length)
+              {
+                return; 
+              }
+              
+              // First try the 'Show messages' row
+              if(!scrollToFirstVisibleRow('MessageRowHeaderShow' + projectName))
+              {
+                // Failed to find a visible row for 'Show messages', try an actual message row 
+                scrollToFirstVisibleRow('MessageRowClass' + projectName); 
+              }
+            }
+           </script></head><body><h1 _locID="ConversionReport">
+          Migration Report - </h1><div id="content"><h2 _locID="OverviewTitle">Overview</h2><div id="overview"><table><tr><th></th><th _locID="ProjectTableHeader">Project</th><th _locID="PathTableHeader">Path</th><th _locID="ErrorsTableHeader">Errors</th><th _locID="WarningsTableHeader">Warnings</th><th _locID="MessagesTableHeader">Messages</th></tr><tr><td class="IconErrorEncoded" /><td><strong><a href="#TestApplication">TestApplication</a></strong></td><td>test\TestFabricApplication\TestApplication\TestApplication.sfproj</td><td class="textCentered"><a href="#TestApplicationError">1</a></td><td class="textCentered"><a>0</a></td><td class="textCentered"><a href="#">0</a></td></tr></table></div><h2 _locID="SolutionAndProjectsTitle">Solution and projects</h2><div id="messages"><a name="TestApplication" /><h3>TestApplication</h3><table><tr id="TestApplicationHeaderRow"><th></th><th class="messageCell" _locID="MessageTableHeader">Message</th></tr><tr name="ErrorRowClassTestApplication"><td class="IconErrorEncoded"><a name="TestApplicationError" /></td><td class="messageCell"><strong>test\TestFabricApplication\TestApplication\TestApplication.sfproj:
+        </strong><span>The application which this project type is based on was not found. Please try this link for further information: a07b5eb6-e848-4116-a8d0-a826331d98c6</span></td></tr></table></div></div></body></html>

--- a/src/DurableTask.Core/TaskActivityDispatcher.cs
+++ b/src/DurableTask.Core/TaskActivityDispatcher.cs
@@ -54,7 +54,8 @@ namespace DurableTask.Core
                 "TaskActivityDispatcher",
                 item => item.Id,
                 this.OnFetchWorkItemAsync,
-                this.OnProcessWorkItemAsync)
+                this.OnProcessWorkItemAsync,
+                this.RenewUntil)
             {
                 AbortWorkItem = orchestrationService.AbandonTaskActivityWorkItemAsync,
                 GetDelayInSecondsAfterOnFetchException = orchestrationService.GetDelayInSecondsAfterOnFetchException,
@@ -94,8 +95,6 @@ namespace DurableTask.Core
 
         async Task OnProcessWorkItemAsync(TaskActivityWorkItem workItem)
         {
-            Task? renewTask = null;
-            using var renewCancellationTokenSource = new CancellationTokenSource();
 
             TaskMessage taskMessage = workItem.TaskMessage;
             OrchestrationInstance orchestrationInstance = taskMessage.OrchestrationInstance;
@@ -143,14 +142,6 @@ namespace DurableTask.Core
 
                 this.logHelper.TaskActivityStarting(orchestrationInstance, scheduledEvent);
                 TaskActivity? taskActivity = this.objectManager.GetObject(scheduledEvent.Name, scheduledEvent.Version);
-
-                if (workItem.LockedUntilUtc < DateTime.MaxValue)
-                {
-                    // start a task to run RenewUntil
-                    renewTask = Task.Factory.StartNew(
-                        () => this.RenewUntil(workItem, renewCancellationTokenSource.Token),
-                        renewCancellationTokenSource.Token);
-                }
 
                 var dispatchContext = new DispatchMiddlewareContext();
                 dispatchContext.SetProperty(taskMessage.OrchestrationInstance);
@@ -271,19 +262,6 @@ namespace DurableTask.Core
             finally
             {
                 diagnosticActivity?.Stop(); // Ensure the activity is stopped here to prevent it from leaking out.
-                if (renewTask != null)
-                {
-                    renewCancellationTokenSource.Cancel();
-                    try
-                    {
-                        // wait the renewTask finish
-                        await renewTask;
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        // ignore
-                    }
-                }
             }
         }
 

--- a/src/DurableTask.Core/TaskActivityDispatcher.cs
+++ b/src/DurableTask.Core/TaskActivityDispatcher.cs
@@ -265,7 +265,7 @@ namespace DurableTask.Core
             }
         }
 
-        async Task RenewUntil(TaskActivityWorkItem workItem, CancellationToken cancellationToken)
+        internal async Task RenewUntil(TaskActivityWorkItem workItem, CancellationToken cancellationToken)
         {
             try
             {

--- a/src/DurableTask.Core/TaskActivityWorkItem.cs
+++ b/src/DurableTask.Core/TaskActivityWorkItem.cs
@@ -19,17 +19,12 @@ namespace DurableTask.Core
     /// <summary>
     /// An active instance / work item of a task activity
     /// </summary>
-    public class TaskActivityWorkItem
+    public class TaskActivityWorkItem : WorkItemBase
     {
         /// <summary>
         /// The Id of the work work item, likely related to the task message
         /// </summary>
         public string Id;
-
-        /// <summary>
-        /// The datetime this work item is locked until
-        /// </summary>
-        public DateTime LockedUntilUtc;
 
         /// <summary>
         /// The task message associated with this work item

--- a/src/DurableTask.Core/TaskOrchestrationWorkItem.cs
+++ b/src/DurableTask.Core/TaskOrchestrationWorkItem.cs
@@ -20,7 +20,7 @@ namespace DurableTask.Core
     /// <summary>
     /// An active instance / work item of an orchestration
     /// </summary>
-    public class TaskOrchestrationWorkItem
+    public class TaskOrchestrationWorkItem : WorkItemBase
     {
         /// <summary>
         /// The instance id of this orchestration
@@ -33,11 +33,6 @@ namespace DurableTask.Core
         public OrchestrationRuntimeState OrchestrationRuntimeState;
 
         /// <summary>
-        /// The datetime this orchestration work item is locked until
-        /// </summary>
-        public DateTime LockedUntilUtc;
-
-        /// <summary>
         /// The list of new task messages associated with this work item instance
         /// </summary>
         public IList<TaskMessage> NewMessages;
@@ -47,11 +42,6 @@ namespace DurableTask.Core
         /// providers that intend to leverage extended sessions.
         /// </summary>
         public IOrchestrationSession Session;
-
-        /// <summary>
-        /// The trace context used for correlation.
-        /// </summary>
-        public TraceContextBase TraceContext;
 
         /// <summary>
         /// The flag of extendedSession.

--- a/src/DurableTask.Core/TrackingWorkItem.cs
+++ b/src/DurableTask.Core/TrackingWorkItem.cs
@@ -19,17 +19,12 @@ namespace DurableTask.Core
     /// <summary>
     /// An active tracking work item
     /// </summary>
-    public class TrackingWorkItem
+    public class TrackingWorkItem : WorkItemBase
     {
         /// <summary>
         /// The instance id of this tracking work item
         /// </summary>
         public string InstanceId;
-
-        /// <summary>
-        /// The datetime this work item is locked until
-        /// </summary>
-        public DateTime LockedUntilUtc;
 
         /// <summary>
         /// The list of new messages to process tracking for

--- a/src/DurableTask.Core/WorkItemBase.cs
+++ b/src/DurableTask.Core/WorkItemBase.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace DurableTask.Core
+{
+    /// <summary>
+    /// Base class for Work Items.
+    /// </summary>
+    public abstract class WorkItemBase
+    {
+        /// <summary>
+        /// The datetime this work item is locked until
+        /// </summary>
+        public DateTime LockedUntilUtc;
+
+        /// <summary>
+        /// The trace context used for correlation.
+        /// </summary>
+        public TraceContextBase TraceContext;
+    }
+}

--- a/src/DurableTask.Core/WorkItemDispatcher.cs
+++ b/src/DurableTask.Core/WorkItemDispatcher.cs
@@ -94,10 +94,10 @@ namespace DurableTask.Core
         /// Creates a new Work Item Dispatcher with given name and identifier method
         /// </summary>
         /// <param name="name">Name identifying this dispatcher for logging and diagnostics</param>
-        /// <param name="workItemIdentifier"></param>
-        /// <param name="fetchWorkItem"></param>
-        /// <param name="processWorkItem"></param>
-        /// <param name="renewWorkItem"></param>
+        /// <param name="workItemIdentifier">Identifier for the WorkItem</param>
+        /// <param name="fetchWorkItem">Action to fetch the work item.</param>
+        /// <param name="processWorkItem">Action to process the work item.</param>
+        /// <param name="renewWorkItem">Action to renew the work item to maintain locking.</param>
         public WorkItemDispatcher(
             string name,
             Func<T, string> workItemIdentifier,
@@ -110,7 +110,7 @@ namespace DurableTask.Core
             this.workItemIdentifier = workItemIdentifier ?? throw new ArgumentNullException(nameof(workItemIdentifier));
             this.FetchWorkItem = fetchWorkItem ?? throw new ArgumentNullException(nameof(fetchWorkItem));
             this.ProcessWorkItem = processWorkItem ?? throw new ArgumentNullException(nameof(processWorkItem));
-            this.RenewWorkItem = renewWorkItem ?? throw new ArgumentNullException(nameof(processWorkItem));
+            this.RenewWorkItem = renewWorkItem ?? throw new ArgumentNullException(nameof(renewWorkItem));
         }
 
         /// <summary>

--- a/src/DurableTask.Core/WorkItemDispatcher.cs
+++ b/src/DurableTask.Core/WorkItemDispatcher.cs
@@ -303,10 +303,6 @@ namespace DurableTask.Core
                         "WorkItemDispatcherDispatch-TaskCanceledException",
                         this.GetFormattedLog(dispatcherId, $"TaskCanceledException while fetching workItem, should be harmless: {exception.Message}"));
                     delaySecs = this.GetDelayInSecondsAfterOnFetchException(exception);
-                    
-                    // cancel the renewal task in case of failure after fetching.
-                    renewCancellationTokenSource.Cancel();
-                    await renewTask;
                 }
                 catch (Exception exception)
                 {

--- a/src/DurableTask.Core/WorkItemDispatcher.cs
+++ b/src/DurableTask.Core/WorkItemDispatcher.cs
@@ -471,7 +471,6 @@ namespace DurableTask.Core
             }
             finally
             {
-
                 Interlocked.Decrement(ref this.concurrentWorkItemCount);
                 this.concurrencyLock.Release();
             }

--- a/src/DurableTask.Core/WorkItemDispatcher.cs
+++ b/src/DurableTask.Core/WorkItemDispatcher.cs
@@ -303,6 +303,10 @@ namespace DurableTask.Core
                         "WorkItemDispatcherDispatch-TaskCanceledException",
                         this.GetFormattedLog(dispatcherId, $"TaskCanceledException while fetching workItem, should be harmless: {exception.Message}"));
                     delaySecs = this.GetDelayInSecondsAfterOnFetchException(exception);
+                    
+                    // cancel the renewal task in case of failure after fetching.
+                    renewCancellationTokenSource.Cancel();
+                    await renewTask;
                 }
                 catch (Exception exception)
                 {

--- a/src/DurableTask.Core/WorkItemDispatcher.cs
+++ b/src/DurableTask.Core/WorkItemDispatcher.cs
@@ -27,6 +27,7 @@ namespace DurableTask.Core
     /// </summary>
     /// <typeparam name="T">The typed Object to dispatch</typeparam>
     public class WorkItemDispatcher<T> : IDisposable
+        where T: WorkItemBase
     {
         const int DefaultMaxConcurrentWorkItems = 20;
         const int DefaultDispatcherCount = 1;
@@ -64,7 +65,8 @@ namespace DurableTask.Core
         Func<TimeSpan, CancellationToken, Task<T>> FetchWorkItem { get; }
 
         Func<T, Task> ProcessWorkItem { get; }
-        
+        Func<T, CancellationToken, Task> RenewWorkItem { get; }
+
         /// <summary>
         /// Method to execute for safely releasing a work item
         /// </summary>
@@ -95,17 +97,20 @@ namespace DurableTask.Core
         /// <param name="workItemIdentifier"></param>
         /// <param name="fetchWorkItem"></param>
         /// <param name="processWorkItem"></param>
+        /// <param name="renewWorkItem"></param>
         public WorkItemDispatcher(
-            string name, 
+            string name,
             Func<T, string> workItemIdentifier,
             Func<TimeSpan, CancellationToken, Task<T>> fetchWorkItem,
-            Func<T, Task> processWorkItem)
+            Func<T, Task> processWorkItem,
+            Func<T, CancellationToken, Task> renewWorkItem)
         {
             this.name = name;
             this.id = Guid.NewGuid().ToString("N");
             this.workItemIdentifier = workItemIdentifier ?? throw new ArgumentNullException(nameof(workItemIdentifier));
             this.FetchWorkItem = fetchWorkItem ?? throw new ArgumentNullException(nameof(fetchWorkItem));
             this.ProcessWorkItem = processWorkItem ?? throw new ArgumentNullException(nameof(processWorkItem));
+            this.RenewWorkItem = renewWorkItem ?? throw new ArgumentNullException(nameof(processWorkItem));
         }
 
         /// <summary>
@@ -141,9 +146,9 @@ namespace DurableTask.Core
                         this.LogHelper.DispatcherStarting(context);
 
                         // We just want this to Run we intentionally don't wait
-                        #pragma warning disable 4014
+#pragma warning disable 4014
                         Task.Run(() => this.DispatchAsync(context));
-                        #pragma warning restore 4014
+#pragma warning restore 4014
                     }
                 }
                 finally
@@ -238,7 +243,7 @@ namespace DurableTask.Core
                             TraceEventType.Warning,
                             "WorkItemDispatcherDispatch-MaxOperations",
                             this.GetFormattedLog(dispatcherId, $"Max concurrent operations ({this.concurrentWorkItemCount}) are already in progress. Still waiting for next accept."));
-                        
+
                         logThrottle = false;
                     }
 
@@ -249,17 +254,27 @@ namespace DurableTask.Core
 
                 var delaySecs = 0;
                 T workItem = default(T);
+                Task renewTask =Task.CompletedTask;
+                using var renewCancellationTokenSource = new CancellationTokenSource();
+
                 try
                 {
                     Interlocked.Increment(ref this.activeFetchers);
                     this.LogHelper.FetchWorkItemStarting(context, DefaultReceiveTimeout, this.concurrentWorkItemCount, this.MaxConcurrentWorkItems);
                     TraceHelper.Trace(
-                        TraceEventType.Verbose, 
+                        TraceEventType.Verbose,
                         "WorkItemDispatcherDispatch-StartFetch",
                         this.GetFormattedLog(dispatcherId, $"Starting fetch with timeout of {DefaultReceiveTimeout} ({this.concurrentWorkItemCount}/{this.MaxConcurrentWorkItems} max)"));
 
                     Stopwatch timer = Stopwatch.StartNew();
                     workItem = await this.FetchWorkItem(DefaultReceiveTimeout, this.shutdownCancellationTokenSource.Token);
+
+                    if (workItem.LockedUntilUtc < DateTime.MaxValue)
+                    {
+                        // start a task to run Renewal of Work Items.
+                        renewTask = Task.Factory.StartNew(
+                            () => this.RenewWorkItem(workItem, renewCancellationTokenSource.Token));
+                    }
 
                     if (!IsNull(workItem))
                     {
@@ -273,7 +288,7 @@ namespace DurableTask.Core
                     }
 
                     TraceHelper.Trace(
-                        TraceEventType.Verbose, 
+                        TraceEventType.Verbose,
                         "WorkItemDispatcherDispatch-EndFetch",
                         this.GetFormattedLog(dispatcherId, $"After fetch ({timer.ElapsedMilliseconds} ms) ({this.concurrentWorkItemCount}/{this.MaxConcurrentWorkItems} max)"));
                 }
@@ -294,7 +309,7 @@ namespace DurableTask.Core
                     if (!this.isStarted)
                     {
                         TraceHelper.Trace(
-                            TraceEventType.Information, 
+                            TraceEventType.Information,
                             "WorkItemDispatcherDispatch-HarmlessException",
                             this.GetFormattedLog(dispatcherId, $"Harmless exception while fetching workItem after Stop(): {exception.Message}"));
                     }
@@ -303,8 +318,8 @@ namespace DurableTask.Core
                         this.LogHelper.FetchWorkItemFailure(context, exception);
                         // TODO : dump full node context here
                         TraceHelper.TraceException(
-                            TraceEventType.Warning, 
-                            "WorkItemDispatcherDispatch-Exception", 
+                            TraceEventType.Warning,
+                            "WorkItemDispatcherDispatch-Exception",
                             exception,
                             this.GetFormattedLog(dispatcherId, $"Exception while fetching workItem: {exception.Message}"));
                         delaySecs = this.GetDelayInSecondsAfterOnFetchException(exception);
@@ -329,9 +344,30 @@ namespace DurableTask.Core
                     {
                         Interlocked.Increment(ref this.concurrentWorkItemCount);
                         // We just want this to Run we intentionally don't wait
-                        #pragma warning disable 4014 
-                        Task.Run(() => this.ProcessWorkItemAsync(context, workItem));
-                        #pragma warning restore 4014
+#pragma warning disable 4014
+                        Task.Run(async () => {
+                            try
+                            {
+                                this.ProcessWorkItemAsync(context, workItem);
+                            }
+                            finally 
+                            {
+                                try
+                                {
+                                    renewCancellationTokenSource.Cancel();
+                                    await renewTask;
+                                }
+                                catch (ObjectDisposedException)
+                                {
+                                    // ignore
+                                }
+                                catch (OperationCanceledException)
+                                {
+                                    // ignore
+                                }
+                            }
+                            });
+#pragma warning restore 4014
 
                         scheduledWorkItem = true;
                     }
@@ -356,7 +392,7 @@ namespace DurableTask.Core
 
         async Task ProcessWorkItemAsync(WorkItemDispatcherContext context, object workItemObj)
         {
-            var workItem = (T) workItemObj;
+            var workItem = (T)workItemObj;
             var abortWorkItem = true;
             string workItemId = string.Empty;
 
@@ -366,7 +402,7 @@ namespace DurableTask.Core
 
                 this.LogHelper.ProcessWorkItemStarting(context, workItemId);
                 TraceHelper.Trace(
-                    TraceEventType.Information, 
+                    TraceEventType.Information,
                     "WorkItemDispatcherProcess-Begin",
                     this.GetFormattedLog(context.DispatcherId, $"Starting to process workItem {workItemId}"));
 
@@ -376,7 +412,7 @@ namespace DurableTask.Core
 
                 this.LogHelper.ProcessWorkItemCompleted(context, workItemId);
                 TraceHelper.Trace(
-                    TraceEventType.Information, 
+                    TraceEventType.Information,
                     "WorkItemDispatcherProcess-End",
                     this.GetFormattedLog(context.DispatcherId, $"Finished processing workItem {workItemId}"));
 
@@ -390,12 +426,12 @@ namespace DurableTask.Core
                     $"Backing off for {BackOffIntervalOnInvalidOperationSecs} seconds",
                     exception);
                 TraceHelper.TraceException(
-                    TraceEventType.Error, 
-                    "WorkItemDispatcherProcess-TypeMissingException", 
+                    TraceEventType.Error,
+                    "WorkItemDispatcherProcess-TypeMissingException",
                     exception,
                     this.GetFormattedLog(context.DispatcherId, $"Exception while processing workItem {workItemId}"));
                 TraceHelper.Trace(
-                    TraceEventType.Error, 
+                    TraceEventType.Error,
                     "WorkItemDispatcherProcess-TypeMissingBackingOff",
                     "Backing off after invalid operation by " + BackOffIntervalOnInvalidOperationSecs);
 
@@ -405,8 +441,8 @@ namespace DurableTask.Core
             catch (Exception exception) when (!Utils.IsFatal(exception))
             {
                 TraceHelper.TraceException(
-                    TraceEventType.Error, 
-                    "WorkItemDispatcherProcess-Exception", 
+                    TraceEventType.Error,
+                    "WorkItemDispatcherProcess-Exception",
                     exception,
                     this.GetFormattedLog(context.DispatcherId, $"Exception while processing workItem {workItemId}"));
 
@@ -419,7 +455,7 @@ namespace DurableTask.Core
                         $"Backing off for {delayInSecs} seconds until {CountDownToZeroDelay} successful operations",
                         exception);
                     TraceHelper.Trace(
-                        TraceEventType.Error, 
+                        TraceEventType.Error,
                         "WorkItemDispatcherProcess-BackingOff",
                         "Backing off after exception by at least " + delayInSecs + " until " + CountDownToZeroDelay +
                         " successful operations");
@@ -435,6 +471,7 @@ namespace DurableTask.Core
             }
             finally
             {
+
                 Interlocked.Decrement(ref this.concurrentWorkItemCount);
                 this.concurrencyLock.Release();
             }

--- a/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
+++ b/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
@@ -221,7 +221,8 @@ namespace DurableTask.ServiceBus
                     "TrackingDispatcher",
                     item => item == null ? string.Empty : item.InstanceId,
                     FetchTrackingWorkItemAsync,
-                    ProcessTrackingWorkItemAsync)
+                    ProcessTrackingWorkItemAsync,
+                    (T,token) => Task.CompletedTask)
                 {
                     GetDelayInSecondsAfterOnFetchException = GetDelayInSecondsAfterOnFetchException,
                     GetDelayInSecondsAfterOnProcessException = GetDelayInSecondsAfterOnProcessException,


### PR DESCRIPTION
Fixes #1150 
The summary of changes is as follows:
1. Adds a `WorkItemBase` to extract common properties for Work Items.
2. Pulls the logic to renew work item lock in `WorkItemDispatcher`.

Open Question:
Do we want to add a renewal policy for Tracking store items too? If not, why?
