### PR TITLE
Add versioning to DTFx orchestration dispatch

### DIFF
--- a/Test/DurableTask.Core.Tests/VersionSettingsTests.cs
+++ b/Test/DurableTask.Core.Tests/VersionSettingsTests.cs
@@ -1,0 +1,42 @@
+﻿using DurableTask.Core.Settings;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DurableTask.Core.Tests
+{
+    [TestClass]
+    public class VersionSettingsTests
+    {
+        [TestMethod]
+        [DataRow("1.0.0", "1.0.0", 0)]
+        [DataRow("1.1.0", "1.0.0", 1)]
+        [DataRow("1.0.0", "1.1.0", -1)]
+        [DataRow("1", "1", 0)]
+        [DataRow("2", "1", 1)]
+        [DataRow("1", "2", -1)]
+        [DataRow("", "1", -1)]
+        [DataRow("1", "", 1)]
+        [DataRow("", "", 0)]
+        public void TestVersionComparison(string orchVersion, string settingVersion, int expectedComparison)
+        {
+            int result = VersioningSettings.CompareVersions(orchVersion, settingVersion);
+
+            if (expectedComparison == 0)
+            {
+                Assert.AreEqual(0, result, $"Expected {orchVersion} to be equal to {settingVersion}");
+            }
+            else if (expectedComparison < 0)
+            {
+                Assert.IsTrue(result < 0, $"Expected {orchVersion} to be less than {settingVersion}");
+            }
+            else
+            {
+                Assert.IsTrue(result > 0, $"Expected {orchVersion} to be greater than {settingVersion}");
+            }
+        }
+    }
+}

--- a/Test/DurableTask.Core.Tests/VersionSettingsTests.cs
+++ b/Test/DurableTask.Core.Tests/VersionSettingsTests.cs
@@ -1,10 +1,18 @@
-﻿using DurableTask.Core.Settings;
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+using DurableTask.Core.Settings;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DurableTask.Core.Tests
 {

--- a/src/DurableTask.Core/Settings/VersioningSettings.cs
+++ b/src/DurableTask.Core/Settings/VersioningSettings.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+using System;
 
 namespace DurableTask.Core.Settings
 {

--- a/src/DurableTask.Core/Settings/VersioningSettings.cs
+++ b/src/DurableTask.Core/Settings/VersioningSettings.cs
@@ -1,0 +1,106 @@
+﻿using System;
+
+namespace DurableTask.Core.Settings
+{
+    /// <summary>
+    /// Collection of settings that define the overall versioning behavior.
+    /// </summary>
+    public class VersioningSettings
+    {
+        /// <summary>
+        /// Defines the version matching strategy for the Durable Task worker.
+        /// </summary>
+        public enum VersionMatchStrategy
+        {
+            /// <summary>
+            /// Ignore Orchestration version, all work received is processed.
+            /// </summary>
+            None = 0,
+
+            /// <summary>
+            /// Worker will only process Tasks from Orchestrations with the same version as the worker.
+            /// </summary>
+            Strict = 1,
+
+            /// <summary>
+            /// Worker will process Tasks from Orchestrations whose version is less than or equal to the worker.
+            /// </summary>
+            CurrentOrOlder = 2,
+        }
+
+        /// <summary>
+        /// Defines the versioning failure strategy for the Durable Task worker.
+        /// </summary>
+        public enum VersionFailureStrategy
+        {
+            /// <summary>
+            /// Do not change the orchestration state if the version does not adhere to the matching strategy.
+            /// </summary>
+            Reject = 0,
+
+            /// <summary>
+            /// Fail the orchestration if the version does not adhere to the matching strategy.
+            /// </summary>
+            Fail = 1,
+        }
+
+        /// <summary>
+        /// Gets or sets the version associated with the settings.
+        /// </summary>
+        public string Version { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the <see cref="VersionMatchStrategy"/> that is used for matching versions.
+        /// </summary>
+        public VersionMatchStrategy MatchStrategy { get; set; } = VersionMatchStrategy.None;
+
+        /// <summary>
+        /// Gets or sets the <see cref="VersionFailureStrategy"/> that is used to determine what happens on a versioning failure.
+        /// </summary>
+        public VersionFailureStrategy FailureStrategy { get; set; } = VersionFailureStrategy.Reject;
+
+        /// <summary>
+        /// Compare two versions to each other.
+        /// </summary>
+        /// <remarks>
+        /// This method's comparison is handled in the following order:
+        ///   1. The versions are checked if they are empty (non-versioned). Both being empty signifies equality.
+        ///   2. If sourceVersion is empty but otherVersion is defined, this is treated as the source being less than the other.
+        ///   3. If otherVersion is empty but sourceVersion is defined, this is treated as the source being greater than the other.
+        ///   4. Both versions are attempted to be parsed into System.Version and compared as such.
+        ///   5. If all else fails, a direct string comparison is done between the versions.
+        /// </remarks>
+        /// <param name="sourceVersion">The source version that will be compared against the other version.</param>
+        /// <param name="otherVersion">The other version to compare against.</param>
+        /// <returns>An int representing how sourceVersion compares to otherVersion.</returns>
+        public static int CompareVersions(string sourceVersion, string otherVersion)
+        {
+            // Both versions are empty, treat as equal.
+            if (string.IsNullOrWhiteSpace(sourceVersion) && string.IsNullOrWhiteSpace(otherVersion))
+            {
+                return 0;
+            }
+
+            // An empty version in the context is always less than a defined version in the parameter.
+            if (string.IsNullOrWhiteSpace(sourceVersion))
+            {
+                return -1;
+            }
+
+            // An empty version in the parameter is always less than a defined version in the context.
+            if (string.IsNullOrWhiteSpace(otherVersion))
+            {
+                return 1;
+            }
+
+            // If both versions use the .NET Version class, return that comparison.
+            if (System.Version.TryParse(sourceVersion, out Version parsedSourceVersion) && System.Version.TryParse(otherVersion, out Version parsedOtherVersion))
+            {
+                return parsedSourceVersion.CompareTo(parsedOtherVersion);
+            }
+
+            // If we have gotten to here, we don't know the syntax of the versions we are comparing, use a string comparison as a final check.
+            return string.Compare(sourceVersion, otherVersion, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/DurableTask.Core/TaskHubWorker.cs
+++ b/src/DurableTask.Core/TaskHubWorker.cs
@@ -78,15 +78,30 @@ namespace DurableTask.Core
         /// </summary>
         /// <param name="orchestrationService">Reference the orchestration service implementation</param>
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging</param>
-        /// <param name="versioningSettings">The <see cref="VersioningSettings"/> that define how orchestration versions are handled</param>
-        public TaskHubWorker(IOrchestrationService orchestrationService, ILoggerFactory loggerFactory = null, VersioningSettings versioningSettings = null)
+        public TaskHubWorker(IOrchestrationService orchestrationService, ILoggerFactory loggerFactory = null)
             : this(
                   orchestrationService,
                   new NameVersionObjectManager<TaskOrchestration>(),
                   new NameVersionObjectManager<TaskActivity>(),
                   new NameVersionObjectManager<TaskEntity>(),
-                  loggerFactory,
-                  versioningSettings)
+                  loggerFactory)
+        {
+        }
+
+        /// <summary>
+        ///     Create a new TaskHubWorker with given OrchestrationService
+        /// </summary>
+        /// <param name="orchestrationService">Reference the orchestration service implementation</param>
+        /// <param name="versioningSettings">The <see cref="VersioningSettings"/> that define how orchestration versions are handled</param>
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging</param>
+        public TaskHubWorker(IOrchestrationService orchestrationService, VersioningSettings versioningSettings, ILoggerFactory loggerFactory = null)
+            : this(
+                  orchestrationService,
+                  new NameVersionObjectManager<TaskOrchestration>(),
+                  new NameVersionObjectManager<TaskActivity>(),
+                  new NameVersionObjectManager<TaskEntity>(),
+                  versioningSettings,
+                  loggerFactory)
         {
         }
 
@@ -117,20 +132,41 @@ namespace DurableTask.Core
         /// <param name="orchestrationObjectManager">The <see cref="INameVersionObjectManager{TaskOrchestration}"/> for orchestrations</param>
         /// <param name="activityObjectManager">The <see cref="INameVersionObjectManager{TaskActivity}"/> for activities</param>
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging</param>
-        /// <param name="versioningSettings">The <see cref="VersioningSettings"/> that define how orchestration versions are handled</param>
         public TaskHubWorker(
             IOrchestrationService orchestrationService,
             INameVersionObjectManager<TaskOrchestration> orchestrationObjectManager,
             INameVersionObjectManager<TaskActivity> activityObjectManager,
-            ILoggerFactory loggerFactory = null,
-            VersioningSettings versioningSettings = null)
+            ILoggerFactory loggerFactory = null)
              : this(
                 orchestrationService,
                 orchestrationObjectManager,
                 activityObjectManager,
                 new NameVersionObjectManager<TaskEntity>(),
-                loggerFactory,
-                versioningSettings)
+                loggerFactory)
+        {
+        }
+
+        /// <summary>
+        ///     Create a new <see cref="TaskHubWorker"/> with given <see cref="IOrchestrationService"/> and name version managers
+        /// </summary>
+        /// <param name="orchestrationService">The orchestration service implementation</param>
+        /// <param name="orchestrationObjectManager">The <see cref="INameVersionObjectManager{TaskOrchestration}"/> for orchestrations</param>
+        /// <param name="activityObjectManager">The <see cref="INameVersionObjectManager{TaskActivity}"/> for activities</param>
+        /// <param name="versioningSettings">The <see cref="VersioningSettings"/> that define how orchestration versions are handled</param>
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging</param>
+        public TaskHubWorker(
+            IOrchestrationService orchestrationService,
+            INameVersionObjectManager<TaskOrchestration> orchestrationObjectManager,
+            INameVersionObjectManager<TaskActivity> activityObjectManager,
+            VersioningSettings versioningSettings,
+            ILoggerFactory loggerFactory = null)
+             : this(
+                orchestrationService,
+                orchestrationObjectManager,
+                activityObjectManager,
+                new NameVersionObjectManager<TaskEntity>(),
+                versioningSettings,
+                loggerFactory)
         {
         }
 
@@ -142,14 +178,38 @@ namespace DurableTask.Core
         /// <param name="activityObjectManager">NameVersionObjectManager for Activities</param>
         /// <param name="entityObjectManager">The NameVersionObjectManager for entities. The version is the entity key.</param>
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging</param>
-        /// <param name="versioningSettings">The <see cref="VersioningSettings"/> that define how orchestration versions are handled</param>
         public TaskHubWorker(
             IOrchestrationService orchestrationService,
             INameVersionObjectManager<TaskOrchestration> orchestrationObjectManager,
             INameVersionObjectManager<TaskActivity> activityObjectManager,
             INameVersionObjectManager<TaskEntity> entityObjectManager,
-            ILoggerFactory loggerFactory = null,
-            VersioningSettings versioningSettings = null)
+            ILoggerFactory loggerFactory = null)
+            : this(
+                  orchestrationService,
+                  orchestrationObjectManager,
+                  activityObjectManager,
+                  entityObjectManager,
+                  null,
+                  loggerFactory)
+        {
+        }
+
+        /// <summary>
+        ///     Create a new TaskHubWorker with given OrchestrationService and name version managers
+        /// </summary>
+        /// <param name="orchestrationService">Reference the orchestration service implementation</param>
+        /// <param name="orchestrationObjectManager">NameVersionObjectManager for Orchestrations</param>
+        /// <param name="activityObjectManager">NameVersionObjectManager for Activities</param>
+        /// <param name="entityObjectManager">The NameVersionObjectManager for entities. The version is the entity key.</param>
+        /// <param name="versioningSettings">The <see cref="VersioningSettings"/> that define how orchestration versions are handled</param>
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use for logging</param>
+        public TaskHubWorker(
+            IOrchestrationService orchestrationService,
+            INameVersionObjectManager<TaskOrchestration> orchestrationObjectManager,
+            INameVersionObjectManager<TaskActivity> activityObjectManager,
+            INameVersionObjectManager<TaskEntity> entityObjectManager,
+            VersioningSettings versioningSettings,
+            ILoggerFactory loggerFactory = null)
         {
             this.orchestrationManager = orchestrationObjectManager ?? throw new ArgumentException("orchestrationObjectManager");
             this.activityManager = activityObjectManager ?? throw new ArgumentException("activityObjectManager");

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -13,12 +13,6 @@
 #nullable enable
 namespace DurableTask.Core
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Linq;
-    using System.Threading;
-    using System.Threading.Tasks;
     using DurableTask.Core.Command;
     using DurableTask.Core.Common;
     using DurableTask.Core.Entities;
@@ -27,7 +21,14 @@ namespace DurableTask.Core
     using DurableTask.Core.Logging;
     using DurableTask.Core.Middleware;
     using DurableTask.Core.Serializing;
+    using DurableTask.Core.Settings;
     using DurableTask.Core.Tracing;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
     using ActivityStatusCode = Tracing.ActivityStatusCode;
 
     /// <summary>
@@ -47,13 +48,15 @@ namespace DurableTask.Core
         readonly IEntityOrchestrationService? entityOrchestrationService;
         readonly EntityBackendProperties? entityBackendProperties;
         readonly TaskOrchestrationEntityParameters? entityParameters;
+        readonly VersioningSettings? versioningSettings;
 
         internal TaskOrchestrationDispatcher(
             IOrchestrationService orchestrationService,
             INameVersionObjectManager<TaskOrchestration> objectManager,
             DispatchMiddlewarePipeline dispatchPipeline,
             LogHelper logHelper,
-            ErrorPropagationMode errorPropagationMode)
+            ErrorPropagationMode errorPropagationMode,
+            VersioningSettings versioningSettings)
         {
             this.objectManager = objectManager ?? throw new ArgumentNullException(nameof(objectManager));
             this.orchestrationService = orchestrationService ?? throw new ArgumentNullException(nameof(orchestrationService));
@@ -63,6 +66,7 @@ namespace DurableTask.Core
             this.entityOrchestrationService = orchestrationService as IEntityOrchestrationService;
             this.entityBackendProperties = this.entityOrchestrationService?.EntityBackendProperties;
             this.entityParameters = TaskOrchestrationEntityParameters.FromEntityBackendProperties(this.entityBackendProperties);
+            this.versioningSettings = versioningSettings;
 
             this.dispatcher = new WorkItemDispatcher<TaskOrchestrationWorkItem>(
                 "TaskOrchestrationDispatcher",
@@ -155,7 +159,7 @@ namespace DurableTask.Core
             {
                 // Keep track of orchestrator generation changes, maybe update target position
                 string executionId = message.OrchestrationInstance.ExecutionId;
-                if(previousExecutionId != executionId)
+                if (previousExecutionId != executionId)
                 {
                     // We want to re-position the ExecutionStarted event after the "right-most"
                     // event with a non-null executionID that came before it.
@@ -217,7 +221,7 @@ namespace DurableTask.Core
 
                 CorrelationTraceClient.Propagate(
                     () =>
-                    {                
+                    {
                         // Check if it is extended session.
                         // TODO: Remove this code - it looks incorrect and dangerous
                         isExtendedSession = this.concurrentSessionLock.Acquire();
@@ -305,7 +309,7 @@ namespace DurableTask.Core
             var isCompleted = false;
             var continuedAsNew = false;
             var isInterrupted = false;
-            
+
             // correlation
             CorrelationTraceClient.Propagate(() => CorrelationTraceContext.Current = workItem.TraceContext);
 
@@ -363,6 +367,44 @@ namespace DurableTask.Core
                         continuedAsNew = false;
                         continuedAsNewMessage = null;
 
+                        IReadOnlyList<OrchestratorAction> decisions = new List<OrchestratorAction>();
+                        bool versioningFailed = false;
+
+                        if (this.versioningSettings != null)
+                        {
+                            switch (this.versioningSettings.MatchStrategy)
+                            {
+                                case VersioningSettings.VersionMatchStrategy.None:
+                                    // No versioning, do nothing
+                                    break;
+                                case VersioningSettings.VersionMatchStrategy.Strict:
+                                    versioningFailed = this.versioningSettings.Version != runtimeState.Version;
+                                    break;
+                                case VersioningSettings.VersionMatchStrategy.CurrentOrOlder:
+                                    // Positive result indicates the orchestration version is higher than the versioning settings.
+                                    versioningFailed = VersioningSettings.CompareVersions(runtimeState.Version, this.versioningSettings.Version) > 0;
+                                    break;
+                            }
+
+                            if (versioningFailed)
+                            {
+                                if (this.versioningSettings.FailureStrategy == VersioningSettings.VersionFailureStrategy.Fail)
+                                {
+                                    var failureAction = new OrchestrationCompleteOrchestratorAction
+                                    {
+                                        Id = runtimeState.PastEvents.Count,
+                                        FailureDetails = new FailureDetails("VersionMismatch", "Orchestration version did not comply with Worker Versioning", null, null, true),
+                                        OrchestrationStatus = OrchestrationStatus.Failed,
+                                    };
+                                    decisions = new List<OrchestratorAction> { failureAction };
+                                }
+                                else // Abandon work item in all other cases (will be retried later).
+                                {
+                                    await this.orchestrationService.AbandonTaskOrchestrationWorkItemAsync(workItem);
+                                    break;
+                                }
+                            }
+                        }
 
                         this.logHelper.OrchestrationExecuting(runtimeState.OrchestrationInstance!, runtimeState.Name);
                         TraceHelper.TraceInstance(
@@ -372,16 +414,18 @@ namespace DurableTask.Core
                             "Executing user orchestration: {0}",
                             JsonDataConverter.Default.Serialize(runtimeState.GetOrchestrationRuntimeStateDump(), true));
 
-                        if (workItem.Cursor == null)
+                        if (!versioningFailed)
                         {
-                            workItem.Cursor = await this.ExecuteOrchestrationAsync(runtimeState, workItem);
+                            if (workItem.Cursor == null)
+                            {
+                                workItem.Cursor = await this.ExecuteOrchestrationAsync(runtimeState, workItem);
+                            }
+                            else
+                            {
+                                await this.ResumeOrchestrationAsync(workItem);
+                            }
+                            decisions = workItem.Cursor.LatestDecisions.ToList();
                         }
-                        else
-                        {
-                            await this.ResumeOrchestrationAsync(workItem);
-                        }
-
-                        IReadOnlyList<OrchestratorAction> decisions = workItem.Cursor.LatestDecisions.ToList();
 
                         this.logHelper.OrchestrationExecuted(
                             runtimeState.OrchestrationInstance!,
@@ -618,7 +662,7 @@ namespace DurableTask.Core
                 continuedAsNew ? null : timerMessages,
                 continuedAsNewMessage,
                 instanceState);
-            
+
             if (workItem.RestoreOriginalRuntimeStateDuringCompletion)
             {
                 workItem.OrchestrationRuntimeState = runtimeState;
@@ -1143,11 +1187,11 @@ namespace DurableTask.Core
         {
             var historyEvent = new EventSentEvent(sendEventAction.Id)
             {
-                 InstanceId = sendEventAction.Instance?.InstanceId,
-                 Name = sendEventAction.EventName,
-                 Input = sendEventAction.EventData
+                InstanceId = sendEventAction.Instance?.InstanceId,
+                Name = sendEventAction.EventName,
+                Input = sendEventAction.EventData
             };
-            
+
             runtimeState.AddEvent(historyEvent);
 
             EventRaisedEvent eventRaisedEvent = new EventRaisedEvent(-1, sendEventAction.EventData)
@@ -1169,7 +1213,7 @@ namespace DurableTask.Core
                 Event = eventRaisedEvent
             };
         }
- 
+
         internal class NonBlockingCountdownLock
         {
             int available;

--- a/test/DurableTask.AzureStorage.Tests/AutoStartOrchestrationCreator.cs
+++ b/test/DurableTask.AzureStorage.Tests/AutoStartOrchestrationCreator.cs
@@ -24,14 +24,16 @@ namespace DurableTask.AzureStorage.Tests
     {
         readonly TaskOrchestration instance;
         readonly Type prototype;
+        readonly string version;
 
         /// <summary>
         /// Creates a new AutoStartOrchestrationCreator of supplied type
         /// </summary>
         /// <param name="type">Type to use for the creator</param>
-        public AutoStartOrchestrationCreator(Type type)
+        public AutoStartOrchestrationCreator(Type type, string version = null)
         {
             this.prototype = type;
+            this.version = version;
             Initialize(type);
         }
 
@@ -39,9 +41,10 @@ namespace DurableTask.AzureStorage.Tests
         /// Creates a new AutoStartOrchestrationCreator using type of supplied object instance
         /// </summary>
         /// <param name="instance">Object instances to infer the type from</param>
-        public AutoStartOrchestrationCreator(TaskOrchestration instance)
+        public AutoStartOrchestrationCreator(TaskOrchestration instance, string version = null)
         {
             this.instance = instance;
+            this.version = version;
             Initialize(instance);
         }
 
@@ -59,7 +62,7 @@ namespace DurableTask.AzureStorage.Tests
         void Initialize(object obj)
         {
             Name = $"@{NameVersionHelper.GetDefaultName(obj)}";
-            Version = NameVersionHelper.GetDefaultVersion(obj);
+            Version = !string.IsNullOrEmpty(version) ? this.version : NameVersionHelper.GetDefaultVersion(obj);
         }
     }
 }

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -30,6 +30,7 @@ namespace DurableTask.AzureStorage.Tests
     using DurableTask.Core;
     using DurableTask.Core.Exceptions;
     using DurableTask.Core.History;
+    using DurableTask.Core.Settings;
     using Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Utility;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
@@ -522,7 +523,7 @@ namespace DurableTask.AzureStorage.Tests
                 List<HistoryStateEvent> thirdHistoryEventsAfterPurging = await client.GetOrchestrationHistoryAsync(thirdInstanceId);
                 Assert.AreEqual(0, thirdHistoryEventsAfterPurging.Count);
 
-                List<HistoryStateEvent>fourthHistoryEventsAfterPurging = await client.GetOrchestrationHistoryAsync(fourthInstanceId);
+                List<HistoryStateEvent> fourthHistoryEventsAfterPurging = await client.GetOrchestrationHistoryAsync(fourthInstanceId);
                 Assert.AreEqual(0, fourthHistoryEventsAfterPurging.Count);
 
                 firstOrchestrationStateList = await client.GetStateAsync(firstInstanceId);
@@ -928,7 +929,7 @@ namespace DurableTask.AzureStorage.Tests
 
                 // Test case 3: external event now goes through
                 await client.ResumeAsync("wakeUp");
-                status  = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(10));
+                status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(10));
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
                 Assert.AreEqual(changedStatus, JToken.Parse(status?.Status));
 
@@ -1811,7 +1812,7 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
-        private StringBuilder GenerateMediumRandomStringPayload(int numChars = 128*1024, short utf8ByteSize = 1, short utf16ByteSize = 2)
+        private StringBuilder GenerateMediumRandomStringPayload(int numChars = 128 * 1024, short utf8ByteSize = 1, short utf16ByteSize = 2)
         {
             string Chars;
             if (utf16ByteSize != 2 && utf16ByteSize != 4)
@@ -2196,7 +2197,7 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
-                /// <summary>
+        /// <summary>
         /// Validates scheduled starts, ensuring they are executed according to defined start date time
         /// </summary>
         /// <param name="enableExtendedSessions"></param>
@@ -2407,6 +2408,87 @@ namespace DurableTask.AzureStorage.Tests
                     status = state.First();
                     Assert.AreEqual(OrchestrationStatus.Running, status.OrchestrationStatus);
                 }
+                await host.StopAsync();
+            }
+        }
+
+        [TestMethod]
+        [DataRow(VersioningSettings.VersionMatchStrategy.Strict)]
+        [DataRow(VersioningSettings.VersionMatchStrategy.CurrentOrOlder)]
+        [DataRow(VersioningSettings.VersionMatchStrategy.None)]
+        public async Task OrchestrationFailsWithVersionMismatch(VersioningSettings.VersionMatchStrategy matchStrategy)
+        {
+            using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(false, versioningSettings: new VersioningSettings
+            {
+                Version = "1",
+                MatchStrategy = matchStrategy,
+                FailureStrategy = VersioningSettings.VersionFailureStrategy.Fail
+            }))
+            {
+                await host.StartAsync();
+
+                var client = await host.StartOrchestrationAsync(typeof(Orchestrations.SayHelloInline), "World", tags: new Dictionary<string, string>(), version: "2");
+                var status = await client.WaitForCompletionAsync(StandardTimeout);
+
+                if (matchStrategy == VersioningSettings.VersionMatchStrategy.None)
+                {
+                    Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
+                }
+                else
+                {
+                    Assert.AreEqual(OrchestrationStatus.Failed, status?.OrchestrationStatus);
+                }
+
+                await host.StopAsync();
+            }
+        }
+
+        [TestMethod]
+        [DataRow(VersioningSettings.VersionMatchStrategy.Strict, "1.0.0")]
+        [DataRow(VersioningSettings.VersionMatchStrategy.CurrentOrOlder, "1.0.0")]
+        [DataRow(VersioningSettings.VersionMatchStrategy.CurrentOrOlder, "0.9.0")]
+        [DataRow(VersioningSettings.VersionMatchStrategy.None, "1.0.0")]
+        public async Task OrchestrationSucceedsWithVersion(VersioningSettings.VersionMatchStrategy matchStrategy, string orchestrationVersion)
+        {
+            using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(false, versioningSettings: new VersioningSettings
+            {
+                Version = "1.0.0",
+                MatchStrategy = matchStrategy,
+                FailureStrategy = VersioningSettings.VersionFailureStrategy.Fail
+            }))
+            {
+                await host.StartAsync();
+
+                var client = await host.StartOrchestrationAsync(typeof(Orchestrations.SayHelloInline), "World", tags: new Dictionary<string, string>(), version: orchestrationVersion);
+                var status = await client.WaitForCompletionAsync(StandardTimeout);
+
+                Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
+
+                await host.StopAsync();
+            }
+        }
+
+        [TestMethod]
+        public async Task OrchestrationRejectsWithVersionMismatch()
+        {
+            using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(false, versioningSettings: new VersioningSettings
+            {
+                Version = "1",
+                MatchStrategy = VersioningSettings.VersionMatchStrategy.Strict,
+                FailureStrategy = VersioningSettings.VersionFailureStrategy.Reject
+            }))
+            {
+                await host.StartAsync();
+
+                var client = await host.StartOrchestrationAsync(typeof(Orchestrations.SayHelloInline), "World", tags: new Dictionary<string, string>(), version: "2");
+                // We intend for this to timeout as the work should be getting rejected.
+                var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(10));
+                Assert.IsNull(status);
+
+                // We should either be pending (recently rejected) or running (to be rejected).
+                status = await client.GetStatusAsync();
+                Assert.IsTrue(OrchestrationStatus.Running == status?.OrchestrationStatus || OrchestrationStatus.Pending == status?.OrchestrationStatus);
+
                 await host.StopAsync();
             }
         }

--- a/test/DurableTask.AzureStorage.Tests/TestHelpers.cs
+++ b/test/DurableTask.AzureStorage.Tests/TestHelpers.cs
@@ -13,13 +13,14 @@
 #nullable enable
 namespace DurableTask.AzureStorage.Tests
 {
+    using DurableTask.Core.Logging;
+    using DurableTask.Core.Settings;
+    using Microsoft.Extensions.Logging;
     using System;
     using System.Configuration;
     using System.Diagnostics;
     using System.Diagnostics.Tracing;
     using System.Threading.Tasks;
-    using DurableTask.Core.Logging;
-    using Microsoft.Extensions.Logging;
 
     static class TestHelpers
     {
@@ -28,6 +29,7 @@ namespace DurableTask.AzureStorage.Tests
             int extendedSessionTimeoutInSeconds = 30,
             bool fetchLargeMessages = true,
             bool allowReplayingTerminalInstances = false,
+            VersioningSettings? versioningSettings = null,
             Action<AzureStorageOrchestrationServiceSettings>? modifySettingsAction = null)
         {
             AzureStorageOrchestrationServiceSettings settings = GetTestAzureStorageOrchestrationServiceSettings(
@@ -38,7 +40,7 @@ namespace DurableTask.AzureStorage.Tests
             // Give the caller a chance to make test-specific changes to the settings
             modifySettingsAction?.Invoke(settings);
 
-            return new TestOrchestrationHost(settings);
+            return new TestOrchestrationHost(settings, versioningSettings);
         }
 
         public static AzureStorageOrchestrationServiceSettings GetTestAzureStorageOrchestrationServiceSettings(


### PR DESCRIPTION
This commit adds versioning similar to the feature created in durabletask-dotnet. This portion of versioning allows for an orchestration to be failed or abandonned based on the configuration provided.

The actual configuration will be provided in a follow-up PR in the web extensions as it should be handled through the host.json file.