### PR TITLE
Updating dependencies to resolve component governance issues

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
 
   <!-- Product dependencies -->
   <ItemGroup>
-    <PackageVersion Include="Azure.Core" Version="1.43.0" />
+    <PackageVersion Include="Azure.Core" Version="1.44.1" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.19.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.24.0" />
@@ -23,7 +23,6 @@
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Services.Client" Version="5.8.5" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageVersion Include="Microsoft.ServiceFabric" Version="6.4.617" />
     <PackageVersion Include="Microsoft.ServiceFabric.Data" Version="3.3.617" />
     <PackageVersion Include="Microsoft.ServiceFabric.Services" Version="3.3.617" />
@@ -54,8 +53,6 @@
     <PackageVersion Include="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer.NetCore" Version="2.0.1406.4" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Core" Version="5.2.6" />
     <PackageVersion Include="Microsoft.Diagnostics.EventFlow.Core" Version="1.5.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="Moq" Version="4.10.0" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.5.0" />
@@ -104,12 +101,18 @@
     <PackageVersion Include="Vio.DurableTask.Hosting" Version="2.2.1" />
   </ItemGroup>
 
-  <!-- Samples dependencies with net8.0-->
+  <!-- Dependencies specific to net8.0-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+  </ItemGroup>
+  
 
   <!-- Samples dependencies with net462-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -51,7 +51,7 @@
     <PackageVersion Include="CommandLineParser" Version="2.4.3" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageVersion Include="CommandLineParser" Version="1.9.71" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageVersion Include="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer.NetCore" Version="2.0.1406.4" />
-    <PackageVersion Include="Microsoft.AspNet.WebApi.Core" Version="5.2.6" />
+    <PackageVersion Include="Microsoft.AspNet.WebApi.Core" Version="5.3.0" />
     <PackageVersion Include="Microsoft.Diagnostics.EventFlow.Core" Version="1.5.6" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="Moq" Version="4.10.0" />
@@ -65,15 +65,15 @@
     <PackageVersion Include="WindowsAzure.Storage" Version="8.7.0" Condition="'$(TargetFramework)' == 'net462'" />
   </ItemGroup>
 
-  <!-- Test dependencies with netcoreapp3.1-->
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <!-- Test dependencies with net6.0-->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageVersion Include="EnterpriseLibrary.SemanticLogging.NetCore" Version="2.0.1406.4" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
 
   <!-- Test dependencies with net472-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
+    <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Owin" Version="5.3.0" />
     <PackageVersion Include="Microsoft.Owin.Hosting" Version="4.2.2" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,15 +10,15 @@
   <!-- Product dependencies -->
   <ItemGroup>
     <PackageVersion Include="Azure.Core" Version="1.43.0" />
-    <PackageVersion Include="Azure.Data.Tables" Version="12.9.1" />
-    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.17.0" />
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.22.1" />
-    <PackageVersion Include="Azure.Storage.Queues" Version="12.20.0" />
+    <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
+    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.19.0" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.24.0" />
+    <PackageVersion Include="Azure.Storage.Queues" Version="12.22.0" />
     <PackageVersion Include="Castle.Core" Version="5.0.0" />
     <PackageVersion Include="ImpromptuInterface" Version="6.2.2" Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'" />
     <PackageVersion Include="ImpromptuInterface" Version="7.0.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.21.0" />
-    <PackageVersion Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.6" />
+    <PackageVersion Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.3.0" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Services.Client" Version="5.8.5" />
@@ -76,16 +76,16 @@
 
   <!-- Test dependencies with net472-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.6" />
-    <PackageVersion Include="Microsoft.AspNet.WebApi.Owin" Version="5.2.6" />
-    <PackageVersion Include="Microsoft.Owin.Hosting" Version="4.0.0" />
+    <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
+    <PackageVersion Include="Microsoft.AspNet.WebApi.Owin" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.Owin.Hosting" Version="4.2.2" />
   </ItemGroup>
 
   <!-- Test dependencies with net462-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageVersion Include="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" />
     <PackageVersion Include="EnterpriseLibrary.SemanticLogging.TextFile" version="2.0.1406.1" />
-    <PackageVersion Include="Microsoft.Owin.Hosting" Version="4.0.0" />
+    <PackageVersion Include="Microsoft.Owin.Hosting" Version="4.2.2" />
     <PackageVersion Include="Microsoft.Tpl.Dataflow" version="4.5.24" />
   </ItemGroup>
 

--- a/samples/Correlation.Samples/Correlation.Samples.csproj
+++ b/samples/Correlation.Samples/Correlation.Samples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Correlation.Samples/DurableTaskCorrelationTelemetryInitializer.cs
+++ b/samples/Correlation.Samples/DurableTaskCorrelationTelemetryInitializer.cs
@@ -313,7 +313,7 @@ namespace Correlation.Samples
             if (initializeFromCurrent)
             {
                 opTelemetry.Id = activity.SpanId.ToHexString();
-                if (activity.ParentSpanId != null)
+                if (activity.ParentSpanId != default)
                 {
                     opTelemetry.Context.Operation.ParentId = activity.ParentSpanId.ToHexString();
                 }

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -40,7 +40,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" />
     <PackageReference Include="Azure.Data.Tables" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Azure.Storage.Queues" />

--- a/test/DurableTask.ServiceBus.Tests/DurableTask.ServiceBus.Tests.csproj
+++ b/test/DurableTask.ServiceBus.Tests/DurableTask.ServiceBus.Tests.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">
@@ -28,7 +28,7 @@
     <PackageReference Include="WindowsAzure.ServiceBus" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Azure.Data.Tables" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="EnterpriseLibrary.SemanticLogging.NetCore" />
@@ -60,7 +60,7 @@
     <Reference Include="System.Configuration" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <None Update="testhost.dll.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/test/DurableTask.ServiceBus.Tests/OrchestrationHubTableClientTests.cs
+++ b/test/DurableTask.ServiceBus.Tests/OrchestrationHubTableClientTests.cs
@@ -274,14 +274,14 @@ namespace DurableTask.ServiceBus.Tests
             return true;
         }
 
-        bool CompareHistoryEntity(AzureTableOrchestrationHistoryEventEntity expected, AzureTableOrchestrationHistoryEventEntity actual)
+        static bool CompareHistoryEntity(AzureTableOrchestrationHistoryEventEntity expected, AzureTableOrchestrationHistoryEventEntity actual)
         {
             // TODO : history comparison!
             return expected.InstanceId.Equals(actual.InstanceId) && expected.ExecutionId.Equals(actual.ExecutionId) &&
                    expected.SequenceNumber == actual.SequenceNumber;
         }
 
-        bool CompareStateEntity(AzureTableOrchestrationStateEntity expected, AzureTableOrchestrationStateEntity actual)
+        static bool CompareStateEntity(AzureTableOrchestrationStateEntity expected, AzureTableOrchestrationStateEntity actual)
         {
             return
                 expected.State.OrchestrationInstance.InstanceId.Equals(actual.State.OrchestrationInstance.InstanceId) &&
@@ -289,8 +289,7 @@ namespace DurableTask.ServiceBus.Tests
                 expected.State.Name.Equals(actual.State.Name) &&
                 expected.State.CreatedTime.Equals(actual.State.CreatedTime) &&
                 expected.State.LastUpdatedTime.Equals(actual.State.LastUpdatedTime) &&
-                // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-                (expected.State.CompletedTime == null && actual.State.CompletedTime == null ||
+                (expected.State.CompletedTime == default && actual.State.CompletedTime == default ||
                  expected.State.CompletedTime.Equals(actual.State.CompletedTime)) &&
                 expected.State.Status.Equals(actual.State.Status) &&
                 expected.State.Input.Equals(actual.State.Input) &&
@@ -298,7 +297,7 @@ namespace DurableTask.ServiceBus.Tests
                  expected.State.Output.Equals(actual.State.Output));
         }
 
-        IEnumerable<AzureTableOrchestrationHistoryEventEntity> CreateHistoryEntities(AzureTableClient azureTableClient, string instanceId,
+        static IEnumerable<AzureTableOrchestrationHistoryEventEntity> CreateHistoryEntities(AzureTableClient azureTableClient, string instanceId,
             string genId, int count)
         {
             var historyEntities = new List<AzureTableOrchestrationHistoryEventEntity>();
@@ -314,7 +313,7 @@ namespace DurableTask.ServiceBus.Tests
             return historyEntities;
         }
 
-        IEnumerable<AzureTableOrchestrationStateEntity> CreateStateEntities(AzureTableClient azureTableClient, string instanceId, string genId)
+        static IEnumerable<AzureTableOrchestrationStateEntity> CreateStateEntities(AzureTableClient azureTableClient, string instanceId, string genId)
         {
             var entities = new List<AzureTableOrchestrationStateEntity>();
             var runtimeState = new OrchestrationState


### PR DESCRIPTION
The main issues to be resolved are older versions of System.Text.Json (6.0.9) and Microsoft.Owin (2.0.2), which are brought in via transitive dependencies but have known vulnerabilities. These are all minor version updates so hoping they won't result in any breaking changes. 🤞