### PR TITLE
Loosen exception matching logic in IsCausedBy<T>

### DIFF
--- a/src/DurableTask.Core/FailureDetails.cs
+++ b/src/DurableTask.Core/FailureDetails.cs
@@ -149,14 +149,10 @@ namespace DurableTask.Core
                     .Select(a => a.GetType(this.ErrorType, throwOnError: false))
                     .Where(t => t is not null)
                     .ToList();
-                if (matchingExceptionTypes.Count == 1)
-                {
-                    exceptionType = matchingExceptionTypes[0];
-                }
-                else if (matchingExceptionTypes.Count > 1)
-                {
-                    throw new AmbiguousMatchException($"Multiple exception types with the name '{this.ErrorType}' were found.");
-                }
+
+                // Previously, this logic would only return true if matchingExceptionTypes found only one assembly with a type matching ErrorType.
+                // Now, it will return true if any matching assembly has a type that is assignable to T.
+                return matchingExceptionTypes.Any(matchType => typeof(T).IsAssignableFrom(matchType));
             }
 
             return exceptionType != null && typeof(T).IsAssignableFrom(exceptionType);

--- a/src/DurableTask.Core/FailureDetails.cs
+++ b/src/DurableTask.Core/FailureDetails.cs
@@ -197,10 +197,9 @@ namespace DurableTask.Core
             {
                 // This last check works for exception types defined in any loaded assembly (e.g. NuGet packages, etc.).
                 // This is a fallback that should rarely be needed except in obscure cases.
-                List<Type> matchingExceptionTypes = AppDomain.CurrentDomain.GetAssemblies()
+                var matchingExceptionTypes = AppDomain.CurrentDomain.GetAssemblies()
                     .Select(a => a.GetType(this.ErrorType, throwOnError: false))
-                    .Where(t => t is not null)
-                    .ToList();
+                    .Where(t => t is not null);
 
                 // Previously, this logic would only return true if matchingExceptionTypes found only one assembly with a type matching ErrorType.
                 // Now, it will return true if any matching assembly has a type that is assignable to T.

--- a/test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
+++ b/test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
@@ -16,6 +16,8 @@ namespace DurableTask.Core.Tests
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Reflection;
+    using System.Reflection.Emit;
     using System.Runtime.Serialization;
     using System.Threading.Tasks;
     using DurableTask.Core.Exceptions;
@@ -540,6 +542,38 @@ namespace DurableTask.Core.Tests
                 : base(info, context)
             {
             }
+        }
+
+        [TestMethod]
+        public void IsCausedBy_DoesNotThrow_WhenMultipleAssembliesDefineSameType()
+        {
+            // Create two dynamic assemblies, each containing an Exception-derived type with the
+            // same fully qualified name. This simulates the scenario where the same exception type
+            // is loaded from multiple assemblies (e.g. different NuGet package versions).
+            string typeName = "TestDynamic.DuplicateException";
+            CreateDynamicAssemblyWithExceptionType(typeName, "DynAssembly1");
+            CreateDynamicAssemblyWithExceptionType(typeName, "DynAssembly2");
+
+            // Create a FailureDetails whose ErrorType won't be resolved by Type.GetType(),
+            // typeof(T).Assembly, or the calling assembly, forcing the AppDomain fallback path.
+            var details = new FailureDetails(
+                typeName, "Test error", stackTrace: null, innerFailure: null, isNonRetriable: false);
+
+            // The old implementation would either throw AmbiguousMatchException or return false
+            // when multiple assemblies contained the same type. The fix uses Any() so this should
+            // succeed without throwing.
+            bool result = details.IsCausedBy<Exception>();
+
+            Assert.IsTrue(result);
+        }
+
+        static void CreateDynamicAssemblyWithExceptionType(string typeName, string assemblyName)
+        {
+            var asmName = new AssemblyName(assemblyName);
+            var asmBuilder = AssemblyBuilder.DefineDynamicAssembly(asmName, AssemblyBuilderAccess.Run);
+            var modBuilder = asmBuilder.DefineDynamicModule(assemblyName);
+            var typeBuilder = modBuilder.DefineType(typeName, TypeAttributes.Public, typeof(Exception));
+            typeBuilder.CreateType();
         }
     }
 }


### PR DESCRIPTION
Currently, if we match multiple assemblies in FailureDetails.IsCausedBy<T>'s final case, we throw AmbiguousMatchException. This can be detrimental when multiple versions of the same assembly are loaded. This softens this check so that if multiple assemblies are matched to the FailureDetails' name, we will return true if any are assignable to T. 

Found from a bug where the Durable Functions WebJobs extension loaded into the Functions Host checks if a FailureDetails returned from the user activity code IsCausedBy<OutOfMemoryException> and threw an exception due to the host loading multiple versions of the DLL from which the exception originated (even though the exception was thrown in the dotnet isolated worker). 