### PR TITLE
Add timeout wehn Read&Write Parititon Table 

### DIFF
--- a/src/DurableTask.ApplicationInsights/DurableTask.ApplicationInsights.csproj
+++ b/src/DurableTask.ApplicationInsights/DurableTask.ApplicationInsights.csproj
@@ -11,7 +11,7 @@
     <!-- Version Info -->
     <PropertyGroup>
         <MajorVersion>0</MajorVersion>
-        <MinorVersion>2</MinorVersion>
+        <MinorVersion>3</MinorVersion>
         <PatchVersion>0</PatchVersion>
         <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
         <FileVersion>$(VersionPrefix).0</FileVersion>

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationServiceSettings.cs
@@ -171,6 +171,14 @@ namespace DurableTask.AzureStorage
         public bool AllowReplayingTerminalInstances { get; set; } = false;
 
         /// <summary>
+        /// Specifies the timeout (in seconds) for read and write operations on the partition table in partition manager V3 (table partition manager).
+        /// This helps detect and recover from potential silent hangs caused by Azure Storage client's internal retries. 
+        /// If the operation exceeds the timeout, a PartitionManagerWarning is logged and the operation is retried.
+        /// The default time is 2 seconds.
+        /// </summary>
+        public TimeSpan PartitionTableOperationTimeout { get; set; } = TimeSpan.FromSeconds(2);
+
+        /// <summary>
         /// If UseAppLease is true, gets or sets the AppLeaseOptions used for acquiring the lease to start the application.
         /// </summary>
         public AppLeaseOptions AppLeaseOptions { get; set; } = AppLeaseOptions.DefaultOptions;

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -21,8 +21,8 @@
   <!-- Version Info -->
   <PropertyGroup>
     <MajorVersion>2</MajorVersion>
-    <MinorVersion>0</MinorVersion>
-    <PatchVersion>2</PatchVersion>
+    <MinorVersion>1</MinorVersion>
+    <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <FileVersion>$(VersionPrefix).0</FileVersion>
     <!-- FileVersionRevision is expected to be set by the CI. This is useful for distinguishing between multiple builds of the same version. -->

--- a/src/DurableTask.AzureStorage/Partitioning/TablePartitionManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/TablePartitionManager.cs
@@ -118,7 +118,10 @@ namespace DurableTask.AzureStorage.Partitioning
 
                 try
                 {
-                    ReadTableReponse response = await this.tableLeaseManager.ReadAndWriteTableAsync(isShuttingDown, forcefulShutdownToken);
+                    using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+                    using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(forcefulShutdownToken, timeoutCts.Token);
+
+                    ReadTableReponse response = await this.tableLeaseManager.ReadAndWriteTableAsync(isShuttingDown, linkedCts.Token);
 
                     // If shutdown is requested and already released all ownership leases, then break the loop. 
                     if (isShuttingDown && response.ReleasedAllLeases)
@@ -145,6 +148,20 @@ namespace DurableTask.AzureStorage.Partitioning
                 // Exception Status 412 represents an out of date ETag. We already logged this.
                 catch (DurableTaskStorageException ex) when (ex.HttpStatusCode == (int)HttpStatusCode.PreconditionFailed)
                 {
+                    consecutiveFailureCount++;
+                }
+                // ReadAndWriteTableAsync exceeded the 2-second timeout.
+                // This may indicate a transient storage or network issue.
+                // The operation will be retried immediately unless it fails more than 10 consecutive times.
+                catch (OperationCanceledException) when (!forcefulShutdownToken.IsCancellationRequested)
+                {
+                    this.settings.Logger.PartitionManagerWarning(
+                        this.storageAccountName,
+                        this.settings.TaskHubName,
+                        this.settings.WorkerId,
+                        partitionId: NotApplicable,
+                        details: "Operation to read and write the partition table exceeded the 2-second timeout.");
+
                     consecutiveFailureCount++;
                 }
                 // Eat any unexpected exceptions.

--- a/src/DurableTask.AzureStorage/Partitioning/TablePartitionManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/TablePartitionManager.cs
@@ -118,7 +118,7 @@ namespace DurableTask.AzureStorage.Partitioning
 
                 try
                 {
-                    using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+                    using var timeoutCts = new CancellationTokenSource(this.settings.PartitionTableOperationTimeout);
                     using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(forcefulShutdownToken, timeoutCts.Token);
 
                     ReadTableReponse response = await this.tableLeaseManager.ReadAndWriteTableAsync(isShuttingDown, linkedCts.Token);
@@ -150,7 +150,7 @@ namespace DurableTask.AzureStorage.Partitioning
                 {
                     consecutiveFailureCount++;
                 }
-                // ReadAndWriteTableAsync exceeded the 2-second timeout.
+                // ReadAndWriteTableAsync exceeded the set timeout.
                 // This may indicate a transient storage or network issue.
                 // The operation will be retried immediately unless it fails more than 10 consecutive times.
                 catch (OperationCanceledException) when (!forcefulShutdownToken.IsCancellationRequested)


### PR DESCRIPTION
- Add a 2-second timeout when calling `ReadAndWriteTableAsync`  at TablePartitionManager.

This helps guard against cases where the read or write hangs silently, as Azure Storage client has its own retry policies. If the timeout is hit, a `PartitionManagerWarning` is logged and the operation is retried.
- Bump DTFx.AzureStorage and DTFx.ApplicationInsights minor to align with the  DTFx.Core version increment.