### PR TITLE
Reverting breaking change regarding methods with optional parameters

### DIFF
--- a/src/DurableTask.Core/Entities/ClientEntityHelpers.cs
+++ b/src/DurableTask.Core/Entities/ClientEntityHelpers.cs
@@ -36,7 +36,7 @@ namespace DurableTask.Core.Entities
         /// <returns>The event to send.</returns>
         public static EntityMessageEvent EmitOperationSignal(OrchestrationInstance targetInstance, Guid requestId, string operationName, string? input, (DateTime Original, DateTime Capped)? scheduledTimeUtc)
         {
-            return EmitOperationSignal(targetInstance, requestId, operationName, input, scheduledTimeUtc, parentTraceContext: null, requestTime: null, createTrace: false);
+            return EmitOperationSignal(targetInstance, requestId, operationName, input, scheduledTimeUtc, parentTraceContext: null, requestTime: null);
         }
 
         /// <summary>
@@ -51,7 +51,7 @@ namespace DurableTask.Core.Entities
         /// <param name="requestTime">The time at which the request was made.</param>
         /// <param name="createTrace">Whether to create a trace for this signal operation.</param>
         /// <returns>The event to send.</returns>
-        public static EntityMessageEvent EmitOperationSignal(OrchestrationInstance targetInstance, Guid requestId, string operationName, string? input, (DateTime Original, DateTime Capped)? scheduledTimeUtc, DistributedTraceContext? parentTraceContext = null, DateTimeOffset? requestTime = null, bool createTrace = false)
+        public static EntityMessageEvent EmitOperationSignal(OrchestrationInstance targetInstance, Guid requestId, string operationName, string? input, (DateTime Original, DateTime Capped)? scheduledTimeUtc, DistributedTraceContext? parentTraceContext, DateTimeOffset? requestTime, bool createTrace = false)
         {
             var request = new RequestMessage()
             {

--- a/src/DurableTask.Core/Entities/ClientEntityHelpers.cs
+++ b/src/DurableTask.Core/Entities/ClientEntityHelpers.cs
@@ -33,6 +33,20 @@ namespace DurableTask.Core.Entities
         /// <param name="operationName">The name of the operation.</param>
         /// <param name="input">The serialized input for the operation.</param>
         /// <param name="scheduledTimeUtc">The time to schedule this signal, or null if not a scheduled signal</param>
+        /// <returns>The event to send.</returns>
+        public static EntityMessageEvent EmitOperationSignal(OrchestrationInstance targetInstance, Guid requestId, string operationName, string? input, (DateTime Original, DateTime Capped)? scheduledTimeUtc)
+        {
+            return EmitOperationSignal(targetInstance, requestId, operationName, input, scheduledTimeUtc, parentTraceContext: null, requestTime: null, createTrace: false);
+        }
+
+        /// <summary>
+        /// Create an event to represent an entity signal.
+        /// </summary>
+        /// <param name="targetInstance">The target instance.</param>
+        /// <param name="requestId">A unique identifier for the request.</param>
+        /// <param name="operationName">The name of the operation.</param>
+        /// <param name="input">The serialized input for the operation.</param>
+        /// <param name="scheduledTimeUtc">The time to schedule this signal, or null if not a scheduled signal</param>
         /// <param name="parentTraceContext">The parent trace context for this operation.</param>
         /// <param name="requestTime">The time at which the request was made.</param>
         /// <param name="createTrace">Whether to create a trace for this signal operation.</param>

--- a/src/DurableTask.Core/Entities/OrchestrationEntityContext.cs
+++ b/src/DurableTask.Core/Entities/OrchestrationEntityContext.cs
@@ -237,7 +237,7 @@ namespace DurableTask.Core.Entities
             (DateTime Original, DateTime Capped)? scheduledTimeUtc,
             string? input)
         {
-            return EmitRequestMessage(target, operationName, oneWay, operationId, scheduledTimeUtc, input, requestTime: null, createTrace: false);
+            return EmitRequestMessage(target, operationName, oneWay, operationId, scheduledTimeUtc, input, requestTime: null);
         }
 
         /// <summary>
@@ -259,7 +259,7 @@ namespace DurableTask.Core.Entities
             Guid operationId,
             (DateTime Original, DateTime Capped)? scheduledTimeUtc,
             string? input,
-            DateTimeOffset? requestTime = null,
+            DateTimeOffset? requestTime,
             bool createTrace = false)
         {
             this.CheckEntitySupport();

--- a/src/DurableTask.Core/Entities/OrchestrationEntityContext.cs
+++ b/src/DurableTask.Core/Entities/OrchestrationEntityContext.cs
@@ -228,6 +228,27 @@ namespace DurableTask.Core.Entities
         /// <param name="operationId">A unique identifier for this request.</param>
         /// <param name="scheduledTimeUtc">A time for which to schedule the delivery, or null if this is not a scheduled message</param>
         /// <param name="input">The operation input</param>
+        /// <returns>The event to send.</returns>
+        public EntityMessageEvent EmitRequestMessage(
+            OrchestrationInstance target,
+            string operationName,
+            bool oneWay,
+            Guid operationId,
+            (DateTime Original, DateTime Capped)? scheduledTimeUtc,
+            string? input)
+        {
+            return EmitRequestMessage(target, operationName, oneWay, operationId, scheduledTimeUtc, input, requestTime: null, createTrace: false);
+        }
+
+        /// <summary>
+        /// Creates a request message to be sent to an entity.
+        /// </summary>
+        /// <param name="target">The target entity.</param>
+        /// <param name="operationName">The name of the operation.</param>
+        /// <param name="oneWay">If true, this is a signal, otherwise it is a call.</param>
+        /// <param name="operationId">A unique identifier for this request.</param>
+        /// <param name="scheduledTimeUtc">A time for which to schedule the delivery, or null if this is not a scheduled message</param>
+        /// <param name="input">The operation input</param>
         /// <param name="requestTime">The time at which the request was made.</param>
         /// <param name="createTrace">Whether or not to create an entity-specific trace for this event</param>
         /// <returns>The event to send.</returns>


### PR DESCRIPTION
This [PR ](https://github.com/Azure/durabletask/pull/1198) introduced breaking changes in that two public methods (`ClientEntityHelpers.EmitOperationSignal` and `OrchestrationEntityContext.EmitRequestMessage`) were changed to include optional parameters. Instead, new methods should have been made with these optional parameters and the old methods with the existing method signatures retained. This PR reverts to the old method signatures and introduces the signatures with optional parameters as new methods (which the old methods simply call, passing null for the new parameters). 