### PR TITLE
Avoid eager trace payload construction when diagnostics are disabled

### DIFF
--- a/Test/DurableTask.Core.Tests/TraceHelperTests.cs
+++ b/Test/DurableTask.Core.Tests/TraceHelperTests.cs
@@ -14,8 +14,10 @@
 #nullable enable
 namespace DurableTask.Core.Tests
 {
+    using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Diagnostics.Tracing;
     using DurableTask.Core.Entities.OperationFormat;
     using DurableTask.Core.Tracing;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -23,6 +25,7 @@ namespace DurableTask.Core.Tests
     using TraceActivityStatusCode = DurableTask.Core.Tracing.ActivityStatusCode;
 
     [TestClass]
+    [DoNotParallelize]
     public class TraceHelperTests
     {
         [TestMethod]
@@ -63,6 +66,270 @@ namespace DurableTask.Core.Tests
             TraceHelper.EndActivitiesForProcessingEntityInvocation(activities, failingResults, batchFailureDetails: null);
 
             Assert.AreEqual(DiagnosticsActivityStatusCode.Error, activities[0].Status);
+        }
+
+        [TestMethod]
+        public void TraceFactoriesRunOnlyWhenRequestedLevelIsEnabled()
+        {
+            using var listener = new CapturingEventListener();
+            listener.Enable(EventLevel.Warning);
+
+            var instance = new OrchestrationInstance
+            {
+                InstanceId = "instance",
+                ExecutionId = "execution",
+            };
+            int traceFactoryCalls = 0;
+            int sessionFactoryCalls = 0;
+            int instanceFactoryCalls = 0;
+
+            TraceHelper.Trace(
+                TraceEventType.Information,
+                "TraceFactory",
+                () =>
+                {
+                    traceFactoryCalls++;
+                    return "trace payload";
+                });
+            TraceHelper.TraceSession(
+                TraceEventType.Information,
+                "SessionFactory",
+                "session",
+                () =>
+                {
+                    sessionFactoryCalls++;
+                    return "session payload";
+                });
+            TraceHelper.TraceInstance(
+                TraceEventType.Information,
+                "InstanceFactory",
+                instance,
+                () =>
+                {
+                    instanceFactoryCalls++;
+                    return "instance payload";
+                });
+
+            Assert.AreEqual(0, traceFactoryCalls);
+            Assert.AreEqual(0, sessionFactoryCalls);
+            Assert.AreEqual(0, instanceFactoryCalls);
+            Assert.AreEqual(0, listener.Events.Count);
+
+            listener.Enable(EventLevel.Informational);
+
+            TraceHelper.Trace(
+                TraceEventType.Information,
+                "TraceFactory",
+                () =>
+                {
+                    traceFactoryCalls++;
+                    return "trace payload";
+                });
+            TraceHelper.TraceSession(
+                TraceEventType.Information,
+                "SessionFactory",
+                "session",
+                () =>
+                {
+                    sessionFactoryCalls++;
+                    return "session payload";
+                });
+            TraceHelper.TraceInstance(
+                TraceEventType.Information,
+                "InstanceFactory",
+                instance,
+                () =>
+                {
+                    instanceFactoryCalls++;
+                    return "instance payload";
+                });
+
+            Assert.AreEqual(1, traceFactoryCalls);
+            Assert.AreEqual(1, sessionFactoryCalls);
+            Assert.AreEqual(1, instanceFactoryCalls);
+            Assert.AreEqual(3, listener.Events.Count);
+            AssertEvent(listener.Events[0], "trace payload", "TraceFactory");
+            AssertEvent(listener.Events[1], "session payload", "SessionFactory");
+            AssertEvent(listener.Events[2], "instance payload", "InstanceFactory");
+        }
+
+        [TestMethod]
+        public void TraceFormattingRunsOnlyWhenRequestedLevelIsEnabled()
+        {
+            using var listener = new CapturingEventListener();
+            listener.Enable(EventLevel.Warning);
+
+            var instance = new OrchestrationInstance
+            {
+                InstanceId = "instance",
+                ExecutionId = "execution",
+            };
+            var traceValue = new CountingValue("trace payload");
+            var sessionValue = new CountingValue("session payload");
+            var instanceValue = new CountingValue("instance payload");
+
+            TraceHelper.Trace(TraceEventType.Information, "TraceFormat", "{0}", traceValue);
+            TraceHelper.TraceSession(TraceEventType.Information, "SessionFormat", "session", "{0}", sessionValue);
+            TraceHelper.TraceInstance(TraceEventType.Information, "InstanceFormat", instance, "{0}", instanceValue);
+
+            Assert.AreEqual(0, traceValue.ToStringCalls);
+            Assert.AreEqual(0, sessionValue.ToStringCalls);
+            Assert.AreEqual(0, instanceValue.ToStringCalls);
+            Assert.AreEqual(0, listener.Events.Count);
+
+            listener.Enable(EventLevel.Informational);
+
+            TraceHelper.Trace(TraceEventType.Information, "TraceFormat", "{0}", traceValue);
+            TraceHelper.TraceSession(TraceEventType.Information, "SessionFormat", "session", "{0}", sessionValue);
+            TraceHelper.TraceInstance(TraceEventType.Information, "InstanceFormat", instance, "{0}", instanceValue);
+
+            Assert.AreEqual(1, traceValue.ToStringCalls);
+            Assert.AreEqual(1, sessionValue.ToStringCalls);
+            Assert.AreEqual(1, instanceValue.ToStringCalls);
+            Assert.AreEqual(3, listener.Events.Count);
+            AssertEvent(listener.Events[0], "trace payload", "TraceFormat");
+            AssertEvent(listener.Events[1], "session payload", "SessionFormat");
+            AssertEvent(listener.Events[2], "instance payload", "InstanceFormat");
+        }
+
+        [TestMethod]
+        public void TraceExceptionPayloadsRunOnlyWhenRequestedLevelIsEnabled()
+        {
+            using var listener = new CapturingEventListener();
+            listener.Enable(EventLevel.Warning);
+
+            var exception = new InvalidOperationException("failure");
+            int factoryCalls = 0;
+            var formatValue = new CountingValue("format payload");
+
+            Exception factoryResult = TraceHelper.TraceException(
+                TraceEventType.Information,
+                "ExceptionFactory",
+                exception,
+                () =>
+                {
+                    factoryCalls++;
+                    return "factory payload";
+                });
+            Exception formatResult = TraceHelper.TraceException(
+                TraceEventType.Information,
+                "ExceptionFormat",
+                exception,
+                "{0}",
+                formatValue);
+
+            Assert.AreSame(exception, factoryResult);
+            Assert.AreSame(exception, formatResult);
+            Assert.AreEqual(0, factoryCalls);
+            Assert.AreEqual(0, formatValue.ToStringCalls);
+            Assert.AreEqual(0, listener.Events.Count);
+
+            listener.Enable(EventLevel.Informational);
+
+            factoryResult = TraceHelper.TraceException(
+                TraceEventType.Information,
+                "ExceptionFactory",
+                exception,
+                () =>
+                {
+                    factoryCalls++;
+                    return "factory payload";
+                });
+            formatResult = TraceHelper.TraceException(
+                TraceEventType.Information,
+                "ExceptionFormat",
+                exception,
+                "{0}",
+                formatValue);
+
+            Assert.AreSame(exception, factoryResult);
+            Assert.AreSame(exception, formatResult);
+            Assert.AreEqual(1, factoryCalls);
+            Assert.AreEqual(1, formatValue.ToStringCalls);
+            Assert.AreEqual(2, listener.Events.Count);
+            AssertEvent(listener.Events[0], FormatExceptionMessage("factory payload", exception), "ExceptionFactory");
+            AssertEvent(listener.Events[1], FormatExceptionMessage("format payload", exception), "ExceptionFormat");
+        }
+
+        static void AssertEvent(CapturedEvent capturedEvent, string message, string eventType)
+        {
+            Assert.AreEqual(3, capturedEvent.EventId);
+            Assert.AreEqual(7, capturedEvent.PayloadCount);
+            Assert.AreEqual(message, capturedEvent.Message);
+            Assert.AreEqual(eventType, capturedEvent.EventType);
+        }
+
+        static string FormatExceptionMessage(string message, Exception exception)
+        {
+            return message + "\nException: " + exception.GetType() + " : " + exception.Message + "\n\t" +
+                   exception.StackTrace + "\nInner Exception: " + exception.InnerException?.ToString();
+        }
+
+        sealed class CountingValue
+        {
+            readonly string value;
+
+            public CountingValue(string value)
+            {
+                this.value = value;
+            }
+
+            public int ToStringCalls { get; private set; }
+
+            public override string ToString()
+            {
+                this.ToStringCalls++;
+                return this.value;
+            }
+        }
+
+        sealed class CapturedEvent
+        {
+            public CapturedEvent(int eventId, int payloadCount, string message, string eventType)
+            {
+                this.EventId = eventId;
+                this.PayloadCount = payloadCount;
+                this.Message = message;
+                this.EventType = eventType;
+            }
+
+            public int EventId { get; }
+
+            public int PayloadCount { get; }
+
+            public string Message { get; }
+
+            public string EventType { get; }
+        }
+
+        sealed class CapturingEventListener : EventListener
+        {
+            readonly List<CapturedEvent> events = new List<CapturedEvent>();
+
+            public IReadOnlyList<CapturedEvent> Events => this.events;
+
+            public void Enable(EventLevel eventLevel)
+            {
+                this.EnableEvents(DefaultEventSource.Log, eventLevel, DefaultEventSource.Keywords.Diagnostics);
+            }
+
+            public override void Dispose()
+            {
+                this.DisableEvents(DefaultEventSource.Log);
+                base.Dispose();
+            }
+
+            protected override void OnEventWritten(EventWrittenEventArgs eventData)
+            {
+                if (eventData.EventSource == DefaultEventSource.Log &&
+                    eventData.Payload != null &&
+                    eventData.Payload.Count == 7 &&
+                    eventData.Payload[4] is string message &&
+                    eventData.Payload[6] is string eventType)
+                {
+                    this.events.Add(new CapturedEvent(eventData.EventId, eventData.Payload.Count, message, eventType));
+                }
+            }
         }
     }
 }

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -26,6 +26,7 @@ namespace DurableTask.Core
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Globalization;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
@@ -438,8 +439,10 @@ namespace DurableTask.Core
                             TraceEventType.Verbose,
                             "TaskOrchestrationDispatcher-ExecuteUserOrchestration-Begin",
                             runtimeState.OrchestrationInstance!,
-                            "Executing user orchestration: {0}",
-                            JsonDataConverter.Default.Serialize(runtimeState.GetOrchestrationRuntimeStateDump(), true));
+                            () => string.Format(
+                                CultureInfo.InvariantCulture,
+                                "Executing user orchestration: {0}",
+                                JsonDataConverter.Default.Serialize(runtimeState.GetOrchestrationRuntimeStateDump(), true)));
 
                         if (!versioningFailed)
                         {
@@ -472,9 +475,11 @@ namespace DurableTask.Core
                             TraceEventType.Information,
                             "TaskOrchestrationDispatcher-ExecuteUserOrchestration-End",
                             runtimeState.OrchestrationInstance!,
-                            "Executed user orchestration. Received {0} orchestrator actions: {1}",
-                            decisions.Count,
-                            string.Join(", ", decisions.Select(d => d.Id + ":" + d.OrchestratorActionType)));
+                            () => string.Format(
+                                CultureInfo.InvariantCulture,
+                                "Executed user orchestration. Received {0} orchestrator actions: {1}",
+                                decisions.Count,
+                                string.Join(", ", decisions.Select(d => d.Id + ":" + d.OrchestratorActionType))));
 
                         // TODO: Exception handling for invalid decisions, which is increasingly likely
                         //       when custom middleware is involved (e.g. out-of-process scenarios).

--- a/src/DurableTask.Core/Tracing/DefaultEventSource.cs
+++ b/src/DurableTask.Core/Tracing/DefaultEventSource.cs
@@ -92,6 +92,24 @@ namespace DurableTask.Core.Tracing
         /// </summary>
         public bool IsCriticalEnabled => IsEnabled(EventLevel.Critical, Keywords.Diagnostics);
 
+        [NonEvent]
+        internal bool IsEventEnabled(TraceEventType eventLevel)
+        {
+            switch (eventLevel)
+            {
+                case TraceEventType.Critical:
+                    return IsCriticalEnabled;
+                case TraceEventType.Error:
+                    return IsErrorEnabled;
+                case TraceEventType.Warning:
+                    return IsWarningEnabled;
+                case TraceEventType.Information:
+                    return IsInfoEnabled;
+                default:
+                    return IsTraceEnabled;
+            }
+        }
+
         /// <summary>
         /// Trace an event for the supplied event type and parameters
         /// </summary>

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -712,6 +712,11 @@ namespace DurableTask.Core.Tracing
         /// </summary>
         public static void Trace(TraceEventType eventLevel, string eventType, Func<string> generateMessage)
         {
+            if (!DefaultEventSource.Log.IsEventEnabled(eventLevel))
+            {
+                return;
+            }
+
             ExceptionHandlingWrapper(
                 () => DefaultEventSource.Log.TraceEvent(eventLevel, Source, string.Empty, string.Empty, string.Empty, generateMessage(), eventType));
         }
@@ -721,6 +726,11 @@ namespace DurableTask.Core.Tracing
         /// </summary>
         public static void Trace(TraceEventType eventLevel, string eventType, string format, params object[] args)
         {
+            if (!DefaultEventSource.Log.IsEventEnabled(eventLevel))
+            {
+                return;
+            }
+
             ExceptionHandlingWrapper(
                 () => DefaultEventSource.Log.TraceEvent(eventLevel, Source, string.Empty, string.Empty, string.Empty, FormatString(format, args), eventType));
         }
@@ -730,6 +740,11 @@ namespace DurableTask.Core.Tracing
         /// </summary>
         public static void TraceSession(TraceEventType eventLevel, string eventType, string sessionId, Func<string> generateMessage)
         {
+            if (!DefaultEventSource.Log.IsEventEnabled(eventLevel))
+            {
+                return;
+            }
+
             ExceptionHandlingWrapper(
                 () => DefaultEventSource.Log.TraceEvent(eventLevel, Source, string.Empty, string.Empty, sessionId, generateMessage(), eventType));
         }
@@ -739,6 +754,11 @@ namespace DurableTask.Core.Tracing
         /// </summary>
         public static void TraceSession(TraceEventType eventLevel, string eventType, string sessionId, string format, params object[] args)
         {
+            if (!DefaultEventSource.Log.IsEventEnabled(eventLevel))
+            {
+                return;
+            }
+
             ExceptionHandlingWrapper(
                 () => DefaultEventSource.Log.TraceEvent(eventLevel, Source, string.Empty, string.Empty, sessionId, FormatString(format, args), eventType));
         }
@@ -749,6 +769,11 @@ namespace DurableTask.Core.Tracing
         public static void TraceInstance(TraceEventType eventLevel, string eventType, OrchestrationInstance orchestrationInstance,
             string format, params object[] args)
         {
+            if (!DefaultEventSource.Log.IsEventEnabled(eventLevel))
+            {
+                return;
+            }
+
             ExceptionHandlingWrapper(
                 () => DefaultEventSource.Log.TraceEvent(
                     eventLevel,
@@ -766,6 +791,11 @@ namespace DurableTask.Core.Tracing
         public static void TraceInstance(TraceEventType eventLevel, string eventType, OrchestrationInstance orchestrationInstance,
             Func<string> generateMessage)
         {
+            if (!DefaultEventSource.Log.IsEventEnabled(eventLevel))
+            {
+                return;
+            }
+
             ExceptionHandlingWrapper(
                 () => DefaultEventSource.Log.TraceEvent(
                     eventLevel,
@@ -880,6 +910,11 @@ namespace DurableTask.Core.Tracing
         static ExceptionDispatchInfo TraceExceptionCore(TraceEventType eventLevel, string eventType, string iid, string eid, ExceptionDispatchInfo exceptionDispatchInfo,
             string format, params object[] args)
         {
+            if (!DefaultEventSource.Log.IsEventEnabled(eventLevel))
+            {
+                return exceptionDispatchInfo;
+            }
+
             Exception exception = exceptionDispatchInfo.SourceException;
 
             string newFormat = format + "\nException: " + exception.GetType() + " : " + exception.Message + "\n\t" +
@@ -895,6 +930,11 @@ namespace DurableTask.Core.Tracing
         static Exception TraceExceptionCore(TraceEventType eventLevel, string eventType, string iid, string eid, Exception exception,
             Func<string> generateMessage)
         {
+            if (!DefaultEventSource.Log.IsEventEnabled(eventLevel))
+            {
+                return exception;
+            }
+
             string newFormat = generateMessage() + "\nException: " + exception.GetType() + " : " + exception.Message +
                                "\n\t" + exception.StackTrace + "\nInner Exception: " +
                                exception.InnerException?.ToString();

--- a/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
+++ b/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
@@ -550,7 +550,7 @@ namespace DurableTask.ServiceBus
                 TraceEventType.Information,
                 "ServiceBusOrchestrationService-LockNextTaskOrchestrationWorkItem-MessageToProcess",
                 session.SessionId,
-                GetFormattedLog(
+                () => GetFormattedLog(
                     $@"{newMessages.Count} new messages to process: {
                             string.Join(",", newMessages.Select(m => m.MessageId))}, max latency: {
                             newMessages.Max(message => message.DeliveryLatency())}ms"));
@@ -1364,7 +1364,7 @@ namespace DurableTask.ServiceBus
                 TraceEventType.Information,
                 "ServiceBusOrchestrationService-FetchTrackingWorkItem-Messages",
                 session.SessionId,
-                GetFormattedLog($"{newMessages.Count} new tracking messages to process: {string.Join(",", newMessages.Select(m => m.MessageId))}"));
+                () => GetFormattedLog($"{newMessages.Count} new tracking messages to process: {string.Join(",", newMessages.Select(m => m.MessageId))}"));
 
             ServiceBusUtils.CheckAndLogDeliveryCount(newMessages, this.Settings.MaxTrackingDeliveryCount);
 
@@ -1579,7 +1579,7 @@ namespace DurableTask.ServiceBus
                 TraceEventType.Information,
                 "ServiceBusOrchestrationService-SentMessageLog",
                 session.SessionId,
-            GetFormattedLog($@"{messages.Count.ToString()} messages queued for {messageType}: {
+                () => GetFormattedLog($@"{messages.Count.ToString()} messages queued for {messageType}: {
                         string.Join(",", messages.Select(m =>
                         {
                             string scheduledTime = m.Message.ScheduledEnqueueTimeUtc > DateTime.MinValue


### PR DESCRIPTION
## Summary
- guard `TraceHelper` factory, format, and exception payload construction with the matching `EventSource` level check
- defer orchestration runtime-state serialization, decision joins, and Service Bus batch formatting until diagnostics are enabled
- add regression coverage proving factories and formatting are skipped when disabled, execute exactly once when enabled, and preserve event IDs, schemas, event types, messages, and exception return values

## Compatibility and performance
This does not change public APIs or EventSource event IDs/schemas. Enabled diagnostic payloads remain unchanged. When the requested level is disabled, high-throughput dispatch paths now avoid runtime-state serialization, LINQ enumeration, `string.Join`, interpolation, and final formatting allocations.

## Validation
- `dotnet test Test\DurableTask.Core.Tests\DurableTask.Core.Tests.csproj -f net8.0 --filter "FullyQualifiedName~TraceHelperTests|FullyQualifiedName~CommonTests.ShouldValidateEventSource"`
- `dotnet test Test\DurableTask.Core.Tests\DurableTask.Core.Tests.csproj -f net48 --filter "FullyQualifiedName~TraceHelperTests|FullyQualifiedName~CommonTests.ShouldValidateEventSource"`
- `dotnet build src\DurableTask.ServiceBus\DurableTask.ServiceBus.csproj`

Fixes #1377