### PR TITLE
Adding a warning for a continue-as-new call on a failed orchestration

### DIFF
--- a/src/DurableTask.Core/Command/OrchestrationCompleteOrchestratorAction.cs
+++ b/src/DurableTask.Core/Command/OrchestrationCompleteOrchestratorAction.cs
@@ -56,5 +56,10 @@ namespace DurableTask.Core.Command
         /// Gets a list of events that should be carried over when continuing an orchestration as new.
         /// </summary>
         public IList<HistoryEvent> CarryoverEvents { get; } = new List<HistoryEvent>();
+
+        /// <summary>
+        /// Gets a collection of tags associated with the completion action.
+        /// </summary>
+        public IDictionary<string, string> Tags { get; } = new Dictionary<string, string>();
     }
 }

--- a/src/DurableTask.Core/Logging/EventIds.cs
+++ b/src/DurableTask.Core/Logging/EventIds.cs
@@ -69,5 +69,7 @@ namespace DurableTask.Core.Logging
         public const int RenewOrchestrationWorkItemFailed = 72;
 
         public const int OrchestrationDebugTrace = 73;
+
+        public const int OrchestrationCompletedWithWarning = 74;
     }
 }

--- a/src/DurableTask.Core/Logging/LogEvents.cs
+++ b/src/DurableTask.Core/Logging/LogEvents.cs
@@ -1099,6 +1099,54 @@ namespace DurableTask.Core.Logging
 #nullable disable
 
         /// <summary>
+        /// Log event representing a warning associated with an orchestration completing.
+        /// </summary>
+        internal class OrchestrationCompletedWithWarning : StructuredLogEvent, IEventSourceEvent
+        {
+
+            public OrchestrationCompletedWithWarning(
+                OrchestrationInstance instance,
+                string orchestrationStatus,
+                string warningMessage)
+            {
+                this.InstanceId = instance.InstanceId;
+                this.ExecutionId = instance.ExecutionId;
+                this.RuntimeStatus = orchestrationStatus;
+                this.Details = warningMessage;
+            }
+
+            [StructuredLogField]
+            public string InstanceId { get; }
+
+            [StructuredLogField]
+            public string ExecutionId { get; }
+
+            [StructuredLogField]
+            public string RuntimeStatus { get; }
+
+            [StructuredLogField]
+            public string Details { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.OrchestrationCompletedWithWarning,
+                nameof(EventIds.OrchestrationCompletedWithWarning));
+
+            public override LogLevel Level => LogLevel.Warning;
+
+            protected override string CreateLogMessage() =>
+                $"{this.InstanceId}: Orchestration completed with warning: {this.Details}";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                StructuredEventSource.Log.OrchestrationCompletedWithWarning(
+                    this.InstanceId,
+                    this.ExecutionId,
+                    this.RuntimeStatus,
+                    this.Details,
+                    Utils.AppName,
+                    Utils.PackageVersion);
+        }
+
+        /// <summary>
         /// Log event representing an orchestration aborted event, which can happen if the host is shutting down.
         /// </summary>
         internal class OrchestrationAborted : StructuredLogEvent, IEventSourceEvent

--- a/src/DurableTask.Core/Logging/LogHelper.cs
+++ b/src/DurableTask.Core/Logging/LogHelper.cs
@@ -485,6 +485,23 @@ namespace DurableTask.Core.Logging
         }
 
         /// <summary>
+        /// Logs a warning associated with an orchestration completing.
+        /// </summary>
+        /// <param name="instance">The orchestration instance of the orchestration.</param>
+        /// <param name="orchestrationStatus">The status of the completed orchestration.</param>
+        /// <param name="warningMessage">The warning message to log.</param>
+        internal void OrchestrationCompletedWithWarning(
+            OrchestrationInstance instance,
+            OrchestrationStatus orchestrationStatus,
+            string warningMessage)
+        {
+            if (this.IsStructuredLoggingEnabled)
+            {
+                this.WriteStructuredLog(new LogEvents.OrchestrationCompletedWithWarning(instance, orchestrationStatus.ToString(), warningMessage));
+            }
+        }
+
+        /// <summary>
         /// Logs that an orchestration execution was aborted.
         /// </summary>
         /// <param name="instance">The orchestration instance that aborted execution.</param>

--- a/src/DurableTask.Core/Logging/StructuredEventSource.cs
+++ b/src/DurableTask.Core/Logging/StructuredEventSource.cs
@@ -579,6 +579,29 @@ namespace DurableTask.Core.Logging
             }
         }
 
+        [Event(EventIds.OrchestrationCompletedWithWarning, Level = EventLevel.Warning, Version = 1)]
+        internal void OrchestrationCompletedWithWarning(
+            string InstanceId,
+            string ExecutionId,
+            string RuntimeStatus,
+            string Details,
+            string AppName,
+            string ExtensionVersion)
+        {
+            if (this.IsEnabled(EventLevel.Warning))
+            {
+                // TODO: Use WriteEventCore for better performance
+                this.WriteEvent(
+                    EventIds.OrchestrationCompletedWithWarning,
+                    InstanceId,
+                    ExecutionId,
+                    RuntimeStatus,
+                    Details,
+                    AppName,
+                    ExtensionVersion);
+            }
+        }
+
         [Event(EventIds.OrchestrationAborted, Level = EventLevel.Warning, Version = 1)]
         internal void OrchestrationAborted(
             string InstanceId,

--- a/src/DurableTask.Core/OrchestrationTags.cs
+++ b/src/DurableTask.Core/OrchestrationTags.cs
@@ -57,6 +57,11 @@ namespace DurableTask.Core
         public const string CreateTraceForNewOrchestration = "MS_CreateTrace";
 
         /// <summary>
+        /// The warning logged when an orchestration completes, if any.
+        /// </summary>
+        public const string CompleteOrchestrationLogWarning = "MS_CompleteOrchestrationLogWarning";
+
+        /// <summary>
         /// Check whether the given tags contain the fire and forget tag
         /// </summary>
         /// <param name="tags"></param>

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -709,15 +709,6 @@ namespace DurableTask.Core
             }
             else
             {
-                if (this.continueAsNew != null && orchestrationStatus == OrchestrationStatus.Failed)
-                {
-                    TraceHelper.TraceSession(
-                        TraceEventType.Warning,
-                        "TaskOrchestrationContext-ContinueAsNewForFailedOrchestration",
-                        OrchestrationInstance.InstanceId,
-                        "Continue as new called for a failed orchestration, orchestration will complete");
-                }
-
                 if (this.executionCompletedOrTerminated)
                 {
                     return;
@@ -730,6 +721,12 @@ namespace DurableTask.Core
                 completedOrchestratorAction.Details = details;
                 completedOrchestratorAction.OrchestrationStatus = orchestrationStatus;
                 completedOrchestratorAction.FailureDetails = failureDetails;
+
+                if (this.continueAsNew != null && orchestrationStatus == OrchestrationStatus.Failed)
+                {
+                    completedOrchestratorAction.Tags[OrchestrationTags.CompleteOrchestrationLogWarning] = 
+                        "Continue as new called for a failed orchestration, orchestration will complete.";
+                }
             }
 
             completedOrchestratorAction.Id = id;

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -964,6 +964,10 @@ namespace DurableTask.Core
 
             runtimeState.AddEvent(executionCompletedEvent);
 
+            if (completeOrchestratorAction.Tags.TryGetValue(OrchestrationTags.CompleteOrchestrationLogWarning, out string warningMessage))
+            {
+                this.logHelper.OrchestrationCompletedWithWarning(runtimeState.OrchestrationInstance!, completeOrchestratorAction.OrchestrationStatus, warningMessage);
+            }
             this.logHelper.OrchestrationCompleted(runtimeState, completeOrchestratorAction);
             TraceHelper.TraceInstance(
                 runtimeState.OrchestrationStatus == OrchestrationStatus.Failed ? TraceEventType.Warning : TraceEventType.Information,


### PR DESCRIPTION
This PR adds a warning when the `TaskOrchestrationContext` detects that continue-as-new has been called on a failed orchestration (in which case the continue-as-new is ignored and the orchestration is completed in a "failed" state). It does this by introducing a new generic `OrchestrationCompletedWithWarning` log and a new `Tags` field to the `OrchestrationCompleteOrchestratorAction` which can be leveraged generically in the future for other such cases.

Solves #1261 