### PR TITLE
Updating pipelines for release testing

### DIFF
--- a/eng/ci/code-mirror.yml
+++ b/eng/ci/code-mirror.yml
@@ -5,7 +5,7 @@ trigger:
     # Keep this set limited as appropriate (don't mirror individual user branches).
     - main
     - durabletask-core-v2
-    - neetart/dtfx_sf_pipeline
+    - vabachu/v320-release
 
 resources:
   repositories:

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -4,7 +4,7 @@ trigger:
         include:
             - main
             - durabletask-core-v2
-            - neetart/dtfx_sf_pipeline
+            - vabachu/v320-release
 
 # CI only, does not trigger on PRs.
 pr: none

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -7,7 +7,7 @@ trigger:
     include:
     - main
     - durabletask-core-v2
-    - neetart/dtfx_sf_pipeline
+    - vabachu/v320-release
 
 # Run nightly to catch new CVEs and to report SDL often.
 schedules:


### PR DESCRIPTION
Adding vabachu/v320-release to the trigger list in the `eng/ci` files to be able to run the pipeline from this branch and create test packages.