### PR TITLE
Add the PartitionId value to the ProcessingMessage log event

### DIFF
--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -1019,7 +1019,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(EventIds.ProcessingMessage, Level = EventLevel.Informational, Task = Tasks.Processing, Opcode = EventOpcode.Receive, Version = 5)]
+        [Event(EventIds.ProcessingMessage, Level = EventLevel.Informational, Task = Tasks.Processing, Opcode = EventOpcode.Receive, Version = 6)]
         public void ProcessingMessage(
             Guid relatedActivityId,
             string Account,
@@ -1030,6 +1030,7 @@ namespace DurableTask.AzureStorage
             string ExecutionId,
             string MessageId,
             int Age,
+            string PartitionId,
             long SequenceNumber,
             int Episode,
             bool IsExtendedSession,
@@ -1047,6 +1048,7 @@ namespace DurableTask.AzureStorage
                 ExecutionId ?? string.Empty,
                 MessageId,
                 Age,
+                PartitionId,
                 SequenceNumber,
                 Episode,
                 IsExtendedSession,

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -752,7 +752,10 @@ namespace DurableTask.AzureStorage
                         }
                         else
                         {
-                            session.TraceProcessingMessage(message, isExtendedSession: false);
+                            session.TraceProcessingMessage(
+                                message,
+                                isExtendedSession: false,
+                                partitionId: session.ControlQueue.Name);
                         }
                     }
 
@@ -1525,7 +1528,7 @@ namespace DurableTask.AzureStorage
                     });
 
                 TraceMessageReceived(this.settings, session.MessageData, this.azureStorageClient.QueueAccountName);
-                session.TraceProcessingMessage(message, isExtendedSession: false);
+                session.TraceProcessingMessage(message, isExtendedSession: false, this.workItemQueue.Name);
 
                 if (!this.activeActivitySessions.TryAdd(message.Id, session))
                 {

--- a/src/DurableTask.AzureStorage/Logging/LogEvents.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogEvents.cs
@@ -2500,6 +2500,7 @@ namespace DurableTask.AzureStorage.Logging
                 string executionId,
                 string messageId,
                 int age,
+                string partitionId,
                 long sequenceNumber,
                 int episode,
                 bool isExtendedSession)
@@ -2513,6 +2514,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.ExecutionId = executionId;
                 this.MessageId = messageId;
                 this.Age = age;
+                this.PartitionId = partitionId;
                 this.SequenceNumber = sequenceNumber;
                 this.Episode = episode;
                 this.IsExtendedSession = isExtendedSession;
@@ -2545,6 +2547,9 @@ namespace DurableTask.AzureStorage.Logging
             public int Age { get; }
 
             [StructuredLogField]
+            public string PartitionId { get; }
+
+            [StructuredLogField]
             public long SequenceNumber { get; }
 
             [StructuredLogField]
@@ -2572,6 +2577,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.ExecutionId,
                 this.MessageId,
                 this.Age,
+                this.PartitionId,
                 this.SequenceNumber,
                 this.Episode,
                 this.IsExtendedSession,

--- a/src/DurableTask.AzureStorage/Logging/LogHelper.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogHelper.cs
@@ -823,6 +823,7 @@ namespace DurableTask.AzureStorage.Logging
             string executionId,
             string messageId,
             int age,
+            string partitionId,
             long sequenceNumber,
             int episode,
             bool isExtendedSession)
@@ -837,6 +838,7 @@ namespace DurableTask.AzureStorage.Logging
                 executionId,
                 messageId,
                 age,
+                partitionId,
                 sequenceNumber,
                 episode,
                 isExtendedSession);

--- a/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
+++ b/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
@@ -114,7 +114,7 @@ namespace DurableTask.AzureStorage.Messaging
             var messages = new List<TaskMessage>(this.CurrentMessageBatch.Count);
             foreach (MessageData msg in this.CurrentMessageBatch)
             {
-                this.TraceProcessingMessage(msg, isExtendedSession: true);
+                this.TraceProcessingMessage(msg, isExtendedSession: true, partitionId: this.ControlQueue.Name);
                 messages.Add(msg.TaskMessage);
             }
 

--- a/src/DurableTask.AzureStorage/Messaging/Session.cs
+++ b/src/DurableTask.AzureStorage/Messaging/Session.cs
@@ -45,7 +45,7 @@ namespace DurableTask.AzureStorage.Messaging
             AnalyticsEventSource.SetLogicalTraceActivityId(this.TraceActivityId);
         }
 
-        public void TraceProcessingMessage(MessageData data, bool isExtendedSession)
+        public void TraceProcessingMessage(MessageData data, bool isExtendedSession, string partitionId)
         {
             if (data == null)
             {
@@ -64,7 +64,8 @@ namespace DurableTask.AzureStorage.Messaging
                 taskMessage.OrchestrationInstance.InstanceId,
                 taskMessage.OrchestrationInstance.ExecutionId,
                 queueMessage.MessageId,
-                Math.Max(0, (int)DateTimeOffset.UtcNow.Subtract(queueMessage.InsertedOn.Value).TotalMilliseconds),
+                age: Math.Max(0, (int)DateTimeOffset.UtcNow.Subtract(queueMessage.InsertedOn.Value).TotalMilliseconds),
+                partitionId,
                 data.SequenceNumber,
                 data.Episode.GetValueOrDefault(-1),
                 isExtendedSession);


### PR DESCRIPTION
There are certain kinds of high latency investigations that are hard to debug because we don't have the partition ID included in the ProcessingMessage log event. This PR adds that value.