### PR TITLE
Adding a new parameterless constructor to `ExecutionRewoundEvent`

### DIFF
--- a/src/DurableTask.Core/History/ExecutionRewoundEvent.cs
+++ b/src/DurableTask.Core/History/ExecutionRewoundEvent.cs
@@ -39,6 +39,12 @@ namespace DurableTask.Core.History
             this.Reason = reason;
         }
 
+        // Private ctor for JSON deserialization (required by some storage providers and out-of-proc executors)
+        ExecutionRewoundEvent()
+            : base(-1)
+        {
+        }
+
         /// <summary>
         /// Gets the event type
         /// </summary>


### PR DESCRIPTION
Added a new private parameterless constructor for the `ExecutionRewoundEvent` to enable JSON deserialization, otherwise it cannot choose between the two constructors with parameters