### PR TITLE
Add missing table storage read metrics

### DIFF
--- a/src/DurableTask.AzureStorage/Partitioning/BlobPartitionLeaseManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/BlobPartitionLeaseManager.cs
@@ -77,7 +77,7 @@ namespace DurableTask.AzureStorage.Partitioning
             await foreach (Page<Blob> page in this.taskHubContainer.ListBlobsAsync(this.blobDirectoryName, cancellationToken: cancellationToken).AsPages())
             {
                 // Start each of the Tasks in parallel
-                Task<BlobPartitionLease>[] downloadTasks = page.Values.Select(b => this.DownloadLeaseBlob(b, cancellationToken)).ToArray();
+                Task<BlobPartitionLease>[] downloadTasks = page.Values.Select(b => DownloadLeaseBlob(b, cancellationToken)).ToArray();
 
                 foreach (Task<BlobPartitionLease> downloadTask in downloadTasks)
                 {
@@ -134,7 +134,7 @@ namespace DurableTask.AzureStorage.Partitioning
             Blob leaseBlob = this.taskHubContainer.GetBlobReference(partitionId, this.blobDirectoryName);
             if (await leaseBlob.ExistsAsync(cancellationToken))
             {
-                return await this.DownloadLeaseBlob(leaseBlob, cancellationToken);
+                return await DownloadLeaseBlob(leaseBlob, cancellationToken);
             }
 
             return null;
@@ -315,7 +315,7 @@ namespace DurableTask.AzureStorage.Partitioning
             return null;
         }
 
-        async Task<BlobPartitionLease> DownloadLeaseBlob(Blob blob, CancellationToken cancellationToken)
+        static async Task<BlobPartitionLease> DownloadLeaseBlob(Blob blob, CancellationToken cancellationToken)
         {
             using BlobDownloadStreamingResult result = await blob.DownloadStreamingAsync(cancellationToken);
             BlobPartitionLease deserializedLease = Utils.DeserializeFromJson<BlobPartitionLease>(result.Content);

--- a/src/DurableTask.AzureStorage/Storage/Table.cs
+++ b/src/DurableTask.AzureStorage/Storage/Table.cs
@@ -62,7 +62,7 @@ namespace DurableTask.AzureStorage.Storage
         {
             // TODO: Re-evaluate the use of an "Exists" method as it was intentional omitted from the client API
             List<TableItem> tables = await this.tableServiceClient
-                .QueryAsync(filter: $"TableName eq '{tableClient.Name}'", cancellationToken: cancellationToken)
+                .QueryAsync(filter: $"TableName eq '{this.tableClient.Name}'", cancellationToken: cancellationToken)
                 .DecorateFailure()
                 .ToListAsync(cancellationToken);
 
@@ -173,9 +173,15 @@ namespace DurableTask.AzureStorage.Storage
             return new TableTransactionResults(batchResults, stopwatch.Elapsed);
         }
 
-        public TableQueryResponse<T> ExecuteQueryAsync<T>(string? filter = null, int? maxPerPage = null, IEnumerable<string>? select = null, CancellationToken cancellationToken = default) where T : class, ITableEntity, new()
+        public TableQueryResponse<T> ExecuteQueryAsync<T>(
+            string? filter = null,
+            int? maxPerPage = null,
+            IEnumerable<string>? select = null,
+            CancellationToken cancellationToken = default) where T : class, ITableEntity, new()
         {
-            return new TableQueryResponse<T>(this.tableClient.QueryAsync<T>(filter, maxPerPage, select, cancellationToken).DecorateFailure());
+            return new TableQueryResponse<T>(
+                this.tableClient.QueryAsync<T>(filter, maxPerPage, select, cancellationToken).DecorateFailure(),
+                this.stats);
         }
     }
 }


### PR DESCRIPTION
While writing some Kusto queries for our dashboard, I noticed that we have all zeros for table storage *read* metrics. This is likely a regression from when we swapped Azure Storage SDKs, which required a big code refactor. It's important that we fix this so that we have an accurate idea of the amount of data we're reading from table storage, which appears to be a contributing factor to several incidents.

I added some tiny code cleanup changes in this PR as well, but the main focus is on adding the missing table storage read metrics.