### PR TITLE
Added a "LatestEvents" field to the FetchedInstanceHistory log

### DIFF
--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -306,7 +306,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(EventIds.FetchedInstanceHistory, Level = EventLevel.Informational, Version = 4)]
+        [Event(EventIds.FetchedInstanceHistory, Level = EventLevel.Informational, Version = 5)]
         public void FetchedInstanceHistory(
             string Account,
             string TaskHub,

--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -318,6 +318,7 @@ namespace DurableTask.AzureStorage
             long LatencyMs,
             string ETag,
             DateTime LastCheckpointTime,
+            string LatestEvents,
             string AppName,
             string ExtensionVersion)
         {
@@ -333,6 +334,7 @@ namespace DurableTask.AzureStorage
                 LatencyMs,
                 ETag ?? string.Empty,
                 LastCheckpointTime,
+                LatestEvents,
                 AppName,
                 ExtensionVersion);
         }

--- a/src/DurableTask.AzureStorage/Logging/LogEvents.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogEvents.cs
@@ -745,7 +745,8 @@ namespace DurableTask.AzureStorage.Logging
                 int requestCount,
                 long latencyMs,
                 string eTag,
-                DateTime lastCheckpointTime)
+                DateTime lastCheckpointTime,
+                string latestEvents)
             {
                 this.Account = account;
                 this.TaskHub = taskHub;
@@ -757,6 +758,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.LatencyMs = latencyMs;
                 this.ETag = eTag;
                 this.LastCheckpointTime = lastCheckpointTime;
+                this.LatestEvents = latestEvents;
             }
 
             [StructuredLogField]
@@ -789,6 +791,9 @@ namespace DurableTask.AzureStorage.Logging
             [StructuredLogField]
             public DateTime LastCheckpointTime { get; }
 
+            [StructuredLogField]
+            public string LatestEvents { get; }
+
             public override EventId EventId => new EventId(
                 EventIds.FetchedInstanceHistory,
                 nameof(EventIds.FetchedInstanceHistory));
@@ -811,6 +816,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.LatencyMs,
                 this.ETag,
                 this.LastCheckpointTime,
+                this.LatestEvents,
                 Utils.AppName,
                 Utils.ExtensionVersion);
         }

--- a/src/DurableTask.AzureStorage/Logging/LogHelper.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogHelper.cs
@@ -261,7 +261,8 @@ namespace DurableTask.AzureStorage.Logging
             int requestCount,
             long latencyMs,
             string eTag,
-            DateTime lastCheckpointTime)
+            DateTime lastCheckpointTime,
+            string latestEvents)
         {
             var logEvent = new LogEvents.FetchedInstanceHistory(
                 account,
@@ -273,7 +274,8 @@ namespace DurableTask.AzureStorage.Logging
                 requestCount,
                 latencyMs,
                 eTag,
-                lastCheckpointTime);
+                lastCheckpointTime,
+                latestEvents);
             this.WriteStructuredLog(logEvent);
         }
 

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -14,8 +14,6 @@
 namespace DurableTask.AzureStorage.Tracking
 {
     using System;
-    using System.Collections;
-    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -14,6 +14,7 @@
 namespace DurableTask.AzureStorage.Tracking
 {
     using System;
+    using System.Collections;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Diagnostics;
@@ -226,7 +227,8 @@ namespace DurableTask.AzureStorage.Tracking
                 results.RequestCount,
                 results.ElapsedMilliseconds,
                 eTagValue?.ToString(),
-                checkpointCompletionTime);
+                checkpointCompletionTime,
+                string.Join(",", historyEvents.Skip(Math.Max(0, historyEvents.Count - 10)).Select(e => e.EventType.ToString())));
 
             return new OrchestrationHistory(historyEvents, checkpointCompletionTime, eTagValue, trackingStoreContext);
         }
@@ -261,7 +263,8 @@ namespace DurableTask.AzureStorage.Tracking
                 results.RequestCount,
                 results.ElapsedMilliseconds,
                 eTag: string.Empty,
-                DateTime.MinValue);
+                DateTime.MinValue,
+                string.Join(",", entities.Skip(Math.Max(0, entities.Count - 10)).Select(e => e.GetString(nameof(HistoryEvent.EventType)))));
 
             return entities;
         }


### PR DESCRIPTION
As per the title, this PR introduces a new log field to log the last 10 events from a fetch instance history call to improve our telemetry.