### PR TITLE
Use System.Linq.AsyncEnumerable over System.Linq.Async

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="ImpromptuInterface" Version="7.0.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Services.Client" Version="5.8.5" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
@@ -30,7 +30,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="System.Collections.Immutable" Version="1.2.0" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
-    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
+    <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.0" />
     <PackageVersion Include="System.Reactive.Compatibility" Version="4.4.1" />
     <PackageVersion Include="System.Reactive.Core" Version="4.4.1" />
   </ItemGroup>

--- a/samples/Correlation.Samples/Correlation.Samples.csproj
+++ b/samples/Correlation.Samples/Correlation.Samples.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/DistributedTraceSample/ApplicationInsights/ApplicationInsightsSample.csproj
+++ b/samples/DistributedTraceSample/ApplicationInsights/ApplicationInsightsSample.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <UserSecretsId>d4d9b2e3-fb2a-4de6-9747-3d6d3b639d1a</UserSecretsId>
     <ApplicationInsightsResourceId>dummy-value</ApplicationInsightsResourceId>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/DistributedTraceSample/OpenTelemetry/OpenTelemetrySample.csproj
+++ b/samples/DistributedTraceSample/OpenTelemetry/OpenTelemetrySample.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Azure.Storage.Queues" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
-    <PackageReference Include="System.Linq.Async" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -273,7 +273,7 @@ namespace DurableTask.AzureStorage
             // "Remote" -> the instance ID info comes from the Instances table that we're querying
             IAsyncEnumerable<OrchestrationState> instances = this.trackingStore.GetStateAsync(instanceIds, cancellationToken);
             IDictionary<string, OrchestrationState> remoteOrchestrationsById = 
-                await instances.ToDictionaryAsync(o => o.OrchestrationInstance.InstanceId, cancellationToken);
+                await instances.ToDictionaryAsync(o => o.OrchestrationInstance.InstanceId, StringComparer.Ordinal, cancellationToken);
 
             foreach (MessageData message in executionStartedMessages)
             {

--- a/tools/DurableTask.props
+++ b/tools/DurableTask.props
@@ -15,6 +15,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>embedded</DebugType>
     <IncludeSymbols>false</IncludeSymbols>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <!-- SourceLink Dependency for GitHub-->


### PR DESCRIPTION
Now that [`System.Linq.Async`'s APIs have been incorporated into the BCL](https://github.com/dotnet/runtime/issues/79782), there is a new package called `System.Linq.AsyncEnumerable`. However, if an assembly targets .NET 10 (or uses the `System.Linq.AsyncEnumerable` package), the class `AsyncEnumerable` has a collision.

Given that the package `System.Linq.AsyncEnumerable` has a .NET Standard 2.0 target, I think we should migrate to this package to play nicely with .NET 10+

(I also included `SuppressTfmSupportBuildWarnings` to ignore the sort of "poison-pill" targets files. These new packages should work despite the scary warning messages)