### PR TITLE
Log ScheduledEnqueueTimeUtc for timer messages in SentMessageLog

### DIFF
--- a/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
+++ b/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
@@ -1580,7 +1580,7 @@ namespace DurableTask.ServiceBus
                 "ServiceBusOrchestrationService-SentMessageLog",
                 session.SessionId,
             GetFormattedLog($@"{messages.Count.ToString()} messages queued for {messageType}: {
-                        string.Join(",", messages.Select(m => $"{m.Message.MessageId} <{m.Action?.Event.EventId.ToString()}>"))}"));
+                        string.Join(",", messages.Select(m => $"{m.Message.MessageId} <{m.Action?.Event.EventId.ToString()}>{(m.Message.ScheduledEnqueueTimeUtc > DateTime.MinValue ? $" ScheduledEnqueueTimeUtc:{m.Message.ScheduledEnqueueTimeUtc:O}" : "")}"))}"));
         }
 
         async Task<OrchestrationRuntimeState> GetSessionStateAsync(IMessageSession session, IOrchestrationServiceBlobStore orchestrationServiceBlobStore)


### PR DESCRIPTION
## Problem

When DurableTask creates a timer (\CreateTimer\ orchestrator action), the \ScheduledEnqueueTimeUtc\ is set on the Service Bus message but **never logged to telemetry**. This makes it difficult to investigate orchestration stalls caused by lost or delayed scheduled messages — investigators must infer the expected fire time from orchestration parameters (\BillingPeriod\, \TimeShift\, previous \TimerFired\ timestamps).

## Context

Two Sev2 incidents ([IcM 761467738](https://portal.microsofticm.com/imp/v3/incidents/details/761467738), [IcM 758301760](https://portal.microsofticm.com/imp/v3/incidents/details/758301760)) involved Service Bus scheduled messages that were committed successfully but **never delivered**, causing billing eternal orchestrations to stall silently for 16–24 hours. Investigation required multiple rounds of Kusto queries across \DurableTask\, \Billing\, \Orchestration\, and \TaskHubKpiRaw\ tables to infer the expected fire time and confirm the message was lost.

## Solution

Add the \ScheduledEnqueueTimeUtc\ to the existing \ServiceBusOrchestrationService-SentMessageLog\ trace event for timer messages. Non-timer messages (worker, sub-orchestration) are unaffected since their \ScheduledEnqueueTimeUtc\ is \DateTime.MinValue\ and is omitted from the log.

**Before:**
\\\
1 messages queued for Timer Message: abc123 <-1>
\\\

**After:**
\\\
1 messages queued for Timer Message: abc123 <-1> ScheduledEnqueueTimeUtc:2026-03-12T03:04:00.0000000Z
\\\

## Change

Single line change in \LogSentMessages()\ in \ServiceBusOrchestrationService.cs\ — appends the scheduled time when present.

## Testing

- Build succeeds with 0 warnings, 0 errors
- No behavior change — logging only
- Non-timer messages unaffected (\ScheduledEnqueueTimeUtc == DateTime.MinValue\ is filtered out)