### PR TITLE
Add ContinueAsNew fresh-trace support for periodic orchestrations

### DIFF
--- a/Test/DurableTask.Core.Tests/ContinueAsNewTraceBehaviorTests.cs
+++ b/Test/DurableTask.Core.Tests/ContinueAsNewTraceBehaviorTests.cs
@@ -125,8 +125,8 @@ namespace DurableTask.Core.Tests
             serializer.WriteObject(stream, currentEvent);
 
             string json = Encoding.UTF8.GetString(stream.ToArray())
-                .Replace(",\"GenerateNewTrace\":false", string.Empty, StringComparison.Ordinal)
-                .Replace("\"GenerateNewTrace\":false,", string.Empty, StringComparison.Ordinal);
+                .Replace(",\"GenerateNewTrace\":false", string.Empty)
+                .Replace("\"GenerateNewTrace\":false,", string.Empty);
 
             using var oldPayload = new MemoryStream(Encoding.UTF8.GetBytes(json));
             var deserialized = (ExecutionStartedEvent?)serializer.ReadObject(oldPayload);

--- a/Test/DurableTask.Core.Tests/ContinueAsNewTraceBehaviorTests.cs
+++ b/Test/DurableTask.Core.Tests/ContinueAsNewTraceBehaviorTests.cs
@@ -14,6 +14,7 @@ namespace DurableTask.Core.Tests
     using System.IO;
     using System.Linq;
     using System.Runtime.Serialization.Json;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -113,7 +114,7 @@ namespace DurableTask.Core.Tests
         {
             // An event serialized without GenerateNewTrace should deserialize with false.
             // This simulates loading a pre-upgrade event from storage.
-            var oldEvent = new ExecutionStartedEvent(-1, "input")
+            var currentEvent = new ExecutionStartedEvent(-1, "input")
             {
                 OrchestrationInstance = new OrchestrationInstance { InstanceId = "test", ExecutionId = "exec1" },
                 Name = "TestOrch",
@@ -121,10 +122,14 @@ namespace DurableTask.Core.Tests
 
             var serializer = new DataContractJsonSerializer(typeof(ExecutionStartedEvent));
             using var stream = new MemoryStream();
-            serializer.WriteObject(stream, oldEvent);
+            serializer.WriteObject(stream, currentEvent);
 
-            stream.Position = 0;
-            var deserialized = (ExecutionStartedEvent?)serializer.ReadObject(stream);
+            string json = Encoding.UTF8.GetString(stream.ToArray())
+                .Replace(",\"GenerateNewTrace\":false", string.Empty, StringComparison.Ordinal)
+                .Replace("\"GenerateNewTrace\":false,", string.Empty, StringComparison.Ordinal);
+
+            using var oldPayload = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            var deserialized = (ExecutionStartedEvent?)serializer.ReadObject(oldPayload);
 
             Assert.IsNotNull(deserialized);
             Assert.IsFalse(deserialized.GenerateNewTrace, "Pre-upgrade events should default to false");
@@ -395,6 +400,37 @@ namespace DurableTask.Core.Tests
 
             activity.Stop();
             DistributedTraceActivity.Current = null;
+        }
+
+        [TestMethod]
+        public void TraceHelper_DoesNotConsumeFreshTraceSignals_WhenProducerActivityIsSuppressed()
+        {
+            listener?.Dispose();
+            listener = new ActivityListener
+            {
+                ShouldListenTo = source => source.Name == "DurableTask.Core",
+                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.None,
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var startEvent = new ExecutionStartedEvent(-1, "input")
+            {
+                GenerateNewTrace = true,
+                OrchestrationInstance = new OrchestrationInstance { InstanceId = "test-suppressed", ExecutionId = "exec1" },
+                Name = "TestOrch",
+                Tags = new Dictionary<string, string>
+                {
+                    [OrchestrationTags.CreateTraceForNewOrchestration] = "true",
+                },
+            };
+
+            Activity? activity = TraceHelper.StartTraceActivityForOrchestrationExecution(startEvent);
+
+            Assert.IsNull(activity, "No activity should be created when the producer span is suppressed");
+            Assert.IsTrue(startEvent.GenerateNewTrace, "GenerateNewTrace should remain for replay");
+            Assert.IsTrue(startEvent.Tags.ContainsKey(OrchestrationTags.CreateTraceForNewOrchestration),
+                "Legacy trace-creation tag should remain for replay");
+            Assert.IsNull(startEvent.ParentTraceContext, "No trace identity should be persisted when no producer span exists");
         }
 
         #endregion

--- a/Test/DurableTask.Core.Tests/ContinueAsNewTraceBehaviorTests.cs
+++ b/Test/DurableTask.Core.Tests/ContinueAsNewTraceBehaviorTests.cs
@@ -1,0 +1,486 @@
+// ---------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ---------------------------------------------------------------
+#nullable enable
+namespace DurableTask.Core.Tests
+{
+    using DurableTask.Core.Command;
+    using DurableTask.Core.History;
+    using DurableTask.Core.Tracing;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
+    using System.Runtime.Serialization.Json;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Tests for the ContinueAsNew fresh-trace feature.
+    ///
+    /// Background: Long-running periodic orchestrations that use ContinueAsNew accumulate all
+    /// generations into a single distributed trace, making individual cycles hard to observe.
+    /// This feature adds an opt-in <see cref="ContinueAsNewTraceBehavior.StartNewTrace"/> option
+    /// that starts the next generation in a fresh trace while preserving the default lineage
+    /// behavior for existing users.
+    ///
+    /// The trace identity lifecycle:
+    ///   1. Orchestrator calls ContinueAsNew(version, input, options) with StartNewTrace.
+    ///   2. Dispatcher creates the next ExecutionStartedEvent with GenerateNewTrace = true
+    ///      and does NOT copy the old ParentTraceContext.
+    ///   3. TraceHelper.StartTraceActivityForOrchestrationExecution sees GenerateNewTrace,
+    ///      creates a fresh root producer span, stores its identity in ParentTraceContext,
+    ///      and resets GenerateNewTrace = false.
+    ///   4. On subsequent replays, GenerateNewTrace is false and the persisted ParentTraceContext
+    ///      identity is used — ensuring stable span identity across replays.
+    /// </summary>
+    [TestClass]
+    public class ContinueAsNewTraceBehaviorTests
+    {
+        private ActivityListener? listener;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            // Set up an ActivityListener so System.Diagnostics.Activity spans are actually created.
+            listener = new ActivityListener
+            {
+                ShouldListenTo = source => source.Name == "DurableTask.Core",
+                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
+            };
+            ActivitySource.AddActivityListener(listener);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            DistributedTraceActivity.Current?.Stop();
+            DistributedTraceActivity.Current = null;
+            listener?.Dispose();
+        }
+
+        #region ExecutionStartedEvent.GenerateNewTrace property
+
+        [TestMethod]
+        public void GenerateNewTrace_DefaultIsFalse()
+        {
+            // A new event should default to false so existing behavior is unchanged.
+            var evt = new ExecutionStartedEvent(-1, "input");
+            Assert.IsFalse(evt.GenerateNewTrace);
+        }
+
+        [TestMethod]
+        public void GenerateNewTrace_CopyConstructorPreservesValue()
+        {
+            var original = new ExecutionStartedEvent(-1, "input")
+            {
+                GenerateNewTrace = true,
+                OrchestrationInstance = new OrchestrationInstance { InstanceId = "test", ExecutionId = "exec1" },
+                Name = "TestOrch",
+            };
+
+            var copy = new ExecutionStartedEvent(original);
+            Assert.IsTrue(copy.GenerateNewTrace, "Copy constructor should preserve GenerateNewTrace = true");
+        }
+
+        [TestMethod]
+        public void GenerateNewTrace_SurvivesJsonSerialization()
+        {
+            // GenerateNewTrace must survive serialization because the event is persisted
+            // to storage and must signal TraceHelper on the first execution.
+            var original = new ExecutionStartedEvent(-1, "input")
+            {
+                GenerateNewTrace = true,
+                OrchestrationInstance = new OrchestrationInstance { InstanceId = "test", ExecutionId = "exec1" },
+                Name = "TestOrch",
+            };
+
+            var serializer = new DataContractJsonSerializer(typeof(ExecutionStartedEvent));
+            using var stream = new MemoryStream();
+            serializer.WriteObject(stream, original);
+
+            stream.Position = 0;
+            var deserialized = (ExecutionStartedEvent?)serializer.ReadObject(stream);
+
+            Assert.IsNotNull(deserialized);
+            Assert.IsTrue(deserialized.GenerateNewTrace, "GenerateNewTrace should survive JSON round-trip");
+        }
+
+        [TestMethod]
+        public void GenerateNewTrace_FalseByDefault_BackwardCompatible()
+        {
+            // An event serialized without GenerateNewTrace should deserialize with false.
+            // This simulates loading a pre-upgrade event from storage.
+            var oldEvent = new ExecutionStartedEvent(-1, "input")
+            {
+                OrchestrationInstance = new OrchestrationInstance { InstanceId = "test", ExecutionId = "exec1" },
+                Name = "TestOrch",
+            };
+
+            var serializer = new DataContractJsonSerializer(typeof(ExecutionStartedEvent));
+            using var stream = new MemoryStream();
+            serializer.WriteObject(stream, oldEvent);
+
+            stream.Position = 0;
+            var deserialized = (ExecutionStartedEvent?)serializer.ReadObject(stream);
+
+            Assert.IsNotNull(deserialized);
+            Assert.IsFalse(deserialized.GenerateNewTrace, "Pre-upgrade events should default to false");
+        }
+
+        #endregion
+
+        #region Tag isolation — GenerateNewTrace does NOT leak through tags
+
+        [TestMethod]
+        public void GenerateNewTrace_DoesNotAppearInTags()
+        {
+            // The property-based approach should never pollute the customer-facing Tags dictionary.
+            var evt = new ExecutionStartedEvent(-1, "input")
+            {
+                GenerateNewTrace = true,
+                Tags = new Dictionary<string, string> { { "user-tag", "value" } },
+                OrchestrationInstance = new OrchestrationInstance { InstanceId = "test", ExecutionId = "exec1" },
+                Name = "TestOrch",
+            };
+
+            Assert.IsFalse(evt.Tags.ContainsKey("MS_CreateTrace"),
+                "GenerateNewTrace should use a typed property, not a tag");
+            Assert.IsFalse(evt.Tags.ContainsKey("GenerateNewTrace"),
+                "GenerateNewTrace should not appear as a tag");
+        }
+
+        [TestMethod]
+        public void GenerateNewTrace_DoesNotLeakThroughTagCloning()
+        {
+            // This is the key test for the tag-leak bug found during review.
+            // GenerateNewTrace is a property, not a tag, so it cannot leak through tag cloning.
+            var genNTags = new Dictionary<string, string> { { "app-tag", "hello" } };
+
+            // Simulate dispatcher creating Gen N+1's event with StartNewTrace
+            var genN1Event = new ExecutionStartedEvent(-1, "input")
+            {
+                Tags = new Dictionary<string, string>(genNTags), // clone of Gen N's tags
+                GenerateNewTrace = true,
+                OrchestrationInstance = new OrchestrationInstance { InstanceId = "test", ExecutionId = "exec1" },
+                Name = "TestOrch",
+            };
+
+            // Simulate Gen N+1 doing a default ContinueAsNew (no StartNewTrace).
+            // Dispatcher clones Gen N+1's tags but sets GenerateNewTrace from the action (false).
+            var genN2Tags = new Dictionary<string, string>(genN1Event.Tags);
+            var genN2Event = new ExecutionStartedEvent(-1, "input")
+            {
+                Tags = genN2Tags,
+                GenerateNewTrace = false, // from the action, not inherited
+                OrchestrationInstance = new OrchestrationInstance { InstanceId = "test", ExecutionId = "exec2" },
+                Name = "TestOrch",
+            };
+
+            Assert.IsFalse(genN2Event.GenerateNewTrace,
+                "GenerateNewTrace must not leak to subsequent generations through tag cloning");
+            Assert.AreEqual(1, genN2Event.Tags.Count, "Only application tags should be present");
+        }
+
+        #endregion
+
+        #region OrchestrationCompleteOrchestratorAction
+
+        [TestMethod]
+        public void Action_ContinueAsNewTraceBehavior_DefaultIsPreserve()
+        {
+            var action = new OrchestrationCompleteOrchestratorAction();
+            Assert.AreEqual(ContinueAsNewTraceBehavior.PreserveTraceContext, action.ContinueAsNewTraceBehavior);
+        }
+
+        [TestMethod]
+        public void Action_ContinueAsNewTraceBehavior_CanBeSetToStartNewTrace()
+        {
+            var action = new OrchestrationCompleteOrchestratorAction
+            {
+                ContinueAsNewTraceBehavior = ContinueAsNewTraceBehavior.StartNewTrace,
+            };
+            Assert.AreEqual(ContinueAsNewTraceBehavior.StartNewTrace, action.ContinueAsNewTraceBehavior);
+        }
+
+        #endregion
+
+        #region TraceHelper — GenerateNewTrace consumption and trace creation
+
+        [TestMethod]
+        public void TraceHelper_GenerateNewTrace_CreatesNewRootTrace()
+        {
+            // When GenerateNewTrace=true and no ParentTraceContext, TraceHelper should create
+            // a fresh producer span (new root trace) and then create the orchestration span.
+            var startEvent = new ExecutionStartedEvent(-1, "input")
+            {
+                GenerateNewTrace = true,
+                OrchestrationInstance = new OrchestrationInstance { InstanceId = "test", ExecutionId = "exec1" },
+                Name = "TestOrch",
+            };
+
+            Activity? activity = TraceHelper.StartTraceActivityForOrchestrationExecution(startEvent);
+
+            Assert.IsNotNull(activity, "Should create an orchestration activity for fresh trace");
+            Assert.IsFalse(startEvent.GenerateNewTrace, "GenerateNewTrace should be reset after consumption");
+            Assert.IsNotNull(startEvent.ParentTraceContext, "ParentTraceContext should be set by the producer span");
+            Assert.IsNotNull(startEvent.ParentTraceContext.Id, "Durable Id should be stored for replay");
+            Assert.IsNotNull(startEvent.ParentTraceContext.SpanId, "Durable SpanId should be stored for replay");
+
+            activity.Stop();
+            DistributedTraceActivity.Current = null;
+        }
+
+        [TestMethod]
+        public void TraceHelper_GenerateNewTrace_ReplayUsesPersistedIdentity()
+        {
+            // Simulates: first execution creates a fresh trace and persists identity.
+            // Subsequent replay loads the event with GenerateNewTrace=false and persisted
+            // Id/SpanId. The orchestration span should restore the same identity.
+            var startEvent = new ExecutionStartedEvent(-1, "input")
+            {
+                GenerateNewTrace = true,
+                OrchestrationInstance = new OrchestrationInstance { InstanceId = "test", ExecutionId = "exec1" },
+                Name = "TestOrch",
+            };
+
+            // First execution — creates fresh trace
+            Activity? firstActivity = TraceHelper.StartTraceActivityForOrchestrationExecution(startEvent);
+            Assert.IsNotNull(firstActivity);
+
+            string firstTraceId = firstActivity.TraceId.ToString();
+            string firstSpanId = firstActivity.SpanId.ToString();
+
+            firstActivity.Stop();
+            DistributedTraceActivity.Current = null;
+
+            // Simulate replay — GenerateNewTrace was reset, Id/SpanId persisted
+            Assert.IsFalse(startEvent.GenerateNewTrace);
+
+            Activity? replayActivity = TraceHelper.StartTraceActivityForOrchestrationExecution(startEvent);
+            Assert.IsNotNull(replayActivity);
+            Assert.AreEqual(firstTraceId, replayActivity.TraceId.ToString(),
+                "Replay should use the same trace ID from the persisted identity");
+            Assert.AreEqual(firstSpanId, replayActivity.SpanId.ToString(),
+                "Replay should use the same span ID from the persisted identity");
+
+            replayActivity.Stop();
+            DistributedTraceActivity.Current = null;
+        }
+
+        [TestMethod]
+        public void TraceHelper_PreserveTrace_NullParentReturnsNull()
+        {
+            // Default behavior: GenerateNewTrace=false and no ParentTraceContext → no activity.
+            var startEvent = new ExecutionStartedEvent(-1, "input")
+            {
+                GenerateNewTrace = false,
+                OrchestrationInstance = new OrchestrationInstance { InstanceId = "test", ExecutionId = "exec1" },
+                Name = "TestOrch",
+            };
+
+            Activity? activity = TraceHelper.StartTraceActivityForOrchestrationExecution(startEvent);
+            Assert.IsNull(activity, "No activity should be created when there's no parent trace context");
+        }
+
+        [TestMethod]
+        public void TraceHelper_GenerateNewTrace_ProducesNewTraceId_NotInheritedFromAmbient()
+        {
+            // Verify the fresh trace gets a genuinely new trace ID, not inherited from ambient.
+            using var ambientActivity = new Activity("ambient-parent");
+            ambientActivity.SetIdFormat(ActivityIdFormat.W3C);
+            ambientActivity.Start();
+            string ambientTraceId = ambientActivity.TraceId.ToString();
+
+            var startEvent = new ExecutionStartedEvent(-1, "input")
+            {
+                GenerateNewTrace = true,
+                OrchestrationInstance = new OrchestrationInstance { InstanceId = "test", ExecutionId = "exec1" },
+                Name = "TestOrch",
+            };
+
+            // Stop ambient before calling TraceHelper (mirrors real dispatcher behavior
+            // where the previous generation's activity is stopped before the next starts)
+            ambientActivity.Stop();
+
+            Activity? activity = TraceHelper.StartTraceActivityForOrchestrationExecution(startEvent);
+            Assert.IsNotNull(activity);
+            Assert.AreNotEqual(ambientTraceId, activity.TraceId.ToString(),
+                "Fresh trace should NOT inherit the ambient trace ID");
+
+            activity.Stop();
+            DistributedTraceActivity.Current = null;
+        }
+
+        #endregion
+
+        #region TaskOrchestrationContext — ContinueAsNew overloads
+
+        [TestMethod]
+        public void Context_ContinueAsNew_WithStartNewTrace_SetsTraceBehavior()
+        {
+            var instance = new OrchestrationInstance { InstanceId = "test", ExecutionId = Guid.NewGuid().ToString() };
+            var context = new TestableTaskOrchestrationContext(instance, TaskScheduler.Default);
+
+            context.ContinueAsNew(null, "test-input", new ContinueAsNewOptions
+            {
+                TraceBehavior = ContinueAsNewTraceBehavior.StartNewTrace,
+            });
+
+            // Verify the pending action has the correct trace behavior
+            var actions = context.GetActions();
+            Assert.AreEqual(1, actions.Count);
+            var completeAction = (OrchestrationCompleteOrchestratorAction)actions[0];
+            Assert.AreEqual(OrchestrationStatus.ContinuedAsNew, completeAction.OrchestrationStatus);
+            Assert.AreEqual(ContinueAsNewTraceBehavior.StartNewTrace, completeAction.ContinueAsNewTraceBehavior);
+        }
+
+        [TestMethod]
+        public void Context_ContinueAsNew_Default_PreservesTrace()
+        {
+            var instance = new OrchestrationInstance { InstanceId = "test", ExecutionId = Guid.NewGuid().ToString() };
+            var context = new TestableTaskOrchestrationContext(instance, TaskScheduler.Default);
+
+            context.ContinueAsNew("input");
+
+            var actions = context.GetActions();
+            Assert.AreEqual(1, actions.Count);
+            var completeAction = (OrchestrationCompleteOrchestratorAction)actions[0];
+            Assert.AreEqual(ContinueAsNewTraceBehavior.PreserveTraceContext, completeAction.ContinueAsNewTraceBehavior);
+        }
+
+        [TestMethod]
+        public void Context_ContinueAsNew_WithVersion_SetsTraceBehavior()
+        {
+            var instance = new OrchestrationInstance { InstanceId = "test", ExecutionId = Guid.NewGuid().ToString() };
+            var context = new TestableTaskOrchestrationContext(instance, TaskScheduler.Default);
+
+            context.ContinueAsNew("2.0", "test-input", new ContinueAsNewOptions
+            {
+                TraceBehavior = ContinueAsNewTraceBehavior.StartNewTrace,
+            });
+
+            var actions = context.GetActions();
+            Assert.AreEqual(1, actions.Count);
+            var completeAction = (OrchestrationCompleteOrchestratorAction)actions[0];
+            Assert.AreEqual("2.0", completeAction.NewVersion);
+            Assert.AreEqual(ContinueAsNewTraceBehavior.StartNewTrace, completeAction.ContinueAsNewTraceBehavior);
+        }
+
+        [TestMethod]
+        public void Context_ContinueAsNew_LastCallWins()
+        {
+            // When ContinueAsNew is called multiple times, the last call's options win.
+            var instance = new OrchestrationInstance { InstanceId = "test", ExecutionId = Guid.NewGuid().ToString() };
+            var context = new TestableTaskOrchestrationContext(instance, TaskScheduler.Default);
+
+            context.ContinueAsNew(null, "input1", new ContinueAsNewOptions
+            {
+                TraceBehavior = ContinueAsNewTraceBehavior.StartNewTrace,
+            });
+
+            // Second call with default behavior should overwrite
+            context.ContinueAsNew(null, "input2", new ContinueAsNewOptions
+            {
+                TraceBehavior = ContinueAsNewTraceBehavior.PreserveTraceContext,
+            });
+
+            var actions = context.GetActions();
+            Assert.AreEqual(1, actions.Count);
+            var completeAction = (OrchestrationCompleteOrchestratorAction)actions[0];
+            Assert.AreEqual(ContinueAsNewTraceBehavior.PreserveTraceContext, completeAction.ContinueAsNewTraceBehavior,
+                "Last ContinueAsNew call should win");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Context_ContinueAsNew_NullOptions_Throws()
+        {
+            var instance = new OrchestrationInstance { InstanceId = "test", ExecutionId = Guid.NewGuid().ToString() };
+            var context = new TestableTaskOrchestrationContext(instance, TaskScheduler.Default);
+            context.ContinueAsNew(null, "input", (ContinueAsNewOptions)null!);
+        }
+
+        #endregion
+
+        #region Base class — NotSupportedException for unsupported implementations
+
+        [TestMethod]
+        [ExpectedException(typeof(NotSupportedException))]
+        public void BaseClass_ContinueAsNewWithOptions_ThrowsNotSupported()
+        {
+            var ctx = new MinimalOrchestrationContext();
+            ctx.ContinueAsNew("1.0", "input", new ContinueAsNewOptions());
+        }
+
+        #endregion
+
+        #region ContinueAsNewOptions defaults
+
+        [TestMethod]
+        public void ContinueAsNewOptions_DefaultTraceBehavior_IsPreserve()
+        {
+            var options = new ContinueAsNewOptions();
+            Assert.AreEqual(ContinueAsNewTraceBehavior.PreserveTraceContext, options.TraceBehavior);
+        }
+
+        #endregion
+
+        #region Test helpers
+
+        /// <summary>
+        /// A minimal OrchestrationContext subclass that does NOT override the options overload.
+        /// Used to verify the base class throws NotSupportedException.
+        /// </summary>
+        private class MinimalOrchestrationContext : OrchestrationContext
+        {
+            public override void ContinueAsNew(object input) { }
+            public override void ContinueAsNew(string newVersion, object input) { }
+            public override Task<T> CreateSubOrchestrationInstance<T>(string name, string version, string instanceId, object input)
+                => throw new NotImplementedException();
+            public override Task<T> CreateSubOrchestrationInstance<T>(string name, string version, string instanceId, object input, IDictionary<string, string> tags)
+                => throw new NotImplementedException();
+            public override Task<T> CreateSubOrchestrationInstance<T>(string name, string version, object input)
+                => throw new NotImplementedException();
+            public override Task<TResult> ScheduleTask<TResult>(string name, string version, params object[] parameters)
+                => throw new NotImplementedException();
+            public override Task<T> CreateTimer<T>(DateTime fireAt, T state)
+                => throw new NotImplementedException();
+            public override Task<T> CreateTimer<T>(DateTime fireAt, T state, CancellationToken cancelToken)
+                => throw new NotImplementedException();
+            public override void SendEvent(OrchestrationInstance orchestrationInstance, string eventName, object eventData)
+                => throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// A testable TaskOrchestrationContext that exposes the pending actions.
+        /// ContinueAsNew is stored internally until CompleteOrchestration is called,
+        /// at which point it becomes visible through OrchestratorActions.
+        /// </summary>
+        private class TestableTaskOrchestrationContext : TaskOrchestrationContext
+        {
+            public TestableTaskOrchestrationContext(OrchestrationInstance instance, TaskScheduler scheduler)
+                : base(instance, scheduler)
+            {
+                CurrentUtcDateTime = DateTime.UtcNow;
+            }
+
+            public IReadOnlyList<OrchestratorAction> GetActions()
+            {
+                // Trigger the completion path that moves continueAsNew into the actions map
+                CompleteOrchestration("result", null, OrchestrationStatus.Completed);
+                return OrchestratorActions.ToList();
+            }
+
+            public override Task<TResult> ScheduleTask<TResult>(string name, string version, params object[] parameters)
+                => base.ScheduleTask<TResult>(name, version, parameters);
+
+            public override Task<T> CreateTimer<T>(DateTime fireAt, T state, CancellationToken cancelToken)
+                => Task.FromResult(state);
+        }
+
+        #endregion
+    }
+}

--- a/Test/DurableTask.Core.Tests/ContinueAsNewTraceBehaviorTests.cs
+++ b/Test/DurableTask.Core.Tests/ContinueAsNewTraceBehaviorTests.cs
@@ -314,6 +314,89 @@ namespace DurableTask.Core.Tests
             DistributedTraceActivity.Current = null;
         }
 
+        [TestMethod]
+        public void TraceHelper_LegacyTag_CreatesNewRootTrace()
+        {
+            // Backward compatibility: when the legacy CreateTraceForNewOrchestration tag is set
+            // (as done by durabletask-dotnet's ShimDurableTaskClient), TraceHelper should create
+            // a fresh root trace — same behavior as GenerateNewTrace=true.
+            var startEvent = new ExecutionStartedEvent(-1, "input")
+            {
+                GenerateNewTrace = false,
+                OrchestrationInstance = new OrchestrationInstance { InstanceId = "test-legacy", ExecutionId = "exec1" },
+                Name = "TestOrch",
+                Tags = new Dictionary<string, string>
+                {
+                    [OrchestrationTags.CreateTraceForNewOrchestration] = "true",
+                },
+            };
+
+            Activity? activity = TraceHelper.StartTraceActivityForOrchestrationExecution(startEvent);
+
+            Assert.IsNotNull(activity, "Should create an orchestration activity via legacy tag");
+            Assert.IsFalse(startEvent.Tags.ContainsKey(OrchestrationTags.CreateTraceForNewOrchestration),
+                "Legacy tag should be consumed (removed) after use");
+            Assert.IsNotNull(startEvent.ParentTraceContext, "ParentTraceContext should be set by the producer span");
+
+            activity.Stop();
+            DistributedTraceActivity.Current = null;
+        }
+
+        [TestMethod]
+        public void TraceHelper_LegacyTag_PreservesOtherTags()
+        {
+            // Ensure consuming the legacy tag does not affect other user-defined tags.
+            var startEvent = new ExecutionStartedEvent(-1, "input")
+            {
+                GenerateNewTrace = false,
+                OrchestrationInstance = new OrchestrationInstance { InstanceId = "test-tags", ExecutionId = "exec1" },
+                Name = "TestOrch",
+                Tags = new Dictionary<string, string>
+                {
+                    [OrchestrationTags.CreateTraceForNewOrchestration] = "true",
+                    ["user-tag"] = "my-value",
+                },
+            };
+
+            Activity? activity = TraceHelper.StartTraceActivityForOrchestrationExecution(startEvent);
+
+            Assert.IsNotNull(activity);
+            Assert.IsFalse(startEvent.Tags.ContainsKey(OrchestrationTags.CreateTraceForNewOrchestration),
+                "Legacy tag should be removed");
+            Assert.AreEqual("my-value", startEvent.Tags["user-tag"],
+                "User tags should be preserved");
+
+            activity.Stop();
+            DistributedTraceActivity.Current = null;
+        }
+
+        [TestMethod]
+        public void TraceHelper_BothGenerateNewTraceAndLegacyTag_WorksTogether()
+        {
+            // When both GenerateNewTrace and the legacy tag are set, both should be consumed
+            // to prevent the tag from triggering a second fresh trace on replay.
+            var startEvent = new ExecutionStartedEvent(-1, "input")
+            {
+                GenerateNewTrace = true,
+                OrchestrationInstance = new OrchestrationInstance { InstanceId = "test-both", ExecutionId = "exec1" },
+                Name = "TestOrch",
+                Tags = new Dictionary<string, string>
+                {
+                    [OrchestrationTags.CreateTraceForNewOrchestration] = "true",
+                },
+            };
+
+            Activity? activity = TraceHelper.StartTraceActivityForOrchestrationExecution(startEvent);
+
+            Assert.IsNotNull(activity, "Should create an orchestration activity");
+            Assert.IsFalse(startEvent.GenerateNewTrace, "GenerateNewTrace should be reset");
+            Assert.IsFalse(startEvent.Tags.ContainsKey(OrchestrationTags.CreateTraceForNewOrchestration),
+                "Legacy tag should also be consumed to prevent double trace on replay");
+
+            activity.Stop();
+            DistributedTraceActivity.Current = null;
+        }
+
         #endregion
 
         #region TaskOrchestrationContext — ContinueAsNew overloads

--- a/docs/telemetry/distributed-tracing.md
+++ b/docs/telemetry/distributed-tracing.md
@@ -209,6 +209,24 @@ Traces are automatically correlated across:
 - Orchestration → Activity
 - Client → Orchestration
 
+### Continue-as-new trace behavior
+
+By default, `ContinueAsNew` preserves the current distributed trace context. This keeps generations of the same orchestration instance connected in one trace.
+
+For long-running or periodic orchestrations, use `ContinueAsNewOptions` with `ContinueAsNewTraceBehavior.StartNewTrace` to start the next generation in a fresh trace:
+
+```csharp
+context.ContinueAsNew(
+    newVersion: null,
+    input: nextInput,
+    options: new ContinueAsNewOptions
+    {
+        TraceBehavior = ContinueAsNewTraceBehavior.StartNewTrace,
+    });
+```
+
+The orchestration instance ID is preserved, but the next generation gets a new trace ID. Use this when each loop or cycle should be independently visible in your telemetry backend.
+
 ### Example Trace Hierarchy
 
 ```text

--- a/docs/telemetry/traces/semantic-conventions.md
+++ b/docs/telemetry/traces/semantic-conventions.md
@@ -69,6 +69,12 @@ Attributes:
 | durabletask.task.execution_id  | Execution ID of the enqueued orchestration  |
 | exception.*  | Exception details on failure. |
 
+##### Continue-as-new fresh traces
+
+When `ContinueAsNew` is used with `ContinueAsNewTraceBehavior.StartNewTrace`, DurableTask emits this producer span shape for the next generation even though no external client call occurred. The producer span is the root of a new trace, starts at the next generation's orchestration-created timestamp, and ends when the worker establishes the trace before running the generation.
+
+The following `orchestration:{orchestrationName}(@{orchestrationVersion})?` server span is a child of this producer span. The orchestration instance ID is preserved, but the new generation is not parented to the previous generation's trace.
+
 #### Client: Starting a sub-orchestration
 
 Represents enqueueing and waiting for a sub-orchestration to complete 

--- a/src/DurableTask.Core/Command/OrchestrationCompleteOrchestratorAction.cs
+++ b/src/DurableTask.Core/Command/OrchestrationCompleteOrchestratorAction.cs
@@ -61,5 +61,12 @@ namespace DurableTask.Core.Command
         /// Gets a collection of tags associated with the completion action.
         /// </summary>
         public IDictionary<string, string> Tags { get; } = new Dictionary<string, string>();
+
+        /// <summary>
+        /// Gets or sets how distributed tracing should behave for the next <c>ContinueAsNew</c> generation.
+        /// Defaults to <see cref="ContinueAsNewTraceBehavior.PreserveTraceContext"/>.
+        /// </summary>
+        public ContinueAsNewTraceBehavior ContinueAsNewTraceBehavior { get; set; } =
+            ContinueAsNewTraceBehavior.PreserveTraceContext;
     }
 }

--- a/src/DurableTask.Core/ContinueAsNewOptions.cs
+++ b/src/DurableTask.Core/ContinueAsNewOptions.cs
@@ -1,0 +1,46 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+#nullable enable
+namespace DurableTask.Core
+{
+    /// <summary>
+    /// Configures how an orchestration continues as new.
+    /// </summary>
+    public sealed class ContinueAsNewOptions
+    {
+        /// <summary>
+        /// Gets or sets how distributed tracing should behave for the next generation.
+        /// The default is <see cref="ContinueAsNewTraceBehavior.PreserveTraceContext"/>,
+        /// which keeps the next generation in the same distributed trace.
+        /// </summary>
+        public ContinueAsNewTraceBehavior TraceBehavior { get; set; } =
+            ContinueAsNewTraceBehavior.PreserveTraceContext;
+    }
+
+    /// <summary>
+    /// Describes how distributed tracing should behave for the next <c>ContinueAsNew</c> generation.
+    /// </summary>
+    public enum ContinueAsNewTraceBehavior
+    {
+        /// <summary>
+        /// Preserve the current trace lineage across generations. This is the default.
+        /// </summary>
+        PreserveTraceContext = 0,
+
+        /// <summary>
+        /// Start the next generation in a fresh distributed trace. Useful for long-running
+        /// periodic orchestrations where each cycle should be independently observable.
+        /// </summary>
+        StartNewTrace = 1,
+    }
+}

--- a/src/DurableTask.Core/History/ExecutionStartedEvent.cs
+++ b/src/DurableTask.Core/History/ExecutionStartedEvent.cs
@@ -71,6 +71,7 @@ namespace DurableTask.Core.History
             Correlation = other.Correlation;
             ScheduledStartTime = other.ScheduledStartTime;
             Generation = other.Generation;
+            GenerateNewTrace = other.GenerateNewTrace;
         }
 
         /// <summary>
@@ -132,6 +133,15 @@ namespace DurableTask.Core.History
         /// </summary>
         [DataMember]
         public int? Generation { get; set; }
+
+        /// <summary>
+        /// When true, indicates that this execution should start a fresh distributed trace
+        /// rather than inheriting the trace context from the previous generation.
+        /// This flag is consumed once by the trace infrastructure and reset to false after
+        /// the new trace is created, so that subsequent replays use the persisted trace identity.
+        /// </summary>
+        [DataMember]
+        public bool GenerateNewTrace { get; set; }
 
         // Used for Continue-as-New scenarios
         internal void SetParentTraceContext(ExecutionStartedEvent parent)

--- a/src/DurableTask.Core/OrchestrationContext.cs
+++ b/src/DurableTask.Core/OrchestrationContext.cs
@@ -452,6 +452,33 @@ namespace DurableTask.Core
         public abstract void ContinueAsNew(string newVersion, object input);
 
         /// <summary>
+        ///     Checkpoint the orchestration instance by completing the current execution in the ContinueAsNew
+        ///     state and creating a new execution of this instance with the specified input parameter.
+        ///     This overload allows the caller to customize how the next generation behaves, such as
+        ///     starting a fresh distributed trace.
+        /// </summary>
+        /// <param name="newVersion">
+        ///     New version of the orchestration to start. Pass <c>null</c> to keep the current version.
+        /// </param>
+        /// <param name="input">
+        ///     Input to the new execution of this instance. This is the same type as the one used to start
+        ///     the first execution of this orchestration instance.
+        /// </param>
+        /// <param name="options">
+        ///     Options that customize the next generation.
+        /// </param>
+        /// <exception cref="NotSupportedException">
+        ///     Thrown if the current <see cref="OrchestrationContext"/> implementation does not support
+        ///     <see cref="ContinueAsNewOptions"/>. Override this method in a derived class to add support.
+        /// </exception>
+        public virtual void ContinueAsNew(string newVersion, object input, ContinueAsNewOptions options)
+        {
+            throw new NotSupportedException(
+                $"This {GetType().Name} implementation does not support ContinueAsNewOptions. " +
+                "Override this method in a derived class to add support.");
+        }
+
+        /// <summary>
         ///     Create a proxy client class to schedule remote TaskActivities via a strongly typed interface.
         /// </summary>
         /// <typeparam name="T"></typeparam>

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -249,12 +249,12 @@ namespace DurableTask.Core
 
         public override void ContinueAsNew(object input)
         {
-            ContinueAsNewCore(null, input, new ContinueAsNewOptions());
+            this.ContinueAsNew(null, input, new ContinueAsNewOptions());
         }
 
         public override void ContinueAsNew(string newVersion, object input)
         {
-            ContinueAsNewCore(newVersion, input, new ContinueAsNewOptions());
+            this.ContinueAsNew(newVersion, input, new ContinueAsNewOptions());
         }
 
         public override void ContinueAsNew(string newVersion, object input, ContinueAsNewOptions options)

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -33,6 +33,7 @@ namespace DurableTask.Core
         private readonly IDictionary<int, OpenTaskInfo> openTasks;
         private readonly IDictionary<int, OrchestratorAction> orchestratorActionsMap;
         private OrchestrationCompleteOrchestratorAction continueAsNew;
+        static readonly ContinueAsNewOptions DefaultContinueAsNewOptions = new ContinueAsNewOptions();
         private bool executionCompletedOrTerminated;
         private int idCounter;
         private readonly Queue<HistoryEvent> eventsWhileSuspended;
@@ -249,12 +250,12 @@ namespace DurableTask.Core
 
         public override void ContinueAsNew(object input)
         {
-            this.ContinueAsNew(null, input, new ContinueAsNewOptions());
+            this.ContinueAsNew(null, input, DefaultContinueAsNewOptions);
         }
 
         public override void ContinueAsNew(string newVersion, object input)
         {
-            this.ContinueAsNew(newVersion, input, new ContinueAsNewOptions());
+            this.ContinueAsNew(newVersion, input, DefaultContinueAsNewOptions);
         }
 
         public override void ContinueAsNew(string newVersion, object input, ContinueAsNewOptions options)

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -33,7 +33,7 @@ namespace DurableTask.Core
         private readonly IDictionary<int, OpenTaskInfo> openTasks;
         private readonly IDictionary<int, OrchestratorAction> orchestratorActionsMap;
         private OrchestrationCompleteOrchestratorAction continueAsNew;
-        static readonly ContinueAsNewOptions DefaultContinueAsNewOptions = new ContinueAsNewOptions();
+        private static readonly ContinueAsNewOptions DefaultContinueAsNewOptions = new ContinueAsNewOptions();
         private bool executionCompletedOrTerminated;
         private int idCounter;
         private readonly Queue<HistoryEvent> eventsWhileSuspended;

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -249,15 +249,25 @@ namespace DurableTask.Core
 
         public override void ContinueAsNew(object input)
         {
-            ContinueAsNew(null, input);
+            ContinueAsNewCore(null, input, new ContinueAsNewOptions());
         }
 
         public override void ContinueAsNew(string newVersion, object input)
         {
-            ContinueAsNewCore(newVersion, input);
+            ContinueAsNewCore(newVersion, input, new ContinueAsNewOptions());
         }
 
-        void ContinueAsNewCore(string newVersion, object input)
+        public override void ContinueAsNew(string newVersion, object input, ContinueAsNewOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            ContinueAsNewCore(newVersion, input, options);
+        }
+
+        void ContinueAsNewCore(string newVersion, object input, ContinueAsNewOptions options)
         {
             string serializedInput = this.MessageDataConverter.SerializeInternal(input);
 
@@ -265,7 +275,8 @@ namespace DurableTask.Core
             {
                 Result = serializedInput,
                 OrchestrationStatus = OrchestrationStatus.ContinuedAsNew,
-                NewVersion = newVersion
+                NewVersion = newVersion,
+                ContinueAsNewTraceBehavior = options.TraceBehavior,
             };
         }
 

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -26,6 +26,7 @@ namespace DurableTask.Core
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Globalization;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
@@ -641,8 +642,20 @@ namespace DurableTask.Core
                                     continueAsNewExecutionStarted!.Correlation = CorrelationTraceContext.Current.SerializableTraceContext;
                                 });
 
-                                // Copy the distributed trace context, if any
-                                continueAsNewExecutionStarted!.SetParentTraceContext(runtimeState.ExecutionStartedEvent);
+                                // Copy the distributed trace context to preserve lineage, unless
+                                // the next generation was explicitly requested to start a fresh trace.
+                                if (!continueAsNewExecutionStarted!.GenerateNewTrace)
+                                {
+                                    continueAsNewExecutionStarted.SetParentTraceContext(runtimeState.ExecutionStartedEvent);
+                                }
+                                else
+                                {
+                                    // Stamp the request time so the producer span created by TraceHelper
+                                    // uses an accurate start time instead of the dequeue time.
+                                    continueAsNewExecutionStarted.Tags ??= new Dictionary<string, string>();
+                                    continueAsNewExecutionStarted.Tags[OrchestrationTags.RequestTime] =
+                                        DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture);
+                                }
 
                                 runtimeState = new OrchestrationRuntimeState();
                                 runtimeState.AddEvent(new OrchestratorStartedEvent(-1));
@@ -1055,10 +1068,13 @@ namespace DurableTask.Core
                         InstanceId = runtimeState.OrchestrationInstance!.InstanceId,
                         ExecutionId = Guid.NewGuid().ToString("N")
                     },
-                    Tags = runtimeState.Tags,
+                    // Clone tags to avoid mutating the current generation's tag dictionary
+                    Tags = runtimeState.Tags != null ? new Dictionary<string, string>(runtimeState.Tags) : null,
                     ParentInstance = runtimeState.ParentInstance,
                     Name = runtimeState.Name,
-                    Version = completeOrchestratorAction.NewVersion ?? runtimeState.Version
+                    Version = completeOrchestratorAction.NewVersion ?? runtimeState.Version,
+                    // Signal that the next generation should start a fresh distributed trace
+                    GenerateNewTrace = completeOrchestratorAction.ContinueAsNewTraceBehavior == ContinueAsNewTraceBehavior.StartNewTrace,
                 };
 
                 taskMessage.OrchestrationInstance = startedEvent.OrchestrationInstance;

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -650,8 +650,8 @@ namespace DurableTask.Core
                                 }
                                 else
                                 {
-                                    // Stamp the request time so the producer span created by TraceHelper
-                                    // uses an accurate start time instead of the dequeue time.
+                                    // Stamp the dispatcher processing time for this continuation request
+                                    // so the producer span created by TraceHelper uses this timestamp.
                                     continueAsNewExecutionStarted.Tags ??= new Dictionary<string, string>();
                                     continueAsNewExecutionStarted.Tags[OrchestrationTags.RequestTime] =
                                         DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture);
@@ -1068,8 +1068,13 @@ namespace DurableTask.Core
                         InstanceId = runtimeState.OrchestrationInstance!.InstanceId,
                         ExecutionId = Guid.NewGuid().ToString("N")
                     },
-                    // Clone tags to avoid mutating the current generation's tag dictionary
-                    Tags = runtimeState.Tags != null ? new Dictionary<string, string>(runtimeState.Tags) : null,
+                    // Clone tags to avoid mutating the current generation's tag dictionary.
+                    // Preserve the comparer if the underlying type is Dictionary<string, string>.
+                    Tags = runtimeState.Tags == null
+                        ? null
+                        : runtimeState.Tags is Dictionary<string, string> dictionaryTags
+                            ? new Dictionary<string, string>(dictionaryTags, dictionaryTags.Comparer)
+                            : new Dictionary<string, string>(runtimeState.Tags),
                     ParentInstance = runtimeState.ParentInstance,
                     Name = runtimeState.Name,
                     Version = completeOrchestratorAction.NewVersion ?? runtimeState.Version,

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -627,6 +627,8 @@ namespace DurableTask.Core
                         {
                             if (continuedAsNew)
                             {
+                                OrchestrationRuntimeState completedRuntimeState = runtimeState;
+
                                 TraceHelper.TraceSession(
                                     TraceEventType.Information,
                                     "TaskOrchestrationDispatcher-UpdatingStateForContinuation",
@@ -644,14 +646,6 @@ namespace DurableTask.Core
                                 if (!continueAsNewExecutionStarted!.GenerateNewTrace)
                                 {
                                     continueAsNewExecutionStarted.SetParentTraceContext(runtimeState.ExecutionStartedEvent);
-                                }
-                                else
-                                {
-                                    // Stamp the dispatcher processing time for this continuation request
-                                    // so the producer span created by TraceHelper uses this timestamp.
-                                    continueAsNewExecutionStarted.Tags ??= new Dictionary<string, string>();
-                                    continueAsNewExecutionStarted.Tags[OrchestrationTags.RequestTime] =
-                                        DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture);
                                 }
 
                                 runtimeState = new OrchestrationRuntimeState();
@@ -672,6 +666,11 @@ namespace DurableTask.Core
                                 workItem.OrchestrationRuntimeState = runtimeState;
 
                                 workItem.Cursor = null;
+
+                                traceActivity = RestartTraceActivityForContinueAsNewIfNeeded(
+                                    traceActivity,
+                                    completedRuntimeState,
+                                    continueAsNewExecutionStarted);
                             }
 
                             instanceState = Utils.BuildOrchestrationState(runtimeState);
@@ -1130,6 +1129,23 @@ namespace DurableTask.Core
             TraceHelper.SetRuntimeStatusTag(runtimeState.OrchestrationStatus.ToString());
             DistributedTraceActivity.Current?.Stop();
             DistributedTraceActivity.Current = null;
+        }
+
+        internal static Activity? RestartTraceActivityForContinueAsNewIfNeeded(
+            Activity? currentTraceActivity,
+            OrchestrationRuntimeState completedRuntimeState,
+            ExecutionStartedEvent continueAsNewExecutionStarted)
+        {
+            if (!continueAsNewExecutionStarted.GenerateNewTrace)
+            {
+                return currentTraceActivity;
+            }
+
+            TraceHelper.SetRuntimeStatusTag(completedRuntimeState.OrchestrationStatus.ToString());
+            currentTraceActivity?.Stop();
+            DistributedTraceActivity.Current = null;
+
+            return TraceHelper.StartTraceActivityForOrchestrationExecution(continueAsNewExecutionStarted);
         }
 
         private static void SetOrchestrationActivityStatus(OrchestrationCompleteOrchestratorAction completeOrchestratorAction)

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -26,7 +26,6 @@ namespace DurableTask.Core
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Globalization;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -95,12 +95,21 @@ namespace DurableTask.Core.Tracing
                 return null;
             }
 
-            // When GenerateNewTrace is set, create a fresh root trace for this orchestration.
-            // The flag is consumed once and reset so that subsequent replays use the
-            // persisted trace identity rather than creating yet another new trace.
-            if (startEvent.GenerateNewTrace)
+            // Check both the typed GenerateNewTrace property (used by ContinueAsNew)
+            // and the legacy CreateTraceForNewOrchestration tag (used by external clients
+            // like durabletask-dotnet's ShimDurableTaskClient) for backward compatibility.
+            bool shouldGenerateNewTrace = startEvent.GenerateNewTrace;
+            if (!shouldGenerateNewTrace &&
+                startEvent.Tags != null &&
+                startEvent.Tags.ContainsKey(OrchestrationTags.CreateTraceForNewOrchestration))
+            {
+                shouldGenerateNewTrace = true;
+            }
+
+            if (shouldGenerateNewTrace)
             {
                 startEvent.GenerateNewTrace = false;
+                startEvent.Tags?.Remove(OrchestrationTags.CreateTraceForNewOrchestration);
                 // Note that if we create the trace activity for starting a new orchestration here, then its duration will be longer since its end time will be set to once we 
                 // start processing the orchestration rather than when the request for a new orchestration is committed to storage. 
                 using var activityForNewOrchestration = StartActivityForNewOrchestration(startEvent);

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -108,11 +108,15 @@ namespace DurableTask.Core.Tracing
 
             if (shouldGenerateNewTrace)
             {
-                startEvent.GenerateNewTrace = false;
-                startEvent.Tags?.Remove(OrchestrationTags.CreateTraceForNewOrchestration);
                 // Note that if we create the trace activity for starting a new orchestration here, then its duration will be longer since its end time will be set to once we 
                 // start processing the orchestration rather than when the request for a new orchestration is committed to storage. 
                 using var activityForNewOrchestration = StartActivityForNewOrchestration(startEvent);
+
+                // Consume the signals only after the fresh trace is successfully created,
+                // so that if StartActivityForNewOrchestration throws, the signals remain
+                // intact for retry.
+                startEvent.GenerateNewTrace = false;
+                startEvent.Tags?.Remove(OrchestrationTags.CreateTraceForNewOrchestration);
             }
 
             if (!startEvent.TryGetParentTraceContext(out ActivityContext activityContext))

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -112,11 +112,14 @@ namespace DurableTask.Core.Tracing
                 // start processing the orchestration rather than when the request for a new orchestration is committed to storage. 
                 using var activityForNewOrchestration = StartActivityForNewOrchestration(startEvent);
 
-                // Consume the signals only after the fresh trace is successfully created,
-                // so that if StartActivityForNewOrchestration throws, the signals remain
-                // intact for retry.
-                startEvent.GenerateNewTrace = false;
-                startEvent.Tags?.Remove(OrchestrationTags.CreateTraceForNewOrchestration);
+                // Consume the signals only after the fresh trace identity is established.
+                // ActivitySource.StartActivity may return null when sampling suppresses the
+                // producer span, in which case the request must remain for replay.
+                if (activityForNewOrchestration != null || startEvent.ParentTraceContext != null)
+                {
+                    startEvent.GenerateNewTrace = false;
+                    startEvent.Tags?.Remove(OrchestrationTags.CreateTraceForNewOrchestration);
+                }
             }
 
             if (!startEvent.TryGetParentTraceContext(out ActivityContext activityContext))
@@ -124,9 +127,10 @@ namespace DurableTask.Core.Tracing
                 return null;
             }
 
+            DistributedTraceContext parentTraceContext = startEvent.ParentTraceContext!;
             string activityName = CreateSpanName(TraceActivityConstants.Orchestration, startEvent.Name, startEvent.Version);
             ActivityKind activityKind = ActivityKind.Server;
-            DateTimeOffset startTime = startEvent.ParentTraceContext.ActivityStartTime ?? default;
+            DateTimeOffset startTime = parentTraceContext.ActivityStartTime ?? default;
 
             Activity? activity = ActivityTraceSource.StartActivity(
                 activityName,
@@ -148,16 +152,16 @@ namespace DurableTask.Core.Tracing
                 activity.SetTag(Schema.Task.Version, startEvent.Version);
             }
 
-            if (startEvent.ParentTraceContext.Id != null && startEvent.ParentTraceContext.SpanId != null)
+            if (parentTraceContext.Id != null && parentTraceContext.SpanId != null)
             {
-                activity.SetId(startEvent.ParentTraceContext.Id!);
-                activity.SetSpanId(startEvent.ParentTraceContext.SpanId!);
+                activity.SetId(parentTraceContext.Id!);
+                activity.SetSpanId(parentTraceContext.SpanId!);
             }
             else
             {
-                startEvent.ParentTraceContext.Id = activity.Id;
-                startEvent.ParentTraceContext.SpanId = activity.SpanId.ToString();
-                startEvent.ParentTraceContext.ActivityStartTime = activity.StartTimeUtc;
+                parentTraceContext.Id = activity.Id;
+                parentTraceContext.SpanId = activity.SpanId.ToString();
+                parentTraceContext.ActivityStartTime = activity.StartTimeUtc;
             }
 
             DistributedTraceActivity.Current = activity;

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -95,9 +95,12 @@ namespace DurableTask.Core.Tracing
                 return null;
             }
 
-            if (startEvent.Tags != null && startEvent.Tags.ContainsKey(OrchestrationTags.CreateTraceForNewOrchestration))
+            // When GenerateNewTrace is set, create a fresh root trace for this orchestration.
+            // The flag is consumed once and reset so that subsequent replays use the
+            // persisted trace identity rather than creating yet another new trace.
+            if (startEvent.GenerateNewTrace)
             {
-                startEvent.Tags.Remove(OrchestrationTags.CreateTraceForNewOrchestration);
+                startEvent.GenerateNewTrace = false;
                 // Note that if we create the trace activity for starting a new orchestration here, then its duration will be longer since its end time will be set to once we 
                 // start processing the orchestration rather than when the request for a new orchestration is committed to storage. 
                 using var activityForNewOrchestration = StartActivityForNewOrchestration(startEvent);

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -49,9 +49,11 @@ namespace DurableTask.Core.Tracing
                 return null;
             }
 
-            DateTimeOffset? startTime = null;
-            // In the case that a request time for the start orchestration request is provided via ExecutionStartedEvent.Tags, we will use this as the start time of the Activity rather than the current time
-            if (startEvent.Tags != null && startEvent.Tags.ContainsKey(OrchestrationTags.RequestTime) &&
+            DateTimeOffset startTime = GetActivityStartTime(startEvent.Timestamp);
+
+            // Honor the legacy RequestTime tag for backward compatibility with older payloads.
+            if (startEvent.Tags != null &&
+                startEvent.Tags.ContainsKey(OrchestrationTags.RequestTime) &&
                 DateTimeOffset.TryParse(startEvent.Tags[OrchestrationTags.RequestTime], CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out DateTimeOffset requestTime))
             {
                 startTime = requestTime;
@@ -61,7 +63,7 @@ namespace DurableTask.Core.Tracing
                 CreateSpanName(TraceActivityConstants.CreateOrchestration, startEvent.Name, startEvent.Version),
                 kind: ActivityKind.Producer,
                 parentContext: parentTraceContext,
-                startTime: startTime ?? default);
+                startTime: startTime);
 
             if (newActivity != null)
             {
@@ -74,11 +76,21 @@ namespace DurableTask.Core.Tracing
                 {
                     newActivity.SetTag(Schema.Task.Version, startEvent.Version);
                 }
-                
+
                 startEvent.SetParentTraceContext(newActivity);
+                startEvent.Tags?.Remove(OrchestrationTags.RequestTime);
             }
 
             return newActivity;
+        }
+
+        private static DateTimeOffset GetActivityStartTime(DateTime timestamp)
+        {
+            DateTime utcTimestamp = timestamp.Kind == DateTimeKind.Unspecified
+                ? DateTime.SpecifyKind(timestamp, DateTimeKind.Utc)
+                : timestamp.ToUniversalTime();
+
+            return new DateTimeOffset(utcTimestamp);
         }
 
         /// <summary>

--- a/test/DurableTask.Core.Tests/ContinueAsNewTraceBehaviorTests.cs
+++ b/test/DurableTask.Core.Tests/ContinueAsNewTraceBehaviorTests.cs
@@ -11,6 +11,7 @@ namespace DurableTask.Core.Tests
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Runtime.Serialization.Json;
@@ -376,6 +377,58 @@ namespace DurableTask.Core.Tests
         }
 
         [TestMethod]
+        public void TraceHelper_UsesExecutionStartedTimestamp_WithoutLeakingTags()
+        {
+            var timestamp = new DateTime(2026, 04, 24, 01, 02, 03, DateTimeKind.Utc);
+            var startEvent = new ExecutionStartedEvent(-1, "input")
+            {
+                Timestamp = timestamp,
+                OrchestrationInstance = new OrchestrationInstance { InstanceId = "test-request-time", ExecutionId = "exec1" },
+                Name = "TestOrch",
+                Tags = new Dictionary<string, string>
+                {
+                    ["user-tag"] = "my-value",
+                },
+            };
+
+            Activity? activity = TraceHelper.StartActivityForNewOrchestration(startEvent);
+
+            Assert.IsNotNull(activity, "Should create a producer activity for the orchestration start");
+            Assert.AreEqual(timestamp, activity.StartTimeUtc, "Producer span should use the ExecutionStartedEvent timestamp");
+            Assert.AreEqual("my-value", startEvent.Tags["user-tag"], "User tags should be preserved");
+            Assert.IsFalse(startEvent.Tags.ContainsKey(OrchestrationTags.RequestTime),
+                "RequestTime should not leak into the persisted user-visible tag bag");
+
+            activity.Stop();
+        }
+
+        [TestMethod]
+        public void TraceHelper_LegacyRequestTimeTag_IsConsumedAfterProducerCreation()
+        {
+            var requestTime = new DateTimeOffset(2026, 04, 24, 01, 02, 03, TimeSpan.Zero);
+            var startEvent = new ExecutionStartedEvent(-1, "input")
+            {
+                OrchestrationInstance = new OrchestrationInstance { InstanceId = "test-request-tag", ExecutionId = "exec1" },
+                Name = "TestOrch",
+                Tags = new Dictionary<string, string>
+                {
+                    [OrchestrationTags.RequestTime] = requestTime.ToString("O", CultureInfo.InvariantCulture),
+                    ["user-tag"] = "my-value",
+                },
+            };
+
+            Activity? activity = TraceHelper.StartActivityForNewOrchestration(startEvent);
+
+            Assert.IsNotNull(activity, "Should create a producer activity for the orchestration start");
+            Assert.AreEqual(requestTime.UtcDateTime, activity.StartTimeUtc, "Producer span should honor the legacy RequestTime tag");
+            Assert.AreEqual("my-value", startEvent.Tags["user-tag"], "User tags should be preserved");
+            Assert.IsFalse(startEvent.Tags.ContainsKey(OrchestrationTags.RequestTime),
+                "Legacy RequestTime should be consumed after use so it does not leak to users");
+
+            activity.Stop();
+        }
+
+        [TestMethod]
         public void TraceHelper_BothGenerateNewTraceAndLegacyTag_WorksTogether()
         {
             // When both GenerateNewTrace and the legacy tag are set, both should be consumed
@@ -431,6 +484,51 @@ namespace DurableTask.Core.Tests
             Assert.IsTrue(startEvent.Tags.ContainsKey(OrchestrationTags.CreateTraceForNewOrchestration),
                 "Legacy trace-creation tag should remain for replay");
             Assert.IsNull(startEvent.ParentTraceContext, "No trace identity should be persisted when no producer span exists");
+        }
+
+        [TestMethod]
+        public void Dispatcher_RestartsTraceActivity_ForContinueAsNewStartNewTrace()
+        {
+            var currentExecutionStarted = new ExecutionStartedEvent(-1, "input")
+            {
+                GenerateNewTrace = true,
+                OrchestrationInstance = new OrchestrationInstance { InstanceId = "test-current", ExecutionId = "exec1" },
+                Name = "TestOrch",
+            };
+
+            var completedRuntimeState = new OrchestrationRuntimeState();
+            completedRuntimeState.AddEvent(currentExecutionStarted);
+            completedRuntimeState.AddEvent(new ContinueAsNewEvent(1, "next-input"));
+
+            Activity? currentActivity = TraceHelper.StartTraceActivityForOrchestrationExecution(currentExecutionStarted);
+            Assert.IsNotNull(currentActivity, "Current execution should have an orchestration activity");
+
+            string currentTraceId = currentActivity.TraceId.ToString();
+
+            var nextExecutionStarted = new ExecutionStartedEvent(-1, "next-input")
+            {
+                GenerateNewTrace = true,
+                OrchestrationInstance = new OrchestrationInstance { InstanceId = "test-current", ExecutionId = "exec2" },
+                Name = "TestOrch",
+            };
+
+            Activity? nextActivity = TaskOrchestrationDispatcher.RestartTraceActivityForContinueAsNewIfNeeded(
+                currentActivity,
+                completedRuntimeState,
+                nextExecutionStarted);
+
+            Assert.IsNotNull(nextActivity, "Next generation should start its own orchestration activity");
+            Assert.AreNotEqual(currentTraceId, nextActivity.TraceId.ToString(),
+                "StartNewTrace should restart the next generation in a fresh trace");
+            Assert.AreSame(nextActivity, DistributedTraceActivity.Current,
+                "The restarted activity should become the ambient orchestration activity");
+            Assert.IsFalse(nextExecutionStarted.GenerateNewTrace,
+                "The fresh-trace signal should be consumed once the next generation activity starts");
+            Assert.IsNotNull(nextExecutionStarted.ParentTraceContext,
+                "The next generation should persist the fresh trace identity for replay");
+
+            nextActivity.Stop();
+            DistributedTraceActivity.Current = null;
         }
 
         #endregion

--- a/test/DurableTask.Core.Tests/ContinueAsNewTraceBehaviorTests.cs
+++ b/test/DurableTask.Core.Tests/ContinueAsNewTraceBehaviorTests.cs
@@ -1,6 +1,16 @@
-// ---------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// ---------------------------------------------------------------
+//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
 #nullable enable
 namespace DurableTask.Core.Tests
 {


### PR DESCRIPTION
## Summary

Long-running periodic orchestrations that use `ContinueAsNew` accumulate all generations into a single distributed trace. This adds an opt-in `ContinueAsNewTraceBehavior.StartNewTrace` option that starts the next generation in a fresh trace.

## Motivation

Orchestrations that run on a schedule (e.g., every 5 hours) via `ContinueAsNew` end up with a single trace spanning days/weeks/months, making:
- Individual cycle performance hard to measure
- Trace viewers slow/unresponsive with thousands of spans
- Anomaly detection across cycles impossible

## API Changes

- `ContinueAsNewOptions` class with `TraceBehavior` property
- `ContinueAsNewTraceBehavior` enum: `PreserveTraceContext` (default) | `StartNewTrace`
- New `ContinueAsNew(string, object, ContinueAsNewOptions)` overload on `OrchestrationContext`

```csharp
// Start a fresh trace for the next generation
context.ContinueAsNew(null, input, new ContinueAsNewOptions
{
    TraceBehavior = ContinueAsNewTraceBehavior.StartNewTrace,
});
```

## Implementation

Uses a typed `bool GenerateNewTrace` property on `ExecutionStartedEvent` (not tags) to signal fresh-trace behavior. The property is consumed once by `TraceHelper` (creates a fresh root producer span, stores identity in `ParentTraceContext`, resets to `false`). Subsequent replays use the persisted identity — stable span ID across replays.

### Signal flow

1. **Orchestrator** calls `ContinueAsNew(version, input, options)` → sets `ContinueAsNewTraceBehavior` on `OrchestrationCompleteOrchestratorAction`
2. **Dispatcher** creates the next `ExecutionStartedEvent` with `GenerateNewTrace = true` and **skips** copying the old `ParentTraceContext`
3. **TraceHelper** sees `GenerateNewTrace`, creates a fresh root producer span, stores its identity in `ParentTraceContext`, and **resets** `GenerateNewTrace = false`
4. **Subsequent replays** use the persisted identity — stable span ID across replays

### Design decisions

| Decision | Rationale |
|----------|-----------|
| **Typed `bool` property on `ExecutionStartedEvent`** instead of tags | Avoids customer tag namespace collision; avoids cross-generation tag leaking through `CloneTags`; typed and self-documenting |
| **Tags are now cloned** (not shared by reference) | Prevents mutation of the current generation's tag dictionary during continuation |
| **Base class throws `NotSupportedException`** | External `OrchestrationContext` implementations cannot silently ignore `StartNewTrace` |
| **Single 3-param overload** (version + input + options) | The 2-param overload `(object input, ContinueAsNewOptions options)` was ambiguous with `(string newVersion, object input)`; users pass `null` for version to keep current |
| **Legacy `Correlation` pipeline unchanged** | The two trace systems (`System.Diagnostics.Activity` vs legacy Correlation) are independent; only `ParentTraceContext` controls the new pipeline |

### Replay safety

- `GenerateNewTrace` is consumed once and reset to `false`
- The **result** (trace identity in `ParentTraceContext.Id`/`.SpanId`) is persisted
- Subsequent replays restore from persisted identity, not the signal
- On crash before first persist, a new trace is created (consistent since no state from the abandoned attempt survived)

## Backward Compatibility

- Default behavior is `PreserveTraceContext` — zero change for existing users
- `GenerateNewTrace` defaults to `false` — pre-upgrade serialized events deserialize correctly
- `ContinueAsNewTraceBehavior` defaults to `PreserveTraceContext` (0) on the action
- Existing `ContinueAsNew(object)` and `ContinueAsNew(string, object)` are unchanged

## Tests

31 tests passing covering:
- `GenerateNewTrace` property: default value, copy constructor, JSON serialization, backward compat
- Tag isolation: property doesn't appear in or leak through tags
- `TraceHelper`: fresh trace creation, consume-and-reset, replay with persisted identity, ambient activity isolation
- `TaskOrchestrationContext`: new overloads, last-call-wins, null options rejection
- Base class `NotSupportedException`
- `ContinueAsNewOptions` defaults
