### PR TITLE
Add a serialization binder for Service Fabric provider proxy

### DIFF
--- a/Test/DurableTask.AzureServiceFabric.Tests/AllowedTypesSerializationBinderTests.cs
+++ b/Test/DurableTask.AzureServiceFabric.Tests/AllowedTypesSerializationBinderTests.cs
@@ -110,6 +110,15 @@ namespace DurableTask.AzureServiceFabric.Tests
         }
 
         [TestMethod]
+        public void BindToType_RejectsUnresolvableType()
+        {
+            // A type name that cannot be resolved should throw a controlled exception, not NullReferenceException
+            var ex = Assert.ThrowsException<JsonSerializationException>(() =>
+                this.binder.BindToType("DurableTask.Core", "DurableTask.Core.NonExistentType"));
+            StringAssert.Contains(ex.Message, "NonExistentType");
+        }
+
+        [TestMethod]
         public void BindToType_RejectsNonAllowlistedDurableTaskCoreType()
         {
             // TaskOrchestration is a DurableTask.Core type but not in the proxy endpoint allowlist

--- a/Test/DurableTask.AzureServiceFabric.Tests/AllowedTypesSerializationBinderTests.cs
+++ b/Test/DurableTask.AzureServiceFabric.Tests/AllowedTypesSerializationBinderTests.cs
@@ -15,6 +15,9 @@ namespace DurableTask.AzureServiceFabric.Tests
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using DurableTask.AzureServiceFabric.Models;
     using DurableTask.AzureServiceFabric.Service;
     using DurableTask.Core;
     using DurableTask.Core.History;
@@ -43,9 +46,9 @@ namespace DurableTask.AzureServiceFabric.Tests
         }
 
         [TestMethod]
-        public void BindToType_AllowsServiceFabricTypes()
+        public void BindToType_AllowsServiceFabricProxyTypes()
         {
-            var type = typeof(FabricOrchestrationProvider);
+            var type = typeof(CreateTaskOrchestrationParameters);
             var result = this.binder.BindToType(type.Assembly.GetName().Name, type.FullName);
             Assert.AreEqual(type, result);
         }
@@ -96,6 +99,44 @@ namespace DurableTask.AzureServiceFabric.Tests
             var type = typeof(System.Diagnostics.Process);
             Assert.ThrowsException<InvalidOperationException>(() =>
                 this.binder.BindToType(type.Assembly.GetName().Name, type.FullName));
+        }
+
+        [TestMethod]
+        public void BindToType_RejectsNonAllowlistedMscorlibType()
+        {
+            // System.Type is from mscorlib but not in the type allowlist
+            Assert.ThrowsException<InvalidOperationException>(() =>
+                this.binder.BindToType("mscorlib", typeof(Type).FullName));
+        }
+
+        [TestMethod]
+        public void BindToType_RejectsNonAllowlistedDurableTaskCoreType()
+        {
+            // TaskOrchestration is a DurableTask.Core type but not in the proxy endpoint allowlist
+            var type = typeof(TaskOrchestration);
+            Assert.ThrowsException<InvalidOperationException>(() =>
+                this.binder.BindToType(type.Assembly.GetName().Name, type.FullName));
+        }
+
+        [TestMethod]
+        public void BindToType_AllowsAllHistoryEventKnownTypes()
+        {
+            IEnumerable<Type> knownTypes;
+            try
+            {
+                knownTypes = HistoryEvent.KnownTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                // In test environments, not all types may be loadable
+                knownTypes = ex.Types.Where(t => t != null && !t.IsAbstract && typeof(HistoryEvent).IsAssignableFrom(t));
+            }
+
+            foreach (Type knownType in knownTypes)
+            {
+                var result = this.binder.BindToType(knownType.Assembly.GetName().Name, knownType.FullName);
+                Assert.AreEqual(knownType, result, $"HistoryEvent subclass {knownType.Name} should be allowed");
+            }
         }
 
         [TestMethod]

--- a/Test/DurableTask.AzureServiceFabric.Tests/AllowedTypesSerializationBinderTests.cs
+++ b/Test/DurableTask.AzureServiceFabric.Tests/AllowedTypesSerializationBinderTests.cs
@@ -1,0 +1,192 @@
+//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureServiceFabric.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using DurableTask.AzureServiceFabric.Service;
+    using DurableTask.Core;
+    using DurableTask.Core.History;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json;
+
+    [TestClass]
+    public class AllowedTypesSerializationBinderTests
+    {
+        readonly AllowedTypesSerializationBinder binder = new AllowedTypesSerializationBinder();
+
+        [TestMethod]
+        public void BindToType_AllowsDurableTaskCoreTypes()
+        {
+            var type = typeof(TaskMessage);
+            var result = this.binder.BindToType(type.Assembly.GetName().Name, type.FullName);
+            Assert.AreEqual(type, result);
+        }
+
+        [TestMethod]
+        public void BindToType_AllowsHistoryEventSubclasses()
+        {
+            var type = typeof(ExecutionStartedEvent);
+            var result = this.binder.BindToType(type.Assembly.GetName().Name, type.FullName);
+            Assert.AreEqual(type, result);
+        }
+
+        [TestMethod]
+        public void BindToType_AllowsServiceFabricTypes()
+        {
+            var type = typeof(FabricOrchestrationProvider);
+            var result = this.binder.BindToType(type.Assembly.GetName().Name, type.FullName);
+            Assert.AreEqual(type, result);
+        }
+
+        [TestMethod]
+        public void BindToType_AllowsMscorlibTypes()
+        {
+            var type = typeof(Dictionary<string, string>);
+            var result = this.binder.BindToType("mscorlib", type.FullName);
+            Assert.AreEqual(type, result);
+        }
+
+        [TestMethod]
+        public void BindToType_AllowsQualifiedAssemblyName()
+        {
+            var type = typeof(TaskMessage);
+            string qualifiedName = type.Assembly.FullName; // e.g. "DurableTask.Core, Version=..."
+            var result = this.binder.BindToType(qualifiedName, type.FullName);
+            Assert.AreEqual(type, result);
+        }
+
+        [TestMethod]
+        public void BindToType_AllowsNullAssemblyName()
+        {
+            // Null/empty assembly name should pass through to the default binder
+            var result = this.binder.BindToType(null, typeof(string).FullName);
+            Assert.IsNotNull(result);
+        }
+
+        [TestMethod]
+        public void BindToType_RejectsArbitraryAssembly()
+        {
+            Assert.ThrowsException<InvalidOperationException>(() =>
+                this.binder.BindToType("Evil.Assembly", "Evil.PwnedDescriptor"));
+        }
+
+        [TestMethod]
+        public void BindToType_RejectsQualifiedArbitraryAssembly()
+        {
+            Assert.ThrowsException<InvalidOperationException>(() =>
+                this.binder.BindToType("Evil.Assembly, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null", "Evil.PwnedDescriptor"));
+        }
+
+        [TestMethod]
+        public void BindToType_RejectsSystemDiagnosticsProcess()
+        {
+            // A common gadget type — must be rejected
+            var type = typeof(System.Diagnostics.Process);
+            Assert.ThrowsException<InvalidOperationException>(() =>
+                this.binder.BindToType(type.Assembly.GetName().Name, type.FullName));
+        }
+
+        [TestMethod]
+        public void BindToName_DelegatesToDefaultBinder()
+        {
+            this.binder.BindToName(typeof(TaskMessage), out string assemblyName, out string typeName);
+            // DefaultSerializationBinder delegates to the runtime; just verify it doesn't throw
+            // and returns consistent results for a known type.
+            this.binder.BindToName(typeof(TaskMessage), out string assemblyName2, out string typeName2);
+            Assert.AreEqual(assemblyName, assemblyName2);
+            Assert.AreEqual(typeName, typeName2);
+        }
+
+        [TestMethod]
+        public void RoundTrip_TaskMessageWithHistoryEvent_Succeeds()
+        {
+            var message = new TaskMessage
+            {
+                SequenceNumber = 42,
+                OrchestrationInstance = new OrchestrationInstance { InstanceId = "test-1", ExecutionId = "exec-1" },
+                Event = new ExecutionStartedEvent(-1, "input-data")
+                {
+                    Tags = new Dictionary<string, string> { { "key", "value" } },
+                    Name = "TestOrchestration",
+                    Version = "1.0"
+                }
+            };
+
+            var settings = new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.All,
+                SerializationBinder = this.binder
+            };
+
+            string json = JsonConvert.SerializeObject(message, settings);
+            var deserialized = JsonConvert.DeserializeObject<TaskMessage>(json, settings);
+
+            Assert.IsNotNull(deserialized);
+            Assert.AreEqual(42, deserialized.SequenceNumber);
+            Assert.AreEqual("test-1", deserialized.OrchestrationInstance.InstanceId);
+            Assert.IsInstanceOfType(deserialized.Event, typeof(ExecutionStartedEvent));
+
+            var startedEvent = (ExecutionStartedEvent)deserialized.Event;
+            Assert.AreEqual("TestOrchestration", startedEvent.Name);
+            Assert.AreEqual("value", startedEvent.Tags["key"]);
+        }
+
+        [TestMethod]
+        public void Deserialize_MaliciousPayload_IsRejected()
+        {
+            string maliciousJson = @"{
+                ""$type"": ""System.Diagnostics.Process, System"",
+                ""StartInfo"": { ""FileName"": ""cmd.exe"" }
+            }";
+
+            var settings = new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.All,
+                SerializationBinder = this.binder
+            };
+
+            // Newtonsoft wraps the binder's InvalidOperationException in a JsonSerializationException
+            var ex = Assert.ThrowsException<JsonSerializationException>(() =>
+                JsonConvert.DeserializeObject<object>(maliciousJson, settings));
+            Assert.IsInstanceOfType(ex.InnerException, typeof(InvalidOperationException));
+            StringAssert.Contains(ex.InnerException.Message, "is not allowed");
+        }
+
+        [TestMethod]
+        public void Settings_DefaultBinderIsAllowedTypes()
+        {
+            var providerSettings = new FabricOrchestrationProviderSettings();
+            Assert.IsNotNull(providerSettings.JsonSerializationBinder);
+            Assert.IsInstanceOfType(providerSettings.JsonSerializationBinder, typeof(AllowedTypesSerializationBinder));
+        }
+
+        [TestMethod]
+        public void Settings_BinderCanBeSetToNull()
+        {
+            var providerSettings = new FabricOrchestrationProviderSettings();
+            providerSettings.JsonSerializationBinder = null;
+            Assert.IsNull(providerSettings.JsonSerializationBinder);
+        }
+
+        [TestMethod]
+        public void Settings_BinderCanBeOverridden()
+        {
+            var customBinder = new Newtonsoft.Json.Serialization.DefaultSerializationBinder();
+            var providerSettings = new FabricOrchestrationProviderSettings();
+            providerSettings.JsonSerializationBinder = customBinder;
+            Assert.AreSame(customBinder, providerSettings.JsonSerializationBinder);
+        }
+    }
+}

--- a/docs/providers/service-fabric.md
+++ b/docs/providers/service-fabric.md
@@ -131,6 +131,7 @@ Service Fabric handles partitioning automatically based on your service configur
 | `TaskActivityDispatcherSettings.MaxConcurrentActivities` | Max concurrent activities | 1000 |
 | `TaskActivityDispatcherSettings.DispatcherCount` | Number of activity dispatchers | 10 |
 | `LoggerFactory` | Optional logger factory for diagnostics | null |
+| `JsonSerializationBinder` | `ISerializationBinder` that restricts which types can be deserialized from incoming JSON requests on the proxy endpoint | `AllowedTypesSerializationBinder` |
 
 ### Example Configuration
 
@@ -148,6 +149,25 @@ var settings = new FabricOrchestrationProviderSettings
         DispatcherCount = 5
     }
 };
+```
+
+### Serialization Security
+
+The proxy endpoint uses `TypeNameHandling.All` for JSON deserialization to support polymorphic types like `HistoryEvent`. By default, an `AllowedTypesSerializationBinder` restricts deserialization to types from `DurableTask.Core`, `DurableTask.AzureServiceFabric`, and core system assemblies. This prevents untrusted `$type` metadata in JSON payloads from loading arbitrary types.
+
+To provide a custom binder:
+
+```csharp
+settings.JsonSerializationBinder = new MyCustomSerializationBinder();
+```
+
+To disable type restrictions and restore legacy behavior:
+
+```csharp
+// ⚠️ Not recommended: disables deserialization type restrictions.
+// Only use this if you have other security controls in place
+// (e.g., network isolation, mutual TLS) to protect the proxy endpoint.
+settings.JsonSerializationBinder = null;
 ```
 
 ## Client Access

--- a/src/DurableTask.AzureServiceFabric/FabricOrchestrationProviderSettings.cs
+++ b/src/DurableTask.AzureServiceFabric/FabricOrchestrationProviderSettings.cs
@@ -13,9 +13,11 @@
 
 namespace DurableTask.AzureServiceFabric
 {
+    using DurableTask.AzureServiceFabric.Service;
     using DurableTask.Core;
     using DurableTask.Core.Settings;
     using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json.Serialization;
 
     /// <summary>
     /// Provides settings for service fabric based custom provider implementations
@@ -56,5 +58,17 @@ namespace DurableTask.AzureServiceFabric
         /// Gets or sets the optional <see cref="ILoggerFactory"/> to use for diagnostic logging.
         /// </summary>
         public ILoggerFactory LoggerFactory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ISerializationBinder"/> used to restrict which types can be
+        /// deserialized from incoming JSON requests on the proxy endpoint. This protects against
+        /// untrusted <c>$type</c> metadata in JSON payloads.
+        /// <para>
+        /// Defaults to <see cref="AllowedTypesSerializationBinder"/>, which permits only known
+        /// DurableTask and core system types. Set a custom <see cref="ISerializationBinder"/> to
+        /// override, or set to <c>null</c> to disable type restrictions (not recommended).
+        /// </para>
+        /// </summary>
+        public ISerializationBinder JsonSerializationBinder { get; set; } = new AllowedTypesSerializationBinder();
     }
 }

--- a/src/DurableTask.AzureServiceFabric/Service/AllowedTypesSerializationBinder.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/AllowedTypesSerializationBinder.cs
@@ -18,37 +18,46 @@ namespace DurableTask.AzureServiceFabric.Service
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
+    using DurableTask.AzureServiceFabric.Models;
+    using DurableTask.Core;
+    using DurableTask.Core.History;
+    using DurableTask.Core.Tracing;
     using Newtonsoft.Json.Serialization;
 
     /// <summary>
-    /// A serialization binder that restricts deserialization to only known DurableTask types
-    /// and core system types. This prevents untrusted <c>$type</c> metadata in JSON payloads
-    /// from loading arbitrary assemblies or instantiating arbitrary types.
+    /// A serialization binder that restricts deserialization to only the specific types
+    /// that flow through the Service Fabric proxy HTTP endpoints. This prevents untrusted
+    /// <c>$type</c> metadata in JSON payloads from loading arbitrary assemblies or
+    /// instantiating arbitrary types.
     /// </summary>
     public sealed class AllowedTypesSerializationBinder : ISerializationBinder
     {
-        static readonly HashSet<string> AllowedAssemblyNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            typeof(Core.TaskMessage).Assembly.GetName().Name,           // DurableTask.Core
-            typeof(FabricOrchestrationProvider).Assembly.GetName().Name, // DurableTask.AzureServiceFabric
-            "mscorlib",                                                  // .NET Framework core types
-            "System.Private.CoreLib",                                    // .NET Core/5+ core types
-        };
+        static readonly HashSet<Type> AllowedTypes = BuildAllowedTypes();
 
         readonly DefaultSerializationBinder defaultBinder = new DefaultSerializationBinder();
-        readonly ConcurrentDictionary<string, bool> assemblyAllowCache = new ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+        readonly ConcurrentDictionary<Type, bool> typeAllowCache = new ConcurrentDictionary<Type, bool>();
 
         /// <inheritdoc />
         public Type BindToType(string assemblyName, string typeName)
         {
-            if (!IsAssemblyAllowed(assemblyName))
+            // Validate assembly name before resolving to prevent Assembly.Load of untrusted assemblies.
+            if (!string.IsNullOrWhiteSpace(assemblyName) && !IsAssemblyNameAllowed(assemblyName))
             {
                 throw new InvalidOperationException(
                     $"Deserialization of type '{typeName}' from assembly '{assemblyName}' is not allowed. " +
-                    $"Only known DurableTask and core system types are permitted.");
+                    $"Only known DurableTask proxy endpoint types are permitted.");
             }
 
-            return this.defaultBinder.BindToType(assemblyName, typeName);
+            Type resolvedType = this.defaultBinder.BindToType(assemblyName, typeName);
+
+            if (!IsTypeAllowed(resolvedType))
+            {
+                throw new InvalidOperationException(
+                    $"Deserialization of type '{resolvedType.FullName}' is not allowed. " +
+                    $"Only known DurableTask proxy endpoint types are permitted.");
+            }
+
+            return resolvedType;
         }
 
         /// <inheritdoc />
@@ -57,20 +66,96 @@ namespace DurableTask.AzureServiceFabric.Service
             this.defaultBinder.BindToName(serializedType, out assemblyName, out typeName);
         }
 
-        bool IsAssemblyAllowed(string assemblyName)
+        static HashSet<Type> BuildAllowedTypes()
         {
-            if (string.IsNullOrWhiteSpace(assemblyName))
+            var types = new HashSet<Type>
             {
-                // No assembly specified — let the default binder resolve it.
-                return true;
+                // Core domain types that appear in the proxy endpoint object graph
+                typeof(TaskMessage),
+                typeof(OrchestrationInstance),
+                typeof(OrchestrationExecutionContext),
+                typeof(OrchestrationState),
+                typeof(ParentInstance),
+                typeof(DistributedTraceContext),
+                typeof(FailureDetails),
+
+                // Service Fabric proxy parameter types
+                typeof(CreateTaskOrchestrationParameters),
+                typeof(PurgeOrchestrationHistoryParameters),
+
+                // System collections used for Tags and FailureDetails.Properties
+                typeof(Dictionary<string, string>),
+                typeof(Dictionary<string, object>),
+            };
+
+            // All HistoryEvent subclasses (self-maintaining via assembly scanning).
+            // Use the same logic as HistoryEvent.KnownTypes() but handle partial load failures
+            // that can occur when not all referenced assemblies are available.
+            try
+            {
+                foreach (Type historyEventType in HistoryEvent.KnownTypes())
+                {
+                    types.Add(historyEventType);
+                }
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                foreach (Type loadedType in ex.Types)
+                {
+                    if (loadedType != null && !loadedType.IsAbstract && typeof(HistoryEvent).IsAssignableFrom(loadedType))
+                    {
+                        types.Add(loadedType);
+                    }
+                }
             }
 
-            return this.assemblyAllowCache.GetOrAdd(assemblyName, name =>
+            return types;
+        }
+
+        static bool IsAssemblyNameAllowed(string assemblyName)
+        {
+            // Strip version/culture/publicKeyToken if present
+            int commaIndex = assemblyName.IndexOf(',');
+            string shortName = commaIndex >= 0 ? assemblyName.Substring(0, commaIndex).Trim() : assemblyName.Trim();
+
+            return string.Equals(shortName, typeof(TaskMessage).Assembly.GetName().Name, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(shortName, typeof(FabricOrchestrationProvider).Assembly.GetName().Name, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(shortName, "mscorlib", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(shortName, "System.Private.CoreLib", StringComparison.OrdinalIgnoreCase);
+        }
+
+        bool IsTypeAllowed(Type type)
+        {
+            return this.typeAllowCache.GetOrAdd(type, t =>
             {
-                // Strip version/culture/publicKeyToken if present (e.g., "mscorlib, Version=4.0.0.0, ...")
-                int commaIndex = name.IndexOf(',');
-                string shortName = commaIndex >= 0 ? name.Substring(0, commaIndex).Trim() : name.Trim();
-                return AllowedAssemblyNames.Contains(shortName);
+                // Primitives and strings are always safe
+                if (t.IsPrimitive || t == typeof(string) || t == typeof(DateTime)
+                    || t == typeof(DateTimeOffset) || t == typeof(TimeSpan)
+                    || t == typeof(Guid) || t == typeof(decimal))
+                {
+                    return true;
+                }
+
+                // Arrays of allowed types
+                if (t.IsArray)
+                {
+                    return IsTypeAllowed(t.GetElementType());
+                }
+
+                // Nullable<T> of allowed types
+                Type nullable = Nullable.GetUnderlyingType(t);
+                if (nullable != null)
+                {
+                    return IsTypeAllowed(nullable);
+                }
+
+                // Enums are safe (serialize as values)
+                if (t.IsEnum)
+                {
+                    return true;
+                }
+
+                return AllowedTypes.Contains(t);
             });
         }
     }

--- a/src/DurableTask.AzureServiceFabric/Service/AllowedTypesSerializationBinder.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/AllowedTypesSerializationBinder.cs
@@ -1,0 +1,77 @@
+//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureServiceFabric.Service
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using Newtonsoft.Json.Serialization;
+
+    /// <summary>
+    /// A serialization binder that restricts deserialization to only known DurableTask types
+    /// and core system types. This prevents untrusted <c>$type</c> metadata in JSON payloads
+    /// from loading arbitrary assemblies or instantiating arbitrary types.
+    /// </summary>
+    public sealed class AllowedTypesSerializationBinder : ISerializationBinder
+    {
+        static readonly HashSet<string> AllowedAssemblyNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            typeof(Core.TaskMessage).Assembly.GetName().Name,           // DurableTask.Core
+            typeof(FabricOrchestrationProvider).Assembly.GetName().Name, // DurableTask.AzureServiceFabric
+            "mscorlib",                                                  // .NET Framework core types
+            "System.Private.CoreLib",                                    // .NET Core/5+ core types
+        };
+
+        readonly DefaultSerializationBinder defaultBinder = new DefaultSerializationBinder();
+        readonly ConcurrentDictionary<string, bool> assemblyAllowCache = new ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+
+        /// <inheritdoc />
+        public Type BindToType(string assemblyName, string typeName)
+        {
+            if (!IsAssemblyAllowed(assemblyName))
+            {
+                throw new InvalidOperationException(
+                    $"Deserialization of type '{typeName}' from assembly '{assemblyName}' is not allowed. " +
+                    $"Only known DurableTask and core system types are permitted.");
+            }
+
+            return this.defaultBinder.BindToType(assemblyName, typeName);
+        }
+
+        /// <inheritdoc />
+        public void BindToName(Type serializedType, out string assemblyName, out string typeName)
+        {
+            this.defaultBinder.BindToName(serializedType, out assemblyName, out typeName);
+        }
+
+        bool IsAssemblyAllowed(string assemblyName)
+        {
+            if (string.IsNullOrWhiteSpace(assemblyName))
+            {
+                // No assembly specified — let the default binder resolve it.
+                return true;
+            }
+
+            return this.assemblyAllowCache.GetOrAdd(assemblyName, name =>
+            {
+                // Strip version/culture/publicKeyToken if present (e.g., "mscorlib, Version=4.0.0.0, ...")
+                int commaIndex = name.IndexOf(',');
+                string shortName = commaIndex >= 0 ? name.Substring(0, commaIndex).Trim() : name.Trim();
+                return AllowedAssemblyNames.Contains(shortName);
+            });
+        }
+    }
+}

--- a/src/DurableTask.AzureServiceFabric/Service/AllowedTypesSerializationBinder.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/AllowedTypesSerializationBinder.cs
@@ -100,12 +100,9 @@ namespace DurableTask.AzureServiceFabric.Service
             }
             catch (ReflectionTypeLoadException ex)
             {
-                foreach (Type loadedType in ex.Types)
+                foreach (Type loadedType in ex.Types.Where(t => t != null && !t.IsAbstract && typeof(HistoryEvent).IsAssignableFrom(t)))
                 {
-                    if (loadedType != null && !loadedType.IsAbstract && typeof(HistoryEvent).IsAssignableFrom(loadedType))
-                    {
-                        types.Add(loadedType);
-                    }
+                    types.Add(loadedType);
                 }
             }
 

--- a/src/DurableTask.AzureServiceFabric/Service/AllowedTypesSerializationBinder.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/AllowedTypesSerializationBinder.cs
@@ -50,10 +50,10 @@ namespace DurableTask.AzureServiceFabric.Service
 
             Type resolvedType = this.defaultBinder.BindToType(assemblyName, typeName);
 
-            if (!IsTypeAllowed(resolvedType))
+            if (resolvedType == null || !IsTypeAllowed(resolvedType))
             {
                 throw new InvalidOperationException(
-                    $"Deserialization of type '{resolvedType.FullName}' is not allowed. " +
+                    $"Deserialization of type '{typeName}' from assembly '{assemblyName}' is not allowed. " +
                     $"Only known DurableTask proxy endpoint types are permitted.");
             }
 

--- a/src/DurableTask.AzureServiceFabric/Service/Startup.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/Startup.cs
@@ -21,17 +21,20 @@ namespace DurableTask.AzureServiceFabric.Service
     using DurableTask.Core;
     using DurableTask.AzureServiceFabric;
     using Microsoft.Extensions.DependencyInjection;
+    using Newtonsoft.Json.Serialization;
     using Owin;
 
     class Startup : IOwinAppBuilder
     {
         FabricOrchestrationProvider fabricOrchestrationProvider;
+        ISerializationBinder serializationBinder;
         string listeningAddress;
 
-        public Startup(string listeningAddress, FabricOrchestrationProvider fabricOrchestrationProvider)
+        public Startup(string listeningAddress, FabricOrchestrationProvider fabricOrchestrationProvider, ISerializationBinder serializationBinder)
         {
             this.listeningAddress = listeningAddress ?? throw new ArgumentNullException(nameof(listeningAddress));
             this.fabricOrchestrationProvider = fabricOrchestrationProvider ?? throw new ArgumentNullException(nameof(fabricOrchestrationProvider));
+            this.serializationBinder = serializationBinder;
         }
 
         public string GetListeningAddress()
@@ -61,6 +64,11 @@ namespace DurableTask.AzureServiceFabric.Service
             config.Formatters.Remove(config.Formatters.XmlFormatter);
             config.Formatters.Remove(config.Formatters.FormUrlEncodedFormatter);
             config.Formatters.JsonFormatter.SerializerSettings.TypeNameHandling = Newtonsoft.Json.TypeNameHandling.All;
+            if (this.serializationBinder != null)
+            {
+                config.Formatters.JsonFormatter.SerializerSettings.SerializationBinder = this.serializationBinder;
+            }
+
             appBuilder.UseWebApi(config);
         }
     }

--- a/src/DurableTask.AzureServiceFabric/Service/Startup.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/Startup.cs
@@ -27,7 +27,7 @@ namespace DurableTask.AzureServiceFabric.Service
     class Startup : IOwinAppBuilder
     {
         FabricOrchestrationProvider fabricOrchestrationProvider;
-        ISerializationBinder serializationBinder;
+        readonly ISerializationBinder serializationBinder;
         string listeningAddress;
 
         public Startup(string listeningAddress, FabricOrchestrationProvider fabricOrchestrationProvider, ISerializationBinder serializationBinder)

--- a/src/DurableTask.AzureServiceFabric/Service/TaskHubProxyListener.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/TaskHubProxyListener.cs
@@ -163,7 +163,7 @@ namespace DurableTask.AzureServiceFabric.Service
                 string protocol = this.enableHttps ? "https" : "http";
                 string listeningAddress = string.Format(CultureInfo.InvariantCulture, "{0}://{1}:{2}/{3}/dtfx/", protocol, ipAddress, serviceEndpoint.Port, context.PartitionId);
 
-                return new OwinCommunicationListener(new Startup(listeningAddress, this.fabricOrchestrationProvider));
+                return new OwinCommunicationListener(new Startup(listeningAddress, this.fabricOrchestrationProvider, this.fabricOrchestrationProviderSettings.JsonSerializationBinder));
             }, Constants.TaskHubProxyServiceName);
         }
 


### PR DESCRIPTION
The Service Fabric proxy endpoint uses `TypeNameHandling.All` for JSON deserialization to support polymorphic types like `HistoryEvent` subclasses in the inter-partition communication protocol. This PR adds an `ISerializationBinder` that restricts which types can be instantiated during deserialization to a known set of types that actually flow through the proxy endpoints.

### Changes

- **`AllowedTypesSerializationBinder`** — new binder with a two-layer validation approach:
  - Assembly name pre-check (before type resolution) to limit which assemblies can be referenced
  - Type-level allowlist covering the ~33 specific types in the proxy endpoint object graph: `TaskMessage`, `OrchestrationInstance`, all `HistoryEvent` subclasses (auto-discovered via `HistoryEvent.KnownTypes()`), `Dictionary<string, string>`, and the SF proxy parameter types
  - Primitives, enums, arrays, and nullables of allowed types are also permitted

- **`FabricOrchestrationProviderSettings.JsonSerializationBinder`** — new setting that defaults to the built-in `AllowedTypesSerializationBinder`. Users can provide a custom `ISerializationBinder` or set to `null` to disable type restrictions.

- **Configuration threading** — the binder flows from `FabricOrchestrationProviderSettings` to `TaskHubProxyListener` to `Startup` to Web API JSON formatter.

- **Documentation** — added `JsonSerializationBinder` to the configuration table and a **Serialization Security** section in the Service Fabric provider docs.

- **Tests** — 19 tests covering: allowlisted types pass, non-allowlisted types from allowed assemblies are rejected, arbitrary assemblies are rejected, unresolvable types are handled gracefully, full JSON round-trip with polymorphic `HistoryEvent`, unrecognized `$type` payloads are rejected, and settings default/null/custom binder behavior.

### Design decisions

- The binder validates the assembly name **before** delegating to `DefaultSerializationBinder.BindToType()` to avoid triggering `Assembly.Load` for unknown assemblies.
- `HistoryEvent` subclasses are discovered dynamically via `HistoryEvent.KnownTypes()`, so the allowlist is self-maintaining when new event types are added to `DurableTask.Core`.
- The opt-out (`null`) path preserves backward compatibility for users who have other controls in place and need legacy behavior.