### PR TITLE
reset pending orchestrations when worker restart

### DIFF
--- a/Test/DurableTask.AzureStorage.Tests/OrchestrationSessionTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/OrchestrationSessionTests.cs
@@ -22,6 +22,7 @@ namespace DurableTask.AzureStorage.Tests
     using System.Threading.Tasks;
     using DurableTask.AzureStorage.Messaging;
     using DurableTask.AzureStorage.Monitoring;
+    using DurableTask.AzureStorage.Storage;
     using DurableTask.AzureStorage.Tracking;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
@@ -222,6 +223,83 @@ namespace DurableTask.AzureStorage.Tests
 
             manager.GetStats(out _, out _, out int count);
             Assert.AreEqual(0, count, "Should still have no active sessions");
+        }
+
+        [TestMethod]
+        public async Task GetNextSessionAsync_DrainedReadyQueueNode_IsIgnored()
+        {
+            var settings = new AzureStorageOrchestrationServiceSettings
+            {
+                StorageAccountClientProvider = new StorageAccountClientProvider("UseDevelopmentStorage=true"),
+            };
+            var stats = new AzureStorageOrchestrationServiceStats();
+            var trackingStore = new Mock<ITrackingStore>();
+
+            using var manager = new OrchestrationSessionManager(
+                "testaccount",
+                settings,
+                stats,
+                trackingStore.Object);
+
+            var storageClient = new AzureStorageClient(settings);
+            var messageManager = new MessageManager(settings, storageClient, settings.TaskHubName);
+            var controlQueue = new ControlQueue(storageClient, "partition-0", messageManager);
+
+            object pendingBatch = CreatePendingBatch(controlQueue);
+            object node = AddPendingBatchNode(manager, pendingBatch);
+            RemovePendingBatchNode(manager, node);
+            EnqueueReadyForProcessingNode(manager, node);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+            try
+            {
+                await manager.GetNextSessionAsync(entitiesOnly: false, cts.Token);
+                Assert.Fail("Expected cancellation after the drained node was skipped.");
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        static object CreatePendingBatch(ControlQueue controlQueue)
+        {
+            Type pendingBatchType = typeof(OrchestrationSessionManager)
+                .GetNestedType("PendingMessageBatch", BindingFlags.NonPublic);
+
+            return Activator.CreateInstance(
+                pendingBatchType,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                binder: null,
+                args: new object[] { controlQueue, "instance1", "execution1" },
+                culture: null);
+        }
+
+        static object AddPendingBatchNode(OrchestrationSessionManager manager, object pendingBatch)
+        {
+            object pendingBatches = GetPrivateField(manager, "pendingOrchestrationMessageBatches");
+            MethodInfo addLast = pendingBatches.GetType().GetMethod("AddLast", new[] { pendingBatch.GetType() });
+            return addLast.Invoke(pendingBatches, new[] { pendingBatch });
+        }
+
+        static void RemovePendingBatchNode(OrchestrationSessionManager manager, object node)
+        {
+            object pendingBatches = GetPrivateField(manager, "pendingOrchestrationMessageBatches");
+            MethodInfo remove = pendingBatches.GetType().GetMethod("Remove", new[] { node.GetType() });
+            remove.Invoke(pendingBatches, new[] { node });
+        }
+
+        static void EnqueueReadyForProcessingNode(OrchestrationSessionManager manager, object node)
+        {
+            object readyQueue = GetPrivateField(manager, "orchestrationsReadyForProcessingQueue");
+            MethodInfo enqueue = readyQueue.GetType().GetMethod("Enqueue");
+            enqueue.Invoke(readyQueue, new[] { node });
+        }
+
+        static object GetPrivateField(object target, string fieldName)
+        {
+            FieldInfo field = target.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(field);
+            return field.GetValue(target);
         }
     }
 }

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -553,7 +553,7 @@ namespace DurableTask.AzureStorage
         {
             var controlQueue = new ControlQueue(this.azureStorageClient, lease.PartitionId, this.messageManager);
             await controlQueue.CreateIfNotExistsAsync();
-            this.orchestrationSessionManager.ResumeListeningIfOwnQueue(lease.PartitionId, controlQueue, this.shutdownSource.Token);
+            await this.orchestrationSessionManager.ResumeListeningIfOwnQueue(lease.PartitionId, controlQueue, this.shutdownSource.Token);
         }
 
         internal Task OnIntentLeaseReleasedAsync(BlobPartitionLease lease, CloseReason reason)
@@ -572,21 +572,20 @@ namespace DurableTask.AzureStorage
             this.allControlQueues[lease.PartitionId] = controlQueue;
         }
 
-        internal void DropLostControlQueue(TablePartitionLease partition)
+        internal async Task DropLostControlQueue(TablePartitionLease partition)
         {
             // If lease is lost but we're still dequeuing messages, remove the queue
             if (this.allControlQueues.TryGetValue(partition.RowKey, out ControlQueue controlQueue) &&
                 this.OwnedControlQueues.Contains(controlQueue) &&
                 partition.CurrentOwner != this.settings.WorkerId)
             {
-                this.orchestrationSessionManager.RemoveQueue(partition.RowKey, CloseReason.LeaseLost, nameof(DropLostControlQueue));
+                await this.orchestrationSessionManager.RemoveQueue(partition.RowKey, CloseReason.LeaseLost, nameof(DropLostControlQueue));
             }
         }
 
         internal Task OnOwnershipLeaseReleasedAsync(BlobPartitionLease lease, CloseReason reason)
         {
-            this.orchestrationSessionManager.RemoveQueue(lease.PartitionId, reason, "Ownership LeaseCollectionBalancer");
-            return Utils.CompletedTask;
+            return this.orchestrationSessionManager.RemoveQueue(lease.PartitionId, reason, "Ownership LeaseCollectionBalancer");
         }
 
         internal async Task OnTableLeaseAcquiredAsync(TablePartitionLease lease)

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -1249,7 +1249,13 @@ namespace DurableTask.AzureStorage
                 {
                     var messages = session.DeferredMessages.ToList();
                     session.DeferredMessages.Clear();
-                    this.orchestrationSessionManager.AddMessageToPendingOrchestration(session.ControlQueue, messages, session.TraceActivityId, CancellationToken.None);
+                    IReadOnlyList<MessageData> messagesToAbandon = this.orchestrationSessionManager.AddMessageToPendingOrchestration(
+                        session.ControlQueue,
+                        messages,
+                        session.TraceActivityId,
+                        CancellationToken.None);
+
+                    await this.orchestrationSessionManager.AbandonMessagesForDrainAsync(session.ControlQueue, messagesToAbandon);
                 }
             }
             // Handle the case where the 'ETag' has changed, which implies another worker has taken over this work item while
@@ -1524,8 +1530,11 @@ namespace DurableTask.AzureStorage
             if (this.orchestrationSessionManager.TryReleaseSession(
                 instanceId,
                 this.shutdownSource.Token,
-                out OrchestrationSession session))
+                out OrchestrationSession session,
+                out IReadOnlyList<MessageData> messagesToAbandon))
             {
+                await this.orchestrationSessionManager.AbandonMessagesForDrainAsync(session.ControlQueue, messagesToAbandon);
+
                 // Some messages may need to be discarded
                 await session.DiscardedMessages.ParallelForEachAsync(
                     this.settings.MaxStorageOperationConcurrency,

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -23,6 +23,7 @@ namespace DurableTask.AzureStorage.Messaging
     using DurableTask.AzureStorage.Monitoring;
     using DurableTask.AzureStorage.Partitioning;
     using DurableTask.AzureStorage.Storage;
+    using DurableTask.Core;
 
     class ControlQueue : TaskHubQueue, IDisposable
     {
@@ -207,6 +208,50 @@ namespace DurableTask.AzureStorage.Messaging
         {
             this.stats.PendingOrchestratorMessages.TryRemove(message.OriginalQueueMessage.MessageId, out _);
             return base.AbandonMessageAsync(message, session);
+        }
+
+        /// <summary>
+        /// Abandons a message with zero visibility timeout so it becomes immediately visible
+        /// for another partition owner to pick up. This is used during drain to avoid stranding
+        /// messages that were dequeued but not yet promoted to active sessions.
+        /// </summary>
+        public async Task AbandonMessageForDrainAsync(MessageData message)
+        {
+            this.stats.PendingOrchestratorMessages.TryRemove(message.OriginalQueueMessage.MessageId, out _);
+
+            QueueMessage queueMessage = message.OriginalQueueMessage;
+            TaskMessage taskMessage = message.TaskMessage;
+            OrchestrationInstance instance = taskMessage.OrchestrationInstance;
+
+            this.settings.Logger.AbandoningMessage(
+                this.storageAccountName,
+                this.settings.TaskHubName,
+                taskMessage.Event.EventType.ToString(),
+                Utils.GetTaskEventId(taskMessage.Event),
+                queueMessage.MessageId,
+                instance.InstanceId,
+                instance.ExecutionId,
+                this.storageQueue.Name,
+                message.SequenceNumber,
+                queueMessage.PopReceipt,
+                visibilityTimeoutSeconds: 0);
+
+            try
+            {
+                await this.storageQueue.UpdateMessageAsync(
+                    queueMessage,
+                    TimeSpan.Zero,
+                    clientRequestId: null);
+            }
+            catch (Exception e)
+            {
+                this.settings.Logger.PartitionManagerWarning(
+                    this.storageAccountName,
+                    this.settings.TaskHubName,
+                    this.settings.WorkerId,
+                    this.Name,
+                    $"Failed to abandon message {queueMessage.MessageId} during drain: {e.Message}");
+            }
         }
 
         public override Task DeleteMessageAsync(MessageData message, SessionBase? session = null)

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -19,7 +19,6 @@ namespace DurableTask.AzureStorage.Messaging
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-    using Azure;
     using Azure.Storage.Queues.Models;
     using DurableTask.AzureStorage.Monitoring;
     using DurableTask.AzureStorage.Partitioning;
@@ -244,7 +243,7 @@ namespace DurableTask.AzureStorage.Messaging
                     TimeSpan.Zero,
                     clientRequestId: null);
             }
-            catch (RequestFailedException e)
+            catch (DurableTaskStorageException e)
             {
                 this.settings.Logger.PartitionManagerWarning(
                     this.storageAccountName,

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -19,6 +19,7 @@ namespace DurableTask.AzureStorage.Messaging
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Azure;
     using Azure.Storage.Queues.Models;
     using DurableTask.AzureStorage.Monitoring;
     using DurableTask.AzureStorage.Partitioning;
@@ -243,7 +244,7 @@ namespace DurableTask.AzureStorage.Messaging
                     TimeSpan.Zero,
                     clientRequestId: null);
             }
-            catch (Exception e)
+            catch (RequestFailedException e)
             {
                 this.settings.Logger.PartitionManagerWarning(
                     this.storageAccountName,

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -793,6 +793,8 @@ namespace DurableTask.AzureStorage
                 //  1) a batch of messages has been received for a particular instance and
                 //  2) the history for that instance has been fetched
                 LinkedListNode<PendingMessageBatch> node = await readyForProcessingQueue.DequeueAsync(cancellationToken);
+                ControlQueue? queueToAbandon = null;
+                IReadOnlyList<MessageData> messagesToAbandon = EmptyMessageDataList;
 
                 lock (this.messageAndSessionLock)
                 {
@@ -805,7 +807,12 @@ namespace DurableTask.AzureStorage
                     PendingMessageBatch nextBatch = node.Value;
                     this.pendingOrchestrationMessageBatches.Remove(node);
 
-                    if (!this.activeOrchestrationSessions.TryGetValue(nextBatch.OrchestrationInstanceId, out var existingSession))
+                    if (nextBatch.ControlQueue.IsReleased)
+                    {
+                        queueToAbandon = nextBatch.ControlQueue;
+                        messagesToAbandon = nextBatch.Messages.ToList();
+                    }
+                    else if (!this.activeOrchestrationSessions.TryGetValue(nextBatch.OrchestrationInstanceId, out var existingSession))
                     {
                         OrchestrationInstance instance = nextBatch.OrchestrationState?.OrchestrationInstance ??
                             new OrchestrationInstance
@@ -849,26 +856,62 @@ namespace DurableTask.AzureStorage
                         {
                             // To avoid a tight dequeue loop, delay for a bit before putting this node back into the queue.
                             // This is only necessary when the queue is empty. The main dequeue thread must not be blocked
-                            // by this delay, which is why we use Task.Delay(...).ContinueWith(...) instead of await.
-                            Task.Delay(millisecondsDelay: 200).ContinueWith(_ =>
-                            {
-                                lock (this.messageAndSessionLock)
-                                {
-                                    this.pendingOrchestrationMessageBatches.AddLast(node);
-                                    readyForProcessingQueue.Enqueue(node);
-                                }
-                            });
+                            // by this delay, which is why it is scheduled without awaiting here.
+                            _ = this.RequeuePendingBatchAfterDelayAsync(node, readyForProcessingQueue);
                         }
                         else
                         {
-                            this.pendingOrchestrationMessageBatches.AddLast(node);
-                            readyForProcessingQueue.Enqueue(node);
+                            this.RequeueOrAbandonPendingBatchLocked(node, readyForProcessingQueue, out queueToAbandon, out messagesToAbandon);
                         }
                     }
+                }
+
+                if (queueToAbandon != null)
+                {
+                    await this.AbandonMessagesForDrainAsync(queueToAbandon, messagesToAbandon);
                 }
             }
 
             return null;
+        }
+
+        async Task RequeuePendingBatchAfterDelayAsync(
+            LinkedListNode<PendingMessageBatch> node,
+            AsyncQueue<LinkedListNode<PendingMessageBatch>> readyForProcessingQueue)
+        {
+            await Task.Delay(millisecondsDelay: 200);
+
+            ControlQueue? queueToAbandon;
+            IReadOnlyList<MessageData> messagesToAbandon;
+
+            lock (this.messageAndSessionLock)
+            {
+                this.RequeueOrAbandonPendingBatchLocked(node, readyForProcessingQueue, out queueToAbandon, out messagesToAbandon);
+            }
+
+            if (queueToAbandon != null)
+            {
+                await this.AbandonMessagesForDrainAsync(queueToAbandon, messagesToAbandon);
+            }
+        }
+
+        void RequeueOrAbandonPendingBatchLocked(
+            LinkedListNode<PendingMessageBatch> node,
+            AsyncQueue<LinkedListNode<PendingMessageBatch>> readyForProcessingQueue,
+            out ControlQueue? queueToAbandon,
+            out IReadOnlyList<MessageData> messagesToAbandon)
+        {
+            if (node.Value.ControlQueue.IsReleased)
+            {
+                queueToAbandon = node.Value.ControlQueue;
+                messagesToAbandon = node.Value.Messages.ToList();
+                return;
+            }
+
+            this.pendingOrchestrationMessageBatches.AddLast(node);
+            readyForProcessingQueue.Enqueue(node);
+            queueToAbandon = null;
+            messagesToAbandon = EmptyMessageDataList;
         }
 
         /// <summary>

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -84,12 +84,13 @@ namespace DurableTask.AzureStorage
             }
         }
 
-        public void RemoveQueue(string partitionId, CloseReason? reason, string caller)
+        public async Task RemoveQueue(string partitionId, CloseReason? reason, string caller)
         {
             if (this.ownedControlQueues.TryRemove(partitionId, out ControlQueue controlQueue))
             {
                 controlQueue.Release(reason, caller);
                 this.dequeueLoopTasks.TryRemove(partitionId, out _);
+                await this.AbandonPendingMessagesAsync(partitionId, controlQueue);
             }
         }
 
@@ -102,14 +103,14 @@ namespace DurableTask.AzureStorage
             }
         }
 
-        public bool ResumeListeningIfOwnQueue(string partitionId, ControlQueue controlQueue, CancellationToken shutdownToken)
+        public async Task<bool> ResumeListeningIfOwnQueue(string partitionId, ControlQueue controlQueue, CancellationToken shutdownToken)
         {
             if (this.ownedControlQueues.TryGetValue(partitionId, out ControlQueue ownedControlQueue))
             {
                 if (ownedControlQueue.IsReleased)
                 {
                     // The easiest way to resume listening is to re-add a new queue that has not been released.
-                    this.RemoveQueue(partitionId, null, "OrchestrationSessionManager ResumeListeningIfOwnQueue");
+                    await this.RemoveQueue(partitionId, null, "OrchestrationSessionManager ResumeListeningIfOwnQueue");
                     this.AddQueue(partitionId, controlQueue, shutdownToken);
                 }
             }
@@ -236,7 +237,7 @@ namespace DurableTask.AzureStorage
                 }
                 finally
                 {
-                    this.RemoveQueue(partitionId, reason, caller);
+                    await this.RemoveQueue(partitionId, reason, caller);
                 }
             }
         }
@@ -309,7 +310,7 @@ namespace DurableTask.AzureStorage
         /// This prevents a throughput gap equal to the visibility timeout duration when a partition
         /// is released during drain.
         /// </summary>
-        async Task AbandonPendingMessagesAsync(string partitionId)
+        async Task AbandonPendingMessagesAsync(string partitionId, ControlQueue? removedControlQueue = null)
         {
             var messagesToAbandon = new List<(ControlQueue Queue, MessageData Message)>();
 
@@ -336,6 +337,11 @@ namespace DurableTask.AzureStorage
             }
 
             await this.AbandonMessagesForDrainAsync(partitionId, messagesToAbandon);
+
+            if (removedControlQueue != null)
+            {
+                this.SignalSessionWaitersIfNoQueuesRemain(removedControlQueue);
+            }
         }
 
         internal Task AbandonMessagesForDrainAsync(ControlQueue controlQueue, IReadOnlyList<MessageData> messages)
@@ -933,6 +939,24 @@ namespace DurableTask.AzureStorage
         {
             return readyForProcessingQueue.Count == 0 &&
                 !this.ownedControlQueues.Values.Any(queue => !queue.IsReleased);
+        }
+
+        void SignalSessionWaitersIfNoQueuesRemain(ControlQueue releasedControlQueue)
+        {
+            lock (this.messageAndSessionLock)
+            {
+                if (this.ownedControlQueues.Values.Any(queue => !queue.IsReleased))
+                {
+                    return;
+                }
+
+                var orchestratorSentinel = new LinkedListNode<PendingMessageBatch>(
+                    new PendingMessageBatch(releasedControlQueue, string.Empty, executionId: null));
+                var entitySentinel = new LinkedListNode<PendingMessageBatch>(
+                    new PendingMessageBatch(releasedControlQueue, string.Empty, executionId: null));
+                this.orchestrationsReadyForProcessingQueue.Enqueue(orchestratorSentinel);
+                this.entitiesReadyForProcessingQueue.Enqueue(entitySentinel);
+            }
         }
 
         /// <summary>

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -103,7 +103,7 @@ namespace DurableTask.AzureStorage
             }
         }
 
-        public async Task<bool> ResumeListeningIfOwnQueue(string partitionId, ControlQueue controlQueue, CancellationToken shutdownToken)
+        public async Task<bool> ResumeListeningIfOwnQueue(string partitionId, ControlQueue controlQueue, CancellationToken cancellationToken)
         {
             if (this.ownedControlQueues.TryGetValue(partitionId, out ControlQueue ownedControlQueue))
             {
@@ -111,7 +111,7 @@ namespace DurableTask.AzureStorage
                 {
                     // The easiest way to resume listening is to re-add a new queue that has not been released.
                     await this.RemoveQueue(partitionId, null, "OrchestrationSessionManager ResumeListeningIfOwnQueue");
-                    this.AddQueue(partitionId, controlQueue, shutdownToken);
+                    this.AddQueue(partitionId, controlQueue, cancellationToken);
                 }
             }
 

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -795,73 +795,77 @@ namespace DurableTask.AzureStorage
                 LinkedListNode<PendingMessageBatch> node = await readyForProcessingQueue.DequeueAsync(cancellationToken);
                 ControlQueue? queueToAbandon = null;
                 IReadOnlyList<MessageData> messagesToAbandon = EmptyMessageDataList;
+                bool shouldStopWaitingForSessions = false;
 
                 lock (this.messageAndSessionLock)
                 {
                     // Drain may have removed this batch after it was queued for dispatch.
                     if (node.List != this.pendingOrchestrationMessageBatches)
                     {
-                        continue;
-                    }
-
-                    PendingMessageBatch nextBatch = node.Value;
-                    this.pendingOrchestrationMessageBatches.Remove(node);
-
-                    if (nextBatch.ControlQueue.IsReleased)
-                    {
-                        queueToAbandon = nextBatch.ControlQueue;
-                        messagesToAbandon = nextBatch.Messages.ToList();
-                    }
-                    else if (!this.activeOrchestrationSessions.TryGetValue(nextBatch.OrchestrationInstanceId, out var existingSession))
-                    {
-                        OrchestrationInstance instance = nextBatch.OrchestrationState?.OrchestrationInstance ??
-                            new OrchestrationInstance
-                            {
-                                InstanceId = nextBatch.OrchestrationInstanceId,
-                                ExecutionId = nextBatch.OrchestrationExecutionId,
-                            };
-
-                        Guid traceActivityId = AzureStorageOrchestrationService.StartNewLogicalTraceScope(useExisting: true);
-
-                        OrchestrationSession session = new OrchestrationSession(
-                            this.settings,
-                            this.storageAccountName,
-                            instance,
-                            nextBatch.ControlQueue,
-                            nextBatch.Messages,
-                            nextBatch.OrchestrationState,
-                            nextBatch.ETags,
-                            nextBatch.LastCheckpointTime,
-                            nextBatch.TrackingStoreContext,
-                            this.settings.ExtendedSessionIdleTimeout,
-                            this.shutdownToken,
-                            traceActivityId);
-
-                        this.activeOrchestrationSessions.Add(instance.InstanceId, session);
-
-                        return session;
-                    }
-                    else if (nextBatch.OrchestrationExecutionId == existingSession.Instance?.ExecutionId)
-                    {
-                        // there is already an active session with the same execution id.
-                        // The session might be waiting for more messages. If it is, signal them.
-                        existingSession.AddOrReplaceMessages(node.Value.Messages);
+                        shouldStopWaitingForSessions = this.ShouldStopWaitingForSessions(readyForProcessingQueue);
                     }
                     else
                     {
-                        // A message arrived for a different generation of an existing orchestration instance.
-                        // Put it back into the ready queue so that it can be processed once the current generation
-                        // is done executing.
-                        if (readyForProcessingQueue.Count == 0)
+                        PendingMessageBatch nextBatch = node.Value;
+                        this.pendingOrchestrationMessageBatches.Remove(node);
+
+                        if (nextBatch.ControlQueue.IsReleased)
                         {
-                            // To avoid a tight dequeue loop, delay for a bit before putting this node back into the queue.
-                            // This is only necessary when the queue is empty. The main dequeue thread must not be blocked
-                            // by this delay, which is why it is scheduled without awaiting here.
-                            _ = this.RequeuePendingBatchAfterDelayAsync(node, readyForProcessingQueue);
+                            queueToAbandon = nextBatch.ControlQueue;
+                            messagesToAbandon = nextBatch.Messages.ToList();
+                            shouldStopWaitingForSessions = this.ShouldStopWaitingForSessions(readyForProcessingQueue);
+                        }
+                        else if (!this.activeOrchestrationSessions.TryGetValue(nextBatch.OrchestrationInstanceId, out var existingSession))
+                        {
+                            OrchestrationInstance instance = nextBatch.OrchestrationState?.OrchestrationInstance ??
+                                new OrchestrationInstance
+                                {
+                                    InstanceId = nextBatch.OrchestrationInstanceId,
+                                    ExecutionId = nextBatch.OrchestrationExecutionId,
+                                };
+
+                            Guid traceActivityId = AzureStorageOrchestrationService.StartNewLogicalTraceScope(useExisting: true);
+
+                            OrchestrationSession session = new OrchestrationSession(
+                                this.settings,
+                                this.storageAccountName,
+                                instance,
+                                nextBatch.ControlQueue,
+                                nextBatch.Messages,
+                                nextBatch.OrchestrationState,
+                                nextBatch.ETags,
+                                nextBatch.LastCheckpointTime,
+                                nextBatch.TrackingStoreContext,
+                                this.settings.ExtendedSessionIdleTimeout,
+                                this.shutdownToken,
+                                traceActivityId);
+
+                            this.activeOrchestrationSessions.Add(instance.InstanceId, session);
+
+                            return session;
+                        }
+                        else if (nextBatch.OrchestrationExecutionId == existingSession.Instance?.ExecutionId)
+                        {
+                            // there is already an active session with the same execution id.
+                            // The session might be waiting for more messages. If it is, signal them.
+                            existingSession.AddOrReplaceMessages(node.Value.Messages);
                         }
                         else
                         {
-                            this.RequeueOrAbandonPendingBatchLocked(node, readyForProcessingQueue, out queueToAbandon, out messagesToAbandon);
+                            // A message arrived for a different generation of an existing orchestration instance.
+                            // Put it back into the ready queue so that it can be processed once the current generation
+                            // is done executing.
+                            if (readyForProcessingQueue.Count == 0)
+                            {
+                                // To avoid a tight dequeue loop, delay for a bit before putting this node back into the queue.
+                                // This is only necessary when the queue is empty. The main dequeue thread must not be blocked
+                                // by this delay, which is why it is scheduled without awaiting here.
+                                _ = this.RequeuePendingBatchAfterDelayAsync(node, readyForProcessingQueue);
+                            }
+                            else
+                            {
+                                this.RequeueOrAbandonPendingBatchLocked(node, readyForProcessingQueue, out queueToAbandon, out messagesToAbandon);
+                            }
                         }
                     }
                 }
@@ -869,6 +873,11 @@ namespace DurableTask.AzureStorage
                 if (queueToAbandon != null)
                 {
                     await this.AbandonMessagesForDrainAsync(queueToAbandon, messagesToAbandon);
+                }
+
+                if (shouldStopWaitingForSessions)
+                {
+                    return null;
                 }
             }
 
@@ -883,15 +892,21 @@ namespace DurableTask.AzureStorage
 
             ControlQueue? queueToAbandon;
             IReadOnlyList<MessageData> messagesToAbandon;
+            bool shouldStopWaitingForSessions;
 
             lock (this.messageAndSessionLock)
             {
                 this.RequeueOrAbandonPendingBatchLocked(node, readyForProcessingQueue, out queueToAbandon, out messagesToAbandon);
+                shouldStopWaitingForSessions = queueToAbandon != null && this.ShouldStopWaitingForSessions(readyForProcessingQueue);
             }
 
             if (queueToAbandon != null)
             {
                 await this.AbandonMessagesForDrainAsync(queueToAbandon, messagesToAbandon);
+                if (shouldStopWaitingForSessions)
+                {
+                    readyForProcessingQueue.Enqueue(node);
+                }
             }
         }
 
@@ -912,6 +927,12 @@ namespace DurableTask.AzureStorage
             readyForProcessingQueue.Enqueue(node);
             queueToAbandon = null;
             messagesToAbandon = EmptyMessageDataList;
+        }
+
+        bool ShouldStopWaitingForSessions(AsyncQueue<LinkedListNode<PendingMessageBatch>> readyForProcessingQueue)
+        {
+            return readyForProcessingQueue.Count == 0 &&
+                !this.ownedControlQueues.Values.Any(queue => !queue.IsReleased);
         }
 
         /// <summary>

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -261,14 +261,23 @@ namespace DurableTask.AzureStorage
                         $"Timed-out waiting for the dequeue loop to stop during drain.");
                 }
             }
-            catch (Exception e)
+            catch (OperationCanceledException e)
             {
                 this.settings.Logger.PartitionManagerWarning(
                     this.storageAccountName,
                     this.settings.TaskHubName,
                     this.settings.WorkerId,
                     partitionId,
-                    $"Exception while waiting for the dequeue loop to stop during drain. Exception: {e}");
+                    $"Canceled while waiting for the dequeue loop to stop during drain. Exception: {e}");
+            }
+            catch (AggregateException e) when (e.InnerExceptions.All(ex => ex is OperationCanceledException))
+            {
+                this.settings.Logger.PartitionManagerWarning(
+                    this.storageAccountName,
+                    this.settings.TaskHubName,
+                    this.settings.WorkerId,
+                    partitionId,
+                    $"Canceled while waiting for the dequeue loop to stop during drain. Exception: {e}");
             }
         }
 

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -30,8 +30,11 @@ namespace DurableTask.AzureStorage
 
     class OrchestrationSessionManager : IDisposable
     {
+        static readonly IReadOnlyList<MessageData> EmptyMessageDataList = Array.Empty<MessageData>();
+
         readonly Dictionary<string, OrchestrationSession> activeOrchestrationSessions = new Dictionary<string, OrchestrationSession>(StringComparer.OrdinalIgnoreCase);
         readonly ConcurrentDictionary<string, ControlQueue> ownedControlQueues = new ConcurrentDictionary<string, ControlQueue>();
+        readonly ConcurrentDictionary<string, Task> dequeueLoopTasks = new ConcurrentDictionary<string, Task>();
         readonly LinkedList<PendingMessageBatch> pendingOrchestrationMessageBatches = new LinkedList<PendingMessageBatch>();
         readonly AsyncQueue<LinkedListNode<PendingMessageBatch>> orchestrationsReadyForProcessingQueue = new AsyncQueue<LinkedListNode<PendingMessageBatch>>();
         readonly AsyncQueue<LinkedListNode<PendingMessageBatch>> entitiesReadyForProcessingQueue = new AsyncQueue<LinkedListNode<PendingMessageBatch>>();
@@ -67,7 +70,8 @@ namespace DurableTask.AzureStorage
 
             if (this.ownedControlQueues.TryAdd(partitionId, controlQueue))
             {
-                _ = Task.Run(() => this.DequeueLoop(partitionId, controlQueue, cancellationToken));
+                Task dequeueLoopTask = Task.Run(async () => await this.DequeueLoop(partitionId, controlQueue, cancellationToken));
+                this.dequeueLoopTasks[partitionId] = dequeueLoopTask;
             }
             else
             {
@@ -85,6 +89,7 @@ namespace DurableTask.AzureStorage
             if (this.ownedControlQueues.TryRemove(partitionId, out ControlQueue controlQueue))
             {
                 controlQueue.Release(reason, caller);
+                this.dequeueLoopTasks.TryRemove(partitionId, out _);
             }
         }
 
@@ -154,7 +159,13 @@ namespace DurableTask.AzureStorage
                             traceActivityId,
                             cancellationToken);
 
-                        this.AddMessageToPendingOrchestration(controlQueue, filteredMessages, traceActivityId, cancellationToken);
+                        IReadOnlyList<MessageData> messagesToAbandon = this.AddMessageToPendingOrchestration(
+                            controlQueue,
+                            filteredMessages,
+                            traceActivityId,
+                            cancellationToken);
+
+                        await this.AbandonMessagesForDrainAsync(controlQueue, messagesToAbandon);
                     }
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -198,6 +209,8 @@ namespace DurableTask.AzureStorage
             this.ReleaseQueue(partitionId, reason, caller);
             try
             {
+                await this.WaitForDequeueLoopToStopAsync(partitionId, cancellationToken);
+
                 // Wait until all messages from this queue have been processed.
                 while (!cancellationToken.IsCancellationRequested && this.IsControlQueueProcessingMessages(partitionId))
                 {
@@ -216,11 +229,69 @@ namespace DurableTask.AzureStorage
             }
             finally
             {
-                // Make dequeued-but-undispatched messages visible before dropping the partition.
-                await this.AbandonPendingMessagesAsync(partitionId);
-
-                this.RemoveQueue(partitionId, reason, caller);
+                try
+                {
+                    // Make dequeued-but-undispatched messages visible before dropping the partition.
+                    await this.AbandonPendingMessagesAsync(partitionId);
+                }
+                finally
+                {
+                    this.RemoveQueue(partitionId, reason, caller);
+                }
             }
+        }
+
+        async Task WaitForDequeueLoopToStopAsync(string partitionId, CancellationToken cancellationToken)
+        {
+            if (!this.dequeueLoopTasks.TryGetValue(partitionId, out Task dequeueLoopTask))
+            {
+                return;
+            }
+
+            try
+            {
+                bool completed = await WaitForTaskAsync(dequeueLoopTask, cancellationToken);
+                if (!completed)
+                {
+                    this.settings.Logger.PartitionManagerWarning(
+                        this.storageAccountName,
+                        this.settings.TaskHubName,
+                        this.settings.WorkerId,
+                        partitionId,
+                        $"Timed-out waiting for the dequeue loop to stop during drain.");
+                }
+            }
+            catch (Exception e)
+            {
+                this.settings.Logger.PartitionManagerWarning(
+                    this.storageAccountName,
+                    this.settings.TaskHubName,
+                    this.settings.WorkerId,
+                    partitionId,
+                    $"Exception while waiting for the dequeue loop to stop during drain. Exception: {e}");
+            }
+        }
+
+        static async Task<bool> WaitForTaskAsync(Task task, CancellationToken cancellationToken)
+        {
+            if (task.IsCompleted)
+            {
+                await task;
+                return true;
+            }
+
+            var cancellationCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using (cancellationToken.Register(state => ((TaskCompletionSource<bool>)state).TrySetResult(true), cancellationCompletion))
+            {
+                Task completedTask = await Task.WhenAny(task, cancellationCompletion.Task);
+                if (completedTask != task)
+                {
+                    return false;
+                }
+            }
+
+            await task;
+            return true;
         }
 
         /// <summary>
@@ -255,6 +326,27 @@ namespace DurableTask.AzureStorage
                 }
             }
 
+            await this.AbandonMessagesForDrainAsync(partitionId, messagesToAbandon);
+        }
+
+        internal Task AbandonMessagesForDrainAsync(ControlQueue controlQueue, IReadOnlyList<MessageData> messages)
+        {
+            if (messages.Count == 0)
+            {
+                return Utils.CompletedTask;
+            }
+
+            var messagesToAbandon = messages
+                .Select(message => (controlQueue, message))
+                .ToList();
+
+            return this.AbandonMessagesForDrainAsync(controlQueue.Name, messagesToAbandon);
+        }
+
+        async Task AbandonMessagesForDrainAsync(
+            string partitionId,
+            IList<(ControlQueue Queue, MessageData Message)> messagesToAbandon)
+        {
             if (messagesToAbandon.Count > 0)
             {
                 this.settings.Logger.PartitionManagerInfo(
@@ -451,7 +543,7 @@ namespace DurableTask.AzureStorage
         /// <param name="queueMessages">New messages to assign to orchestrators</param>
         /// <param name="traceActivityId">The "related" ActivityId of this operation.</param>
         /// <param name="cancellationToken">Cancellation token in case the orchestration is terminated.</param>
-        internal void AddMessageToPendingOrchestration(
+        internal IReadOnlyList<MessageData> AddMessageToPendingOrchestration(
             ControlQueue controlQueue,
             IEnumerable<MessageData> queueMessages,
             Guid traceActivityId,
@@ -463,6 +555,11 @@ namespace DurableTask.AzureStorage
             //  3. Do we need to add messages to a currently executing orchestration?
             lock (this.messageAndSessionLock)
             {
+                if (controlQueue.IsReleased)
+                {
+                    return queueMessages.ToList();
+                }
+
                 var existingSessionMessages = new Dictionary<OrchestrationSession, List<MessageData>>();
 
                 foreach (MessageData data in queueMessages)
@@ -558,6 +655,8 @@ namespace DurableTask.AzureStorage
                     session.AddOrReplaceMessages(newMessages);
                 }
             }
+
+            return EmptyMessageDataList;
         }
 
         // This method runs on a background task thread
@@ -566,6 +665,11 @@ namespace DurableTask.AzureStorage
             Guid traceActivityId,
             CancellationToken cancellationToken)
         {
+            if (!this.IsPendingBatchActive(node))
+            {
+                return;
+            }
+
             PendingMessageBatch batch = node.Value;
 
             AnalyticsEventSource.SetLogicalTraceActivityId(traceActivityId);
@@ -579,6 +683,11 @@ namespace DurableTask.AzureStorage
                        batch.OrchestrationExecutionId,
                        cancellationToken);
 
+                    if (!this.IsPendingBatchActive(node))
+                    {
+                        return;
+                    }
+
                     batch.OrchestrationState = new OrchestrationRuntimeState(history.Events);
                     batch.ETags.HistoryETag = history.ETag;
                     batch.LastCheckpointTime = history.LastCheckpointTime;
@@ -590,20 +699,34 @@ namespace DurableTask.AzureStorage
                         InstanceStatus? instanceStatus = await this.trackingStore.FetchInstanceStatusAsync(
                             batch.OrchestrationInstanceId,
                             cancellationToken);
+
+                        if (!this.IsPendingBatchActive(node))
+                        {
+                            return;
+                        }
+
                         // The instance could not exist in the case that these messages are for the first execution of a suborchestration,
                         // or an entity-started orchestration, for example
                         batch.ETags.InstanceETag = instanceStatus?.ETag;
                     }
                 }
 
-                if (this.settings.UseSeparateQueueForEntityWorkItems
-                    && DurableTask.Core.Common.Entities.IsEntityInstance(batch.OrchestrationInstanceId))
+                lock (this.messageAndSessionLock)
                 {
-                    this.entitiesReadyForProcessingQueue.Enqueue(node);
-                }
-                else
-                {
-                    this.orchestrationsReadyForProcessingQueue.Enqueue(node);
+                    if (!this.IsPendingBatchActiveLocked(node))
+                    {
+                        return;
+                    }
+
+                    if (this.settings.UseSeparateQueueForEntityWorkItems
+                        && DurableTask.Core.Common.Entities.IsEntityInstance(batch.OrchestrationInstanceId))
+                    {
+                        this.entitiesReadyForProcessingQueue.Enqueue(node);
+                    }
+                    else
+                    {
+                        this.orchestrationsReadyForProcessingQueue.Enqueue(node);
+                    }
                 }
             }
             catch (OperationCanceledException)
@@ -620,12 +743,35 @@ namespace DurableTask.AzureStorage
                     e.ToString());
 
                 // Sleep briefly to avoid a tight failure loop.
-                await Task.Delay(TimeSpan.FromSeconds(5));
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
 
                 // This is a background operation so failure is not an option. All exceptions must be handled.
                 // To avoid starvation, we need to re-enqueue this async operation instead of retrying in a loop.
-                await Task.Run(() => this.ScheduleOrchestrationStatePrefetch(node, traceActivityId, cancellationToken));
+                if (this.IsPendingBatchActive(node))
+                {
+                    await Task.Run(async () => await this.ScheduleOrchestrationStatePrefetch(node, traceActivityId, cancellationToken));
+                }
             }
+        }
+
+        bool IsPendingBatchActive(LinkedListNode<PendingMessageBatch> node)
+        {
+            lock (this.messageAndSessionLock)
+            {
+                return this.IsPendingBatchActiveLocked(node);
+            }
+        }
+
+        bool IsPendingBatchActiveLocked(LinkedListNode<PendingMessageBatch> node)
+        {
+            return node.List == this.pendingOrchestrationMessageBatches && !node.Value.ControlQueue.IsReleased;
         }
 
         public async Task<OrchestrationSession?> GetNextSessionAsync(bool entitiesOnly, CancellationToken cancellationToken)
@@ -737,8 +883,14 @@ namespace DurableTask.AzureStorage
             }
         }
 
-        public bool TryReleaseSession(string instanceId, CancellationToken cancellationToken, out OrchestrationSession session)
+        public bool TryReleaseSession(
+            string instanceId,
+            CancellationToken cancellationToken,
+            out OrchestrationSession session,
+            out IReadOnlyList<MessageData> messagesToAbandon)
         {
+            messagesToAbandon = EmptyMessageDataList;
+
             // Taking this lock ensures we don't add new messages to a session we're about to release.
             lock (this.messageAndSessionLock)
             {
@@ -748,7 +900,7 @@ namespace DurableTask.AzureStorage
                     this.activeOrchestrationSessions.Remove(instanceId))
                 {
                     // Put any unprocessed messages back into the pending buffer.
-                    this.AddMessageToPendingOrchestration(
+                    messagesToAbandon = this.AddMessageToPendingOrchestration(
                         session.ControlQueue,
                         session.PendingMessages.Concat(session.DeferredMessages),
                         session.TraceActivityId,

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -216,8 +216,57 @@ namespace DurableTask.AzureStorage
             }
             finally
             {
-                // Remove the partition from memory
+                // Make dequeued-but-undispatched messages visible before dropping the partition.
+                await this.AbandonPendingMessagesAsync(partitionId);
+
                 this.RemoveQueue(partitionId, reason, caller);
+            }
+        }
+
+        /// <summary>
+        /// Abandons all pending (dequeued but not yet dispatched) messages for the specified partition,
+        /// making them immediately visible in the Azure Storage queue for the new partition owner.
+        /// This prevents a throughput gap equal to the visibility timeout duration when a partition
+        /// is released during drain.
+        /// </summary>
+        async Task AbandonPendingMessagesAsync(string partitionId)
+        {
+            var messagesToAbandon = new List<(ControlQueue Queue, MessageData Message)>();
+
+            lock (this.messageAndSessionLock)
+            {
+                var node = this.pendingOrchestrationMessageBatches.First;
+                while (node != null)
+                {
+                    LinkedListNode<PendingMessageBatch>? next = node.Next;
+                    PendingMessageBatch batch = node.Value;
+
+                    if (string.Equals(batch.ControlQueue.Name, partitionId, StringComparison.OrdinalIgnoreCase))
+                    {
+                        foreach (MessageData message in batch.Messages)
+                        {
+                            messagesToAbandon.Add((batch.ControlQueue, message));
+                        }
+
+                        this.pendingOrchestrationMessageBatches.Remove(node);
+                    }
+
+                    node = next;
+                }
+            }
+
+            if (messagesToAbandon.Count > 0)
+            {
+                this.settings.Logger.PartitionManagerInfo(
+                    this.storageAccountName,
+                    this.settings.TaskHubName,
+                    this.settings.WorkerId,
+                    partitionId,
+                    $"Abandoning {messagesToAbandon.Count} pending message(s) during drain to make them immediately visible for the new partition owner.");
+
+                await messagesToAbandon.ParallelForEachAsync(
+                    this.settings.MaxStorageOperationConcurrency,
+                    item => item.Queue.AbandonMessageForDrainAsync(item.Message));
             }
         }
 
@@ -592,6 +641,12 @@ namespace DurableTask.AzureStorage
 
                 lock (this.messageAndSessionLock)
                 {
+                    // Drain may have removed this batch after it was queued for dispatch.
+                    if (node.List != this.pendingOrchestrationMessageBatches)
+                    {
+                        continue;
+                    }
+
                     PendingMessageBatch nextBatch = node.Value;
                     this.pendingOrchestrationMessageBatches.Remove(node);
 

--- a/src/DurableTask.AzureStorage/Partitioning/TablePartitionManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/TablePartitionManager.cs
@@ -362,7 +362,7 @@ namespace DurableTask.AzureStorage.Partitioning
                     // In a worker becomes unhealthy, it may lose a lease without realizing it and continue listening
                     // for messages. We check for that case here and stop dequeuing messages if we discover that
                     // another worker currently owns the lease.
-                    this.service.DropLostControlQueue(partition);
+                    await this.service.DropLostControlQueue(partition);
 
                     bool claimedLease = false;
                     bool stoleLease = false;

--- a/test/DurableTask.AzureStorage.Tests/OrchestrationSessionTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/OrchestrationSessionTests.cs
@@ -232,7 +232,7 @@ namespace DurableTask.AzureStorage.Tests
         }
 
         [TestMethod]
-        public async Task GetNextSessionAsync_DrainedReadyQueueNode_IsIgnored()
+        public async Task GetNextSessionAsync_DrainedReadyQueueNode_ReturnsNullWhenNoQueuesRemain()
         {
             var settings = new AzureStorageOrchestrationServiceSettings
             {
@@ -257,15 +257,9 @@ namespace DurableTask.AzureStorage.Tests
             EnqueueReadyForProcessingNode(manager, node);
 
             using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
-            try
-            {
-                await manager.GetNextSessionAsync(entitiesOnly: false, cts.Token);
-                Assert.Fail("Expected cancellation after the drained node was skipped.");
-            }
-            catch (OperationCanceledException)
-            {
-                Assert.IsTrue(true, "The drained node was skipped until cancellation.");
-            }
+            OrchestrationSession session = await manager.GetNextSessionAsync(entitiesOnly: false, cts.Token);
+
+            Assert.IsNull(session, "Detached ready nodes should not block dispatch when no queues remain.");
         }
 
         [TestMethod]
@@ -397,7 +391,7 @@ namespace DurableTask.AzureStorage.Tests
         }
 
         [TestMethod]
-        public async Task GetNextSessionAsync_ReleasedDelayedRequeueNode_IsNotRequeued()
+        public async Task GetNextSessionAsync_ReleasedDelayedRequeueNode_AbandonsMessagesAndReturnsNullWhenNoQueuesRemain()
         {
             var settings = new AzureStorageOrchestrationServiceSettings
             {
@@ -439,14 +433,14 @@ namespace DurableTask.AzureStorage.Tests
             object node = AddPendingBatchNode(manager, pendingBatch);
             EnqueueReadyForProcessingNode(manager, node);
 
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
             Task<OrchestrationSession> getNextTask = manager.GetNextSessionAsync(entitiesOnly: false, cts.Token);
 
             await WaitUntilAsync(() => IsNodeDetached(node), TimeSpan.FromSeconds(2));
             controlQueue.Release(null, "test");
-            cts.Cancel();
-            await Assert.ThrowsExceptionAsync<OperationCanceledException>(() => getNextTask);
+            OrchestrationSession session = await getNextTask;
 
+            Assert.IsNull(session, "Released delayed requeue nodes should not block dispatch when no queues remain.");
             await WaitUntilAsync(() => abandonCount == 1, TimeSpan.FromSeconds(2));
 
             Assert.AreEqual(0, GetPendingBatchCount(manager), "Released queue nodes should not be requeued after a delay.");
@@ -455,7 +449,7 @@ namespace DurableTask.AzureStorage.Tests
         }
 
         [TestMethod]
-        public async Task GetNextSessionAsync_ReleasedReadyQueueNode_IsAbandonedImmediately()
+        public async Task GetNextSessionAsync_ReleasedReadyQueueNode_AbandonsMessagesAndReturnsNullWhenNoQueuesRemain()
         {
             var settings = new AzureStorageOrchestrationServiceSettings
             {
@@ -497,14 +491,10 @@ namespace DurableTask.AzureStorage.Tests
             EnqueueReadyForProcessingNode(manager, node);
             controlQueue.Release(null, "test");
 
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-            Task<OrchestrationSession> getNextTask = manager.GetNextSessionAsync(entitiesOnly: false, cts.Token);
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+            OrchestrationSession session = await manager.GetNextSessionAsync(entitiesOnly: false, cts.Token);
 
-            await WaitUntilAsync(() => GetReadyQueueCount(manager) == 0, TimeSpan.FromSeconds(2));
-            await WaitUntilAsync(() => abandonCount == 1, TimeSpan.FromSeconds(2));
-            cts.Cancel();
-            await Assert.ThrowsExceptionAsync<OperationCanceledException>(() => getNextTask);
-
+            Assert.IsNull(session, "Released queue nodes should not block dispatch when no queues remain.");
             Assert.AreEqual(0, GetPendingBatchCount(manager), "Released ready nodes should be removed from pending batches.");
             Assert.AreEqual(1, abandonCount, "Messages from released ready nodes should be immediately abandoned.");
         }

--- a/test/DurableTask.AzureStorage.Tests/OrchestrationSessionTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/OrchestrationSessionTests.cs
@@ -20,10 +20,13 @@ namespace DurableTask.AzureStorage.Tests
     using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
+    using Azure.Storage.Queues.Models;
     using DurableTask.AzureStorage.Messaging;
     using DurableTask.AzureStorage.Monitoring;
     using DurableTask.AzureStorage.Storage;
     using DurableTask.AzureStorage.Tracking;
+    using DurableTask.Core;
+    using DurableTask.Core.History;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
 
@@ -258,7 +261,80 @@ namespace DurableTask.AzureStorage.Tests
             }
             catch (OperationCanceledException)
             {
+                Assert.IsTrue(true, "The drained node was skipped until cancellation.");
             }
+        }
+
+        [TestMethod]
+        public async Task ScheduleOrchestrationStatePrefetch_DetachedNode_DoesNotFetchHistory()
+        {
+            var settings = new AzureStorageOrchestrationServiceSettings
+            {
+                StorageAccountClientProvider = new StorageAccountClientProvider("UseDevelopmentStorage=true"),
+            };
+            var stats = new AzureStorageOrchestrationServiceStats();
+            int fetchCount = 0;
+            var trackingStore = new Mock<ITrackingStore>();
+            trackingStore
+                .Setup(t => t.GetHistoryEventsAsync("instance1", "execution1", It.IsAny<CancellationToken>()))
+                .Callback(() => fetchCount++)
+                .ThrowsAsync(new OperationCanceledException());
+
+            using var manager = new OrchestrationSessionManager(
+                "testaccount",
+                settings,
+                stats,
+                trackingStore.Object);
+
+            var storageClient = new AzureStorageClient(settings);
+            var messageManager = new MessageManager(settings, storageClient, settings.TaskHubName);
+            var controlQueue = new ControlQueue(storageClient, "partition-0", messageManager);
+
+            object pendingBatch = CreatePendingBatch(controlQueue);
+            object node = AddPendingBatchNode(manager, pendingBatch);
+            RemovePendingBatchNode(manager, node);
+
+            await InvokeScheduleOrchestrationStatePrefetch(manager, node, CancellationToken.None);
+
+            Assert.AreEqual(0, fetchCount, "Detached pending batches should not fetch orchestration history.");
+        }
+
+        [TestMethod]
+        public void AddMessageToPendingOrchestration_ReleasedControlQueue_ReturnsMessagesToAbandon()
+        {
+            var settings = new AzureStorageOrchestrationServiceSettings
+            {
+                StorageAccountClientProvider = new StorageAccountClientProvider("UseDevelopmentStorage=true"),
+            };
+            var stats = new AzureStorageOrchestrationServiceStats();
+            var trackingStore = new Mock<ITrackingStore>();
+
+            using var manager = new OrchestrationSessionManager(
+                "testaccount",
+                settings,
+                stats,
+                trackingStore.Object);
+
+            var storageClient = new AzureStorageClient(settings);
+            var messageManager = new MessageManager(settings, storageClient, settings.TaskHubName);
+            var controlQueue = new ControlQueue(storageClient, "partition-0", messageManager);
+            controlQueue.Release(null, "test");
+
+            MessageData message = CreateMessageData();
+            MethodInfo addMessage = typeof(OrchestrationSessionManager).GetMethod(
+                "AddMessageToPendingOrchestration",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+
+            var messagesToAbandon = (IReadOnlyList<MessageData>)addMessage.Invoke(
+                manager,
+                new object[] { controlQueue, new[] { message }, Guid.NewGuid(), CancellationToken.None });
+
+            Assert.IsNotNull(messagesToAbandon, "Released queue messages should be returned for immediate abandon.");
+            Assert.AreEqual(1, messagesToAbandon.Count);
+            Assert.AreSame(message, messagesToAbandon[0]);
+
+            manager.GetStats(out int pendingOrchestratorInstances, out _, out _);
+            Assert.AreEqual(0, pendingOrchestratorInstances, "Released queue messages should not be added to pending batches.");
         }
 
         static object CreatePendingBatch(ControlQueue controlQueue)
@@ -293,6 +369,51 @@ namespace DurableTask.AzureStorage.Tests
             object readyQueue = GetPrivateField(manager, "orchestrationsReadyForProcessingQueue");
             MethodInfo enqueue = readyQueue.GetType().GetMethod("Enqueue");
             enqueue.Invoke(readyQueue, new[] { node });
+        }
+
+        static Task InvokeScheduleOrchestrationStatePrefetch(
+            OrchestrationSessionManager manager,
+            object node,
+            CancellationToken cancellationToken)
+        {
+            MethodInfo schedule = typeof(OrchestrationSessionManager).GetMethod(
+                "ScheduleOrchestrationStatePrefetch",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+
+            return (Task)schedule.Invoke(manager, new[] { node, Guid.NewGuid(), cancellationToken });
+        }
+
+        static MessageData CreateMessageData()
+        {
+            var instance = new OrchestrationInstance
+            {
+                InstanceId = "instance1",
+                ExecutionId = "execution1",
+            };
+
+            var taskMessage = new TaskMessage
+            {
+                OrchestrationInstance = instance,
+                Event = new TimerFiredEvent(0),
+            };
+
+            var message = new MessageData(
+                taskMessage,
+                Guid.NewGuid(),
+                "partition-0",
+                orchestrationEpisode: null,
+                sender: instance);
+
+            message.OriginalQueueMessage = QueuesModelFactory.QueueMessage(
+                Guid.NewGuid().ToString("N"),
+                Guid.NewGuid().ToString("N"),
+                string.Empty,
+                1,
+                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow.AddHours(1),
+                DateTimeOffset.UtcNow.AddMinutes(5));
+
+            return message;
         }
 
         static object GetPrivateField(object target, string fieldName)

--- a/test/DurableTask.AzureStorage.Tests/OrchestrationSessionTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/OrchestrationSessionTests.cs
@@ -21,6 +21,8 @@ namespace DurableTask.AzureStorage.Tests
     using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
+    using Azure;
+    using Azure.Storage.Queues;
     using Azure.Storage.Queues.Models;
     using DurableTask.AzureStorage.Messaging;
     using DurableTask.AzureStorage.Monitoring;
@@ -367,6 +369,146 @@ namespace DurableTask.AzureStorage.Tests
             Assert.AreSame(expected, actual);
         }
 
+        [TestMethod]
+        public async Task AbandonMessageForDrainAsync_DurableTaskStorageException_DoesNotThrow()
+        {
+            var settings = new AzureStorageOrchestrationServiceSettings
+            {
+                StorageAccountClientProvider = new StorageAccountClientProvider("UseDevelopmentStorage=true"),
+            };
+            var storageClient = new AzureStorageClient(settings);
+            var messageManager = new MessageManager(settings, storageClient, settings.TaskHubName);
+            var controlQueue = new ControlQueue(storageClient, "partition-0", messageManager);
+
+            var queueClient = new Mock<QueueClient>();
+            queueClient.SetupGet(q => q.Name).Returns("partition-0");
+            queueClient
+                .Setup(
+                    q => q.UpdateMessageAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<TimeSpan>(),
+                        It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new RequestFailedException(404, "queue update failed"));
+            SetPrivateField(controlQueue.InnerQueue, "queueClient", queueClient.Object);
+
+            await controlQueue.AbandonMessageForDrainAsync(CreateMessageData());
+        }
+
+        [TestMethod]
+        public async Task GetNextSessionAsync_ReleasedDelayedRequeueNode_IsNotRequeued()
+        {
+            var settings = new AzureStorageOrchestrationServiceSettings
+            {
+                StorageAccountClientProvider = new StorageAccountClientProvider("UseDevelopmentStorage=true"),
+            };
+            var stats = new AzureStorageOrchestrationServiceStats();
+            var trackingStore = new Mock<ITrackingStore>();
+
+            using var manager = new OrchestrationSessionManager(
+                "testaccount",
+                settings,
+                stats,
+                trackingStore.Object);
+
+            var storageClient = new AzureStorageClient(settings);
+            var messageManager = new MessageManager(settings, storageClient, settings.TaskHubName);
+            var controlQueue = new ControlQueue(storageClient, "partition-0", messageManager);
+            MessageData message = CreateMessageData();
+            int abandonCount = 0;
+            var queueClient = new Mock<QueueClient>();
+            queueClient.SetupGet(q => q.Name).Returns("partition-0");
+            queueClient
+                .Setup(
+                    q => q.UpdateMessageAsync(
+                        message.OriginalQueueMessage.MessageId,
+                        message.OriginalQueueMessage.PopReceipt,
+                        It.IsAny<string>(),
+                        TimeSpan.Zero,
+                        It.IsAny<CancellationToken>()))
+                .Callback(() => abandonCount++)
+                .ReturnsAsync(Response.FromValue(
+                    QueuesModelFactory.UpdateReceipt("newPopReceipt", DateTimeOffset.UtcNow),
+                    Mock.Of<Response>()));
+            SetPrivateField(controlQueue.InnerQueue, "queueClient", queueClient.Object);
+
+            AddActiveSession(manager, settings, controlQueue, "instance1", "activeExecution");
+            object pendingBatch = CreatePendingBatch(controlQueue);
+            AddMessageToPendingBatch(pendingBatch, message);
+            object node = AddPendingBatchNode(manager, pendingBatch);
+            EnqueueReadyForProcessingNode(manager, node);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            Task<OrchestrationSession> getNextTask = manager.GetNextSessionAsync(entitiesOnly: false, cts.Token);
+
+            await WaitUntilAsync(() => IsNodeDetached(node), TimeSpan.FromSeconds(2));
+            controlQueue.Release(null, "test");
+            cts.Cancel();
+            await Assert.ThrowsExceptionAsync<OperationCanceledException>(() => getNextTask);
+
+            await WaitUntilAsync(() => abandonCount == 1, TimeSpan.FromSeconds(2));
+
+            Assert.AreEqual(0, GetPendingBatchCount(manager), "Released queue nodes should not be requeued after a delay.");
+            Assert.AreEqual(0, GetReadyQueueCount(manager), "Released queue nodes should not be made ready for dispatch.");
+            Assert.AreEqual(1, abandonCount, "Messages from a released delayed requeue node should be immediately abandoned.");
+        }
+
+        [TestMethod]
+        public async Task GetNextSessionAsync_ReleasedReadyQueueNode_IsAbandonedImmediately()
+        {
+            var settings = new AzureStorageOrchestrationServiceSettings
+            {
+                StorageAccountClientProvider = new StorageAccountClientProvider("UseDevelopmentStorage=true"),
+            };
+            var stats = new AzureStorageOrchestrationServiceStats();
+            var trackingStore = new Mock<ITrackingStore>();
+
+            using var manager = new OrchestrationSessionManager(
+                "testaccount",
+                settings,
+                stats,
+                trackingStore.Object);
+
+            var storageClient = new AzureStorageClient(settings);
+            var messageManager = new MessageManager(settings, storageClient, settings.TaskHubName);
+            var controlQueue = new ControlQueue(storageClient, "partition-0", messageManager);
+            MessageData message = CreateMessageData();
+            int abandonCount = 0;
+            var queueClient = new Mock<QueueClient>();
+            queueClient.SetupGet(q => q.Name).Returns("partition-0");
+            queueClient
+                .Setup(
+                    q => q.UpdateMessageAsync(
+                        message.OriginalQueueMessage.MessageId,
+                        message.OriginalQueueMessage.PopReceipt,
+                        It.IsAny<string>(),
+                        TimeSpan.Zero,
+                        It.IsAny<CancellationToken>()))
+                .Callback(() => abandonCount++)
+                .ReturnsAsync(Response.FromValue(
+                    QueuesModelFactory.UpdateReceipt("newPopReceipt", DateTimeOffset.UtcNow),
+                    Mock.Of<Response>()));
+            SetPrivateField(controlQueue.InnerQueue, "queueClient", queueClient.Object);
+
+            object pendingBatch = CreatePendingBatch(controlQueue);
+            AddMessageToPendingBatch(pendingBatch, message);
+            object node = AddPendingBatchNode(manager, pendingBatch);
+            EnqueueReadyForProcessingNode(manager, node);
+            controlQueue.Release(null, "test");
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            Task<OrchestrationSession> getNextTask = manager.GetNextSessionAsync(entitiesOnly: false, cts.Token);
+
+            await WaitUntilAsync(() => GetReadyQueueCount(manager) == 0, TimeSpan.FromSeconds(2));
+            await WaitUntilAsync(() => abandonCount == 1, TimeSpan.FromSeconds(2));
+            cts.Cancel();
+            await Assert.ThrowsExceptionAsync<OperationCanceledException>(() => getNextTask);
+
+            Assert.AreEqual(0, GetPendingBatchCount(manager), "Released ready nodes should be removed from pending batches.");
+            Assert.AreEqual(1, abandonCount, "Messages from released ready nodes should be immediately abandoned.");
+        }
+
         static object CreatePendingBatch(ControlQueue controlQueue)
         {
             Type pendingBatchType = typeof(OrchestrationSessionManager)
@@ -401,6 +543,12 @@ namespace DurableTask.AzureStorage.Tests
             enqueue.Invoke(readyQueue, new[] { node });
         }
 
+        static void AddMessageToPendingBatch(object pendingBatch, MessageData message)
+        {
+            var messages = (ICollection<MessageData>)pendingBatch.GetType().GetProperty("Messages").GetValue(pendingBatch);
+            messages.Add(message);
+        }
+
         static Task InvokeScheduleOrchestrationStatePrefetch(
             OrchestrationSessionManager manager,
             object node,
@@ -411,6 +559,72 @@ namespace DurableTask.AzureStorage.Tests
                 BindingFlags.NonPublic | BindingFlags.Instance);
 
             return (Task)schedule.Invoke(manager, new[] { node, Guid.NewGuid(), cancellationToken });
+        }
+
+        static void AddActiveSession(
+            OrchestrationSessionManager manager,
+            AzureStorageOrchestrationServiceSettings settings,
+            ControlQueue controlQueue,
+            string instanceId,
+            string executionId)
+        {
+            var sessions = (Dictionary<string, OrchestrationSession>)GetPrivateField(manager, "activeOrchestrationSessions");
+            var instance = new OrchestrationInstance
+            {
+                InstanceId = instanceId,
+                ExecutionId = executionId,
+            };
+            var runtimeState = new OrchestrationRuntimeState();
+            runtimeState.AddEvent(new ExecutionStartedEvent(-1, string.Empty)
+            {
+                OrchestrationInstance = instance,
+            });
+
+            sessions[instanceId] = new OrchestrationSession(
+                settings,
+                "testaccount",
+                instance,
+                controlQueue,
+                new List<MessageData>(),
+                runtimeState,
+                eTags: null,
+                DateTime.UtcNow,
+                trackingStoreContext: null,
+                TimeSpan.FromSeconds(30),
+                CancellationToken.None,
+                Guid.NewGuid());
+        }
+
+        static bool IsNodeDetached(object node)
+        {
+            object list = node.GetType().GetProperty("List").GetValue(node);
+            return list == null;
+        }
+
+        static int GetPendingBatchCount(OrchestrationSessionManager manager)
+        {
+            object pendingBatches = GetPrivateField(manager, "pendingOrchestrationMessageBatches");
+            return (int)pendingBatches.GetType().GetProperty("Count").GetValue(pendingBatches);
+        }
+
+        static int GetReadyQueueCount(OrchestrationSessionManager manager)
+        {
+            object readyQueue = GetPrivateField(manager, "orchestrationsReadyForProcessingQueue");
+            return (int)readyQueue.GetType().GetProperty("Count").GetValue(readyQueue);
+        }
+
+        static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            while (!condition())
+            {
+                if (stopwatch.Elapsed > timeout)
+                {
+                    Assert.Fail("Condition was not reached before timeout.");
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(10));
+            }
         }
 
         static MessageData CreateMessageData()
@@ -451,6 +665,13 @@ namespace DurableTask.AzureStorage.Tests
             FieldInfo field = target.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
             Assert.IsNotNull(field);
             return field.GetValue(target);
+        }
+
+        static void SetPrivateField(object target, string fieldName, object value)
+        {
+            FieldInfo field = target.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(field);
+            field.SetValue(target, value);
         }
     }
 }

--- a/test/DurableTask.AzureStorage.Tests/OrchestrationSessionTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/OrchestrationSessionTests.cs
@@ -26,6 +26,7 @@ namespace DurableTask.AzureStorage.Tests
     using Azure.Storage.Queues.Models;
     using DurableTask.AzureStorage.Messaging;
     using DurableTask.AzureStorage.Monitoring;
+    using DurableTask.AzureStorage.Partitioning;
     using DurableTask.AzureStorage.Storage;
     using DurableTask.AzureStorage.Tracking;
     using DurableTask.Core;
@@ -335,6 +336,105 @@ namespace DurableTask.AzureStorage.Tests
         }
 
         [TestMethod]
+        public async Task RemoveQueue_PendingBatch_AbandonsMessages()
+        {
+            var settings = new AzureStorageOrchestrationServiceSettings
+            {
+                StorageAccountClientProvider = new StorageAccountClientProvider("UseDevelopmentStorage=true"),
+            };
+            var stats = new AzureStorageOrchestrationServiceStats();
+            var trackingStore = new Mock<ITrackingStore>();
+
+            using var manager = new OrchestrationSessionManager(
+                "testaccount",
+                settings,
+                stats,
+                trackingStore.Object);
+
+            var storageClient = new AzureStorageClient(settings);
+            var messageManager = new MessageManager(settings, storageClient, settings.TaskHubName);
+            var controlQueue = new ControlQueue(storageClient, "partition-0", messageManager);
+            AddOwnedControlQueue(manager, "partition-0", controlQueue);
+
+            MessageData message = CreateMessageData();
+            int abandonCount = 0;
+            var queueClient = new Mock<QueueClient>();
+            queueClient.SetupGet(q => q.Name).Returns("partition-0");
+            queueClient
+                .Setup(
+                    q => q.UpdateMessageAsync(
+                        message.OriginalQueueMessage.MessageId,
+                        message.OriginalQueueMessage.PopReceipt,
+                        It.IsAny<string>(),
+                        TimeSpan.Zero,
+                        It.IsAny<CancellationToken>()))
+                .Callback(() => abandonCount++)
+                .ReturnsAsync(Response.FromValue(
+                    QueuesModelFactory.UpdateReceipt("newPopReceipt", DateTimeOffset.UtcNow),
+                    Mock.Of<Response>()));
+            SetPrivateField(controlQueue.InnerQueue, "queueClient", queueClient.Object);
+
+            object pendingBatch = CreatePendingBatch(controlQueue);
+            AddMessageToPendingBatch(pendingBatch, message);
+            AddPendingBatchNode(manager, pendingBatch);
+
+            await InvokeRemoveQueue(manager, "partition-0");
+
+            Assert.AreEqual(0, GetPendingBatchCount(manager), "RemoveQueue should remove pending batches for the released queue.");
+            Assert.AreEqual(1, abandonCount, "RemoveQueue should immediately abandon pending messages for the released queue.");
+        }
+
+        [TestMethod]
+        public async Task RemoveQueue_PendingBatch_ReturnsNullToWaitingDispatcher()
+        {
+            var settings = new AzureStorageOrchestrationServiceSettings
+            {
+                StorageAccountClientProvider = new StorageAccountClientProvider("UseDevelopmentStorage=true"),
+            };
+            var stats = new AzureStorageOrchestrationServiceStats();
+            var trackingStore = new Mock<ITrackingStore>();
+
+            using var manager = new OrchestrationSessionManager(
+                "testaccount",
+                settings,
+                stats,
+                trackingStore.Object);
+
+            var storageClient = new AzureStorageClient(settings);
+            var messageManager = new MessageManager(settings, storageClient, settings.TaskHubName);
+            var controlQueue = new ControlQueue(storageClient, "partition-0", messageManager);
+            AddOwnedControlQueue(manager, "partition-0", controlQueue);
+
+            MessageData message = CreateMessageData();
+            var queueClient = new Mock<QueueClient>();
+            queueClient.SetupGet(q => q.Name).Returns("partition-0");
+            queueClient
+                .Setup(
+                    q => q.UpdateMessageAsync(
+                        message.OriginalQueueMessage.MessageId,
+                        message.OriginalQueueMessage.PopReceipt,
+                        It.IsAny<string>(),
+                        TimeSpan.Zero,
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Response.FromValue(
+                    QueuesModelFactory.UpdateReceipt("newPopReceipt", DateTimeOffset.UtcNow),
+                    Mock.Of<Response>()));
+            SetPrivateField(controlQueue.InnerQueue, "queueClient", queueClient.Object);
+
+            object pendingBatch = CreatePendingBatch(controlQueue);
+            AddMessageToPendingBatch(pendingBatch, message);
+            AddPendingBatchNode(manager, pendingBatch);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+            Task<OrchestrationSession> getNextTask = manager.GetNextSessionAsync(entitiesOnly: false, cts.Token);
+
+            await InvokeRemoveQueue(manager, "partition-0");
+            OrchestrationSession session = await getNextTask;
+
+            Assert.IsNull(session, "Removing the last queue should unblock dispatchers waiting for a session.");
+        }
+
+        [TestMethod]
         public async Task WaitForDequeueLoopToStopAsync_FaultedDequeueLoop_PropagatesUnexpectedException()
         {
             var settings = new AzureStorageOrchestrationServiceSettings();
@@ -531,6 +631,22 @@ namespace DurableTask.AzureStorage.Tests
             object readyQueue = GetPrivateField(manager, "orchestrationsReadyForProcessingQueue");
             MethodInfo enqueue = readyQueue.GetType().GetMethod("Enqueue");
             enqueue.Invoke(readyQueue, new[] { node });
+        }
+
+        static void AddOwnedControlQueue(OrchestrationSessionManager manager, string partitionId, ControlQueue controlQueue)
+        {
+            var ownedQueues = (ConcurrentDictionary<string, ControlQueue>)GetPrivateField(manager, "ownedControlQueues");
+            ownedQueues[partitionId] = controlQueue;
+        }
+
+        static async Task InvokeRemoveQueue(OrchestrationSessionManager manager, string partitionId)
+        {
+            MethodInfo removeQueue = typeof(OrchestrationSessionManager).GetMethod("RemoveQueue");
+            object result = removeQueue.Invoke(manager, new object[] { partitionId, CloseReason.LeaseLost, "test" });
+            if (result is Task task)
+            {
+                await task;
+            }
         }
 
         static void AddMessageToPendingBatch(object pendingBatch, MessageData message)

--- a/test/DurableTask.AzureStorage.Tests/OrchestrationSessionTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/OrchestrationSessionTests.cs
@@ -14,6 +14,7 @@
 namespace DurableTask.AzureStorage.Tests
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
@@ -335,6 +336,35 @@ namespace DurableTask.AzureStorage.Tests
 
             manager.GetStats(out int pendingOrchestratorInstances, out _, out _);
             Assert.AreEqual(0, pendingOrchestratorInstances, "Released queue messages should not be added to pending batches.");
+        }
+
+        [TestMethod]
+        public async Task WaitForDequeueLoopToStopAsync_FaultedDequeueLoop_PropagatesUnexpectedException()
+        {
+            var settings = new AzureStorageOrchestrationServiceSettings();
+            var stats = new AzureStorageOrchestrationServiceStats();
+            var trackingStore = new Mock<ITrackingStore>();
+
+            using var manager = new OrchestrationSessionManager(
+                "testaccount",
+                settings,
+                stats,
+                trackingStore.Object);
+
+            var dequeueLoopTasks = (ConcurrentDictionary<string, Task>)GetPrivateField(manager, "dequeueLoopTasks");
+            var expected = new InvalidOperationException("unexpected dequeue loop failure");
+            dequeueLoopTasks["partition-0"] = Task.FromException(expected);
+
+            MethodInfo wait = typeof(OrchestrationSessionManager).GetMethod(
+                "WaitForDequeueLoopToStopAsync",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+
+            Task waitTask = (Task)wait.Invoke(manager, new object[] { "partition-0", CancellationToken.None });
+
+            InvalidOperationException actual = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => waitTask);
+
+            Assert.AreSame(expected, actual);
         }
 
         static object CreatePendingBatch(ControlQueue controlQueue)


### PR DESCRIPTION
This PR improves partition drain behavior for Azure Storage control queues. When a partition is released, any control queue messages that were already dequeued but not yet dispatched to an active orchestration session are now abandoned with zero visibility timeout, making them immediately visible for the next partition owner.

The change prevents a throughput gap during lease transitions where pending in-memory messages could otherwise remain invisible until their original visibility timeout expired.

Related ICM: https://portal.microsofticm.com/imp/v5/incidents/details/21000001021644/summary