### PR TITLE
[DurableTask.ServiceBus] List only containers starting with prefix 

### DIFF
--- a/src/DurableTask.ServiceBus/Tracking/BlobStorageClient.cs
+++ b/src/DurableTask.ServiceBus/Tracking/BlobStorageClient.cs
@@ -136,10 +136,16 @@ namespace DurableTask.ServiceBus.Tracking
         public async Task<IEnumerable<BlobContainerItem>> ListContainersAsync()
         {
             List<BlobContainerItem> results = new List<BlobContainerItem>();
-            var response = this.blobServiceClient.GetBlobContainersAsync();
+            // Use the service client's prefix parameter to only enumerate containers that start with the
+            // configured containerNamePrefix. Also apply a defensive in-memory filter in case of any
+            // unexpected differences in casing or service behavior.
+            var response = this.blobServiceClient.GetBlobContainersAsync(prefix: this.containerNamePrefix);
             await foreach (var container in response)
             {
-                results.Add(container);
+                if (container.Name != null && container.Name.StartsWith(this.containerNamePrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    results.Add(container);
+                }
             }
             return results;
         }


### PR DESCRIPTION
Migration to Azure.Storage nuget introduced a regression, that we started deleting all containers in a storage account. 

Looks like a regression from 
https://github.com/Azure/durabletask/commit/0af3eca8579eaf69025716738defab91f66676a4#diff-076ce870f6eb747780e059b061509af9841565cac934136074c63bc1cdd43007