### PR TITLE
Handle poisoned work items by marking them as failed

### DIFF
--- a/src/DurableTask.Core/Exceptions/WorkItemPoisonedException.cs
+++ b/src/DurableTask.Core/Exceptions/WorkItemPoisonedException.cs
@@ -1,0 +1,24 @@
+// ---------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ---------------------------------------------------------------
+
+namespace DurableTask.Core.Exceptions
+{
+    using System;
+
+    /// <summary>
+    /// Represents a work item that is poisoned and should not be retried.
+    /// </summary>
+    public class WorkItemPoisonedException : Exception
+    {
+        /// <summary>
+        /// Represents a work item that is poisoned and should not be retried.
+        /// </summary>
+        public WorkItemPoisonedException(
+            string message = "Work item is poisoned",
+            Exception innerException = null
+        ) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/DurableTask.Core/Logging/EventIds.cs
+++ b/src/DurableTask.Core/Logging/EventIds.cs
@@ -60,6 +60,7 @@ namespace DurableTask.Core.Logging
         public const int RenewActivityMessageStarting = 65;
         public const int RenewActivityMessageCompleted = 66;
         public const int RenewActivityMessageFailed = 67;
+        public const int TaskActivityPoisoned = 68;
 
         public const int SuspendingInstance = 68;
         public const int ResumingInstance = 69;

--- a/src/DurableTask.Core/Logging/EventIds.cs
+++ b/src/DurableTask.Core/Logging/EventIds.cs
@@ -51,6 +51,7 @@ namespace DurableTask.Core.Logging
         public const int EntityBatchExecuted = 56;
         public const int EntityLockAcquired = 57;
         public const int EntityLockReleased = 58;
+        public const int OrchestrationPoisoned = 59;
 
         public const int TaskActivityStarting = 60;
         public const int TaskActivityCompleted = 61;

--- a/src/DurableTask.Core/Logging/LogEvents.cs
+++ b/src/DurableTask.Core/Logging/LogEvents.cs
@@ -1,4 +1,4 @@
-﻿//  ----------------------------------------------------------------------------------
+//  ----------------------------------------------------------------------------------
 //  Copyright Microsoft Corporation
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -1591,6 +1591,52 @@ namespace DurableTask.Core.Logging
 
             void IEventSourceEvent.WriteEventSource() =>
                 StructuredEventSource.Log.TaskActivityAborted(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.Name,
+                    this.TaskEventId,
+                    this.Details,
+                    Utils.AppName,
+                    Utils.PackageVersion);
+        }
+
+        internal class TaskActivityPoisoned : StructuredLogEvent, IEventSourceEvent
+        {
+            public TaskActivityPoisoned(OrchestrationInstance instance, TaskScheduledEvent taskEvent, string details)
+            {
+                this.InstanceId = instance.InstanceId;
+                this.ExecutionId = instance.ExecutionId;
+                this.Name = taskEvent.Name;
+                this.TaskEventId = taskEvent.EventId;
+                this.Details = details;
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string Name { get; }
+
+            [StructuredLogField]
+            public int TaskEventId { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.TaskActivityPoisoned,
+                nameof(EventIds.TaskActivityPoisoned));
+
+            public override LogLevel Level => LogLevel.Warning;
+
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Task activity {GetEventDescription(this.Name, this.TaskEventId)} is poisoned and was canceled: {this.Details}";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.TaskActivityPoisoned(
                     this.InstanceId,
                     this.ExecutionId,
                     this.Name,

--- a/src/DurableTask.Core/Logging/LogHelper.cs
+++ b/src/DurableTask.Core/Logging/LogHelper.cs
@@ -10,6 +10,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
+
 #nullable enable
 namespace DurableTask.Core.Logging
 {
@@ -34,6 +35,7 @@ namespace DurableTask.Core.Logging
         bool IsStructuredLoggingEnabled => this.log != null;
 
         #region TaskHubWorker
+
         /// <summary>
         /// Logs that a <see cref="TaskHubWorker"/> is starting.
         /// </summary>
@@ -79,6 +81,7 @@ namespace DurableTask.Core.Logging
                 this.WriteStructuredLog(new LogEvents.TaskHubWorkerStopped(latency));
             }
         }
+
         #endregion
 
         #region WorkItemDispatcher traces
@@ -616,6 +619,7 @@ namespace DurableTask.Core.Logging
         #endregion
 
         #region Activity dispatcher
+
         /// <summary>
         /// Logs that a task activity is about to begin execution.
         /// </summary>
@@ -679,6 +683,20 @@ namespace DurableTask.Core.Logging
         }
 
         /// <summary>
+        /// Logs a warning indicating that the activity execution is poisoned and was canceled.
+        /// </summary>
+        /// <param name="instance">The orchestration instance that scheduled this task activity.</param>
+        /// <param name="taskEvent">The history event associated with this activity execution.</param>
+        /// <param name="details">More information about why the execution was canceled.</param>
+        internal void TaskActivityPoisoned(OrchestrationInstance instance, TaskScheduledEvent taskEvent, string details)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.TaskActivityAborted(instance, taskEvent, details));
+            }
+        }
+
+        /// <summary>
         /// Logs that an error occurred when attempting to dispatch an activity work item.
         /// </summary>
         /// <param name="workItem">The work item that caused the failure.</param>
@@ -728,6 +746,7 @@ namespace DurableTask.Core.Logging
                 this.WriteStructuredLog(new LogEvents.RenewActivityMessageFailed(workItem, exception), exception);
             }
         }
+
         #endregion
 
         internal void OrchestrationDebugTrace(string instanceId, string executionId, string details)

--- a/src/DurableTask.Core/Logging/LogHelper.cs
+++ b/src/DurableTask.Core/Logging/LogHelper.cs
@@ -501,6 +501,19 @@ namespace DurableTask.Core.Logging
         }
 
         /// <summary>
+        /// Logs a warning indicating that the activity execution is poisoned and was canceled.
+        /// </summary>
+        /// <param name="instance">The orchestration instance that failed.</param>
+        /// <param name="reason">The reason for the orchestration execution becoming poisoned.</param>
+        internal void OrchestrationPoisoned(OrchestrationInstance instance, string reason)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.OrchestrationPoisoned(instance, reason));
+            }
+        }
+
+        /// <summary>
         /// Helper method for logging the dropping of all messages associated with the specified work item.
         /// </summary>
         /// <param name="workItem">The work item being dropped.</param>
@@ -687,12 +700,12 @@ namespace DurableTask.Core.Logging
         /// </summary>
         /// <param name="instance">The orchestration instance that scheduled this task activity.</param>
         /// <param name="taskEvent">The history event associated with this activity execution.</param>
-        /// <param name="details">More information about why the execution was canceled.</param>
+        /// <param name="details">More information about why the execution failed.</param>
         internal void TaskActivityPoisoned(OrchestrationInstance instance, TaskScheduledEvent taskEvent, string details)
         {
             if (this.IsStructuredLoggingEnabled)
             {
-                this.WriteStructuredLog(new LogEvents.TaskActivityAborted(instance, taskEvent, details));
+                this.WriteStructuredLog(new LogEvents.TaskActivityPoisoned(instance, taskEvent, details));
             }
         }
 

--- a/src/DurableTask.Core/Logging/StructuredEventSource.cs
+++ b/src/DurableTask.Core/Logging/StructuredEventSource.cs
@@ -712,7 +712,7 @@ namespace DurableTask.Core.Logging
                 // TODO: Use WriteEventCore for better performance
                 this.WriteEvent(
                     EventIds.EntityLockReleased,
-                    EntityId, 
+                    EntityId,
                     InstanceId,
                     Id,
                     AppName,
@@ -808,6 +808,32 @@ namespace DurableTask.Core.Logging
                 // TODO: Use WriteEventCore for better performance
                 this.WriteEvent(
                     EventIds.TaskActivityAborted,
+                    InstanceId,
+                    ExecutionId,
+                    Name,
+                    TaskEventId,
+                    Details,
+                    AppName,
+                    ExtensionVersion);
+            }
+        }
+
+        [Event(EventIds.TaskActivityPoisoned, Level = EventLevel.Warning, Version = 1)]
+        internal void TaskActivityPoisoned(
+            string InstanceId,
+            string ExecutionId,
+            string Name,
+            int TaskEventId,
+            string Details,
+            string AppName,
+            string ExtensionVersion
+        )
+        {
+            if (this.IsEnabled(EventLevel.Warning))
+            {
+                // TODO: Use WriteEventCore for better performance
+                this.WriteEvent(
+                    EventIds.TaskActivityPoisoned,
                     InstanceId,
                     ExecutionId,
                     Name,

--- a/src/DurableTask.Core/Logging/StructuredEventSource.cs
+++ b/src/DurableTask.Core/Logging/StructuredEventSource.cs
@@ -599,6 +599,26 @@ namespace DurableTask.Core.Logging
             }
         }
 
+        [Event(EventIds.OrchestrationPoisoned, Level = EventLevel.Warning, Version = 1)]
+        internal void OrchestrationPoisoned(
+            string InstanceId,
+            string ExecutionId,
+            string Details,
+            string AppName,
+            string ExtensionVersion)
+        {
+            if (this.IsEnabled(EventLevel.Warning))
+            {
+                this.WriteEvent(
+                    EventIds.OrchestrationPoisoned,
+                    InstanceId,
+                    ExecutionId,
+                    Details,
+                    AppName,
+                    ExtensionVersion);
+            }
+        }
+
         [Event(EventIds.DiscardingMessage, Level = EventLevel.Warning, Version = 1)]
         internal void DiscardingMessage(
             string InstanceId,

--- a/src/DurableTask.Core/OrchestrationRuntimeState.cs
+++ b/src/DurableTask.Core/OrchestrationRuntimeState.cs
@@ -98,6 +98,19 @@ namespace DurableTask.Core
         }
 
         /// <summary>
+        /// Returns a deep copy of the object.
+        /// </summary>
+        /// <returns>Cloned object</returns>
+        public OrchestrationRuntimeState Clone()
+        {
+            return new OrchestrationRuntimeState(this.Events)
+            {
+                Size = this.Size,
+                Status = this.Status,
+            };
+        }
+
+        /// <summary>
         /// Gets the execution started event
         /// </summary>
         public ExecutionStartedEvent? ExecutionStartedEvent
@@ -188,7 +201,7 @@ namespace DurableTask.Core
         /// <remarks>
         /// An invalid orchestration runtime state means that the history is somehow corrupted.
         /// </remarks>
-        public bool IsValid => 
+        public bool IsValid =>
             this.Events.Count == 0 ||
             this.Events.Count == 1 && this.Events[0].EventType == EventType.OrchestratorStarted ||
             this.ExecutionStartedEvent != null;
@@ -253,8 +266,8 @@ namespace DurableTask.Core
                 historyEvent.EventType == EventType.TaskCompleted &&
                 !completedEventIds.Add(historyEvent.EventId))
             {
-                TraceHelper.Trace(TraceEventType.Warning, 
-                    "OrchestrationRuntimeState-DuplicateEvent", 
+                TraceHelper.Trace(TraceEventType.Warning,
+                    "OrchestrationRuntimeState-DuplicateEvent",
                     "The orchestration '{0}' has already seen a completed task with id {1}.",
                     this.OrchestrationInstance?.InstanceId ?? "",
                     historyEvent.EventId);
@@ -287,7 +300,7 @@ namespace DurableTask.Core
                     // It's not generally expected to receive multiple execution completed events for a given orchestrator, but it's possible under certain race conditions.
                     // For example: when an orchestrator is signaled to terminate at the same time as it attempts to continue-as-new.
                     var log = $"Received new {completedEvent.GetType().Name} event despite the orchestration being already in the {orchestrationStatus} state.";
-                    
+
                     if (orchestrationStatus == OrchestrationStatus.ContinuedAsNew && completedEvent.OrchestrationStatus == OrchestrationStatus.Terminated)
                     {
                         // If the orchestration planned to continue-as-new but termination is requested, we transition to the terminated state.


### PR DESCRIPTION
When orchestrations and activity tasks fail with un-retriable errors (by any worker), they should not be abandoned; instead, they should be marked as completed and with state failed.

This is implemented by catching exceptions of type `WorkItemPoisonedException` which can be raised downstream, for example by a persistence store provider. When that happens, instead of abandoning the work item, the dispatcher marks it as completed.