### PR TITLE
reset pending orchestrations when worker restart

### DIFF
--- a/Test/DurableTask.AzureStorage.Tests/OrchestrationSessionTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/OrchestrationSessionTests.cs
@@ -22,6 +22,7 @@ namespace DurableTask.AzureStorage.Tests
     using System.Threading.Tasks;
     using DurableTask.AzureStorage.Messaging;
     using DurableTask.AzureStorage.Monitoring;
+    using DurableTask.AzureStorage.Storage;
     using DurableTask.AzureStorage.Tracking;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
@@ -222,6 +223,83 @@ namespace DurableTask.AzureStorage.Tests
 
             manager.GetStats(out _, out _, out int count);
             Assert.AreEqual(0, count, "Should still have no active sessions");
+        }
+
+        [TestMethod]
+        public async Task GetNextSessionAsync_DrainedReadyQueueNode_IsIgnored()
+        {
+            var settings = new AzureStorageOrchestrationServiceSettings
+            {
+                StorageAccountClientProvider = new StorageAccountClientProvider("UseDevelopmentStorage=true"),
+            };
+            var stats = new AzureStorageOrchestrationServiceStats();
+            var trackingStore = new Mock<ITrackingStore>();
+
+            using var manager = new OrchestrationSessionManager(
+                "testaccount",
+                settings,
+                stats,
+                trackingStore.Object);
+
+            var storageClient = new AzureStorageClient(settings);
+            var messageManager = new MessageManager(settings, storageClient, settings.TaskHubName);
+            var controlQueue = new ControlQueue(storageClient, "partition-0", messageManager);
+
+            object pendingBatch = CreatePendingBatch(controlQueue);
+            object node = AddPendingBatchNode(manager, pendingBatch);
+            RemovePendingBatchNode(manager, node);
+            EnqueueReadyForProcessingNode(manager, node);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+            try
+            {
+                await manager.GetNextSessionAsync(entitiesOnly: false, cts.Token);
+                Assert.Fail("Expected cancellation after the drained node was skipped.");
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        static object CreatePendingBatch(ControlQueue controlQueue)
+        {
+            Type pendingBatchType = typeof(OrchestrationSessionManager)
+                .GetNestedType("PendingMessageBatch", BindingFlags.NonPublic);
+
+            return Activator.CreateInstance(
+                pendingBatchType,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                binder: null,
+                args: new object[] { controlQueue, "instance1", "execution1" },
+                culture: null);
+        }
+
+        static object AddPendingBatchNode(OrchestrationSessionManager manager, object pendingBatch)
+        {
+            object pendingBatches = GetPrivateField(manager, "pendingOrchestrationMessageBatches");
+            MethodInfo addLast = pendingBatches.GetType().GetMethod("AddLast", new[] { pendingBatch.GetType() });
+            return addLast.Invoke(pendingBatches, new[] { pendingBatch });
+        }
+
+        static void RemovePendingBatchNode(OrchestrationSessionManager manager, object node)
+        {
+            object pendingBatches = GetPrivateField(manager, "pendingOrchestrationMessageBatches");
+            MethodInfo remove = pendingBatches.GetType().GetMethod("Remove", new[] { node.GetType() });
+            remove.Invoke(pendingBatches, new[] { node });
+        }
+
+        static void EnqueueReadyForProcessingNode(OrchestrationSessionManager manager, object node)
+        {
+            object readyQueue = GetPrivateField(manager, "orchestrationsReadyForProcessingQueue");
+            MethodInfo enqueue = readyQueue.GetType().GetMethod("Enqueue");
+            enqueue.Invoke(readyQueue, new[] { node });
+        }
+
+        static object GetPrivateField(object target, string fieldName)
+        {
+            FieldInfo field = target.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(field);
+            return field.GetValue(target);
         }
     }
 }

--- a/Test/DurableTask.AzureStorage.Tests/OrchestrationSessionTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/OrchestrationSessionTests.cs
@@ -258,6 +258,7 @@ namespace DurableTask.AzureStorage.Tests
             }
             catch (OperationCanceledException)
             {
+                Assert.IsTrue(true, "Operation cancellation was expected.");
             }
         }
 

--- a/Test/DurableTask.AzureStorage.Tests/OrchestrationSessionTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/OrchestrationSessionTests.cs
@@ -18,11 +18,11 @@ namespace DurableTask.AzureStorage.Tests
     using System.Diagnostics;
     using System.Linq;
     using System.Reflection;
+    using System.Runtime.CompilerServices;
     using System.Threading;
     using System.Threading.Tasks;
     using DurableTask.AzureStorage.Messaging;
     using DurableTask.AzureStorage.Monitoring;
-    using DurableTask.AzureStorage.Storage;
     using DurableTask.AzureStorage.Tracking;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
@@ -228,10 +228,7 @@ namespace DurableTask.AzureStorage.Tests
         [TestMethod]
         public async Task GetNextSessionAsync_DrainedReadyQueueNode_IsIgnored()
         {
-            var settings = new AzureStorageOrchestrationServiceSettings
-            {
-                StorageAccountClientProvider = new StorageAccountClientProvider("UseDevelopmentStorage=true"),
-            };
+            var settings = new AzureStorageOrchestrationServiceSettings();
             var stats = new AzureStorageOrchestrationServiceStats();
             var trackingStore = new Mock<ITrackingStore>();
 
@@ -241,9 +238,7 @@ namespace DurableTask.AzureStorage.Tests
                 stats,
                 trackingStore.Object);
 
-            var storageClient = new AzureStorageClient(settings);
-            var messageManager = new MessageManager(settings, storageClient, settings.TaskHubName);
-            var controlQueue = new ControlQueue(storageClient, "partition-0", messageManager);
+            var controlQueue = CreateControlQueueWithoutStorage();
 
             object pendingBatch = CreatePendingBatch(controlQueue);
             object node = AddPendingBatchNode(manager, pendingBatch);
@@ -273,6 +268,11 @@ namespace DurableTask.AzureStorage.Tests
                 binder: null,
                 args: new object[] { controlQueue, "instance1", "execution1" },
                 culture: null);
+        }
+
+        static ControlQueue CreateControlQueueWithoutStorage()
+        {
+            return (ControlQueue)RuntimeHelpers.GetUninitializedObject(typeof(ControlQueue));
         }
 
         static object AddPendingBatchNode(OrchestrationSessionManager manager, object pendingBatch)

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -216,7 +216,7 @@ namespace DurableTask.AzureStorage.Messaging
         /// for another partition owner to pick up. This is used during drain to avoid stranding
         /// messages that were dequeued but not yet promoted to active sessions.
         /// </summary>
-        public async Task AbandonMessageForDrainAsync(MessageData message)
+        public async Task AbandonMessageForDrainAsync(MessageData message, CancellationToken cancellationToken = default)
         {
             this.stats.PendingOrchestratorMessages.TryRemove(message.OriginalQueueMessage.MessageId, out _);
 
@@ -242,7 +242,8 @@ namespace DurableTask.AzureStorage.Messaging
                 await this.storageQueue.UpdateMessageAsync(
                     queueMessage,
                     TimeSpan.Zero,
-                    clientRequestId: null);
+                    clientRequestId: null,
+                    cancellationToken: cancellationToken);
             }
             catch (RequestFailedException e)
             {

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -251,7 +251,7 @@ namespace DurableTask.AzureStorage.Messaging
                     this.settings.TaskHubName,
                     this.settings.WorkerId,
                     this.Name,
-                    $"Failed to abandon message {queueMessage.MessageId} during drain: {e.Message}");
+                    $"Failed to abandon message {queueMessage.MessageId} during drain: {e}");
             }
         }
 

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -23,6 +23,7 @@ namespace DurableTask.AzureStorage.Messaging
     using DurableTask.AzureStorage.Monitoring;
     using DurableTask.AzureStorage.Partitioning;
     using DurableTask.AzureStorage.Storage;
+    using DurableTask.Core;
 
     class ControlQueue : TaskHubQueue, IDisposable
     {
@@ -207,6 +208,50 @@ namespace DurableTask.AzureStorage.Messaging
         {
             this.stats.PendingOrchestratorMessages.TryRemove(message.OriginalQueueMessage.MessageId, out _);
             return base.AbandonMessageAsync(message, session);
+        }
+
+        /// <summary>
+        /// Abandons a message with zero visibility timeout so it becomes immediately visible
+        /// for another partition owner to pick up. This is used during drain to avoid stranding
+        /// messages that were dequeued but not yet promoted to active sessions.
+        /// </summary>
+        public async Task AbandonMessageForDrainAsync(MessageData message)
+        {
+            this.stats.PendingOrchestratorMessages.TryRemove(message.OriginalQueueMessage.MessageId, out _);
+
+            QueueMessage queueMessage = message.OriginalQueueMessage;
+            TaskMessage taskMessage = message.TaskMessage;
+            OrchestrationInstance instance = taskMessage.OrchestrationInstance;
+
+            this.settings.Logger.AbandoningMessage(
+                this.storageAccountName,
+                this.settings.TaskHubName,
+                taskMessage.Event.EventType.ToString(),
+                Utils.GetTaskEventId(taskMessage.Event),
+                queueMessage.MessageId,
+                instance.InstanceId,
+                instance.ExecutionId,
+                this.storageQueue.Name,
+                message.SequenceNumber,
+                queueMessage.PopReceipt,
+                visibilityTimeoutSeconds: 0);
+
+            try
+            {
+                await this.storageQueue.UpdateMessageAsync(
+                    queueMessage,
+                    TimeSpan.Zero,
+                    clientRequestId: null);
+            }
+            catch (Exception e)
+            {
+                this.settings.Logger.PartitionManagerWarning(
+                    this.storageAccountName,
+                    this.settings.TaskHubName,
+                    this.settings.WorkerId,
+                    this.Name,
+                    $"Failed to abandon message {queueMessage.MessageId} during drain: {e.Message}");
+            }
         }
 
         public override Task DeleteMessageAsync(MessageData message, SessionBase? session = null)

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -245,7 +245,7 @@ namespace DurableTask.AzureStorage.Messaging
                     clientRequestId: null,
                     cancellationToken: cancellationToken);
             }
-            catch (RequestFailedException e)
+            catch (Exception e)
             {
                 this.settings.Logger.PartitionManagerWarning(
                     this.storageAccountName,

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -19,6 +19,7 @@ namespace DurableTask.AzureStorage.Messaging
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Azure;
     using Azure.Storage.Queues.Models;
     using DurableTask.AzureStorage.Monitoring;
     using DurableTask.AzureStorage.Partitioning;
@@ -243,7 +244,7 @@ namespace DurableTask.AzureStorage.Messaging
                     TimeSpan.Zero,
                     clientRequestId: null);
             }
-            catch (Exception e)
+            catch (RequestFailedException e)
             {
                 this.settings.Logger.PartitionManagerWarning(
                     this.storageAccountName,

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -217,7 +217,28 @@ namespace DurableTask.AzureStorage
             finally
             {
                 // Make dequeued-but-undispatched messages visible before dropping the partition.
-                await this.AbandonPendingMessagesAsync(partitionId);
+                try
+                {
+                    await this.AbandonPendingMessagesAsync(partitionId, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    this.settings.Logger.PartitionManagerWarning(
+                        this.storageAccountName,
+                        this.settings.TaskHubName,
+                        this.settings.WorkerId,
+                        partitionId,
+                        "Canceled while abandoning pending messages during drain.");
+                }
+                catch (Exception e)
+                {
+                    this.settings.Logger.PartitionManagerWarning(
+                        this.storageAccountName,
+                        this.settings.TaskHubName,
+                        this.settings.WorkerId,
+                        partitionId,
+                        $"Failed to abandon pending messages during drain: {e}");
+                }
 
                 this.RemoveQueue(partitionId, reason, caller);
             }
@@ -229,7 +250,7 @@ namespace DurableTask.AzureStorage
         /// This prevents a throughput gap equal to the visibility timeout duration when a partition
         /// is released during drain.
         /// </summary>
-        async Task AbandonPendingMessagesAsync(string partitionId)
+        async Task AbandonPendingMessagesAsync(string partitionId, CancellationToken cancellationToken)
         {
             var messagesToAbandon = new List<(ControlQueue Queue, MessageData Message)>();
 
@@ -257,6 +278,8 @@ namespace DurableTask.AzureStorage
 
             if (messagesToAbandon.Count > 0)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 this.settings.Logger.PartitionManagerInfo(
                     this.storageAccountName,
                     this.settings.TaskHubName,
@@ -266,7 +289,7 @@ namespace DurableTask.AzureStorage
 
                 await messagesToAbandon.ParallelForEachAsync(
                     this.settings.MaxStorageOperationConcurrency,
-                    item => item.Queue.AbandonMessageForDrainAsync(item.Message));
+                    item => item.Queue.AbandonMessageForDrainAsync(item.Message, cancellationToken));
             }
         }
 

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -216,8 +216,57 @@ namespace DurableTask.AzureStorage
             }
             finally
             {
-                // Remove the partition from memory
+                // Make dequeued-but-undispatched messages visible before dropping the partition.
+                await this.AbandonPendingMessagesAsync(partitionId);
+
                 this.RemoveQueue(partitionId, reason, caller);
+            }
+        }
+
+        /// <summary>
+        /// Abandons all pending (dequeued but not yet dispatched) messages for the specified partition,
+        /// making them immediately visible in the Azure Storage queue for the new partition owner.
+        /// This prevents a throughput gap equal to the visibility timeout duration when a partition
+        /// is released during drain.
+        /// </summary>
+        async Task AbandonPendingMessagesAsync(string partitionId)
+        {
+            var messagesToAbandon = new List<(ControlQueue Queue, MessageData Message)>();
+
+            lock (this.messageAndSessionLock)
+            {
+                var node = this.pendingOrchestrationMessageBatches.First;
+                while (node != null)
+                {
+                    LinkedListNode<PendingMessageBatch>? next = node.Next;
+                    PendingMessageBatch batch = node.Value;
+
+                    if (string.Equals(batch.ControlQueue.Name, partitionId, StringComparison.OrdinalIgnoreCase))
+                    {
+                        foreach (MessageData message in batch.Messages)
+                        {
+                            messagesToAbandon.Add((batch.ControlQueue, message));
+                        }
+
+                        this.pendingOrchestrationMessageBatches.Remove(node);
+                    }
+
+                    node = next;
+                }
+            }
+
+            if (messagesToAbandon.Count > 0)
+            {
+                this.settings.Logger.PartitionManagerInfo(
+                    this.storageAccountName,
+                    this.settings.TaskHubName,
+                    this.settings.WorkerId,
+                    partitionId,
+                    $"Abandoning {messagesToAbandon.Count} pending message(s) during drain to make them immediately visible for the new partition owner.");
+
+                await messagesToAbandon.ParallelForEachAsync(
+                    this.settings.MaxStorageOperationConcurrency,
+                    item => item.Queue.AbandonMessageForDrainAsync(item.Message));
             }
         }
 
@@ -592,6 +641,12 @@ namespace DurableTask.AzureStorage
 
                 lock (this.messageAndSessionLock)
                 {
+                    // Drain may have removed this batch after it was queued for dispatch.
+                    if (node.List != this.pendingOrchestrationMessageBatches)
+                    {
+                        continue;
+                    }
+
                     PendingMessageBatch nextBatch = node.Value;
                     this.pendingOrchestrationMessageBatches.Remove(node);
 

--- a/test/DurableTask.AzureStorage.Tests/OrchestrationSessionTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/OrchestrationSessionTests.cs
@@ -261,13 +261,16 @@ namespace DurableTask.AzureStorage.Tests
         {
             Type pendingBatchType = typeof(OrchestrationSessionManager)
                 .GetNestedType("PendingMessageBatch", BindingFlags.NonPublic);
+            Assert.IsNotNull(pendingBatchType);
 
-            return Activator.CreateInstance(
+            object pendingBatch = Activator.CreateInstance(
                 pendingBatchType,
                 BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
                 binder: null,
                 args: new object[] { controlQueue, "instance1", "execution1" },
                 culture: null);
+            Assert.IsNotNull(pendingBatch);
+            return pendingBatch;
         }
 
         static ControlQueue CreateControlQueueWithoutStorage()
@@ -279,13 +282,17 @@ namespace DurableTask.AzureStorage.Tests
         {
             object pendingBatches = GetPrivateField(manager, "pendingOrchestrationMessageBatches");
             MethodInfo addLast = pendingBatches.GetType().GetMethod("AddLast", new[] { pendingBatch.GetType() });
-            return addLast.Invoke(pendingBatches, new[] { pendingBatch });
+            Assert.IsNotNull(addLast);
+            object node = addLast.Invoke(pendingBatches, new[] { pendingBatch });
+            Assert.IsNotNull(node);
+            return node;
         }
 
         static void RemovePendingBatchNode(OrchestrationSessionManager manager, object node)
         {
             object pendingBatches = GetPrivateField(manager, "pendingOrchestrationMessageBatches");
             MethodInfo remove = pendingBatches.GetType().GetMethod("Remove", new[] { node.GetType() });
+            Assert.IsNotNull(remove);
             remove.Invoke(pendingBatches, new[] { node });
         }
 
@@ -293,6 +300,7 @@ namespace DurableTask.AzureStorage.Tests
         {
             object readyQueue = GetPrivateField(manager, "orchestrationsReadyForProcessingQueue");
             MethodInfo enqueue = readyQueue.GetType().GetMethod("Enqueue");
+            Assert.IsNotNull(enqueue);
             enqueue.Invoke(readyQueue, new[] { node });
         }
 


### PR DESCRIPTION
This PR improves partition drain behavior for Azure Storage control queues. When a partition is released, any control queue messages that were already dequeued but not yet dispatched to an active orchestration session are now abandoned with zero visibility timeout, making them immediately visible for the next partition owner.

The change prevents a throughput gap during lease transitions where pending in-memory messages could otherwise remain invisible until their original visibility timeout expired.

Related ICM: https://portal.microsofticm.com/imp/v5/incidents/details/21000001021644/summary