### PR TITLE
Update pipeline branch list to test DurableTask.AzureServiceFabric addition to pipelines

### DIFF
--- a/eng/ci/code-mirror.yml
+++ b/eng/ci/code-mirror.yml
@@ -5,6 +5,7 @@ trigger:
     # Keep this set limited as appropriate (don't mirror individual user branches).
     - main
     - durabletask-core-v2
+    - neetart/dtfx_sf_pipeline
 
 resources:
   repositories:

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -4,6 +4,7 @@ trigger:
         include:
             - main
             - durabletask-core-v2
+            - neetart/dtfx_sf_pipeline
 
 # CI only, does not trigger on PRs.
 pr: none

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -7,6 +7,7 @@ trigger:
     include:
     - main
     - durabletask-core-v2
+    - neetart/dtfx_sf_pipeline
 
 # Run nightly to catch new CVEs and to report SDL often.
 schedules:


### PR DESCRIPTION
This PR adds the branch `neetart/dtfx_sf_pipeline` as an allowed branch to run our ADO pipelines from. We are adding this to test the changes in the branch and will remove the changes once those changes have been tested and merged to `main`.