### PR TITLE
Fix Terminating Pending Orchestration Regression

### DIFF
--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -816,7 +816,7 @@ namespace DurableTask.AzureStorage.Tracking
             await this.CompressLargeMessageAsync(instanceEntity, listOfBlobs: null, cancellationToken: cancellationToken, addBlobPropertyName: false);
 
             Stopwatch stopwatch = Stopwatch.StartNew();
-            await this.InstancesTable.InsertOrMergeEntityAsync(instanceEntity, cancellationToken);
+            await this.InstancesTable.MergeEntityAsync(instanceEntity, ETag.All, cancellationToken);
 
             this.settings.Logger.InstanceStatusUpdate(
                 this.storageAccountName,


### PR DESCRIPTION
When terminating a pending orchestration, I call `MergeEntityAsync` because I assume the instance entity already exists. This assumption is incorrect in the case that an orchestration has since been purged after the termination message has been enqueued. This PR adds a check to see if the instance entity exists, and if the execution ID matches that of the termination message's, before attempting to update the entity's status to terminated.

Solves #1287 