### PR TITLE
Update README to clarify DTFx as a legacy library

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 The Durable Task Framework (DTFx) is a library that allows users to write long running persistent workflows (referred to as _orchestrations_) in C# using simple async/await coding constructs. While it provides similar orchestration primitives to the modern Durable Task SDKs, it predates them and doesn't include the latest features or official Microsoft support. It also requires you to manage hosting, operational infrastructure, and long-term maintenance yourself.
 
-> **📖 Documentation:** Comprehensive documentation is available in the [docs](./docs/README.md) folder. The [GitHub Wiki](https://github.com/Azure/durabletask/wiki) is no longer actively maintained — please refer to the docs folder for up-to-date content.
+> **📖 Documentation:** Legacy documentation for this repository is available in the [docs](./docs/README.md) folder. Note that these docs are no longer maintained.
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 
@@ -38,7 +38,6 @@ The core programming model for the Durable Task Framework is contained in the [D
 
 There are several places where you can learn more about this framework. Note that some are external and not owned by Microsoft:
 
-- [This repo's wiki](https://github.com/Azure/durabletask/wiki), which contains more details about the framework and how it can be used.
 - The following blog series contains useful information: https://abhikmitra.github.io/blog/durable-task/
 - Several useful samples are available here: https://github.com/kaushiksk/durabletask-samples
 - You can watch a video with some of the original maintainers in [Building Workflows with the Durable Task Framework](https://learn.microsoft.com/shows/on-net/building-workflows-with-the-durable-task-framework).


### PR DESCRIPTION
This pull request updates the `README.md` to clarify the support status of the Durable Task Framework (DTFx) and guide users toward modern, supported alternatives. It also improves documentation clarity around legacy components and removes outdated references.

Key documentation and guidance updates:

**Deprecation and support status:**
* Added a prominent notice that DTFx is a legacy library, not officially supported by Microsoft, and recommended alternatives such as Durable Functions and Durable Task SDKs with the Durable Task Scheduler backend.

**Clarifications and documentation improvements:**
* Updated the documentation section to indicate that the docs are legacy and no longer maintained.
* Added a note clarifying that `DurableTask.Emulator` is a legacy in-memory backend for DTFx and is not the same as the supported Durable Task Scheduler emulator.
* Removed references to the unmaintained GitHub wiki to prevent confusion. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L26-L32)