### PR TITLE
Remove dead continuedAsNew code after do-while loop

### DIFF
--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -318,7 +318,6 @@ namespace DurableTask.Core
             var timerMessages = new List<TaskMessage>();
             var orchestratorMessages = new List<TaskMessage>();
             var isCompleted = false;
-            var continuedAsNew = false;
             var isInterrupted = false;
             var isRewinding = false;
 
@@ -326,7 +325,6 @@ namespace DurableTask.Core
             CorrelationTraceClient.Propagate(() => CorrelationTraceContext.Current = workItem.TraceContext);
 
             ExecutionStartedEvent? continueAsNewExecutionStarted = null;
-            TaskMessage? continuedAsNewMessage = null;
             IList<HistoryEvent>? carryOverEvents = null;
             string? carryOverStatus = null;
 
@@ -389,10 +387,11 @@ namespace DurableTask.Core
                 }
                 else
                 {
+                    bool continuedAsNew;
                     do
                     {
                         continuedAsNew = false;
-                        continuedAsNewMessage = null;
+                        TaskMessage? continuedAsNewMessage = null;
 
                         IReadOnlyList<OrchestratorAction> decisions = new List<OrchestratorAction>();
                         bool versioningFailed = false;
@@ -707,10 +706,10 @@ namespace DurableTask.Core
             await this.orchestrationService.CompleteTaskOrchestrationWorkItemAsync(
                 workItem,
                 runtimeState,
-                continuedAsNew ? null : messagesToSend,
+                messagesToSend,
                 orchestratorMessages,
-                continuedAsNew ? null : timerMessages,
-                continuedAsNewMessage,
+                timerMessages,
+                continuedAsNewMessage: null,
                 instanceState);
 
             if (workItem.RestoreOriginalRuntimeStateDuringCompletion)
@@ -718,7 +717,7 @@ namespace DurableTask.Core
                 workItem.OrchestrationRuntimeState = runtimeState;
             }
 
-            return isCompleted || continuedAsNew || isInterrupted || isRewinding;
+            return isCompleted || isInterrupted || isRewinding;
         }
 
         static OrchestrationExecutionContext GetOrchestrationExecutionContext(OrchestrationRuntimeState runtimeState)


### PR DESCRIPTION
## Summary

The `do...while (continuedAsNew)` loop in `OnProcessWorkItemAsync` only exits when `continuedAsNew` is `false`. This means all references to `continuedAsNew` and `continuedAsNewMessage` after the loop are dead code:

- The ternary checks `continuedAsNew ? null : messagesToSend` always evaluate to `messagesToSend` (same for `timerMessages`).
- `continuedAsNewMessage` is always `null` after the loop (it's only assigned when `continuedAsNew` is `true`, which causes another loop iteration).
- `continuedAsNew` in the return statement is always `false`.

This code became dead ~7 years ago in https://github.com/Azure/durabletask/pull/251, so it shouldn't be reflective of any recent change/regression.

## Changes

- Narrowed the scope of `continuedAsNew` to just around the do-while loop
- Moved `continuedAsNewMessage` declaration inside the loop body
- Simplified the `CompleteTaskOrchestrationWorkItemAsync` call arguments
- Removed `continuedAsNew` from the return expression

## Testing

- Build passes
- All 176 DurableTask.Core.Tests pass (82 net48 + 94 net6.0)