### PR TITLE
Fix Null Reference Bug in Instance and History Table Sync

### DIFF
--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1100,8 +1100,8 @@ namespace DurableTask.AzureStorage
                 runtimeState.OrchestrationStatus != OrchestrationStatus.Suspended)
             {
                 InstanceStatus instanceStatus = await this.trackingStore.FetchInstanceStatusAsync(runtimeState.OrchestrationInstance.InstanceId);
-                if (instanceStatus == null || instanceStatus.State.OrchestrationInstance.ExecutionId == runtimeState.OrchestrationInstance.ExecutionId
-                    && instanceStatus.State.OrchestrationStatus != runtimeState.OrchestrationStatus)
+                if (instanceStatus == null || (instanceStatus.State.OrchestrationInstance.ExecutionId == runtimeState.OrchestrationInstance.ExecutionId
+                    && instanceStatus.State.OrchestrationStatus != runtimeState.OrchestrationStatus))
                 {
                     await this.trackingStore.UpdateInstanceStatusAndDeleteOrphanedBlobsForCompletedOrchestrationAsync(
                         runtimeState.OrchestrationInstance.InstanceId,


### PR DESCRIPTION
When attempting to synchronize the instance and history tables in the case that the process died after updating the history table but before updating the instance table upon completing a work item, there can be a null reference exception in the current logic. The problem is I assumed there is always an instance table entry in this situation, but this is not necessarily the case (for example, if this is a suborchestration that had only one round of execution and then immediate completion, it will not have an instance table entry if the process died after updating the history table). This PR fixes the null reference exception in that case.