### PR TITLE
Don't fail orchestrations on missing blobs from previous executions

### DIFF
--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -169,7 +169,7 @@ namespace DurableTask.AzureStorage.Tracking
                                                expectedExecutionId == sentinel?.GetString("ExecutionId")))
             {
                 // The most recent generation will always be in the first history event.
-                executionId = results.Entities[0].GetString("ExecutionId");
+                executionId = sentinel?.GetString("ExecutionId") ?? results.Entities[0].GetString("ExecutionId");
 
                 // Convert the table entities into history events.
                 var events = new List<HistoryEvent>(results.Entities.Count);

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -162,7 +162,8 @@ namespace DurableTask.AzureStorage.Tracking
             TableEntity sentinel = results.Entities.LastOrDefault(e => e.RowKey == SentinelRowKey);
 
             TrackingStoreContext trackingStoreContext = new TrackingStoreContext();
-            if (results.Entities.Count > 0 && sentinel?.GetString("ExecutionId") == expectedExecutionId)
+            if (results.Entities.Count > 0 && (expectedExecutionId == null ||
+                                               expectedExecutionId == sentinel?.GetString("ExecutionId")))
             {
                 // The most recent generation will always be in the first history event.
                 executionId = results.Entities[0].GetString("ExecutionId");

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -202,9 +202,9 @@ namespace DurableTask.AzureStorage.Tracking
                 executionId = expectedExecutionId;
             }
 
-            // Read the checkpoint completion time from the sentinel row, which should always be the last row.
+            // Read the checkpoint completion time from the sentinel row.
             // A sentinel won't exist only if no instance of this ID has ever existed or the instance history
-            // was purged.The IsCheckpointCompleteProperty was newly added _after_ v1.6.4.
+            // was purged. The IsCheckpointCompleteProperty was newly added _after_ v1.6.4.
             DateTime checkpointCompletionTime = DateTime.MinValue;
             ETag? eTagValue = sentinel?.ETag;
             if (sentinel != null &&

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -1113,14 +1113,14 @@ namespace DurableTask.AzureStorage.Tracking
 
         async Task<bool> TryDecompressLargeEntityPropertiesAsync(
             TableEntity entity,
-            List<string> blobs,
+            List<string> listOfBlobs,
             string instanceId,
             string executionId,
             CancellationToken cancellationToken)
         {
             try
             {
-                await this.DecompressLargeEntityProperties(entity, blobs, cancellationToken);
+                await this.DecompressLargeEntityProperties(entity, listOfBlobs, cancellationToken);
                 return true;
             }
             catch (DurableTaskStorageException ex) when (IsMissingBlob(ex))

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -155,12 +155,11 @@ namespace DurableTask.AzureStorage.Tracking
                 .GetHistoryEntitiesResponseInfoAsync(instanceId, expectedExecutionId, null, cancellationToken)
                 .GetResultsAsync(cancellationToken: cancellationToken);
 
-            IList<HistoryEvent> historyEvents;
-            string executionId;
-
             // The sentinel row should always be the last row
             TableEntity sentinel = results.Entities.LastOrDefault(e => e.RowKey == SentinelRowKey);
 
+            IList<HistoryEvent> historyEvents;
+            string executionId;
             TrackingStoreContext trackingStoreContext = new TrackingStoreContext();
             if (results.Entities.Count > 0 && (expectedExecutionId == null ||
                                                expectedExecutionId == sentinel?.GetString("ExecutionId")))

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -184,6 +184,7 @@ namespace DurableTask.AzureStorage.Tracking
                         continue;
                     }
 
+                    // Some entity properties may be stored in blob storage.
                     bool success = await this.TryDecompressLargeEntityPropertiesAsync(
                         entity,
                         trackingStoreContext.Blobs,

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -161,6 +161,10 @@ namespace DurableTask.AzureStorage.Tracking
             IList<HistoryEvent> historyEvents;
             string executionId;
             TrackingStoreContext trackingStoreContext = new TrackingStoreContext();
+
+            // If expectedExecutionId is provided but it does not match the sentinel executionId,
+            // it may belong to a previous generation. In that case, treat it as an unknown executionId
+            // and skip loading history.
             if (results.Entities.Count > 0 && (expectedExecutionId == null ||
                                                expectedExecutionId == sentinel?.GetString("ExecutionId")))
             {

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -1133,9 +1133,9 @@ namespace DurableTask.AzureStorage.Tracking
                 if (sentinelExecutionId != executionId)
                 {
                     // The sentinel contains the execution ID of the most recent execution.
-                    // If it doesn't match the assumed execution ID, this indicates that we are trying
-                    // to load outdated history. This does not indicate a problem yet, so no reason to
-                    // raise an exception, but we should make the caller aware of this.
+                    // If it doesn't match the assumed execution ID, this means that we are trying
+                    // to load outdated history. This does not necessarily indicate a big problem,
+                    // so no reason to raise an exception, but we should make the caller aware of this.
                     return false;
                 }
 

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -1136,6 +1136,13 @@ namespace DurableTask.AzureStorage.Tracking
                     // If it doesn't match the assumed execution ID, this means that we are trying
                     // to load outdated history. This does not necessarily indicate a big problem,
                     // so no reason to raise an exception, but we should make the caller aware of this.
+                    this.settings.Logger.GeneralWarning(
+                        this.azureStorageClient.BlobAccountName,
+                        this.settings.TaskHubName,
+                        $"Missing blob when trying to load history: trying to load previous generation history? "
+                        + $"(entity RowKey: {entity.GetString("RowKey")}, entity ExecutionId: {executionId}, sentinel ExecutionId: {sentinelExecutionId}).",
+                        instanceId);
+
                     return false;
                 }
 

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -193,6 +193,10 @@ namespace DurableTask.AzureStorage.Tracking
                         cancellationToken);
                     if (!success)
                     {
+                        // Some properties were not retrieved because we are apparently trying to load
+                        // outdated history. No reason to raise an exception here, as this does not
+                        // impact orchestration execution, but also no reason to continue loading this
+                        // execution history.
                         break;
                     }
 


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-durable-extension/issues/3022.

Sometimes a duplicate message for an execution that is already finished is received late, when this execution is already completed. For example, this can happen when a message is in fact processed, but the worker failed to remove it from the queue for any reason, so the message automatically reappears in the queue later, potentially when the execution is already finished. In most cases, this is not a problem, and this message will eventually be discarded without any negative consequences. However, here is a sequence of events that leads to a stuck orchestration:

1. A `TaskScheduled` message is delivered to a worker and the worker that starts executing an activity.
2. After successfully executing an activity, the worker fails to remove the `TaskScheduled` message from the queue, but the orchestration continues.
3. The activity returns a large amount of data (>~45K). This data is stored in a blob, and the history table entry contains a reference to this blob.
4. Eventually, the `TaskScheduled` message reappears in the queue and is eventually picked up by a worker. The worker starts executing the activity again (which is fine because Durable Tasks guarantee _at-least-once_ execution, but not _exactly-once_).
5. In the meantime, the orchestrator function invokes `ContinueAsNew`. As a result, all the blobs for the previous execution are deleted (but the history table entries remain).
6. Eventually, the worker finishes the second activity execution and produces a `TaskCompleted` message, which is eventually picked up.
7. This `TaskCompleted` message has the previous execution id, so the worker tries to load the history for that execution id. However, all the blobs are missing. The worker repeatedly tries to retrieve the blobs, hitting the same error, and making no progress on the orchestration anymore. The orchestration is stuck indefinitely for no good reason.

This PR addresses the problem by making the history retrieval logic rely on the execution ID recorded in the sentinel row and skip history entries for different execution IDs, so there will be no attempt to retrieve missing blobs or interpret these history entries in any other way.