### PR TITLE
support for async get custom status on orchestration

### DIFF
--- a/Test/DurableTask.Core.Tests/TaskOrchestrationGetStatusAsyncTests.cs
+++ b/Test/DurableTask.Core.Tests/TaskOrchestrationGetStatusAsyncTests.cs
@@ -1,0 +1,139 @@
+//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using DurableTask.Core.Serializing;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class TaskOrchestrationGetStatusAsyncTests
+    {
+        [TestMethod]
+        public async Task GetStatusAsync_ReturnsSerializedStatus_FromTypedOrchestration()
+        {
+            var orchestration = new SampleTypedOrchestration();
+
+            string syncStatus = orchestration.GetStatus();
+            string asyncStatus = await orchestration.GetStatusAsync();
+
+            Assert.AreEqual(syncStatus, asyncStatus, "Async status should equal sync status");
+
+            var deserialized = (Status)orchestration.DataConverter.Deserialize(asyncStatus, typeof(Status));
+            Assert.AreEqual("running", deserialized.State);
+            Assert.AreEqual(42, deserialized.Progress);
+        }
+
+        [TestMethod]
+        public async Task GetStatusAsync_ReturnsNull_WhenTypedOnGetStatusReturnsNull()
+        {
+            var orchestration = new NullStatusTypedOrchestration();
+
+            string syncStatus = orchestration.GetStatus();
+            string asyncStatus = await orchestration.GetStatusAsync();
+
+            Assert.IsNull(syncStatus, "Sync status should be null when OnGetStatus returns null");
+            Assert.IsNull(asyncStatus, "Async status should be null when OnGetStatus returns null");
+        }
+
+        [TestMethod]
+        public async Task GetStatusAsync_ReturnsSameAsGetStatus_ForNonGenericOrchestration()
+        {
+            var orchestration = new NonGenericOrchestration();
+
+            string syncStatus = orchestration.GetStatus();
+            string asyncStatus = await orchestration.GetStatusAsync();
+
+            Assert.AreEqual("OK", syncStatus);
+            Assert.AreEqual(syncStatus, asyncStatus);
+        }
+
+        [TestMethod]
+        public async Task GetStatusAsync_PropagatesException_WhenGetStatusThrows()
+        {
+            var orchestration = new ThrowingStatusOrchestration();
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () => await orchestration.GetStatusAsync());
+        }
+
+        class SampleTypedOrchestration : TaskOrchestration<string, string, string, Status>
+        {
+            public override Task<string> RunTask(OrchestrationContext context, string input)
+            {
+                return Task.FromResult("done");
+            }
+
+            public override Status OnGetStatus()
+            {
+                return new Status { State = "running", Progress = 42 };
+            }
+        }
+
+        class NullStatusTypedOrchestration : TaskOrchestration<string, string, string, Status>
+        {
+            public override Task<string> RunTask(OrchestrationContext context, string input)
+            {
+                return Task.FromResult("done");
+            }
+
+            public override Status OnGetStatus()
+            {
+                return null;
+            }
+        }
+
+        class NonGenericOrchestration : TaskOrchestration
+        {
+            public override Task<string> Execute(OrchestrationContext context, string input)
+            {
+                return Task.FromResult("done");
+            }
+
+            public override void RaiseEvent(OrchestrationContext context, string name, string input)
+            {
+            }
+
+            public override string GetStatus()
+            {
+                return "OK";
+            }
+        }
+
+        class ThrowingStatusOrchestration : TaskOrchestration
+        {
+            public override Task<string> Execute(OrchestrationContext context, string input)
+            {
+                return Task.FromResult("done");
+            }
+
+            public override void RaiseEvent(OrchestrationContext context, string name, string input)
+            {
+            }
+
+            public override string GetStatus()
+            {
+                throw new InvalidOperationException("boom");
+            }
+        }
+
+        class Status
+        {
+            public string State { get; set; }
+
+            public int Progress { get; set; }
+        }
+    }
+}
+

--- a/src/DurableTask.Core/TaskOrchestration.cs
+++ b/src/DurableTask.Core/TaskOrchestration.cs
@@ -58,6 +58,19 @@ namespace DurableTask.Core
         {
             return await Task.FromResult(GetStatus());
         }
+
+        /// <summary>
+        /// Raises an event in the orchestration asynchronously
+        /// </summary>
+        /// <param name="context">The orchestration context</param>
+        /// <param name="name">Name for this event to be passed to the OnEvent handler</param>
+        /// <param name="input">The serialized input</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        public virtual Task RaiseEventAsync(OrchestrationContext context, string name, string input)
+        {
+            RaiseEvent(context, name, input);
+            return Task.CompletedTask;
+        }
     }
 
     /// <summary>

--- a/src/DurableTask.Core/TaskOrchestration.cs
+++ b/src/DurableTask.Core/TaskOrchestration.cs
@@ -11,6 +11,7 @@
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
 
+#nullable enable
 namespace DurableTask.Core
 {
     using System;
@@ -48,6 +49,15 @@ namespace DurableTask.Core
         /// </summary>
         /// <returns>The status</returns>
         public abstract string GetStatus();
+
+        /// <summary>
+        /// Gets the current status of the orchestration
+        /// </summary>
+        /// <returns>The status</returns>
+        public virtual async Task<string?> GetStatusAsync()
+        {
+            return await Task.FromResult(GetStatus());
+        }
     }
 
     /// <summary>
@@ -97,8 +107,8 @@ namespace DurableTask.Core
             }
             catch (Exception e) when (!Utils.IsFatal(e) && !Utils.IsExecutionAborting(e))
             {
-                string details = null;
-                FailureDetails failureDetails = null;
+                string? details = null;
+                FailureDetails? failureDetails = null;
                 if (context.ErrorPropagationMode == ErrorPropagationMode.SerializeExceptions)
                 {
                     details = Utils.SerializeCause(e, DataConverter);
@@ -164,7 +174,7 @@ namespace DurableTask.Core
         /// <returns>The typed status</returns>
         public virtual TStatus OnGetStatus()
         {
-            return default(TStatus);
+            return default!;
         }
     }
 }


### PR DESCRIPTION
This change is required to support async serialize scenarios of custom status of orchestration like large payload externalianzation feature as described in https://github.com/microsoft/durabletask-dotnet/pull/459

This is added in a non breaking way as virtual function and only will be used in large payload serialization scenario currently.