### PR TITLE
Fix Dependabot alerts, modernize sample dependencies, drop EOL SDK installs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,7 +48,7 @@
   
   <!-- Test dependencies -->
   <ItemGroup>
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.6.0" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.1" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageVersion Include="CommandLineParser" Version="1.9.71" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageVersion Include="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer.NetCore" Version="2.0.1406.4" />
@@ -62,7 +62,7 @@
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.3" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.8" />
     <PackageVersion Include="WindowsAzure.Storage" Version="9.3.3" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageVersion Include="WindowsAzure.Storage" Version="8.7.0" Condition="'$(TargetFramework)' == 'net48'" />
   </ItemGroup>
@@ -90,17 +90,17 @@
 
   <!-- Samples dependencies -->
   <ItemGroup>
-    <PackageVersion Include="Azure.Identity" Version="1.18.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.12.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.21.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.23.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageVersion Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.17.3" />
-    <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.4" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="3.1.32" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="3.1.32" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.1.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.15.3" />
-    <PackageVersion Include="Vio.DurableTask.Hosting" Version="2.2.1" />
+    <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.14.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="Vio.DurableTask.Hosting" Version="2.2.17" />
   </ItemGroup>
 
   <!-- Dependencies specific to net8.0-->
@@ -118,7 +118,7 @@
 
   <!-- Samples dependencies with net48-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-    <PackageVersion Include="ncrontab" version="1.0.0" />
+    <PackageVersion Include="ncrontab" Version="3.4.0" />
   </ItemGroup>
 
 </Project>

--- a/eng/templates/build-steps.yml
+++ b/eng/templates/build-steps.yml
@@ -11,19 +11,6 @@ steps:
 # Start by restoring all the dependencies. This needs to be its own task
 # from what I can tell. We specifically only target DurableTask.AzureStorage
 # and its direct dependencies.
-# Configure all the .NET SDK versions we need
-- task: UseDotNet@2
-  displayName: 'Use the .NET Core 2.1 SDK (required for build signing)'
-  inputs:
-    packageType: 'sdk'
-    version: '2.1.x'
-
-- task: UseDotNet@2
-  displayName: 'Use the .NET Core 3.1 SDK'
-  inputs:
-    packageType: 'sdk'
-    version: '3.1.x'
-
 - task: UseDotNet@2
   displayName: 'Use the .NET 8 SDK'
   inputs:

--- a/samples/Correlation.Samples/Correlation.Samples.csproj
+++ b/samples/Correlation.Samples/Correlation.Samples.csproj
@@ -21,6 +21,8 @@
   <ItemGroup>
     <PackageReference Include="System.Data.SqlClient" />
     <PackageReference Include="System.Net.Http" />
+    <!-- Pinned to override vulnerable transitive (GHSA-cmhx-cq75-c4mj). -->
+    <PackageReference Include="System.Text.RegularExpressions" />
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/samples/Correlation.Samples/TelemetryActivator.cs
+++ b/samples/Correlation.Samples/TelemetryActivator.cs
@@ -69,7 +69,21 @@ namespace Correlation.Samples
             telemetryInitializer.ExcludeComponentCorrelationHttpHeadersOnDomains.Add("127.0.0.1");
             config.TelemetryInitializers.Add(telemetryInitializer);
 
-            config.InstrumentationKey = Environment.GetEnvironmentVariable("APPINSIGHTS_INSTRUMENTATIONKEY");
+            string connectionString = Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING");
+            if (!string.IsNullOrEmpty(connectionString))
+            {
+                config.ConnectionString = connectionString;
+            }
+            else
+            {
+                string instrumentationKey = Environment.GetEnvironmentVariable("APPINSIGHTS_INSTRUMENTATIONKEY");
+                if (!string.IsNullOrEmpty(instrumentationKey))
+                {
+#pragma warning disable CS0618 // InstrumentationKey is obsolete; kept for backward compatibility.
+                    config.InstrumentationKey = instrumentationKey;
+#pragma warning restore CS0618
+                }
+            }
 
             module.Initialize(config);
 

--- a/samples/DistributedTraceSample/ApplicationInsights/ApplicationInsightsSample.csproj
+++ b/samples/DistributedTraceSample/ApplicationInsights/ApplicationInsightsSample.csproj
@@ -9,10 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" VersionOverride="7.0.2" />
     <PackageReference Include="Vio.DurableTask.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" />
+    <!-- Pinned to override vulnerable transitive System.Text.Json 6.0.0 (GHSA-8g4q-xg66-9fp4). -->
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/DistributedTraceSample/OpenTelemetry/OpenTelemetrySample.csproj
+++ b/samples/DistributedTraceSample/OpenTelemetry/OpenTelemetrySample.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="OpenTelemetry.Api" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
   </ItemGroup>
 

--- a/samples/DistributedTraceSample/OpenTelemetry/Program.cs
+++ b/samples/DistributedTraceSample/OpenTelemetry/Program.cs
@@ -31,7 +31,7 @@ namespace OpenTelemetrySample
                 .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("MySample"))
                 .AddSource("DurableTask.Core")
                 .AddConsoleExporter()
-                .AddZipkinExporter()
+                .AddOtlpExporter()
                 .AddAzureMonitorTraceExporter(options =>
                 {
                     options.ConnectionString = Environment.GetEnvironmentVariable("AZURE_MONITOR_CONNECTION_STRING");

--- a/samples/ManagedIdentitySample/DTFx.AzureStorage v1.x/ManagedIdentity.AzStorageV1.csproj
+++ b/samples/ManagedIdentitySample/DTFx.AzureStorage v1.x/ManagedIdentity.AzStorageV1.csproj
@@ -14,6 +14,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <!-- Pinned to override vulnerable transitives from DurableTask 1.x / WindowsAzure.Storage 9.x (GHSA-7jgj-8wvc-jh57, GHSA-cmhx-cq75-c4mj). -->
+    <PackageReference Include="System.Net.Http" />
+    <PackageReference Include="System.Text.RegularExpressions" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Three related cleanups for the `samples/` projects and the public PR validation pipeline:

1. **Fix all 5 open Dependabot security alerts** (transitive deps in samples).
2. **Modernize outdated sample dependencies** (13 package bumps + 1 deprecated package replacement).
3. **Remove EOL .NET Core 2.1 / 3.1 SDK install steps** from the PR validation pipeline (recurring TLS failures as Microsoft retires EOL release infrastructure).

## Dependabot alerts fixed

| # | Advisory | Package | Before → After | Affected sample | Fix |
|---|----------|---------|----------------|-----------------|-----|
| 36 | [GHSA-cmhx-cq75-c4mj](https://github.com/advisories/GHSA-cmhx-cq75-c4mj) | System.Text.RegularExpressions | 4.3.0 → **4.3.1** | ManagedIdentity v1.x | Explicit pin |
| 35 | [GHSA-7jgj-8wvc-jh57](https://github.com/advisories/GHSA-7jgj-8wvc-jh57) | System.Net.Http | 4.3.0 → **4.3.4** | ManagedIdentity v1.x | Explicit pin |
| 31 | [GHSA-8g4q-xg66-9fp4](https://github.com/advisories/GHSA-8g4q-xg66-9fp4) | System.Text.Json | 6.0.0 → **10.0.8** | ApplicationInsightsSample | Explicit pin |
| 28 | [GHSA-rxg9-xrhp-64gj](https://github.com/advisories/GHSA-rxg9-xrhp-64gj) | System.Drawing.Common | 4.7.0 → **6.0.0** | ApplicationInsightsSample | Transitive via WorkerService upgrade |
| 25 | [GHSA-cmhx-cq75-c4mj](https://github.com/advisories/GHSA-cmhx-cq75-c4mj) | System.Text.RegularExpressions | 4.3.0 → **4.3.1** | Correlation.Samples | Explicit pin |

`System.Drawing.Common` is resolved by bumping `Microsoft.ApplicationInsights.WorkerService` from 2.21.0 → 2.23.0, which brings `Drawing.Common 6.0.0` transitively — outside the only known vulnerable ranges (`4.x < 4.7.2` and `5.x < 5.0.3`). No explicit reference or CPM entry is needed.

## Sample dependency modernization (`Directory.Packages.props`)

| Package | Before | After |
|---|---|---|
| Azure.Identity | 1.18.0 | **1.21.0** |
| Azure.Monitor.OpenTelemetry.Exporter | 1.6.0 | **1.8.1** |
| Microsoft.ApplicationInsights.DependencyCollector | 2.12.0 | **2.23.0** |
| Microsoft.ApplicationInsights.WorkerService | 2.21.0 | **2.23.0** |
| Microsoft.Extensions.Azure | 1.7.4 | **1.14.0** |
| Microsoft.Extensions.Configuration | 3.1.32 | **10.0.8** |
| Microsoft.Extensions.Configuration.Json | 3.1.32 | **10.0.8** |
| Microsoft.Extensions.Hosting | 6.0.1 | **10.0.8** |
| OpenTelemetry.Exporter.Console | 1.1.0 | **1.15.3** |
| OpenTelemetry.Exporter.Zipkin *(deprecated)* | — | replaced with **OpenTelemetry.Exporter.OpenTelemetryProtocol 1.15.3** |
| System.Text.Json | 10.0.3 | **10.0.8** |
| Vio.DurableTask.Hosting | 2.2.1 | **2.2.17** |
| ncrontab (net48) | 1.0.0 | **3.4.0** |

### Code changes
- `samples/DistributedTraceSample/OpenTelemetry/Program.cs`: migrate deprecated `AddZipkinExporter()` → `AddOtlpExporter()` (Zipkin exporter package replaced).
- `samples/Correlation.Samples/TelemetryActivator.cs`: migrate from obsolete `TelemetryConfiguration.InstrumentationKey` to `ConnectionString` (`APPLICATIONINSIGHTS_CONNECTION_STRING`) with backward-compat fallback to the legacy `APPINSIGHTS_INSTRUMENTATIONKEY` env var.
- `samples/DistributedTraceSample/ApplicationInsights/ApplicationInsightsSample.csproj`: removed stale `System.Diagnostics.DiagnosticSource VersionOverride="7.0.2"` workaround (no longer needed once Hosting is on 10.x).

## CI fix (`eng/templates/build-steps.yml`)

Removed the two `UseDotNet@2` steps that installed **.NET Core 2.1** and **.NET Core 3.1** SDKs. Both runtimes are long EOL (Aug 2021 and Dec 2022); no project in the repo targets `netcoreapp2.x` or `netcoreapp3.x`. The 2.1 release-index endpoint has become unreliable, producing intermittent TLS handshake failures that fail the whole PR validation pipeline (e.g., build #279849 `DTFxCoreValidate Validate 11`):

```
##[error]Failed to download or parse releases-index.json with error:
write EPROTO ... tlsv1 alert internal error ... SSL alert number 80
```

Builds use VSBuild/MSBuild, and the only SDK actually required is **.NET 8** for the `net8.0` test targets. The official build pipeline (`eng/ci/official-build.yml`) doesn't install these SDKs either.

## Intentionally not modernized
- `Microsoft.Azure.DurableTask.AzureStorage 1.17.3` in ManagedIdentity v1.x (educational pin to demonstrate v1.x usage).
- `EnterpriseLibrary.SemanticLogging` / `CommandLineParser 1.x` in DurableTask.Samples (abandoned / breaking API changes).
- `Microsoft.ApplicationInsights 2.x → 3.x` (major version, out of scope).

## Verification
- ✅ All **6 sample projects**, **4 src libraries**, and **3 test projects** build with **0 warnings, 0 errors**.
- ✅ `dotnet list package --include-transitive` on each affected sample confirms no vulnerable transitive versions remain.
