### PR TITLE
Adding a completed time for terminating a pending orchestration

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1065,7 +1065,11 @@ namespace DurableTask.AzureStorage
                     TaskMessage executionTerminatedEventMessage = newMessages.LastOrDefault(msg => msg.Event is ExecutionTerminatedEvent);
                     if (executionTerminatedEventMessage is not null)
                     {
-                        await this.trackingStore.UpdateStatusForTerminationAsync(instanceId, ((ExecutionTerminatedEvent)executionTerminatedEventMessage.Event).Input);
+                        var executionTerminatedEvent = (ExecutionTerminatedEvent)executionTerminatedEventMessage.Event;
+                        await this.trackingStore.UpdateStatusForTerminationAsync(
+                            instanceId,
+                            executionTerminatedEvent.Input,
+                            executionTerminatedEvent.Timestamp);
                         return $"Instance is {OrchestrationStatus.Terminated}";
                     }
 

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -796,13 +796,18 @@ namespace DurableTask.AzureStorage.Tracking
         }
 
         /// <inheritdoc />
-        public override async Task UpdateStatusForTerminationAsync(string instanceId, string output, CancellationToken cancellationToken = default)
+        public override async Task UpdateStatusForTerminationAsync(
+            string instanceId,
+            string output,
+            DateTime lastUpdatedTime,
+            CancellationToken cancellationToken = default)
         {
             string sanitizedInstanceId = KeySanitation.EscapePartitionKey(instanceId);
             TableEntity entity = new TableEntity(sanitizedInstanceId, "")
             {
                 ["RuntimeStatus"] = OrchestrationStatus.Terminated.ToString("G"),
-                ["LastUpdatedTime"] = DateTime.UtcNow,
+                ["LastUpdatedTime"] = lastUpdatedTime,
+                ["CompletedTime"] = DateTime.UtcNow,
                 [OutputProperty] = output
             };
 

--- a/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/ITrackingStore.cs
@@ -157,8 +157,9 @@ namespace DurableTask.AzureStorage.Tracking
         /// </summary>
         /// <param name="instanceId">The instance being terminated</param>
         /// <param name="output">The output of the orchestration</param>
+        /// <param name="lastUpdatedTime">The last updated time of the orchestration (the time the termination request was created)</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
-        Task UpdateStatusForTerminationAsync(string instanceId, string output, CancellationToken cancellationToken = default);
+        Task UpdateStatusForTerminationAsync(string instanceId, string output, DateTime lastUpdatedTime, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Purge The History and state  which is older than thresholdDateTimeUtc based on the timestamp type specified by timeRangeFilterType

--- a/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
@@ -177,12 +177,17 @@ namespace DurableTask.AzureStorage.Tracking
             return null;
         }
 
-        public override async Task UpdateStatusForTerminationAsync(string instanceId, string output, CancellationToken cancellationToken = default)
+        public override async Task UpdateStatusForTerminationAsync(
+            string instanceId,
+            string output,
+            DateTime lastUpdatedTime,
+            CancellationToken cancellationToken = default)
         {
             // Get the most recent execution and update its status to terminated
             IEnumerable<OrchestrationStateInstanceEntity> instanceEntity = await this.instanceStore.GetOrchestrationStateAsync(instanceId, allInstances: false);
             instanceEntity.Single().State.OrchestrationStatus = OrchestrationStatus.Terminated;
-            instanceEntity.Single().State.LastUpdatedTime = DateTime.UtcNow;
+            instanceEntity.Single().State.LastUpdatedTime = lastUpdatedTime;
+            instanceEntity.Single().State.CompletedTime = DateTime.UtcNow;
             instanceEntity.Single().State.Output = output;
             await this.instanceStore.WriteEntitiesAsync(instanceEntity);
         }

--- a/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
+++ b/src/DurableTask.AzureStorage/Tracking/TrackingStoreBase.cs
@@ -101,7 +101,7 @@ namespace DurableTask.AzureStorage.Tracking
         }
 
         /// <inheritdoc />
-        public abstract Task UpdateStatusForTerminationAsync(string instanceId, string output, CancellationToken cancellationToken = default);
+        public abstract Task UpdateStatusForTerminationAsync(string instanceId, string output, DateTime lastUpdatedTime, CancellationToken cancellationToken = default);
 
         /// <inheritdoc />
         public abstract Task StartAsync(CancellationToken cancellationToken = default);


### PR DESCRIPTION
I forgot to set the "completed time" field in the instance table when handling the case of terminating a pending orchestration in my previous [PR](https://github.com/Azure/durabletask/pull/1256). This PR amends that, and also changes the last updated time to point to the timestamp of the `ExecutionTerminatedEvent`, which follows the existing pattern we have in place [here](https://github.com/Azure/durabletask/blob/b93b187f9df5d324aec2c850f0497ae3e41c3597/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs#L861).