### PR TITLE
Fix blob URL handling for large messages with special characters in instanceId

### DIFF
--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -255,7 +255,7 @@ namespace DurableTask.AzureStorage
 
         public string GetBlobUrl(string blobName)
         {
-            return Uri.UnescapeDataString(this.blobContainer.GetBlobReference(blobName).Uri.AbsoluteUri);
+            return $"{this.blobContainer.GetBlobContainerUri()}/{Uri.EscapeDataString(blobName)}";
         }
 
         public MessageFormatFlags GetMessageFormatFlags(MessageData messageData)

--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -255,7 +255,9 @@ namespace DurableTask.AzureStorage
 
         public string GetBlobUrl(string blobName)
         {
-            return $"{this.blobContainer.GetBlobContainerUri()}/{EscapeBlobNamePreservingSlashes(blobName)}";
+            string baseUri = this.blobContainer.GetBlobContainerUri().ToString();
+
+            return $"{baseUri}/{EscapeBlobNamePreservingSlashes(blobName)}";
         }
 
         public MessageFormatFlags GetMessageFormatFlags(MessageData messageData)

--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -255,7 +255,7 @@ namespace DurableTask.AzureStorage
 
         public string GetBlobUrl(string blobName)
         {
-            return $"{this.blobContainer.GetBlobContainerUri()}/{Uri.EscapeDataString(blobName)}";
+            return $"{this.blobContainer.GetBlobContainerUri()}/{EscapeBlobNamePreservingSlashes(blobName)}";
         }
 
         public MessageFormatFlags GetMessageFormatFlags(MessageData messageData)
@@ -303,6 +303,11 @@ namespace DurableTask.AzureStorage
             }
 
             return storageOperationCount;
+        }
+
+        static string EscapeBlobNamePreservingSlashes(string blobName)
+        {
+            return string.Join("/", blobName.Split('/').Select(Uri.EscapeDataString));
         }
     }
 

--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -305,6 +305,7 @@ namespace DurableTask.AzureStorage
             return storageOperationCount;
         }
 
+        /// Escapes a blob name for safe inclusion in a URI while preserving path structure.
         static string EscapeBlobNamePreservingSlashes(string blobName)
         {
             return string.Join("/", blobName.Split('/').Select(Uri.EscapeDataString));

--- a/src/DurableTask.AzureStorage/Storage/BlobContainer.cs
+++ b/src/DurableTask.AzureStorage/Storage/BlobContainer.cs
@@ -108,6 +108,11 @@ namespace DurableTask.AzureStorage.Storage
                 .DecorateFailure();
         }
 
+        public Uri GetBlobContainerUri()
+        {
+            return this.blobContainerClient.Uri;
+        }
+
         static bool IsHnsFolder(BlobItem item)
         {
             // Check the optional "hdi_isfolder" value in the metadata to determine whether

--- a/test/DurableTask.AzureStorage.Tests/MessageManagerTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/MessageManagerTests.cs
@@ -15,6 +15,7 @@ namespace DurableTask.AzureStorage.Tests
 {
     using System;
     using System.Collections.Generic;
+    using System.Security.Policy;
     using DurableTask.AzureStorage.Storage;
     using DurableTask.Core.History;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -73,7 +74,7 @@ namespace DurableTask.AzureStorage.Tests
         [DataRow("blob.bin")]
         [DataRow("@#$%!")]
         [DataRow("foo/bar/b@z.tar.gz")]
-        public void GetBlobUrlUnescaped(string blob)
+        public void GetBlobUrlEscaped(string blob)
         {
             var settings = new AzureStorageOrchestrationServiceSettings
             {
@@ -82,7 +83,9 @@ namespace DurableTask.AzureStorage.Tests
 
             const string container = "@entity12345";
             var manager = new MessageManager(settings, new AzureStorageClient(settings), container);
-            var expected = $"http://127.0.0.1:10000/devstoreaccount1/{container}/{blob}";
+
+            string blobUrl = Uri.EscapeDataString(blob);
+            var expected = $"http://127.0.0.1:10000/devstoreaccount1/{container}/{blobUrl}";
             Assert.AreEqual(expected, manager.GetBlobUrl(blob));
         }
 

--- a/test/DurableTask.AzureStorage.Tests/MessageManagerTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/MessageManagerTests.cs
@@ -13,13 +13,12 @@
 #nullable enable
 namespace DurableTask.AzureStorage.Tests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Security.Policy;
     using DurableTask.AzureStorage.Storage;
     using DurableTask.Core.History;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Newtonsoft.Json;
+    using System;
+    using System.Collections.Generic;
 
     [TestClass]
     public class MessageManagerTests

--- a/test/DurableTask.AzureStorage.Tests/MessageManagerTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/MessageManagerTests.cs
@@ -70,10 +70,10 @@ namespace DurableTask.AzureStorage.Tests
         }
 
         [DataTestMethod]
-        [DataRow("blob.bin")]
-        [DataRow("@#$%!")]
-        [DataRow("foo/bar/b@z.tar.gz")]
-        public void GetBlobUrlEscaped(string blob)
+        [DataRow("blob.bin", "blob.bin")]
+        [DataRow("@#$%!", "%40%23%24%25%21")]
+        [DataRow("foo/bar/b@z.tar.gz", "foo/bar/b%40z.tar.gz")]
+        public void GetBlobUrlEscaped(string blob, string blobUrl)
         {
             var settings = new AzureStorageOrchestrationServiceSettings
             {
@@ -83,7 +83,6 @@ namespace DurableTask.AzureStorage.Tests
             const string container = "@entity12345";
             var manager = new MessageManager(settings, new AzureStorageClient(settings), container);
 
-            string blobUrl = Uri.EscapeDataString(blob);
             var expected = $"http://127.0.0.1:10000/devstoreaccount1/{container}/{blobUrl}";
             Assert.AreEqual(expected, manager.GetBlobUrl(blob));
         }


### PR DESCRIPTION
When the instanceId contains special characters like '|',' :', or spaces, the generated blob URL becomes invalid because these characters are not allowed unescaped in a URI. This results in the orchestrator returning a blob URL instead of the expected large message content. This PR fixes it by escaping invalid characters when constructing the blob URL.

Solves https://github.com/orgs/Azure/projects/745/views/1?pane=issue&itemId=96361588&issue=Azure%7Cazure-functions-durable-extension%7C3010