### PR TITLE
Remove Rx dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="ImpromptuInterface" Version="7.0.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.8" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Services.Client" Version="5.8.5" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
@@ -31,9 +31,7 @@
     <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageVersion Include="System.Collections.Immutable" Version="1.2.0" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
-    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-    <PackageVersion Include="System.Reactive.Compatibility" Version="4.4.1" />
-    <PackageVersion Include="System.Reactive.Core" Version="4.4.1" />
+    <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.8" />
   </ItemGroup>
   
   <!-- Product dependencies with net48 only-->

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Azure.Storage.Queues" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
-    <PackageReference Include="System.Linq.Async" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -277,7 +277,7 @@ namespace DurableTask.AzureStorage
             // "Remote" -> the instance ID info comes from the Instances table that we're querying
             IAsyncEnumerable<InstanceStatus> instances = this.trackingStore.FetchInstanceStatusAsync(instanceIds, cancellationToken);
             IDictionary<string, InstanceStatus> remoteOrchestrationsById = 
-                await instances.ToDictionaryAsync(o => o.State.OrchestrationInstance.InstanceId, cancellationToken);
+                await instances.ToDictionaryAsync(o => o.State.OrchestrationInstance.InstanceId, cancellationToken: cancellationToken);
 
             foreach (MessageData message in executionStartedMessages)
             {

--- a/src/DurableTask.Core/CorrelationTraceClient.cs
+++ b/src/DurableTask.Core/CorrelationTraceClient.cs
@@ -16,6 +16,7 @@ namespace DurableTask.Core
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Runtime.ExceptionServices;
     using System.Threading.Tasks;
     using DurableTask.Core.Settings;
 
@@ -46,13 +47,13 @@ namespace DurableTask.Core
             Action<Exception> trackExceptionAction)
         {
             listenerSubscription = DiagnosticListener.AllListeners.Subscribe(
-                    delegate (DiagnosticListener listener)
+                    new ActionObserver<DiagnosticListener>(listener =>
                     {
                         if (listener.Name == DiagnosticSourceName)
                         {
                             applicationInsightsSubscription?.Dispose();
 
-                            applicationInsightsSubscription = listener.Subscribe((KeyValuePair<string, object> evt) =>
+                            applicationInsightsSubscription = listener.Subscribe(new ActionObserver<KeyValuePair<string, object>>(evt =>
                             {
                                 if (evt.Key == RequestTrackEvent)
                                 {
@@ -72,9 +73,9 @@ namespace DurableTask.Core
                                     var e = (Exception)evt.Value;
                                     trackExceptionAction(e);
                                 }
-                            });
+                            }));
                         }
-                    });
+                    }));
         }
 
         /// <summary>
@@ -142,6 +143,30 @@ namespace DurableTask.Core
             if (CorrelationSettings.Current.EnableDistributedTracing)
             {
                 action();
+            }
+        }
+
+        sealed class ActionObserver<T> : IObserver<T>
+        {
+            readonly Action<T> onNext;
+
+            public ActionObserver(Action<T> onNext)
+            {
+                this.onNext = onNext ?? throw new ArgumentNullException(nameof(onNext));
+            }
+
+            public void OnCompleted()
+            {
+            }
+
+            public void OnError(Exception error)
+            {
+                ExceptionDispatchInfo.Capture(error).Throw();
+            }
+
+            public void OnNext(T value)
+            {
+                this.onNext(value);
             }
         }
     }

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -39,8 +39,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
-    <PackageReference Include="System.Reactive.Core" />
-    <PackageReference Include="System.Reactive.Compatibility" />
     <PackageReference Include="Castle.Core" />
   </ItemGroup>
 


### PR DESCRIPTION
Updated deprecated packages:
* Removed `System.Reactive.*` - only a simple `Subscribe` extension method was used and can be embedded in the repo.
* Replaced `System.Linq.Async` with `System.Linq.AsyncEnumerable`.