### PR TITLE
Disable storage tracing by default

### DIFF
--- a/src/DurableTask.AzureStorage/Storage/AzureStorageClient.cs
+++ b/src/DurableTask.AzureStorage/Storage/AzureStorageClient.cs
@@ -107,6 +107,10 @@ namespace DurableTask.AzureStorage.Storage
             where TClientOptions : ClientOptions
         {
             TClientOptions options = storageProvider.CreateOptions();
+
+            // Disable distributed tracing by default to reduce the noise in the traces.
+            options.Diagnostics.IsDistributedTracingEnabled = false;
+
             configurePolicies?.Invoke(options);
 
             return storageProvider.CreateClient(options);


### PR DESCRIPTION
This PR disables Azure Storage distributed tracing by default.

.NET Isolated DF app without disabling storage tracing:
![image](https://github.com/user-attachments/assets/e946997e-7e07-46c4-9697-ce6cb4cc7236)

.NET Isolated DF app after disabling storage tracing (tested with the change in this PR):
![image](https://github.com/user-attachments/assets/01c7cefc-35ec-44f1-9e6f-0c5f6eb015a4)
