### PR TITLE
Add .NET 8.0 and .NET 10.0 support to DurableTask.AzureServiceFabric

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,18 +16,20 @@
     <PackageVersion Include="Azure.Storage.Queues" Version="12.22.0" />
     <PackageVersion Include="Castle.Core" Version="5.2.1" />
     <PackageVersion Include="ImpromptuInterface" Version="6.2.2" Condition="'$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'net472'" />
-    <PackageVersion Include="ImpromptuInterface" Version="7.0.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageVersion Include="ImpromptuInterface" Version="7.0.1" Condition="'$(TargetFramework)' != 'net48' AND '$(TargetFramework)' != 'net472'" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net10.0'" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Services.Client" Version="5.8.5" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-    <PackageVersion Include="Microsoft.ServiceFabric" Version="6.4.617" />
-    <PackageVersion Include="Microsoft.ServiceFabric.Data" Version="3.3.617" />
-    <PackageVersion Include="Microsoft.ServiceFabric.Services" Version="3.3.617" />
+    <PackageVersion Include="Microsoft.ServiceFabric" Version="11.3.475" />
+    <PackageVersion Include="Microsoft.ServiceFabric.AspNetCore.Kestrel" Version="8.3.475" />
+    <PackageVersion Include="Microsoft.ServiceFabric.Data" Version="8.3.475" />
+    <PackageVersion Include="Microsoft.ServiceFabric.Services" Version="8.3.475" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.Collections.Immutable" Version="1.2.0" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
@@ -101,13 +103,13 @@
     <PackageVersion Include="Vio.DurableTask.Hosting" Version="2.2.1" />
   </ItemGroup>
 
-  <!-- Dependencies specific to net8.0-->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+  <!-- Dependencies specific to net8.0 or later -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net10.0'">
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0' AND '$(TargetFramework)' != 'net10.0'">
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />

--- a/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
+++ b/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFrameworks>net48;net472</TargetFrameworks>
+    <TargetFrameworks>net48;net472;net8.0;net10.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Microsoft.Azure.DurableTask.AzureServiceFabric</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -16,23 +16,26 @@
     <NoWarn>$(NoWarn);NU5104</NoWarn>
  </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+  <!-- .NET Framework: System.Web reference -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'net472'">
     <Reference Include="System.Web" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <Reference Include="System.Web" />
+  <!-- .NET Framework: OWIN + Web API -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'net472'">
+    <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <!-- Restoring packages for netstandard2.0 causes warnings. As warnings are treated as errors, compilation will fail. -->
-    <!-- Once the packages support netstandard2.0, this project will support netstandard2.0. -->
+  <!-- Modern .NET: ASP.NET Core + Kestrel for Service Fabric -->
+  <ItemGroup Condition="'$(TargetFramework)' != 'net48' AND '$(TargetFramework)' != 'net472'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
+    <PackageReference Include="Microsoft.ServiceFabric.AspNetCore.Kestrel" />
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="ImpromptuInterface" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.ServiceFabric.Data" />
     <PackageReference Include="Microsoft.ServiceFabric.Services" />

--- a/src/DurableTask.AzureServiceFabric/Extensions.cs
+++ b/src/DurableTask.AzureServiceFabric/Extensions.cs
@@ -14,9 +14,12 @@
 namespace DurableTask.AzureServiceFabric
 {
     using System;
+    using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
+#if NETFRAMEWORK
     using System.Web;
+#endif
 
     using DurableTask.AzureServiceFabric.Exceptions;
 
@@ -38,7 +41,7 @@ namespace DurableTask.AzureServiceFabric
             }
 
             // InsanceId consists of valid url characters is treated as valid.
-            var encodedInstanceId = HttpUtility.UrlEncode(instanceId);
+            var encodedInstanceId = WebUtility.UrlEncode(instanceId);
 
             return instanceId.Equals(encodedInstanceId, StringComparison.OrdinalIgnoreCase);
         }

--- a/src/DurableTask.AzureServiceFabric/Remote/DefaultStringPartitionHashing.cs
+++ b/src/DurableTask.AzureServiceFabric/Remote/DefaultStringPartitionHashing.cs
@@ -31,7 +31,7 @@ namespace DurableTask.AzureServiceFabric.Remote
             long hashCode = 0;
             if (!string.IsNullOrEmpty(value))
             {
-                using (var sha256 = SHA256Managed.Create())
+                using (var sha256 = SHA256.Create())
                 {
                     var bytes = Encoding.UTF8.GetBytes(value);
                     var hash = sha256.ComputeHash(bytes);

--- a/src/DurableTask.AzureServiceFabric/Remote/RemoteOrchestrationServiceClient.cs
+++ b/src/DurableTask.AzureServiceFabric/Remote/RemoteOrchestrationServiceClient.cs
@@ -18,11 +18,10 @@ namespace DurableTask.AzureServiceFabric.Remote
     using System.Linq;
     using System.Net;
     using System.Net.Http;
-    using System.Net.Http.Formatting;
     using System.Net.Sockets;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
-    using System.Web;
 
     using DurableTask.Core;
     using DurableTask.Core.Exceptions;
@@ -31,7 +30,6 @@ namespace DurableTask.AzureServiceFabric.Remote
 
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
-    using System.Web.Http.Results;
 
     /// <summary>
     /// Allows to interact with a remote IOrchestrationServiceClient
@@ -115,7 +113,7 @@ namespace DurableTask.AzureServiceFabric.Remote
         {
             instanceId.EnsureValidInstanceId();
 
-            var fragment = $"{this.GetOrchestrationFragment(instanceId)}?reason={HttpUtility.UrlEncode(reason)}";
+            var fragment = $"{this.GetOrchestrationFragment(instanceId)}?reason={WebUtility.UrlEncode(reason)}";
             using (var response = await this.ExecuteRequestWithRetriesAsync(
                 instanceId,
                 async (baseUri) => await this.HttpClient.DeleteAsync(new Uri(baseUri, fragment)),
@@ -193,7 +191,11 @@ namespace DurableTask.AzureServiceFabric.Remote
             foreach (var endpoint in await this.GetAllEndpointsAsync(CancellationToken.None))
             {
                 var uri = $"{endpoint.ToString()}/{GetHistoryFragment()}";
-                var task = this.HttpClient.PostAsJsonAsync(uri, new PurgeOrchestrationHistoryParameters { ThresholdDateTimeUtc = thresholdDateTimeUtc, TimeRangeFilterType = timeRangeFilterType });
+                var task = this.HttpClient.PostAsync(uri,
+                    new StringContent(
+                        JsonConvert.SerializeObject(new PurgeOrchestrationHistoryParameters { ThresholdDateTimeUtc = thresholdDateTimeUtc, TimeRangeFilterType = timeRangeFilterType }),
+                        Encoding.UTF8,
+                        "application/json"));
                 allTasks.Add(task);
             }
 
@@ -303,21 +305,26 @@ namespace DurableTask.AzureServiceFabric.Remote
 
         private async Task PutJsonAsync(string instanceId, string fragment, object @object, CancellationToken cancellationToken)
         {
-            var mediaFormatter = new JsonMediaTypeFormatter()
-            {
-                SerializerSettings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All }
-            };
+            var jsonSettings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All };
+            var jsonContent = new StringContent(
+                JsonConvert.SerializeObject(@object, jsonSettings),
+                Encoding.UTF8,
+                "application/json");
 
             using (var result = await this.ExecuteRequestWithRetriesAsync(
                 instanceId,
-                async (baseUri) => await this.HttpClient.PutAsync(new Uri(baseUri, fragment), @object, mediaFormatter),
+                async (baseUri) => await this.HttpClient.PutAsync(new Uri(baseUri, fragment), jsonContent),
                 cancellationToken))
             {
 
                 // TODO: Improve exception handling
                 if (result.StatusCode == HttpStatusCode.Conflict)
                 {
-                    throw await (result.Content?.ReadAsAsync<OrchestrationAlreadyExistsException>() ?? Task.FromResult(new OrchestrationAlreadyExistsException()));
+                    var errorContent = await (result.Content?.ReadAsStringAsync() ?? Task.FromResult<string>(null));
+                    throw errorContent != null
+                        ? JsonConvert.DeserializeObject<OrchestrationAlreadyExistsException>(errorContent)
+                          ?? new OrchestrationAlreadyExistsException()
+                        : new OrchestrationAlreadyExistsException();
                 }
 
                 if (!result.IsSuccessStatusCode)

--- a/src/DurableTask.AzureServiceFabric/Service/ActivityLoggingMessageHandler.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/ActivityLoggingMessageHandler.cs
@@ -11,6 +11,7 @@
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
 
+#if NETFRAMEWORK
 namespace DurableTask.AzureServiceFabric.Service
 {
     using System;
@@ -47,3 +48,4 @@ namespace DurableTask.AzureServiceFabric.Service
         }
     }
 }
+#endif

--- a/src/DurableTask.AzureServiceFabric/Service/ActivityLoggingMiddleware.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/ActivityLoggingMiddleware.cs
@@ -1,0 +1,65 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+#if !NETFRAMEWORK
+namespace DurableTask.AzureServiceFabric.Service
+{
+    using System;
+    using System.Net;
+    using System.Threading.Tasks;
+
+    using DurableTask.AzureServiceFabric.Tracing;
+
+    using Microsoft.AspNetCore.Http;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// ASP.NET Core middleware for activity logging of proxy service requests.
+    /// </summary>
+    internal class ActivityLoggingMiddleware
+    {
+        private readonly RequestDelegate next;
+
+        public ActivityLoggingMiddleware(RequestDelegate next)
+        {
+            this.next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            string requestMethod = context.Request.Method;
+            string requestPath = context.Request.Path.ToString();
+            string activityId = Guid.NewGuid().ToString("D");
+
+            ServiceFabricProviderEventSource.Tracing.LogProxyServiceRequestInformation(
+                $"{activityId} : Proxy service incoming request {requestPath} with method {requestMethod}");
+
+            try
+            {
+                await this.next(context);
+                ServiceFabricProviderEventSource.Tracing.LogProxyServiceRequestInformation(
+                    $"{activityId} : Proxy service responding request {requestPath} with method {requestMethod} with status code {context.Response.StatusCode}");
+            }
+            catch (Exception exception)
+            {
+                ServiceFabricProviderEventSource.Tracing.LogProxyServiceError(activityId, requestPath, requestMethod, exception);
+                context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+                context.Response.ContentType = "application/json";
+                await context.Response.WriteAsync(JsonConvert.SerializeObject(exception));
+            }
+
+            context.Response.Headers[Constants.ActivityIdHeaderName] = activityId;
+        }
+    }
+}
+#endif

--- a/src/DurableTask.AzureServiceFabric/Service/DefaultDependencyResolver.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/DefaultDependencyResolver.cs
@@ -11,6 +11,7 @@
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
 
+#if NETFRAMEWORK
 namespace DurableTask.AzureServiceFabric.Service
 {
     using System;
@@ -71,3 +72,4 @@ namespace DurableTask.AzureServiceFabric.Service
         #endregion
     }
 }
+#endif

--- a/src/DurableTask.AzureServiceFabric/Service/FabricOrchestrationServiceController.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/FabricOrchestrationServiceController.cs
@@ -16,11 +16,13 @@ namespace DurableTask.AzureServiceFabric.Service
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using System.Web.Http;
-    using System.Web.Http.Results;
     using DurableTask.AzureServiceFabric.Models;
     using DurableTask.Core;
     using DurableTask.Core.Exceptions;
+
+#if NETFRAMEWORK
+    using System.Web.Http;
+    using System.Web.Http.Results;
 
     /// <summary>
     /// A Web Api controller that provides TaskHubClient operations.
@@ -185,4 +187,135 @@ namespace DurableTask.AzureServiceFabric.Service
             return new OkResult(this);
         }
     }
+#else
+    using Microsoft.AspNetCore.Mvc;
+
+    /// <summary>
+    /// An ASP.NET Core controller that provides TaskHubClient operations.
+    /// </summary>
+    [ApiController]
+    public class FabricOrchestrationServiceController : ControllerBase
+    {
+        private readonly IOrchestrationServiceClient orchestrationServiceClient;
+
+        /// <summary>
+        /// Creates an instance of FabricOrchestrationServiceController for given OrchestrationServiceClient
+        /// </summary>
+        /// <param name="orchestrationServiceClient">IOrchestrationServiceClient instance</param>
+        public FabricOrchestrationServiceController(IOrchestrationServiceClient orchestrationServiceClient)
+        {
+            this.orchestrationServiceClient = orchestrationServiceClient;
+        }
+
+        /// <summary>
+        /// Creates a task orchestration.
+        /// </summary>
+        [HttpPut("orchestrations/{orchestrationId}")]
+        public async Task<IActionResult> CreateTaskOrchestration([FromRoute] string orchestrationId, [FromBody] CreateTaskOrchestrationParameters parameters)
+        {
+            parameters.TaskMessage.OrchestrationInstance.InstanceId.EnsureValidInstanceId();
+            if (!orchestrationId.Equals(parameters.TaskMessage.OrchestrationInstance.InstanceId))
+            {
+                return BadRequest($"OrchestrationId from Uri {orchestrationId} doesn't match with the one from body {parameters.TaskMessage.OrchestrationInstance.InstanceId}");
+            }
+
+            try
+            {
+                if (parameters.DedupeStatuses == null)
+                {
+                    await this.orchestrationServiceClient.CreateTaskOrchestrationAsync(parameters.TaskMessage);
+                }
+                else
+                {
+                    await this.orchestrationServiceClient.CreateTaskOrchestrationAsync(parameters.TaskMessage, parameters.DedupeStatuses);
+                }
+
+                return Ok();
+            }
+            catch (OrchestrationAlreadyExistsException orchestrationAlreadyExistsException)
+            {
+                return Conflict(orchestrationAlreadyExistsException);
+            }
+            catch (NotSupportedException notSupportedException)
+            {
+                return BadRequest(notSupportedException.Message);
+            }
+        }
+
+        /// <summary>
+        /// Sends an orchestration message to TaskHubClient.
+        /// </summary>
+        [HttpPost("messages/{messageId}")]
+        public async Task<IActionResult> SendTaskOrchestrationMessage([FromRoute] long messageId, [FromBody] TaskMessage message)
+        {
+            if (messageId != message.SequenceNumber)
+            {
+                return Conflict();
+            }
+
+            message.OrchestrationInstance.InstanceId.EnsureValidInstanceId();
+            await this.orchestrationServiceClient.SendTaskOrchestrationMessageAsync(message);
+            return Ok();
+        }
+
+        /// <summary>
+        /// Sends an array of orchestration messages to TaskHubClient.
+        /// </summary>
+        [HttpPost("messages")]
+        public async Task<IActionResult> SendTaskOrchestrationMessageBatch([FromBody] TaskMessage[] messages)
+        {
+            await this.orchestrationServiceClient.SendTaskOrchestrationMessageBatchAsync(messages);
+            return Ok();
+        }
+
+        /// <summary>
+        /// Gets the state of orchestration.
+        /// </summary>
+        [HttpGet("orchestrations/{orchestrationId}")]
+        public async Task<IActionResult> GetOrchestrationState([FromRoute] string orchestrationId, [FromQuery] string executionId, [FromQuery] bool? allExecutions)
+        {
+            orchestrationId.EnsureValidInstanceId();
+            if (allExecutions.HasValue)
+            {
+                var states = await this.orchestrationServiceClient.GetOrchestrationStateAsync(orchestrationId, allExecutions.Value);
+                return Ok(states);
+            }
+
+            var state = await this.orchestrationServiceClient.GetOrchestrationStateAsync(orchestrationId, executionId);
+            return Ok(state);
+        }
+
+        /// <summary>
+        /// Terminates an orchestration.
+        /// </summary>
+        [HttpDelete("orchestrations/{orchestrationId}")]
+        public async Task<IActionResult> ForceTerminateTaskOrchestration([FromRoute] string orchestrationId, [FromQuery] string reason)
+        {
+            orchestrationId.EnsureValidInstanceId();
+            await this.orchestrationServiceClient.ForceTerminateTaskOrchestrationAsync(orchestrationId, reason);
+            return Ok();
+        }
+
+        /// <summary>
+        /// Gets the history of orchestration.
+        /// </summary>
+        [HttpGet("history/{orchestrationId}")]
+        public async Task<IActionResult> GetOrchestrationHistory([FromRoute] string orchestrationId, [FromQuery] string executionId)
+        {
+            orchestrationId.EnsureValidInstanceId();
+            var result = await this.orchestrationServiceClient.GetOrchestrationHistoryAsync(orchestrationId, executionId);
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Purges orchestration instance state and history for orchestrations older than the specified threshold time.
+        /// </summary>
+        [HttpPost("history")]
+        public async Task<IActionResult> PurgeOrchestrationHistory([FromBody] PurgeOrchestrationHistoryParameters purgeParameters)
+        {
+            await this.orchestrationServiceClient.PurgeOrchestrationHistoryAsync(purgeParameters.ThresholdDateTimeUtc, purgeParameters.TimeRangeFilterType);
+            return Ok();
+        }
+    }
+#endif
 }

--- a/src/DurableTask.AzureServiceFabric/Service/IOwinAppBuilder.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/IOwinAppBuilder.cs
@@ -11,6 +11,7 @@
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
 
+#if NETFRAMEWORK
 namespace DurableTask.AzureServiceFabric.Service
 {
     using Owin;
@@ -34,3 +35,4 @@ namespace DurableTask.AzureServiceFabric.Service
         void Startup(IAppBuilder appBuilder);
     }
 }
+#endif

--- a/src/DurableTask.AzureServiceFabric/Service/OwinCommunicationListener.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/OwinCommunicationListener.cs
@@ -11,6 +11,7 @@
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
 
+#if NETFRAMEWORK
 namespace DurableTask.AzureServiceFabric.Service
 {
     using System;
@@ -106,3 +107,4 @@ namespace DurableTask.AzureServiceFabric.Service
         }
     }
 }
+#endif

--- a/src/DurableTask.AzureServiceFabric/Service/ProxyServiceExceptionHandler.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/ProxyServiceExceptionHandler.cs
@@ -11,6 +11,7 @@
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
 
+#if NETFRAMEWORK
 namespace DurableTask.AzureServiceFabric.Service
 {
     using System;
@@ -36,3 +37,4 @@ namespace DurableTask.AzureServiceFabric.Service
         }
     }
 }
+#endif

--- a/src/DurableTask.AzureServiceFabric/Service/ProxyServiceExceptionLogger.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/ProxyServiceExceptionLogger.cs
@@ -11,6 +11,7 @@
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
 
+#if NETFRAMEWORK
 namespace DurableTask.AzureServiceFabric.Service
 {
     using System;
@@ -34,3 +35,4 @@ namespace DurableTask.AzureServiceFabric.Service
         }
     }
 }
+#endif

--- a/src/DurableTask.AzureServiceFabric/Service/Startup.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/Startup.cs
@@ -14,13 +14,13 @@
 namespace DurableTask.AzureServiceFabric.Service
 {
     using System;
+    using DurableTask.Core;
+    using Microsoft.Extensions.DependencyInjection;
+
+#if NETFRAMEWORK
     using System.Net;
     using System.Web.Http;
     using System.Web.Http.ExceptionHandling;
-
-    using DurableTask.Core;
-    using DurableTask.AzureServiceFabric;
-    using Microsoft.Extensions.DependencyInjection;
     using Owin;
 
     class Startup : IOwinAppBuilder
@@ -64,4 +64,33 @@ namespace DurableTask.AzureServiceFabric.Service
             appBuilder.UseWebApi(config);
         }
     }
+#else
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Newtonsoft.Json;
+
+    class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddSingleton<IOrchestrationServiceClient>(sp =>
+                sp.GetRequiredService<FabricOrchestrationProvider>().OrchestrationServiceClient);
+            services.AddControllers()
+                .AddNewtonsoftJson(options =>
+                {
+                    options.SerializerSettings.TypeNameHandling = TypeNameHandling.All;
+                });
+        }
+
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            app.UseMiddleware<ActivityLoggingMiddleware>();
+            app.UseRouting();
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+        }
+    }
+#endif
 }

--- a/src/DurableTask.AzureServiceFabric/Service/TaskHubProxyListener.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/TaskHubProxyListener.cs
@@ -29,6 +29,12 @@ namespace DurableTask.AzureServiceFabric.Service
     using Microsoft.ServiceFabric.Services.Communication.Runtime;
     using Microsoft.ServiceFabric.Services.Runtime;
 
+#if !NETFRAMEWORK
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.ServiceFabric.Services.Communication.AspNetCore;
+#endif
+
     /// <summary>
     /// Delegate invoked before starting the worker to register orchestrations.
     /// </summary>
@@ -150,6 +156,9 @@ namespace DurableTask.AzureServiceFabric.Service
         {
             return new ServiceReplicaListener(context =>
             {
+                EnsureFabricOrchestrationProviderIsInitialized();
+
+#if NETFRAMEWORK
                 var serviceEndpoint = context.CodePackageActivationContext.GetEndpoint(Constants.TaskHubProxyListenerEndpointName);
                 string ipAddress = context.NodeContext.IPAddressOrFQDN;
 #if DEBUG
@@ -158,12 +167,28 @@ namespace DurableTask.AzureServiceFabric.Service
                     address => (address.AddressFamily == AddressFamily.InterNetwork) && (!IPAddress.IsLoopback(address)));
                 ipAddress = ipv4Address.ToString();
 #endif
-
-                EnsureFabricOrchestrationProviderIsInitialized();
                 string protocol = this.enableHttps ? "https" : "http";
                 string listeningAddress = string.Format(CultureInfo.InvariantCulture, "{0}://{1}:{2}/{3}/dtfx/", protocol, ipAddress, serviceEndpoint.Port, context.PartitionId);
 
                 return new OwinCommunicationListener(new Startup(listeningAddress, this.fabricOrchestrationProvider));
+#else
+                var provider = this.fabricOrchestrationProvider;
+                return new KestrelCommunicationListener(context, Constants.TaskHubProxyListenerEndpointName, (url, listener) =>
+                {
+#pragma warning disable ASPDEPR004, ASPDEPR008 // WebHostBuilder is the required pattern for SF KestrelCommunicationListener
+                    return new WebHostBuilder()
+                        .UseKestrel()
+                        .ConfigureServices(services =>
+                        {
+                            services.AddSingleton<FabricOrchestrationProvider>(provider);
+                        })
+                        .UseStartup<Startup>()
+                        .UseServiceFabricIntegration(listener, ServiceFabricIntegrationOptions.UseUniqueServiceUrl)
+                        .UseUrls(url)
+                        .Build();
+#pragma warning restore ASPDEPR004, ASPDEPR008
+                });
+#endif
             }, Constants.TaskHubProxyServiceName);
         }
 

--- a/test/DurableTask.AzureServiceFabric.Integration.Tests/DeploymentUtil/DeploymentHelper.cs
+++ b/test/DurableTask.AzureServiceFabric.Integration.Tests/DeploymentUtil/DeploymentHelper.cs
@@ -54,7 +54,9 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests.DeploymentUtil
                     var replicas = (await client.QueryManager.GetDeployedReplicaListAsync(node.NodeName, application.ApplicationName)).OfType<DeployedStatefulServiceReplica>();
                     foreach (var replica in replicas)
                     {
+#pragma warning disable CS0618 // RemoveReplicaAsync overload is deprecated in newer SF SDK
                         await client.ServiceManager.RemoveReplicaAsync(node.NodeName, replica.Partitionid, replica.ReplicaId);
+#pragma warning restore CS0618
                     }
                 }
             }

--- a/test/DurableTask.AzureServiceFabric.Integration.Tests/DurableTask.AzureServiceFabric.Integration.Tests.csproj
+++ b/test/DurableTask.AzureServiceFabric.Integration.Tests/DurableTask.AzureServiceFabric.Integration.Tests.csproj
@@ -2,20 +2,23 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFrameworks>net48;net10.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>
-	<!-- Override the centrally managed version -->
-	<PackageReference Include="Microsoft.NET.Test.Sdk" VersionOverride="15.0.0" />
-	<PackageReference Include="MSTest.TestAdapter" VersionOverride="1.4.0" />
-	<PackageReference Include="MSTest.TestFramework" VersionOverride="1.4.0" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" />
+	<PackageReference Include="MSTest.TestAdapter" />
+	<PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="System.Collections.Immutable" VersionOverride="1.5.0" />
     <PackageReference Include="System.Net.Http" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Core" />
     <PackageReference Include="Moq" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+    <PackageReference Include="Microsoft.AspNet.WebApi.Core" />
+    <Reference Include="System.Web" />
   </ItemGroup>
 
   <ItemGroup>
@@ -23,10 +26,6 @@
     <ProjectReference Include="..\..\src\DurableTask.AzureServiceFabric\DurableTask.AzureServiceFabric.csproj" />
     <ProjectReference Include="..\DurableTask.Test.Orchestrations\DurableTask.Test.Orchestrations.csproj" />
     <ProjectReference Include="..\TestFabricApplication\TestApplication.Common\TestApplication.Common.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="System.Web" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DurableTask.AzureServiceFabric.Tests/DurableTask.AzureServiceFabric.Tests.csproj
+++ b/test/DurableTask.AzureServiceFabric.Tests/DurableTask.AzureServiceFabric.Tests.csproj
@@ -2,15 +2,15 @@
 
     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
     <PropertyGroup>
-        <TargetFramework>net48</TargetFramework>
+        <TargetFrameworks>net48;net10.0</TargetFrameworks>
         <Platforms>AnyCPU;x64</Platforms>
     </PropertyGroup>
 
     <ItemGroup>
-	<PackageReference Include="Microsoft.NET.Test.Sdk" VersionOverride="15.0.0" />
-	<PackageReference Include="MSTest.TestAdapter" VersionOverride="1.4.0" />
-	<PackageReference Include="MSTest.TestFramework" VersionOverride="1.4.0" />
-    <PackageReference Include="System.Collections.Immutable" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" />
+	<PackageReference Include="MSTest.TestAdapter" />
+	<PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="System.Collections.Immutable" VersionOverride="1.5.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/TestFabricApplication/TestApplication.Common/TestApplication.Common.csproj
+++ b/test/TestFabricApplication/TestApplication.Common/TestApplication.Common.csproj
@@ -1,12 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net472</TargetFrameworks>
+    <TargetFrameworks>net48;net472;net10.0</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'net472'">
     <PackageReference Include="Microsoft.Owin.Hosting" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric" />
     <PackageReference Include="Microsoft.ServiceFabric.Services" />
   </ItemGroup>


### PR DESCRIPTION
Multi-target the Service Fabric provider to support net48, net472, net8.0, and net10.0. On modern .NET, the OWIN/Web API HTTP layer is replaced with ASP.NET Core Controllers + Kestrel via the official Microsoft.ServiceFabric.AspNetCore.Kestrel integration package.

Key changes:
- Update SF SDK from 6.4.617 to 8.3.475/11.3.475
- Add conditional compilation (#if NETFRAMEWORK / NET6_0_OR_GREATER) for framework-specific code paths
- Replace OWIN + Web API with ASP.NET Core on modern .NET:
  - KestrelCommunicationListener replaces OwinCommunicationListener
  - ASP.NET Core ControllerBase replaces Web API ApiController
  - ActivityLoggingMiddleware replaces ActivityLoggingMessageHandler
  - Built-in DI replaces DefaultDependencyResolver
- Fix cross-platform API usage:
  - HttpUtility.UrlEncode -> WebUtility.UrlEncode
  - SHA256Managed -> SHA256.Create()
  - JsonMediaTypeFormatter -> direct Newtonsoft.Json serialization
- Update test projects to also target net10.0
- Bump Newtonsoft.Json to 13.0.3 for ASP.NET Core compatibility

Existing net48/net472 behavior is fully preserved.