### PR TITLE
Add a warning to the rewind method 

### DIFF
--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -1326,6 +1326,12 @@ namespace DurableTask.Core
             out List<TaskMessage> subOrchestrationRewindMessages,
             out OrchestrationRuntimeState newRuntimeState)
         {
+
+            /* WARNING!!!:
+             * If any changes are made to how this method modifies the orchestration's history, then corresponding changes *must* 
+             * be made in the backend implementations that rely on this method for executing a rewind.
+             */
+
             HashSet<int> failedTaskIds = new();
             subOrchestrationRewindMessages = new();
 


### PR DESCRIPTION
This small PR adds a comment to the rewind method that stipulates that any changes in its logic _must_ be reflected in the backends that rely on it to execute the rewind.