### PR TITLE
Move to Central Package Management For DurableTask repo

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,112 @@
+<Project>
+  <PropertyGroup>
+    <!--
+    More information about central package management:
+    https://learn.microsoft.com/nuget/consume-packages/central-package-management
+    -->
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <!-- Product dependencies -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.21.0" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.6" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+    <PackageVersion Include="Microsoft.ServiceFabric.Data" Version="3.3.617" />
+    <PackageVersion Include="Microsoft.ServiceFabric.Services" Version="3.3.617" />
+    <PackageVersion Include="Microsoft.ServiceFabric" Version="6.4.617" />
+    <PackageVersion Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageVersion Include="Azure.Core" Version="1.43.0" />
+    <PackageVersion Include="Azure.Data.Tables" Version="12.9.1" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.22.1" />
+    <PackageVersion Include="Azure.Storage.Queues" Version="12.20.0" />
+    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
+    <PackageVersion Include="System.Reactive.Core" Version="4.4.1" />
+    <PackageVersion Include="System.Reactive.Compatibility" Version="4.4.1" />
+    <PackageVersion Include="Castle.Core" Version="5.0.0" />
+    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.17.0" />
+    <PackageVersion Include="ImpromptuInterface" Version="6.2.2" Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'" />
+    <PackageVersion Include="ImpromptuInterface" Version="7.0.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+  </ItemGroup>
+  
+  <!-- Product dependencies with net462 only-->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <PackageVersion Include="Microsoft.Azure.KeyVault.Core" version="1.0.0" />
+    <PackageVersion Include="Microsoft.Data.Edm" version="5.8.5" />
+    <PackageVersion Include="Microsoft.Data.OData" version="5.8.5" />
+    <PackageVersion Include="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" />
+    <PackageVersion Include="System.Spatial" version="5.8.5" />
+    <PackageVersion Include="WindowsAzure.ServiceBus" version="4.1.3" />
+  </ItemGroup>
+  
+  <!-- Test dependencies -->
+  <ItemGroup>
+    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <PackageVersion Include="Microsoft.AspNet.WebApi.Core" Version="5.2.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.5.0" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.5.0" />
+    <PackageVersion Include="Moq" Version="4.10.0" />
+    <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageVersion Include="Microsoft.Data.Services.Client" Version="5.8.5" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.0.0-beta.4" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
+    <PackageVersion Include="WindowsAzure.Storage" version="9.3.3" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageVersion Include="WindowsAzure.Storage" version="8.7.0" Condition="'$(TargetFramework)' == 'net462'"/>
+    <PackageVersion Include="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer.NetCore" Version="2.0.1406.4" />
+    <PackageVersion Include="System.Text.Json" Version="6.0.10" />
+    <PackageVersion Include="CommandLineParser" Version="2.4.3" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageVersion Include="CommandLineParser" version="1.9.71" Condition="'$(TargetFramework)' == 'net462'"/>
+    <PackageVersion Include="Microsoft.Diagnostics.EventFlow.Core" Version="1.5.6" />
+  </ItemGroup>
+
+  <!-- Test dependencies with netcoreapp3.1-->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageVersion Include="EnterpriseLibrary.SemanticLogging.NetCore" Version="2.0.1406.4" />
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+  </ItemGroup>
+
+  <!-- Test dependencies with net472-->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.6" />
+    <PackageVersion Include="Microsoft.AspNet.WebApi.Owin" Version="5.2.6" />
+    <PackageVersion Include="Microsoft.Owin.Hosting" Version="4.0.0" />
+  </ItemGroup>
+
+  <!-- Test dependencies with net462-->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <PackageVersion Include="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" />
+    <PackageVersion Include="EnterpriseLibrary.SemanticLogging.TextFile" version="2.0.1406.1" />
+    <PackageVersion Include="Microsoft.Tpl.Dataflow" version="4.5.24" />
+    <PackageVersion Include="Microsoft.Owin.Hosting" Version="4.0.0" />
+  </ItemGroup>
+
+  <!-- Sample dependencies -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="3.1.32" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="3.1.32" />
+	<PackageVersion Include="Microsoft.ApplicationInsights.DependencyCollector" Version ="2.12.0"/>
+    <PackageVersion Include="Vio.DurableTask.Hosting" Version="2.2.1" />
+	<PackageVersion Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+	<PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
+	<PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.1.0" />
+	<PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.1.0" />
+	<PackageVersion Include="Azure.Identity" Version="1.12.0" />
+	<PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.4" />
+	<PackageVersion Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.17.3"/>
+  </ItemGroup>
+
+  <!-- Sample dependencies with net462-->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <PackageVersion Include="ncrontab" version="1.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/DurableTask.sln
+++ b/DurableTask.sln
@@ -62,6 +62,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		azure-pipelines-build.yml = azure-pipelines-build.yml
 		azure-pipelines-release.yml = azure-pipelines-release.yml
 		Directory.Build.targets = Directory.Build.targets
+		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DurableTask.ApplicationInsights", "src\DurableTask.ApplicationInsights\DurableTask.ApplicationInsights.csproj", "{331D783C-C3AF-43DD-9270-6CF22459B2C1}"
@@ -303,7 +304,7 @@ Global
 		{87CA84DE-A0FE-443C-8B2B-AB89F5DF5C24} = {8B797A00-0F43-46F9-8F1A-C945FD4F304F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {2D63A120-9394-48D9-8CA9-1184364FB854}
 		EnterpriseLibraryConfigurationToolBinariesPath = packages\TransientFaultHandling.Core.5.1.1209.1\lib\NET4
+		SolutionGuid = {2D63A120-9394-48D9-8CA9-1184364FB854}
 	EndGlobalSection
 EndGlobal

--- a/samples/Correlation.Samples/Correlation.Samples.csproj
+++ b/samples/Correlation.Samples/Correlation.Samples.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
   </ItemGroup>
 
   <ItemGroup>
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.12.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/DistributedTraceSample/ApplicationInsights/ApplicationInsightsSample.csproj
+++ b/samples/DistributedTraceSample/ApplicationInsights/ApplicationInsightsSample.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
-    <PackageReference Include="Vio.DurableTask.Hosting" Version="2.2.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" VersionOverride="7.0.2" />
+    <PackageReference Include="Vio.DurableTask.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/DistributedTraceSample/OpenTelemetry/OpenTelemetrySample.csproj
+++ b/samples/DistributedTraceSample/OpenTelemetry/OpenTelemetrySample.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.1.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.1.0" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.0.0-beta.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/DurableTask.Samples/DurableTask.Samples.csproj
+++ b/samples/DurableTask.Samples/DurableTask.Samples.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" version="1.9.71" />
-    <PackageReference Include="EnterpriseLibrary.SemanticLogging" Version="2.0.1406.1" />
-    <PackageReference Include="ncrontab" version="1.0.0" />
+    <PackageReference Include="CommandLineParser"  />
+    <PackageReference Include="EnterpriseLibrary.SemanticLogging"  />
+    <PackageReference Include="ncrontab"  />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ManagedIdentitySample/DTFx.AzureStorage v1.x/ManagedIdentity.AzStorageV1.csproj
+++ b/samples/ManagedIdentitySample/DTFx.AzureStorage v1.x/ManagedIdentity.AzStorageV1.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.17.3" />
-    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" />
+    <PackageReference Include="Microsoft.Extensions.Azure" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
   </ItemGroup>
 
 </Project>

--- a/samples/ManagedIdentitySample/DTFx.AzureStorage v2.x/ManagedIdentity.AzStorageV2.csproj
+++ b/samples/ManagedIdentitySample/DTFx.AzureStorage v2.x/ManagedIdentity.AzStorageV2.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <LangVersion>Latest</LangVersion>
@@ -8,12 +8,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="2.0.0-rc.3" />
-    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Microsoft.Extensions.Azure"  />
+    <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" VersionOverride="8.0.0" />
   </ItemGroup>
+
+   <ItemGroup>
+	 <ProjectReference Include="..\..\..\src\DurableTask.AzureStorage\DurableTask.AzureStorage.csproj" />
+	 <ProjectReference Include="..\..\..\src\DurableTask.Core\DurableTask.Core.csproj" />
+</ItemGroup>
 
 </Project>

--- a/src/DurableTask.ApplicationInsights/DurableTask.ApplicationInsights.csproj
+++ b/src/DurableTask.ApplicationInsights/DurableTask.ApplicationInsights.csproj
@@ -24,8 +24,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
+        <PackageReference Include="Microsoft.ApplicationInsights" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
+++ b/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
@@ -17,29 +17,27 @@
  </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="ImpromptuInterface" Version="6.2.2" />
     <Reference Include="System.Web" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <PackageReference Include="ImpromptuInterface" Version="6.2.2" />
     <Reference Include="System.Web" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <!-- Restoring packages for netstandard2.0 causes warnings. As warnings are treated as errors, compilation will fail. -->
     <!-- Once the packages support netstandard2.0, this project will support netstandard2.0. -->
-    <PackageReference Include="ImpromptuInterface" Version="7.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-    <PackageReference Include="Microsoft.ServiceFabric.Data" Version="3.3.617" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="3.3.617" />
-    <PackageReference Include="Microsoft.ServiceFabric" Version="6.4.617" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="ImpromptuInterface" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.ServiceFabric.Data" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services" />
+    <PackageReference Include="Microsoft.ServiceFabric" />
+    <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -40,12 +40,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.43.0" />
-    <PackageReference Include="Azure.Data.Tables" Version="12.9.1" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.22.1" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.20.0" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="Azure.Core" />
+    <PackageReference Include="Azure.Data.Tables" />
+    <PackageReference Include="Azure.Storage.Blobs" />
+    <PackageReference Include="Azure.Storage.Queues" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="System.Linq.Async" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -37,12 +37,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
-    <PackageReference Include="System.Reactive.Core" Version="4.4.1" />
-    <PackageReference Include="System.Reactive.Compatibility" Version="4.4.1" />
-    <PackageReference Include="Castle.Core" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
+    <PackageReference Include="System.Reactive.Core" />
+    <PackageReference Include="System.Reactive.Compatibility" />
+    <PackageReference Include="Castle.Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
+++ b/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
@@ -23,27 +23,25 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
-    <PackageReference Include="ImpromptuInterface" version="6.2.2" />
-    <PackageReference Include="Microsoft.Azure.KeyVault.Core" version="1.0.0" />
-    <PackageReference Include="Microsoft.Data.Edm" version="5.8.5" />
-    <PackageReference Include="Microsoft.Data.OData" version="5.8.5" />
-    <PackageReference Include="Microsoft.Data.Services.Client" version="5.8.5" />
-    <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" />
-    <PackageReference Include="System.Spatial" version="5.8.5" />
-    <PackageReference Include="WindowsAzure.ServiceBus" version="4.1.3" />
+    <PackageReference Include="ImpromptuInterface" />
+    <PackageReference Include="Microsoft.Azure.KeyVault.Core" />
+    <PackageReference Include="Microsoft.Data.Edm" />
+    <PackageReference Include="Microsoft.Data.OData" />
+    <PackageReference Include="Microsoft.Data.Services.Client" />
+    <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" />
+    <PackageReference Include="System.Spatial" />
+    <PackageReference Include="WindowsAzure.ServiceBus" />
     <Reference Include="System.Transactions" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Azure.Data.Tables"  />
+    <PackageReference Include="Azure.Storage.Blobs" />
+    <PackageReference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DurableTask.AzureServiceFabric.Integration.Tests/DurableTask.AzureServiceFabric.Integration.Tests.csproj
+++ b/test/DurableTask.AzureServiceFabric.Integration.Tests/DurableTask.AzureServiceFabric.Integration.Tests.csproj
@@ -8,13 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.6" />
-    <PackageReference Include="Moq" Version="4.10.0" />
+	<!-- Override the centrally managed version -->
+	<PackageReference Include="Microsoft.NET.Test.Sdk" VersionOverride="15.0.0" />
+	<PackageReference Include="MSTest.TestAdapter" VersionOverride="1.4.0" />
+	<PackageReference Include="MSTest.TestFramework" VersionOverride="1.4.0" />
+    <PackageReference Include="System.Collections.Immutable" VersionOverride="1.5.0" />
+    <PackageReference Include="System.Net.Http" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Core" />
+    <PackageReference Include="Moq" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DurableTask.AzureServiceFabric.Tests/DurableTask.AzureServiceFabric.Tests.csproj
+++ b/test/DurableTask.AzureServiceFabric.Tests/DurableTask.AzureServiceFabric.Tests.csproj
@@ -7,10 +7,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-        <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" VersionOverride="15.0.0" />
+	<PackageReference Include="MSTest.TestAdapter" VersionOverride="1.4.0" />
+	<PackageReference Include="MSTest.TestFramework" VersionOverride="1.4.0" />
+    <PackageReference Include="System.Collections.Immutable" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
+++ b/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
@@ -6,8 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" />
-    <PackageReference Include="WindowsAzure.Storage" version="8.7.0" />
+    <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
@@ -16,25 +15,25 @@
 	  "System.Diagnostics.DiagnosticSource 7.0.0-rc.1.22426.10 doesn't support netcoreapp3.1 and has not been tested with it
 	  Consider upgrading your TargetFramework to net6.0 or later. You may also set <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings> 
 	  in the project file to ignore this warning and attempt to run in this unsupported configuration at your own risk."-->
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.0.0-beta.4" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
-    <PackageReference Include="WindowsAzure.Storage" version="9.3.3" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" />
   </ItemGroup>
 
   <!-- Common package dependencies -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.22.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
+    <PackageReference Include="WindowsAzure.Storage" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="Moq" />
 
     <!-- We don't really make use of these dependencies, but 1ES somehow detects them in our test project and flags them for update.
 	Since this is just a test project, and to prevent "warning fatigue" so real CVEs stand out, we choose to upgrade the dependency explicitly to remove the false alarm.-->
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" /> <!-- Version 4.3.1 was detected by default-->
-    <PackageReference Include="Microsoft.Data.Services.Client" Version="5.8.4" /> <!-- Without this, we resolve Microsoft.Data.OData 5.8.2, which is flagged-->
+    <PackageReference Include="System.Data.SqlClient" /> <!-- Version 4.3.1 was detected by default-->
+    <PackageReference Include="Microsoft.Data.Services.Client" /> <!-- Without this, we resolve Microsoft.Data.OData 5.8.2, which is flagged-->
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj
+++ b/test/DurableTask.Core.Tests/DurableTask.Core.Tests.csproj
@@ -6,13 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer.NetCore" Version="2.0.1406.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.10" />
+    <PackageReference Include="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer.NetCore" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DurableTask.Emulator.Tests/DurableTask.Emulator.Tests.csproj
+++ b/test/DurableTask.Emulator.Tests/DurableTask.Emulator.Tests.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DurableTask.Samples.Tests/DurableTask.Samples.Tests.csproj
+++ b/test/DurableTask.Samples.Tests/DurableTask.Samples.Tests.csproj
@@ -6,9 +6,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="1.1.11" />
-		<PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
+	<!-- Override this version-->
+		<PackageReference Include="Microsoft.NET.Test.Sdk" VersionOverride="15.0.0" />
+		<PackageReference Include="MSTest.TestAdapter" VersionOverride="1.1.11" />
+		<PackageReference Include="MSTest.TestFramework" VersionOverride="1.1.11" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/test/DurableTask.ServiceBus.Tests/DurableTask.ServiceBus.Tests.csproj
+++ b/test/DurableTask.ServiceBus.Tests/DurableTask.ServiceBus.Tests.csproj
@@ -10,38 +10,39 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
-    <PackageReference Include="CommandLineParser" version="1.9.71" />
-    <PackageReference Include="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" />
-    <PackageReference Include="ImpromptuInterface" version="6.2.2" />
-    <PackageReference Include="Microsoft.Azure.KeyVault.Core" version="1.0.0" />
-    <PackageReference Include="Microsoft.Data.Edm" version="5.8.5" />
-    <PackageReference Include="Microsoft.Data.OData" version="5.8.5" />
-    <PackageReference Include="Microsoft.Data.Services.Client" version="5.8.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Microsoft.Tpl.Dataflow" version="4.5.24" />
-    <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="System.Spatial" version="5.8.5" />
-    <PackageReference Include="WindowsAzure.ServiceBus" version="4.1.3" />
+    <PackageReference Include="Azure.Data.Tables" />
+    <PackageReference Include="Azure.Storage.Blobs" />
+    <PackageReference Include="CommandLineParser" />
+    <PackageReference Include="EnterpriseLibrary.SemanticLogging" />
+    <PackageReference Include="ImpromptuInterface" />
+    <PackageReference Include="Microsoft.Azure.KeyVault.Core" />
+    <PackageReference Include="Microsoft.Data.Edm" />
+    <PackageReference Include="Microsoft.Data.OData" />
+    <PackageReference Include="Microsoft.Data.Services.Client" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Tpl.Dataflow" />
+    <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="System.Spatial" />
+    <PackageReference Include="WindowsAzure.ServiceBus" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
-    <PackageReference Include="EnterpriseLibrary.SemanticLogging.NetCore" Version="2.0.1406.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageReference Include="Azure.Data.Tables" />
+    <PackageReference Include="Azure.Storage.Blobs" />
+    <PackageReference Include="EnterpriseLibrary.SemanticLogging.NetCore" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\DurableTask.Core\DurableTask.Core.csproj" />
     <ProjectReference Include="..\..\src\DurableTask.ServiceBus\DurableTask.ServiceBus.csproj" />
+    <ProjectReference Include="..\DurableTask.Emulator.Tests\DurableTask.Emulator.Tests.csproj" />
     <ProjectReference Include="..\DurableTask.Test.Orchestrations\DurableTask.Test.Orchestrations.csproj" />
   </ItemGroup>
 

--- a/test/DurableTask.Stress.Tests/DurableTask.Stress.Tests.csproj
+++ b/test/DurableTask.Stress.Tests/DurableTask.Stress.Tests.csproj
@@ -22,15 +22,15 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
-    <PackageReference Include="CommandLineParser" Version="2.4.3" />
-    <PackageReference Include="Microsoft.Diagnostics.EventFlow.Core" Version="1.5.6" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
+    <PackageReference Include="CommandLineParser" />
+    <PackageReference Include="Microsoft.Diagnostics.EventFlow.Core" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="CommandLineParser" version="1.9.71" />
-    <PackageReference Include="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" />
-    <PackageReference Include="EnterpriseLibrary.SemanticLogging.TextFile" version="2.0.1406.1" />
+    <PackageReference Include="CommandLineParser" />
+    <PackageReference Include="EnterpriseLibrary.SemanticLogging" />
+    <PackageReference Include="EnterpriseLibrary.SemanticLogging.TextFile" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestFabricApplication/TestApplication.Common/TestApplication.Common.csproj
+++ b/test/TestFabricApplication/TestApplication.Common/TestApplication.Common.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Owin.Hosting" Version="4.0.0" />
-    <PackageReference Include="Microsoft.ServiceFabric" Version="6.4.617" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="3.3.617" />
+    <PackageReference Include="Microsoft.Owin.Hosting" />
+    <PackageReference Include="Microsoft.ServiceFabric" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestFabricApplication/TestApplication.StatefulService/TestApplication.StatefulService.csproj
+++ b/test/TestFabricApplication/TestApplication.StatefulService/TestApplication.StatefulService.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.6" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.6" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Owin" Version="5.2.6" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Core" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Owin" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -19,7 +19,7 @@
 
   <!-- SourceLink Dependency for GitHub-->
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.*" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- Sign assemblies if the snk file is present -->


### PR DESCRIPTION
As titled. This PR moves to [Central Package Management](https://learn.microsoft.com/en-us/nuget/consume-packages/Central-Package-Management) 

-  Add Directory.package.props. 
Inside it is divided into three sections for folder  src,samples and test 
- Remove all versions at each csproj files
Certain csproj file has `VersionOverride`  to use a different version defined in Directory.pakcages.propsas as some proj might need a lower/higher version.
