### PR TITLE
Adding an Exception Case to CompleteTaskOrchestrationWorkItemAsync

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1215,11 +1215,17 @@ namespace DurableTask.AzureStorage
                     this.orchestrationSessionManager.AddMessageToPendingOrchestration(session.ControlQueue, messages, session.TraceActivityId, CancellationToken.None);
                 }
             }
+            // If the tracking store is of type InstanceStoreBackedTrackingStore, then it will throw a RequestFailedException
             catch (RequestFailedException rfe) when (rfe.Status == (int)HttpStatusCode.PreconditionFailed)
             {
                 // Precondition failure is expected to be handled internally and logged as a warning.
                 // The orchestration dispatcher will handle this exception by abandoning the work item
                 throw new SessionAbortedException("Aborting execution due to failed precondition.", rfe);
+            }
+            // If the tracking store is of type AzureStorageTrackingStore, then it will throw a DurableTaskStorageException which decorates the RequestFailedException
+            catch (DurableTaskStorageException dtse) when (dtse.HttpStatusCode == (int)HttpStatusCode.PreconditionFailed)
+            {
+                throw new SessionAbortedException("Aborting execution due to failed precondition.", dtse);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
`AzureStorageOrchestrationService.CompleteTaskOrchestrationWorkItemAsync` is not correctly catching the exception thrown in the case of an etag mismatch when calling `ITrackingStore.UpdateStateAsync` method. The `InstanceStoreBackedTrackingStore` implementation throws a `RequestFailedException`, which is correctly caught, while the `AzureTableTrackingStore` implementation wraps this exception in a `DurableTaskStorageException`, so this was not being correctly caught. This PR adds this exception check to the method as well.

Note: It is difficult to add testing for this - the best I can think to do is add a unit test to confirm that `AzureTableTrackingStore.UpdateStateAsync` throws the expected `DurableTaskStorageException` with `StatusCode` equal to `HttpStatusCode.PreconditionFailed`, but this method expects a parameter of [type](https://github.com/Azure/durabletask/blob/931cbe0f3d8036b925339c5d3440dd376fd4a5c4/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs#L821)`TrackingStoreContext` which is a private class and can't be instantiated from within the tests. So there seems to be no easy way to test this (this parameter is passed around as a generic `object` in all other classes, and cast to its type from within this method). 