### PR TITLE
Fix renew/delete race in DT.AzureStorage

### DIFF
--- a/src/DurableTask.AzureStorage/Storage/DurableTaskStorageException.cs
+++ b/src/DurableTask.AzureStorage/Storage/DurableTaskStorageException.cs
@@ -16,6 +16,7 @@ namespace DurableTask.AzureStorage.Storage
     using System;
     using Azure;
     using Azure.Storage.Blobs.Models;
+    using Azure.Storage.Queues.Models;
 
     [Serializable]
     class DurableTaskStorageException : Exception
@@ -40,12 +41,18 @@ namespace DurableTask.AzureStorage.Storage
             if (requestFailedException != null)
             {
                 this.HttpStatusCode = requestFailedException.Status;
-                this.LeaseLost = requestFailedException.ErrorCode != null && requestFailedException.ErrorCode == BlobErrorCode.LeaseLost;
+                this.ErrorCode = requestFailedException.ErrorCode;
+                this.LeaseLost = requestFailedException?.ErrorCode == BlobErrorCode.LeaseLost;
+                this.IsPopReceiptMismatch = requestFailedException?.ErrorCode == QueueErrorCode.PopReceiptMismatch;
             }
         }
 
         public int HttpStatusCode { get; }
 
+        public string? ErrorCode { get; }
+
         public bool LeaseLost { get; }
+
+        public bool IsPopReceiptMismatch { get; }
     }
 }

--- a/src/DurableTask.AzureStorage/Storage/Queue.cs
+++ b/src/DurableTask.AzureStorage/Storage/Queue.cs
@@ -83,6 +83,8 @@ namespace DurableTask.AzureStorage.Storage
                     queueMessage.PopReceipt,
                     cancellationToken)
                 .DecorateFailure();
+
+            this.stats.MessagesUpdated.Increment();
         }
 
         public async Task<QueueMessage?> GetMessageAsync(TimeSpan visibilityTimeout, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Fixes #1196 

This issue was discovered as part of investigating ICM#608312432. More details in the issue description. The fix is to retry the delete operation if it fails due to a pop-receipt mismatch. This PR also makes small logging improvements that should help make these kinds of problems easier to diagnose.

I created a console app to reproduce the problem locally and confirm the error details for this kind of scenario.