### PR TITLE
Fixing the case null session state was being set as empty byte array

### DIFF
--- a/src/DurableTask.ServiceBus/Common/Abstraction/ServiceBusAbstraction.cs
+++ b/src/DurableTask.ServiceBus/Common/Abstraction/ServiceBusAbstraction.cs
@@ -140,7 +140,9 @@ namespace DurableTask.ServiceBus.Common.Abstraction
         {
             if (sessionState == null)
             {
-                await this.sessionReceiver.SetSessionStateAsync(new BinaryData(new byte[] { }));
+                // Setting session state to null is equivalent to deleting session state.
+                // Setting session state to empty byte array is not equivalent to deleting session state.
+                await this.sessionReceiver.SetSessionStateAsync(null);
             }
             else
             {


### PR DESCRIPTION
Setting session state to null and setting session state to empty byte array are two different things. They are not the same. Setting session state to null properly cleans up session state in service bus.