### PR TITLE
Fix Concurrent Modification Error in IsControlQueueProcessingMessages

### DIFF
--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -116,7 +116,8 @@ namespace DurableTask.AzureStorage
 
         public bool IsControlQueueProcessingMessages(string partitionId)
         {
-            return this.activeOrchestrationSessions.Values.Where(session => string.Equals(session.ControlQueue.Name, partitionId)).Any();
+            var sessionsSnapshot = this.activeOrchestrationSessions.Values.ToList();
+            return sessionsSnapshot.Any(session => string.Equals(session.ControlQueue.Name, partitionId));
         }
 
         async Task DequeueLoop(string partitionId, ControlQueue controlQueue, CancellationToken cancellationToken)

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -116,8 +116,10 @@ namespace DurableTask.AzureStorage
 
         public bool IsControlQueueProcessingMessages(string partitionId)
         {
-            var sessionsSnapshot = this.activeOrchestrationSessions.Values.ToList();
-            return sessionsSnapshot.Any(session => string.Equals(session.ControlQueue.Name, partitionId));
+            lock (this.messageAndSessionLock)
+            {
+                return this.activeOrchestrationSessions.Values.Where(session => string.Equals(session.ControlQueue.Name, partitionId)).Any();
+            }
         }
 
         async Task DequeueLoop(string partitionId, ControlQueue controlQueue, CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes an `InvalidOperationException` caused by concurrent modifications to `activeOrchestrationSessions` while `IsControlQueueProcessingMessages` is enumerating its values. This issue could surface as a `PartitionManagerError`.

This method is called when there are drain tasks, where concurrent access is expected. To ensure thread safety, we now add a lock before enumeration.