### PR TITLE
Update DurableTask.ApplicationInsights and DurableTask.AzureStorage Version

### DIFF
--- a/src/DurableTask.ApplicationInsights/DurableTask.ApplicationInsights.csproj
+++ b/src/DurableTask.ApplicationInsights/DurableTask.ApplicationInsights.csproj
@@ -11,8 +11,8 @@
     <!-- Version Info -->
     <PropertyGroup>
         <MajorVersion>0</MajorVersion>
-        <MinorVersion>1</MinorVersion>
-        <PatchVersion>6</PatchVersion>
+        <MinorVersion>2</MinorVersion>
+        <PatchVersion>0</PatchVersion>
         <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
         <FileVersion>$(VersionPrefix).0</FileVersion>
         <!-- FileVersionRevision is expected to be set by the CI. This is useful for distinguishing between multiple builds of the same version. -->

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -22,7 +22,7 @@
   <PropertyGroup>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <FileVersion>$(VersionPrefix).0</FileVersion>
     <!-- FileVersionRevision is expected to be set by the CI. This is useful for distinguishing between multiple builds of the same version. -->


### PR DESCRIPTION
As titled. 
 DurableTask.ApplicationInsights v0.1.6 -> v2.0.0 as it uses DurableTask.Core v3.0.0. 
DurableTask.AzureStorage v2.0.0- v2.0.1 for new changes in https://github.com/Azure/durabletask/pull/1159