### PR TITLE
Adding new logic for extended sessions to enable the DTS use-case

### DIFF
--- a/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
+++ b/src/DurableTask.AzureStorage/Messaging/OrchestrationSession.cs
@@ -18,7 +18,6 @@ namespace DurableTask.AzureStorage.Messaging
     using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
-    using Azure;
     using DurableTask.Core;
     using DurableTask.Core.History;
     using Newtonsoft.Json;
@@ -233,6 +232,12 @@ namespace DurableTask.AzureStorage.Messaging
         bool IsNonexistantInstance()
         {
             return this.RuntimeState.Events.Count == 0 || this.RuntimeState.ExecutionStartedEvent == null;
+        }
+
+        public Task EndSessionAsync()
+        {
+            // No-op
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/DurableTask.Core/IOrchestrationSession.cs
+++ b/src/DurableTask.Core/IOrchestrationSession.cs
@@ -11,6 +11,7 @@
 //  limitations under the License.
 //  ----------------------------------------------------------------------------------
 
+#nullable enable
 namespace DurableTask.Core
 {
     using System.Collections.Generic;
@@ -30,5 +31,11 @@ namespace DurableTask.Core
         /// and the dispatcher will shut down the session.
         /// </remarks>
         Task<IList<TaskMessage>> FetchNewOrchestrationMessagesAsync(TaskOrchestrationWorkItem workItem);
+
+        /// <summary>
+        /// Ends the session.
+        /// </summary>
+        /// <returns>A task that completes when the session has been ended.</returns>
+        Task EndSessionAsync();
     }
 }

--- a/src/DurableTask.Core/IOrchestrationSession.cs
+++ b/src/DurableTask.Core/IOrchestrationSession.cs
@@ -30,7 +30,7 @@ namespace DurableTask.Core
         /// or until an internal wait period has expired. In either case, <c>null</c> can be returned
         /// and the dispatcher will shut down the session.
         /// </remarks>
-        Task<IList<TaskMessage>> FetchNewOrchestrationMessagesAsync(TaskOrchestrationWorkItem workItem);
+        Task<IList<TaskMessage>?> FetchNewOrchestrationMessagesAsync(TaskOrchestrationWorkItem workItem);
 
         /// <summary>
         /// Ends the session.

--- a/src/DurableTask.Core/TaskEntityDispatcher.cs
+++ b/src/DurableTask.Core/TaskEntityDispatcher.cs
@@ -193,6 +193,7 @@ namespace DurableTask.Core
                     if (concurrencyLockAcquired)
                     {
                         this.concurrentSessionLock.Release();
+                        await workItem.Session.EndSessionAsync();
                     }
                 }
             }

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -295,6 +295,7 @@ namespace DurableTask.Core
                             "OnProcessWorkItemSession-Release",
                             $"Releasing extended session after {processCount} batch(es).");
                         this.concurrentSessionLock.Release();
+                        await workItem.Session.EndSessionAsync();
                     }
                 }
             }
@@ -553,10 +554,6 @@ namespace DurableTask.Core
                                     orchestratorMessages.AddRange(subOrchestrationRewindMessages);
                                     workItem.OrchestrationRuntimeState = newRuntimeState;
                                     runtimeState = newRuntimeState;
-                                    // Setting this to true here will end an extended session if it is in progress.
-                                    // We don't want to save the state across executions, since we essentially manually modify
-                                    // the orchestration history here and so that stored by the extended session is incorrect.
-                                    isRewinding = true;
                                     break;
                                 default:
                                     throw TraceHelper.TraceExceptionInstance(


### PR DESCRIPTION
This PR introduces new logic in the extended sessions flow that is necessary for the DTS use-case. In particular, it introduces a new `EndSessionAsync` call which will allow DTS to release the work item once the extended session ends.