### PR TITLE
Drop .NET 6 support and modernize dependencies

### DIFF
--- a/.github/workflows/codeQL.yml
+++ b/.github/workflows/codeQL.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -49,25 +49,12 @@ jobs:
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
       with:
         submodules: true
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-
-    - name: Set up .NET Core 2.1
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: '2.1.x'
-
-    - name: Set up .NET Core 3.1
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: '3.1.x'
-
     - name: Set up .NET 8
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: '8.0.x'
 
@@ -79,6 +66,6 @@ jobs:
 
     # Run CodeQL analysis
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,60 +9,62 @@
 
   <!-- Product dependencies -->
   <ItemGroup>
-    <PackageVersion Include="Azure.Core" Version="1.44.1" />
+    <PackageVersion Include="Azure.Core" Version="1.61.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
-    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
-    <PackageVersion Include="Azure.Storage.Queues" Version="12.22.0" />
+    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.2" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.1" />
+    <PackageVersion Include="Azure.Storage.Queues" Version="12.27.1" />
     <PackageVersion Include="Castle.Core" Version="5.2.1" />
-    <PackageVersion Include="ImpromptuInterface" Version="6.2.2" Condition="'$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'net472'" />
-    <PackageVersion Include="ImpromptuInterface" Version="7.0.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageVersion Include="ImpromptuInterface" Version="8.0.6" Condition="'$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'net472'" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Services.Client" Version="5.8.5" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
     <PackageVersion Include="Microsoft.ServiceFabric" Version="6.4.617" />
     <PackageVersion Include="Microsoft.ServiceFabric.Data" Version="3.3.617" />
     <PackageVersion Include="Microsoft.ServiceFabric.Services" Version="3.3.617" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
-    <PackageVersion Include="System.Collections.Immutable" Version="1.2.0" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
-    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-    <PackageVersion Include="System.Reactive.Compatibility" Version="4.4.1" />
-    <PackageVersion Include="System.Reactive.Core" Version="4.4.1" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.17.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="10.0.10" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.10" />
+    <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
+    <PackageVersion Include="System.Reactive.Compatibility" Version="6.1.0" />
+    <PackageVersion Include="System.Reactive.Core" Version="6.1.0" />
   </ItemGroup>
   
   <!-- Product dependencies with net48 only-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-    <PackageVersion Include="Microsoft.Azure.KeyVault.Core" Version="1.0.0" />
+    <PackageVersion Include="Microsoft.Azure.KeyVault.Core" Version="3.0.5" />
     <PackageVersion Include="Microsoft.Data.Edm" Version="5.8.5" />
     <PackageVersion Include="Microsoft.Data.OData" Version="5.8.5" />
-    <PackageVersion Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.2.1" />
+    <PackageVersion Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
+    <PackageVersion Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.2.3" />
     <PackageVersion Include="System.Spatial" Version="5.8.5" />
-    <PackageVersion Include="WindowsAzure.ServiceBus" Version="4.1.3" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="6.36.0" />
+    <PackageVersion Include="WindowsAzure.ServiceBus" Version="7.0.1" />
   </ItemGroup>
   
   <!-- Test dependencies -->
   <ItemGroup>
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.1" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.3" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageVersion Include="CommandLineParser" Version="1.9.71" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageVersion Include="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer.NetCore" Version="2.0.1406.4" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Core" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.Diagnostics.EventFlow.Core" Version="1.5.6" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageVersion Include="Moq" Version="4.10.0" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.5.0" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.5.0" />
-    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
-    <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageVersion Include="Microsoft.Diagnostics.EventFlow.Core" Version="1.13.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="4.3.3" />
+    <PackageVersion Include="MSTest.TestFramework" Version="4.3.3" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
+    <PackageVersion Include="System.Data.SqlClient" Version="4.9.1" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.8" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.10" />
     <PackageVersion Include="WindowsAzure.Storage" Version="9.3.3" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageVersion Include="WindowsAzure.Storage" Version="8.7.0" Condition="'$(TargetFramework)' == 'net48'" />
   </ItemGroup>
@@ -70,49 +72,42 @@
   <!-- Test dependencies with net8.0-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Include="EnterpriseLibrary.SemanticLogging.NetCore" Version="2.0.1406.4" />
-    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
   </ItemGroup>
 
   <!-- Test dependencies with net472-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Owin" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.Owin.Hosting" Version="4.2.2" />
+    <PackageVersion Include="Microsoft.Owin.Hosting" Version="4.2.3" />
   </ItemGroup>
 
   <!-- Test dependencies with net48-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
     <PackageVersion Include="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" />
     <PackageVersion Include="EnterpriseLibrary.SemanticLogging.TextFile" version="2.0.1406.1" />
-    <PackageVersion Include="Microsoft.Owin.Hosting" Version="4.2.2" />
+    <PackageVersion Include="Microsoft.Owin.Hosting" Version="4.2.3" />
     <PackageVersion Include="Microsoft.Tpl.Dataflow" version="4.5.24" />
   </ItemGroup>
 
   <!-- Samples dependencies -->
   <ItemGroup>
-    <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.23.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
-    <PackageVersion Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.17.3" />
+    <PackageVersion Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.17.5" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.14.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
     <PackageVersion Include="Vio.DurableTask.Hosting" Version="2.2.17" />
   </ItemGroup>
 
-  <!-- Dependencies specific to net8.0-->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
   </ItemGroup>
   
 

--- a/Test/DurableTask.AzureStorage.Tests/Storage/DurableTaskStorageExceptionTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/Storage/DurableTaskStorageExceptionTests.cs
@@ -30,7 +30,7 @@ namespace DurableTask.AzureStorage.Tests.Storage
             Assert.IsFalse(exception.LeaseLost);
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true, HttpStatusCode.Conflict, nameof(BlobErrorCode.LeaseLost))]
         [DataRow(false, HttpStatusCode.Conflict, nameof(BlobErrorCode.LeaseNotPresentWithBlobOperation))]
         [DataRow(false, HttpStatusCode.NotFound, nameof(BlobErrorCode.BlobNotFound))]

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,7 +4,7 @@ This guide covers installing the Durable Task Framework (DTFx) packages for your
 
 ## Prerequisites
 
-- .NET 6.0 or later (.NET 10.0 is currently recommended)
+- .NET 8.0 or later (.NET 10.0 is currently recommended)
 - .NET Framework 4.7.2 or later (for .NET Framework projects)
 
 ## NuGet Packages

--- a/docs/providers/service-bus.md
+++ b/docs/providers/service-bus.md
@@ -59,7 +59,7 @@ var client = new TaskHubClient(service, loggerFactory: loggerFactory);
 
 ### Using Managed Identity
 
-The Service Bus provider supports managed identity authentication (.NET Standard 2.0+):
+The Service Bus provider supports managed identity authentication on .NET 8.0 or later and on the .NET Framework 4.7.2 (`net472`) target:
 
 ```csharp
 using Azure.Identity;

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -10,6 +10,12 @@ jobs:
                 sbomPackageName: 'DurableTask SBOM'
 
       steps:
+      - task: UseDotNet@2
+        displayName: 'Use the .NET 8 SDK'
+        inputs:
+          packageType: 'sdk'
+          version: '8.0.x'
+
       # Start by restoring all the dependencies. This needs to be its own task
       # from what I can tell. We specifically only target DurableTask.AzureStorage
       # and its direct dependencies.
@@ -34,7 +40,7 @@ jobs:
         displayName: 'Build (AzureStorage)'
         inputs:
           solution: 'src/DurableTask.AzureStorage/DurableTask.AzureStorage.sln'
-          vsVersion: '16.0'
+          vsVersion: '17.0'
           logFileVerbosity: minimal
           configuration: Release
           msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
@@ -43,7 +49,7 @@ jobs:
         displayName: 'Build (ApplicationInsights)'
         inputs:
           solution: 'src/DurableTask.ApplicationInsights/DurableTask.ApplicationInsights.csproj'
-          vsVersion: '16.0'
+          vsVersion: '17.0'
           logFileVerbosity: minimal
           configuration: Release
           msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
@@ -52,7 +58,7 @@ jobs:
         displayName: 'Build (Emulator)'
         inputs:
           solution: 'src/DurableTask.Emulator/DurableTask.Emulator.csproj'
-          vsVersion: '16.0'
+          vsVersion: '17.0'
           logFileVerbosity: minimal
           configuration: Release
           msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
@@ -61,7 +67,7 @@ jobs:
         displayName: 'Build (ServiceBus)'
         inputs:
           solution: 'src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj'
-          vsVersion: '16.0'
+          vsVersion: '17.0'
           logFileVerbosity: minimal
           configuration: Release
           platform: x64
@@ -71,18 +77,12 @@ jobs:
         displayName: 'Build (AzureServiceFabric)'
         inputs:
           solution: 'src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj'
-          vsVersion: '16.0'
+          vsVersion: '17.0'
           logFileVerbosity: minimal
           configuration: Release
           platform: x64
           msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
 
-      #- task: UseDotNet@2
-      #  displayName: 'Use the .NET Core 6 SDK (required for build signing)'
-      #  inputs:
-      #    packageType: 'sdk'
-      #    version: '6.x.x'
-      
       - template: ci/sign-files.yml@eng
         parameters:
           displayName: Sign assemblies

--- a/samples/Correlation.Samples/docs/getting-started.md
+++ b/samples/Correlation.Samples/docs/getting-started.md
@@ -6,7 +6,7 @@ In this tutorial, you can configure and execute a distributed tracing sample app
 
 The sample application requires these tools. If you don't have it, please click the following link and install it or create it on your Azure subscription.
 
-- [Visual Studio 2019+](https://visualstudio.microsoft.com/vs/)
+- [Visual Studio 2022 17.8+](https://visualstudio.microsoft.com/vs/)
 - [Storage Emulator 5.9+](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-emulator)
 - [Application Insights](https://docs.microsoft.com/en-us/azure/azure-monitor/app/create-new-resource)
 - [Azure Subscription](https://azure.microsoft.com/en-us/)

--- a/samples/DistributedTraceSample/ApplicationInsights/README.md
+++ b/samples/DistributedTraceSample/ApplicationInsights/README.md
@@ -4,7 +4,7 @@ This sample demonstrates direct integration with Azure Application Insights for 
 
 ## Prerequisites
 
-- .NET 6.0 SDK or later
+- .NET 8.0 SDK or later
 - Azure Storage Emulator (Azurite) or Azure Storage account
 - Azure Application Insights resource
 

--- a/samples/DistributedTraceSample/README.md
+++ b/samples/DistributedTraceSample/README.md
@@ -44,7 +44,7 @@ services.TryAddEnumerable(
 
 ## Prerequisites
 
-- .NET 6.0 SDK or later
+- .NET 8.0 SDK or later
 - Azure Storage Emulator (Azurite) or Azure Storage account
 - (Optional) Application Insights resource
 - (Optional) Zipkin instance for OpenTelemetry sample

--- a/src/DurableTask.ApplicationInsights/DurableTask.ApplicationInsights.csproj
+++ b/src/DurableTask.ApplicationInsights/DurableTask.ApplicationInsights.csproj
@@ -2,7 +2,7 @@
 
     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net472</TargetFrameworks>
         <PackageId>Microsoft.Azure.DurableTask.ApplicationInsights</PackageId>
         <NoWarn>NU5125;CS7035</NoWarn>  <!-- TODO: addition of CS7035 (version format doesn't follow convention) is a temporary workaround during 1ES migration -->
     </PropertyGroup>

--- a/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
+++ b/src/DurableTask.AzureServiceFabric/DurableTask.AzureServiceFabric.csproj
@@ -24,12 +24,6 @@
     <Reference Include="System.Web" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <!-- Restoring packages for netstandard2.0 causes warnings. As warnings are treated as errors, compilation will fail. -->
-    <!-- Once the packages support netstandard2.0, this project will support netstandard2.0. -->
-    <PackageReference Include="Newtonsoft.Json" />
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="ImpromptuInterface" />
     <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" />

--- a/src/DurableTask.AzureServiceFabric/README.md
+++ b/src/DurableTask.AzureServiceFabric/README.md
@@ -41,7 +41,7 @@ There are pre-requisites for setting up this project for developing or making co
 
 ## .Net Targets
 
-Currently this project supports .Net 4.6.1, which is framework version of 'netstandard2.0'. Some of the dependency packages do not have support for 'netstandard2.0', once those packages support 'netstandard2.0' this project will also support the same.
+This project supports .NET Framework 4.7.2 or later.
   
 ## Main Contributors
 

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -456,7 +456,9 @@ namespace DurableTask.AzureStorage
             // Disable nagling to improve storage access latency:
             // https://blogs.msdn.microsoft.com/windowsazurestorage/2010/06/25/nagles-algorithm-is-not-friendly-towards-small-requests/
             // Ad-hoc testing has shown very nice improvements (20%-50% drop in queue message age for simple scenarios).
+#if NETFRAMEWORK
             ServicePointManager.FindServicePoint(this.workItemQueue.Uri).UseNagleAlgorithm = false;
+#endif
 
             this.shutdownSource?.Dispose();
             this.shutdownSource = new CancellationTokenSource();
@@ -1158,8 +1160,8 @@ namespace DurableTask.AzureStorage
                 Utils.ConvertDateTimeInHistoryEventsToUTC(timerMessage.Event);
             }   
 
-            OrchestrationSession session;
-            if (!this.orchestrationSessionManager.TryGetExistingSession(workItem.InstanceId, out session))
+            OrchestrationSession session = null;
+            if (!this.orchestrationSessionManager.TryGetExistingSession(workItem.InstanceId, out session) || session == null)
             {
                 this.settings.Logger.AssertFailure(
                     this.azureStorageClient.QueueAccountName,
@@ -1453,8 +1455,8 @@ namespace DurableTask.AzureStorage
         /// <inheritdoc />
         public async Task RenewTaskOrchestrationWorkItemLockAsync(TaskOrchestrationWorkItem workItem)
         {
-            OrchestrationSession session;
-            if (!this.orchestrationSessionManager.TryGetExistingSession(workItem.InstanceId, out session))
+            OrchestrationSession session = null;
+            if (!this.orchestrationSessionManager.TryGetExistingSession(workItem.InstanceId, out session) || session == null)
             {
                 this.settings.Logger.AssertFailure(
                     this.azureStorageClient.QueueAccountName,
@@ -1478,8 +1480,8 @@ namespace DurableTask.AzureStorage
         /// <inheritdoc />
         public Task AbandonTaskOrchestrationWorkItemAsync(TaskOrchestrationWorkItem workItem)
         {
-            OrchestrationSession session;
-            if (!this.orchestrationSessionManager.TryGetExistingSession(workItem.InstanceId, out session))
+            OrchestrationSession session = null;
+            if (!this.orchestrationSessionManager.TryGetExistingSession(workItem.InstanceId, out session) || session == null)
             {
                 this.settings.Logger.AssertFailure(
                     this.azureStorageClient.QueueAccountName,
@@ -1524,7 +1526,8 @@ namespace DurableTask.AzureStorage
             if (this.orchestrationSessionManager.TryReleaseSession(
                 instanceId,
                 this.shutdownSource.Token,
-                out OrchestrationSession session))
+                out OrchestrationSession session) &&
+                session != null)
             {
                 // Some messages may need to be discarded
                 await session.DiscardedMessages.ParallelForEachAsync(
@@ -2150,30 +2153,29 @@ namespace DurableTask.AzureStorage
 
         // TODO: Change this to a sticky assignment so that partition count changes can
         //       be supported: https://github.com/Azure/azure-functions-durable-extension/issues/1
-        async Task<ControlQueue?> GetControlQueueAsync(string instanceId)
+        async Task<ControlQueue> GetControlQueueAsync(string instanceId)
         {
             uint partitionIndex = Fnv1aHashHelper.ComputeHash(instanceId) % (uint)this.settings.PartitionCount;
             string queueName = GetControlQueueName(this.settings.TaskHubName, (int)partitionIndex);
 
-            ControlQueue cachedQueue;
-            if (!this.allControlQueues.TryGetValue(queueName, out cachedQueue))
+            if (this.allControlQueues.TryGetValue(queueName, out ControlQueue? cachedQueue) && cachedQueue != null)
             {
-                // Lock ensures all callers asking for the same partition get the same queue reference back.
-                lock (this.allControlQueues)
-                {
-                    if (!this.allControlQueues.TryGetValue(queueName, out cachedQueue))
-                    {
-                        cachedQueue = new ControlQueue(this.azureStorageClient, queueName, this.messageManager);
-                        this.allControlQueues.TryAdd(queueName, cachedQueue);
-                    }
-                }
-
-                // Important to ensure the queue exists, whether the current thread initialized it or not.
-                // A slightly better design would be to use a semaphore to block non-initializing threads.
-                await cachedQueue.CreateIfNotExistsAsync();
+                return cachedQueue;
             }
 
-            System.Diagnostics.Debug.Assert(cachedQueue != null);
+            // Lock ensures all callers asking for the same partition get the same queue reference back.
+            lock (this.allControlQueues)
+            {
+                if (!this.allControlQueues.TryGetValue(queueName, out cachedQueue) || cachedQueue == null)
+                {
+                    cachedQueue = new ControlQueue(this.azureStorageClient, queueName, this.messageManager);
+                    this.allControlQueues.TryAdd(queueName, cachedQueue);
+                }
+            }
+
+            // Important to ensure the queue exists, whether the current thread initialized it or not.
+            // A slightly better design would be to use a semaphore to block non-initializing threads.
+            await cachedQueue.CreateIfNotExistsAsync();
             return cachedQueue;
         }
 

--- a/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
+++ b/src/DurableTask.AzureStorage/DurableTask.AzureStorage.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <Description>Azure Storage provider extension for the Durable Task Framework.</Description>

--- a/src/DurableTask.AzureStorage/MessageManager.cs
+++ b/src/DurableTask.AzureStorage/MessageManager.cs
@@ -18,9 +18,6 @@ namespace DurableTask.AzureStorage
     using System.IO.Compression;
     using System.Linq;
     using System.Reflection;
-#if !NETSTANDARD2_0
-    using System.Runtime.Serialization;
-#endif
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
@@ -29,9 +26,7 @@ namespace DurableTask.AzureStorage
     using Azure.Storage.Queues.Models;
     using DurableTask.AzureStorage.Storage;
     using Newtonsoft.Json;
-#if NETSTANDARD2_0
     using Newtonsoft.Json.Serialization;
-#endif
 
     /// <summary>
     /// The message manager for messages from MessageData, and DynamicTableEntities
@@ -62,11 +57,7 @@ namespace DurableTask.AzureStorage
             this.taskMessageSerializerSettings = new JsonSerializerSettings
             {
                 TypeNameHandling = TypeNameHandling.Objects,
-#if NETSTANDARD2_0
                 SerializationBinder = new TypeNameSerializationBinder(settings.CustomMessageTypeBinder),
-#else
-                Binder = new TypeNameSerializationBinder(settings.CustomMessageTypeBinder),
-#endif
             };
 
             if (this.settings.UseDataContractSerialization)
@@ -358,7 +349,6 @@ namespace DurableTask.AzureStorage
         }
     }
 
-#if NETSTANDARD2_0
     class TypeNameSerializationBinder : ISerializationBinder
     {
         readonly ICustomTypeBinder customBinder;
@@ -378,27 +368,6 @@ namespace DurableTask.AzureStorage
             return TypeNameSerializationHelper.BindToType(customBinder, assemblyName, typeName);
         }
     }
-#else
-    class TypeNameSerializationBinder : SerializationBinder
-    {
-        readonly ICustomTypeBinder customBinder;
-        public TypeNameSerializationBinder(ICustomTypeBinder customBinder)
-        {
-            this.customBinder = customBinder;
-        }
-
-        public override void BindToName(Type serializedType, out string assemblyName, out string typeName)
-        {
-            TypeNameSerializationHelper.BindToName(customBinder, serializedType, out assemblyName, out typeName);
-        }
-
-        // CodeQL [SM05220] False positive: customer-owned Storage is inside the DTFx trust boundary.
-        public override Type BindToType(string assemblyName, string typeName)
-        {
-            return TypeNameSerializationHelper.BindToType(customBinder, assemblyName, typeName);
-        }
-    }
-#endif
     static class TypeNameSerializationHelper
     {
         static readonly Assembly DurableTaskCore = typeof(DurableTask.Core.TaskMessage).Assembly;

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -241,8 +241,23 @@ namespace DurableTask.AzureStorage.Messaging
         {
             public static readonly MessageOrderingComparer Default = new MessageOrderingComparer();
 
-            public int Compare(MessageData x, MessageData y)
+            public int Compare(MessageData? x, MessageData? y)
             {
+                if (ReferenceEquals(x, y))
+                {
+                    return 0;
+                }
+
+                if (x is null)
+                {
+                    return -1;
+                }
+
+                if (y is null)
+                {
+                    return 1;
+                }
+
                 // Azure Storage is the ultimate authority on the order in which messages were received.
                 // Insertion time only has full second precision, however, so it's not always useful.
                 DateTimeOffset insertionTimeX = x.OriginalQueueMessage.InsertedOn.GetValueOrDefault();

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -157,8 +157,8 @@ namespace DurableTask.AzureStorage.Messaging
             {
                 if (CorrelationTraceContext.GenerateDependencyTracking)
                 {
-                    PropertyInfo nameProperty = taskMessage.Event.GetType().GetProperty("Name");
-                    string name = (nameProperty == null) ? TraceConstants.DependencyDefault : (string)nameProperty.GetValue(taskMessage.Event);
+                    PropertyInfo? nameProperty = taskMessage.Event.GetType().GetProperty("Name");
+                    string name = nameProperty?.GetValue(taskMessage.Event) as string ?? TraceConstants.DependencyDefault;
 
                     var dependencyTraceContext = TraceContextFactory.Create($"{TraceConstants.Orchestrator} {name}");
                     dependencyTraceContext.TelemetryType = TelemetryType.Dependency;

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -82,7 +82,7 @@ namespace DurableTask.AzureStorage
 
         public void RemoveQueue(string partitionId, CloseReason? reason, string caller)
         {
-            if (this.ownedControlQueues.TryRemove(partitionId, out ControlQueue controlQueue))
+            if (this.ownedControlQueues.TryRemove(partitionId, out ControlQueue? controlQueue))
             {
                 controlQueue.Release(reason, caller);
             }
@@ -91,7 +91,7 @@ namespace DurableTask.AzureStorage
 
         public void ReleaseQueue(string partitionId, CloseReason? reason, string caller)
         {
-            if (this.ownedControlQueues.TryGetValue(partitionId, out ControlQueue controlQueue))
+            if (this.ownedControlQueues.TryGetValue(partitionId, out ControlQueue? controlQueue))
             {
                 controlQueue.Release(reason, caller);
             }
@@ -99,7 +99,7 @@ namespace DurableTask.AzureStorage
 
         public bool ResumeListeningIfOwnQueue(string partitionId, ControlQueue controlQueue, CancellationToken shutdownToken)
         {
-            if (this.ownedControlQueues.TryGetValue(partitionId, out ControlQueue ownedControlQueue))
+            if (this.ownedControlQueues.TryGetValue(partitionId, out ControlQueue? ownedControlQueue))
             {
                 if (ownedControlQueue.IsReleased)
                 {
@@ -114,7 +114,7 @@ namespace DurableTask.AzureStorage
 
         public bool IsControlQueueReceivingMessages(string partitionId)
         {
-            return this.ownedControlQueues.TryGetValue(partitionId, out ControlQueue controlQueue)
+            return this.ownedControlQueues.TryGetValue(partitionId, out ControlQueue? controlQueue)
                 && !controlQueue.IsReleased;
         }
 
@@ -277,13 +277,15 @@ namespace DurableTask.AzureStorage
             // "Remote" -> the instance ID info comes from the Instances table that we're querying
             IAsyncEnumerable<InstanceStatus> instances = this.trackingStore.FetchInstanceStatusAsync(instanceIds, cancellationToken);
             IDictionary<string, InstanceStatus> remoteOrchestrationsById = 
-                await instances.ToDictionaryAsync(o => o.State.OrchestrationInstance.InstanceId, cancellationToken);
+                await instances.ToDictionaryAsync(
+                    o => o.State.OrchestrationInstance.InstanceId,
+                    cancellationToken: cancellationToken);
 
             foreach (MessageData message in executionStartedMessages)
             {
                 OrchestrationInstance localInstance = message.TaskMessage.OrchestrationInstance;
                 var expectedGeneration = ((ExecutionStartedEvent)message.TaskMessage.Event).Generation;
-                if (remoteOrchestrationsById.TryGetValue(localInstance.InstanceId, out InstanceStatus remoteInstance) &&
+                if (remoteOrchestrationsById.TryGetValue(localInstance.InstanceId, out InstanceStatus? remoteInstance) &&
                     (remoteInstance.State.OrchestrationInstance.ExecutionId == null || string.Equals(localInstance.ExecutionId, remoteInstance.State.OrchestrationInstance.ExecutionId, StringComparison.OrdinalIgnoreCase)))
                 {
                     // Happy path: The message matches the table status. Alternatively, if the table doesn't have an ExecutionId field (older clients, pre-v1.8.5),
@@ -428,13 +430,13 @@ namespace DurableTask.AzureStorage
                     // We can't do this for ExecutionStarted messages - those must *always* go to the pending list since they are for
                     // creating entirely new orchestration instances.
                     if (data.TaskMessage.Event.EventType != EventType.ExecutionStarted &&
-                        this.activeOrchestrationSessions.TryGetValue(instanceId, out OrchestrationSession session))
+                        this.activeOrchestrationSessions.TryGetValue(instanceId, out OrchestrationSession? session))
                     {
                         // A null executionId value means that this is a management operation, like RaiseEvent or Terminate, which
                         // should be delivered to the current session.
                         if (executionId == null || session.Instance.ExecutionId == executionId)
                         {
-                            List<MessageData> pendingMessages;
+                            List<MessageData>? pendingMessages;
                             if (!existingSessionMessages.TryGetValue(session, out pendingMessages))
                             {
                                 pendingMessages = new List<MessageData>();
@@ -457,7 +459,7 @@ namespace DurableTask.AzureStorage
                     // Unless the message is an ExecutionStarted event, we attempt to assign the current message to an
                     // existing batch by walking backwards through the list of batches until we find one with a matching InstanceID.
                     // This is assumed to be more efficient than walking forward if most messages arrive in the queue in groups.
-                    LinkedListNode<PendingMessageBatch> node = this.pendingOrchestrationMessageBatches.Last;
+                    LinkedListNode<PendingMessageBatch>? node = this.pendingOrchestrationMessageBatches.Last;
                     while (node != null && data.TaskMessage.Event.EventType != EventType.ExecutionStarted)
                     {
                         PendingMessageBatch batch = node.Value;
@@ -674,7 +676,7 @@ namespace DurableTask.AzureStorage
             }
         }
 
-        public bool TryGetExistingSession(string instanceId, out OrchestrationSession session)
+        public bool TryGetExistingSession(string instanceId, out OrchestrationSession? session)
         {
             lock (this.messageAndSessionLock)
             {
@@ -682,7 +684,7 @@ namespace DurableTask.AzureStorage
             }
         }
 
-        public bool TryReleaseSession(string instanceId, CancellationToken cancellationToken, out OrchestrationSession session)
+        public bool TryReleaseSession(string instanceId, CancellationToken cancellationToken, out OrchestrationSession? session)
         {
             // Taking this lock ensures we don't add new messages to a session we're about to release.
             lock (this.messageAndSessionLock)

--- a/src/DurableTask.AzureStorage/Partitioning/LeaseLostException.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/LeaseLostException.cs
@@ -65,6 +65,9 @@ namespace DurableTask.AzureStorage.Partitioning
         /// <see cref="DurableTask.AzureStorage.Partitioning.LeaseLostException" /> class using specified information and context.</summary> 
         /// <param name="info">The serialized information about the exception.</param>
         /// <param name="context">The contextual information about the source or destination.</param>
+#if NET8_0_OR_GREATER
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+#endif
         protected LeaseLostException(SerializationInfo info, StreamingContext context) :
             base(info, context)
         {
@@ -78,6 +81,9 @@ namespace DurableTask.AzureStorage.Partitioning
         /// <summary>Populates a <see cref="System.Runtime.Serialization.SerializationInfo" /> with the data needed to serialize the target object.</summary>
         /// <param name="info">The <see cref="System.Runtime.Serialization.SerializationInfo" /> object to populate with data.</param>
         /// <param name="context">The destination (see StreamingContext) for this serialization.</param>
+#if NET8_0_OR_GREATER
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+#endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/src/DurableTask.AzureStorage/Partitioning/TablePartitionManager.cs
+++ b/src/DurableTask.AzureStorage/Partitioning/TablePartitionManager.cs
@@ -806,7 +806,7 @@ namespace DurableTask.AzureStorage.Partitioning
             // Track partition distribution in the partitionDistribution dictionary. We use this information when balancing partitions.
             static void AddToDictionary(TablePartitionLease partition, Dictionary<string, List<TablePartitionLease>> partitionDistribution, string owner)
             {
-                if (partitionDistribution.TryGetValue(owner, out List<TablePartitionLease> ownedPartitions))
+                if (partitionDistribution.TryGetValue(owner, out List<TablePartitionLease>? ownedPartitions))
                 {
                     ownedPartitions.Add(partition);
                 }

--- a/src/DurableTask.AzureStorage/Storage/BlobContainer.cs
+++ b/src/DurableTask.AzureStorage/Storage/BlobContainer.cs
@@ -118,7 +118,7 @@ namespace DurableTask.AzureStorage.Storage
             // Check the optional "hdi_isfolder" value in the metadata to determine whether
             // the blob is actually a directory. See https://github.com/Azure/azure-sdk-for-python/issues/24814
             return item.Metadata != null
-                && item.Metadata.TryGetValue("hdi_isfolder", out string value)
+                && item.Metadata.TryGetValue("hdi_isfolder", out string? value)
                 && bool.TryParse(value, out bool isFolder)
                 && isFolder;
         }

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -98,8 +98,10 @@ namespace DurableTask.AzureStorage.Tracking
                 t => !t.IsAbstract && t.IsSubclassOf(historyEventType));
 
             PropertyInfo eventTypeProperty = historyEventType.GetProperty(nameof(HistoryEvent.EventType));
+#pragma warning disable SYSLIB0050 // Formatter-based deserialization is retained for backwards-compatible history event materialization.
             this.eventTypeMap = historyEventTypes.ToDictionary(
                 type => ((HistoryEvent)FormatterServices.GetUninitializedObject(type)).EventType);
+#pragma warning restore SYSLIB0050
         }
 
         // For testing
@@ -905,8 +907,10 @@ namespace DurableTask.AzureStorage.Tracking
         /// <inheritdoc />
         public override Task StartAsync(CancellationToken cancellationToken = default)
         {
+#if NETFRAMEWORK
             ServicePointManager.FindServicePoint(this.HistoryTable.Uri).UseNagleAlgorithm = false;
             ServicePointManager.FindServicePoint(this.InstancesTable.Uri).UseNagleAlgorithm = false;
+#endif
 
             return Task.CompletedTask;
         }

--- a/src/DurableTask.AzureStorage/Tracking/TableEntityConverter.cs
+++ b/src/DurableTask.AzureStorage/Tracking/TableEntityConverter.cs
@@ -68,7 +68,9 @@ namespace DurableTask.AzureStorage.Tracking
             #endregion
 
             #region <Type> output = (<Type>)FormatterServices.GetUninitializedObject(typeof(<Type>));
+#pragma warning disable SYSLIB0050 // Formatter-based deserialization is retained for backwards-compatible [DataContract] materialization.
             MethodInfo getUninitializedObjectMethod = typeof(FormatterServices).GetMethod(nameof(FormatterServices.GetUninitializedObject), new Type[] { typeof(Type) });
+#pragma warning restore SYSLIB0050
             body.Add(Expression.Assign(
                 outputVar,
                 Expression.Convert(

--- a/src/DurableTask.Core/Common/Utils.cs
+++ b/src/DurableTask.Core/Common/Utils.cs
@@ -49,17 +49,12 @@ namespace DurableTask.Core.Common
         /// <summary>
         /// Gets the version of the DurableTask.Core nuget package, which by convension is the same as the assembly file version.
         /// </summary>
-        internal static readonly string PackageVersion = FileVersionInfo.GetVersionInfo(typeof(TaskOrchestration).Assembly.Location).FileVersion;
+        internal static readonly string PackageVersion = FileVersionInfo.GetVersionInfo(typeof(TaskOrchestration).Assembly.Location).FileVersion ?? string.Empty;
 
         private static readonly JsonSerializerSettings ObjectJsonSettings = new JsonSerializerSettings
         {
             TypeNameHandling = TypeNameHandling.All,
-
-#if NETSTANDARD2_0
             SerializationBinder = new PackageUpgradeSerializationBinder()
-#else
-            Binder = new PackageUpgradeSerializationBinder()
-#endif
         };
         private static readonly JsonSerializer DefaultObjectJsonSerializer = JsonSerializer.Create(ObjectJsonSettings);
 
@@ -574,7 +569,7 @@ namespace DurableTask.Core.Common
             // This implementation avoids OperationCancelledException
             // https://github.com/dotnet/corefx/issues/2704#issuecomment-131221355
             var tcs = new TaskCompletionSource<bool>();
-            cancellationToken.Register(s => ((TaskCompletionSource<bool>)s).SetResult(true), tcs);
+            cancellationToken.Register(static state => ((TaskCompletionSource<bool>)state!).SetResult(true), tcs);
             return Task.WhenAny(Task.Delay(timeout), tcs.Task);
         }
 
@@ -695,7 +690,7 @@ namespace DurableTask.Core.Common
             // Check if type is of form T[]
             if (typeToConvert.IsArray)
             {
-                Type elementType = typeToConvert.GetElementType();
+                Type elementType = typeToConvert.GetElementType()!;
                 if (elementType.IsGenericParameter)
                 {
                     int index = Array.IndexOf(genericParameters, elementType);

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>NU5125;CS7035</NoWarn> <!-- TODO: addition of CS7035 (version format doesn't follow convention) is a temporary workaround during 1ES migration -->
   </PropertyGroup>

--- a/src/DurableTask.Core/Entities/EntityId.cs
+++ b/src/DurableTask.Core/Entities/EntityId.cs
@@ -79,7 +79,7 @@ namespace DurableTask.Core.Entities
 
       
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return (obj is EntityId other) && this.Equals(other);
         }
@@ -97,9 +97,18 @@ namespace DurableTask.Core.Entities
         }
 
         /// <inheritdoc/>
-        public int CompareTo(object obj)
+        public int CompareTo(object? obj)
         {
-            var other = (EntityId)obj;
+            if (obj is null)
+            {
+                return 1;
+            }
+
+            if (obj is not EntityId other)
+            {
+                throw new ArgumentException($"Object must be of type {nameof(EntityId)}.", nameof(obj));
+            }
+
             return (this.Name, this.Key).CompareTo((other.Name, other.Key));
         }
     }

--- a/src/DurableTask.Core/Entities/OrchestrationEntityContext.cs
+++ b/src/DurableTask.Core/Entities/OrchestrationEntityContext.cs
@@ -129,9 +129,10 @@ namespace DurableTask.Core.Entities
             if (this.IsInsideCriticalSection)
             {
                 var lockToUse = EntityId.FromString(targetInstanceId);
+                EntityId[] criticalSectionLocks = this.criticalSectionLocks ?? throw new InvalidOperationException("Critical section lock state is unavailable.");
                 if (oneWay)
                 {
-                    if (this.criticalSectionLocks.Contains(lockToUse))
+                    if (criticalSectionLocks.Contains(lockToUse))
                     {
                         errorMessage = "Must not signal a locked entity from a critical section.";
                         return false;
@@ -139,14 +140,15 @@ namespace DurableTask.Core.Entities
                 }
                 else
                 {
-                    if (!this.availableLocks!.Remove(lockToUse))
+                    HashSet<EntityId> availableLocks = this.availableLocks ?? throw new InvalidOperationException("Available lock state is unavailable.");
+                    if (!availableLocks.Remove(lockToUse))
                     {
                         if (this.lockAcquisitionPending)
                         {
                             errorMessage = "Must await the completion of the lock request prior to calling any entity.";
                             return false;
                         }
-                        if (this.criticalSectionLocks.Contains(lockToUse))
+                        if (criticalSectionLocks.Contains(lockToUse))
                         {
                             errorMessage = "Must not call an entity from a critical section while a prior call to the same entity is still pending.";
                             return false;
@@ -337,7 +339,8 @@ namespace DurableTask.Core.Entities
         /// <param name="criticalSectionId">The guid for the lock operation</param>
         public void CompleteAcquire(OperationResult result, Guid criticalSectionId)
         {
-            this.availableLocks = new HashSet<EntityId>(this.criticalSectionLocks);
+            EntityId[] criticalSectionLocks = this.criticalSectionLocks ?? throw new InvalidOperationException("Critical section lock state is unavailable.");
+            this.availableLocks = new HashSet<EntityId>(criticalSectionLocks);
             this.lockAcquisitionPending = false;
         }
 

--- a/src/DurableTask.Core/Exceptions/EntitySchedulerException.cs
+++ b/src/DurableTask.Core/Exceptions/EntitySchedulerException.cs
@@ -53,6 +53,9 @@ namespace DurableTask.Core.Exceptions
         /// </summary>
         /// <param name="info">The System.Runtime.Serialization.SerializationInfo that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The System.Runtime.Serialization.StreamingContext that contains contextual information about the source or destination.</param>
+#if NET8_0_OR_GREATER
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+#endif
         protected EntitySchedulerException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/DurableTask.Core/Exceptions/NonDeterministicOrchestrationException.cs
+++ b/src/DurableTask.Core/Exceptions/NonDeterministicOrchestrationException.cs
@@ -65,6 +65,9 @@ namespace DurableTask.Core.Exceptions
         /// </summary>
         /// <param name="info">The System.Runtime.Serialization.SerializationInfo that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The System.Runtime.Serialization.StreamingContext that contains contextual information about the source or destination.</param>
+#if NET8_0_OR_GREATER
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+#endif
         protected NonDeterministicOrchestrationException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/DurableTask.Core/Exceptions/OrchestrationAlreadyExistsException.cs
+++ b/src/DurableTask.Core/Exceptions/OrchestrationAlreadyExistsException.cs
@@ -54,6 +54,9 @@ namespace DurableTask.Core.Exceptions
         /// </summary>
         /// <param name="info">The System.Runtime.Serialization.SerializationInfo that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The System.Runtime.Serialization.StreamingContext that contains contextual information about the source or destination.</param>
+#if NET8_0_OR_GREATER
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+#endif
         protected OrchestrationAlreadyExistsException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/DurableTask.Core/Exceptions/OrchestrationException.cs
+++ b/src/DurableTask.Core/Exceptions/OrchestrationException.cs
@@ -67,14 +67,20 @@ namespace DurableTask.Core.Exceptions
         /// </summary>
         /// <param name="info">The System.Runtime.Serialization.SerializationInfo that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The System.Runtime.Serialization.StreamingContext that contains contextual information about the source or destination.</param>
+#if NET8_0_OR_GREATER
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+#endif
         protected OrchestrationException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
             EventId = info.GetInt32(nameof(EventId));
-            FailureDetails = (FailureDetails)info.GetValue(nameof(FailureDetails), typeof(FailureDetails));
+            FailureDetails = info.GetValue(nameof(FailureDetails), typeof(FailureDetails)) as FailureDetails;
         }
 
         /// <inheritdoc />
+#if NET8_0_OR_GREATER
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+#endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/src/DurableTask.Core/Exceptions/OrchestrationFailureException.cs
+++ b/src/DurableTask.Core/Exceptions/OrchestrationFailureException.cs
@@ -58,6 +58,9 @@ namespace DurableTask.Core.Exceptions
         /// <summary>
         /// Initializes a new instance of the <see cref="OrchestrationFailureException"/> class.
         /// </summary>
+#if NET8_0_OR_GREATER
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+#endif
         protected OrchestrationFailureException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -74,6 +77,9 @@ namespace DurableTask.Core.Exceptions
         /// <summary>
         /// Gets object data for use by serialization.
         /// </summary>
+#if NET8_0_OR_GREATER
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+#endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/src/DurableTask.Core/Exceptions/OrchestrationFrameworkException.cs
+++ b/src/DurableTask.Core/Exceptions/OrchestrationFrameworkException.cs
@@ -63,6 +63,9 @@ namespace DurableTask.Core.Exceptions
         /// </summary>
         /// <param name="info">The System.Runtime.Serialization.SerializationInfo that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The System.Runtime.Serialization.StreamingContext that contains contextual information about the source or destination.</param>
+#if NET8_0_OR_GREATER
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+#endif
         protected OrchestrationFrameworkException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/DurableTask.Core/Exceptions/SessionAbortedException.cs
+++ b/src/DurableTask.Core/Exceptions/SessionAbortedException.cs
@@ -55,6 +55,9 @@ namespace DurableTask.Core.Exceptions
         /// </summary>
         /// <param name="info">The System.Runtime.Serialization.SerializationInfo that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The System.Runtime.Serialization.StreamingContext that contains contextual information about the source or destination.</param>
+#if NET8_0_OR_GREATER
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+#endif
         protected SessionAbortedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/DurableTask.Core/Exceptions/SubOrchestrationFailedException.cs
+++ b/src/DurableTask.Core/Exceptions/SubOrchestrationFailedException.cs
@@ -73,6 +73,9 @@ namespace DurableTask.Core.Exceptions
         /// </summary>
         /// <param name="info">The System.Runtime.Serialization.SerializationInfo that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The System.Runtime.Serialization.StreamingContext that contains contextual information about the source or destination.</param>
+#if NET8_0_OR_GREATER
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+#endif
         protected SubOrchestrationFailedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -82,6 +85,9 @@ namespace DurableTask.Core.Exceptions
         }
 
         /// <inheritdoc />
+#if NET8_0_OR_GREATER
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+#endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/src/DurableTask.Core/Exceptions/TaskFailedException.cs
+++ b/src/DurableTask.Core/Exceptions/TaskFailedException.cs
@@ -73,6 +73,9 @@ namespace DurableTask.Core.Exceptions
         /// </summary>
         /// <param name="info">The System.Runtime.Serialization.SerializationInfo that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The System.Runtime.Serialization.StreamingContext that contains contextual information about the source or destination.</param>
+#if NET8_0_OR_GREATER
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+#endif
         protected TaskFailedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -82,6 +85,9 @@ namespace DurableTask.Core.Exceptions
         }
 
         /// <inheritdoc />
+#if NET8_0_OR_GREATER
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+#endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/src/DurableTask.Core/Exceptions/TaskFailedExceptionDeserializationException.cs
+++ b/src/DurableTask.Core/Exceptions/TaskFailedExceptionDeserializationException.cs
@@ -54,6 +54,9 @@ namespace DurableTask.Core.Exceptions
         /// </summary>
         /// <param name="info">The System.Runtime.Serialization.SerializationInfo that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The System.Runtime.Serialization.StreamingContext that contains contextual information about the source or destination.</param>
+#if NET8_0_OR_GREATER
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+#endif
         protected TaskFailedExceptionDeserializationException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/DurableTask.Core/Exceptions/TaskFailureException.cs
+++ b/src/DurableTask.Core/Exceptions/TaskFailureException.cs
@@ -67,6 +67,9 @@ namespace DurableTask.Core.Exceptions
         /// <summary>
         /// Initializes a new instance of the <see cref="TaskFailureException"/> class.
         /// </summary>
+#if NET8_0_OR_GREATER
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+#endif
         protected TaskFailureException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -82,6 +85,9 @@ namespace DurableTask.Core.Exceptions
         /// <summary>
         /// Gets object data for use by serialization.
         /// </summary>
+#if NET8_0_OR_GREATER
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+#endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/src/DurableTask.Core/Exceptions/TypeMissingException.cs
+++ b/src/DurableTask.Core/Exceptions/TypeMissingException.cs
@@ -54,6 +54,9 @@ namespace DurableTask.Core.Exceptions
         /// </summary>
         /// <param name="info">The System.Runtime.Serialization.SerializationInfo that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The System.Runtime.Serialization.StreamingContext that contains contextual information about the source or destination.</param>
+#if NET8_0_OR_GREATER
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+#endif
         protected TypeMissingException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/DurableTask.Core/FailureDetails.cs
+++ b/src/DurableTask.Core/FailureDetails.cs
@@ -88,7 +88,7 @@ namespace DurableTask.Core
         /// <param name="e">The exception used to generate the failure details.</param>
         /// <param name="properties">The exception properties to include in failure details.</param> 
         public FailureDetails(Exception e, IDictionary<string, object?>? properties)
-            : this(e.GetType().FullName, GetErrorMessage(e), e.StackTrace, FromException(e.InnerException), false, properties)
+            : this(GetErrorType(e), GetErrorMessage(e), e.StackTrace, FromException(e.InnerException), false, properties)
         {
         }
 
@@ -99,7 +99,7 @@ namespace DurableTask.Core
         /// <param name="innerFailure">The inner cause of the failure.</param>
         /// <param name="properties">The exception properties to include in failure details.</param> 
         public FailureDetails(Exception e, FailureDetails innerFailure, IDictionary<string, object?>? properties)
-            : this(e.GetType().FullName, GetErrorMessage(e), e.StackTrace, innerFailure, false, properties)
+            : this(GetErrorType(e), GetErrorMessage(e), e.StackTrace, innerFailure, false, properties)
         {
         }
 
@@ -118,10 +118,10 @@ namespace DurableTask.Core
         /// </summary>
         protected FailureDetails(SerializationInfo info, StreamingContext context)
         {
-            this.ErrorType = info.GetString(nameof(this.ErrorType));
-            this.ErrorMessage = info.GetString(nameof(this.ErrorMessage));
+            this.ErrorType = info.GetString(nameof(this.ErrorType)) ?? string.Empty;
+            this.ErrorMessage = info.GetString(nameof(this.ErrorMessage)) ?? string.Empty;
             this.StackTrace = info.GetString(nameof(this.StackTrace));
-            this.InnerFailure = (FailureDetails)info.GetValue(nameof(this.InnerFailure), typeof(FailureDetails));
+            this.InnerFailure = info.GetValue(nameof(this.InnerFailure), typeof(FailureDetails)) as FailureDetails;
             // Handle backward compatibility for Properties property - defaults to null
             try
             {
@@ -212,7 +212,7 @@ namespace DurableTask.Core
         /// <summary>
         /// Gets whether two <see cref="FailureDetails"/> objects are equivalent using value semantics.
         /// </summary>
-        public override bool Equals(object other) => Equals(other as FailureDetails);
+        public override bool Equals(object? other) => Equals(other as FailureDetails);
 
         /// <summary>
         /// Gets whether two <see cref="FailureDetails"/> objects are equivalent using value semantics.
@@ -235,6 +235,12 @@ namespace DurableTask.Core
         public override int GetHashCode()
         {
             return (ErrorType, ErrorMessage, StackTrace, InnerFailure).GetHashCode();
+        }
+
+        static string GetErrorType(Exception e)
+        {
+            Type exceptionType = e.GetType();
+            return exceptionType.FullName ?? exceptionType.Name;
         }
 
         static string GetErrorMessage(Exception e)

--- a/src/DurableTask.Core/ISupportsDurableTraceContext.cs
+++ b/src/DurableTask.Core/ISupportsDurableTraceContext.cs
@@ -58,13 +58,10 @@ namespace DurableTask.Core
 
         internal static void SetParentTraceContext(this ISupportsDurableTraceContext wrapper, ActivityContext activityContext)
         {
-            if (activityContext != null)
-            {
-                // TODO: update trace flags casting to handle 2 digits
-                wrapper.ParentTraceContext = new DistributedTraceContext(
-                    $"00-{activityContext.TraceId}-{activityContext.SpanId}-0{activityContext.TraceFlags:d}",
-                    activityContext.TraceState);
-            }
+            // TODO: update trace flags casting to handle 2 digits
+            wrapper.ParentTraceContext = new DistributedTraceContext(
+                $"00-{activityContext.TraceId}-{activityContext.SpanId}-0{activityContext.TraceFlags:d}",
+                activityContext.TraceState);
         }
     }
 }

--- a/src/DurableTask.Core/Serializing/JsonDataConverter.cs
+++ b/src/DurableTask.Core/Serializing/JsonDataConverter.cs
@@ -39,11 +39,7 @@ namespace DurableTask.Core.Serializing
             {
                 TypeNameHandling = TypeNameHandling.Objects,
                 DateParseHandling = DateParseHandling.None,
-#if NETSTANDARD2_0
                 SerializationBinder = new PackageUpgradeSerializationBinder()
-#else
-                Binder = new PackageUpgradeSerializationBinder()
-#endif
             })
         { }
 

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -340,23 +340,26 @@ namespace DurableTask.Core
             // Distributed tracing support: each orchestration execution is a trace activity
             // that derives from an established parent trace context. It is expected that some
             // listener will receive these events and publish them to a distributed trace logger.
-            ExecutionStartedEvent startEvent =
+            ExecutionStartedEvent? startEvent =
                 runtimeState.ExecutionStartedEvent ??
                 workItem.NewMessages.Select(msg => msg.Event).OfType<ExecutionStartedEvent>().FirstOrDefault();
-            ExecutionRewoundEvent rewindEvent =
+            ExecutionRewoundEvent? rewindEvent =
                 workItem.NewMessages.Select(msg => msg.Event).OfType<ExecutionRewoundEvent>().LastOrDefault();
 
             if (rewindEvent is not null && runtimeState.OrchestrationStatus != OrchestrationStatus.Running)
             {
                 isRewinding = true;
-                if (rewindEvent.ParentTraceContext != null)
+                if (startEvent != null && rewindEvent.ParentTraceContext != null)
                 {
                     startEvent.ParentTraceContext = rewindEvent.ParentTraceContext;
                 }
-                // We set these to null here so that a new Activity is created to represent the execution of the rewound orchestration.
-                startEvent.ParentTraceContext.SpanId = null;
-                startEvent.ParentTraceContext.Id = null;
-                startEvent.ParentTraceContext.ActivityStartTime = null;
+                if (startEvent?.ParentTraceContext != null)
+                {
+                    // We set these to null here so that a new Activity is created to represent the execution of the rewound orchestration.
+                    startEvent.ParentTraceContext.SpanId = null;
+                    startEvent.ParentTraceContext.Id = null;
+                    startEvent.ParentTraceContext.ActivityStartTime = null;
+                }
             }   
             Activity? traceActivity = TraceHelper.StartTraceActivityForOrchestrationExecution(startEvent);
 
@@ -977,29 +980,41 @@ namespace DurableTask.Core
                     }
                     else if (historyEvent is SubOrchestrationInstanceCompletedEvent subOrchestrationInstanceCompletedEvent)
                     {
-                        SubOrchestrationInstanceCreatedEvent subOrchestrationCreatedEvent = workItem.OrchestrationRuntimeState.Events.OfType<SubOrchestrationInstanceCreatedEvent>().FirstOrDefault(x => x.EventId == subOrchestrationInstanceCompletedEvent.TaskScheduledId);
+                        SubOrchestrationInstanceCreatedEvent? subOrchestrationCreatedEvent = workItem.OrchestrationRuntimeState.Events.OfType<SubOrchestrationInstanceCreatedEvent>().FirstOrDefault(x => x.EventId == subOrchestrationInstanceCompletedEvent.TaskScheduledId);
 
                         // We immediately publish the activity span for this sub-orchestration by creating the activity and immediately calling Dispose() on it.
-                        TraceHelper.EmitTraceActivityForSubOrchestrationCompleted(workItem.OrchestrationRuntimeState.OrchestrationInstance, subOrchestrationCreatedEvent);
+                        if (subOrchestrationCreatedEvent != null)
+                        {
+                            TraceHelper.EmitTraceActivityForSubOrchestrationCompleted(workItem.OrchestrationRuntimeState.OrchestrationInstance, subOrchestrationCreatedEvent);
+                        }
                     }
                     else if (historyEvent is SubOrchestrationInstanceFailedEvent subOrchestrationInstanceFailedEvent)
                     {
-                        SubOrchestrationInstanceCreatedEvent subOrchestrationCreatedEvent = workItem.OrchestrationRuntimeState.Events.OfType<SubOrchestrationInstanceCreatedEvent>().FirstOrDefault(x => x.EventId == subOrchestrationInstanceFailedEvent.TaskScheduledId);
+                        SubOrchestrationInstanceCreatedEvent? subOrchestrationCreatedEvent = workItem.OrchestrationRuntimeState.Events.OfType<SubOrchestrationInstanceCreatedEvent>().FirstOrDefault(x => x.EventId == subOrchestrationInstanceFailedEvent.TaskScheduledId);
 
                         // We immediately publish the activity span for this sub-orchestration by creating the activity and immediately calling Dispose() on it.
-                        TraceHelper.EmitTraceActivityForSubOrchestrationFailed(workItem.OrchestrationRuntimeState.OrchestrationInstance, subOrchestrationCreatedEvent, subOrchestrationInstanceFailedEvent, errorPropagationMode);
+                        if (subOrchestrationCreatedEvent != null)
+                        {
+                            TraceHelper.EmitTraceActivityForSubOrchestrationFailed(workItem.OrchestrationRuntimeState.OrchestrationInstance, subOrchestrationCreatedEvent, subOrchestrationInstanceFailedEvent, errorPropagationMode);
+                        }
                     }
                 }
 
                 if (message.Event is TaskCompletedEvent taskCompletedEvent)
                 {
-                    TaskScheduledEvent taskScheduledEvent = workItem.OrchestrationRuntimeState.Events.OfType<TaskScheduledEvent>().LastOrDefault(x => x.EventId == taskCompletedEvent.TaskScheduledId);
-                    TraceHelper.EmitTraceActivityForTaskCompleted(workItem.OrchestrationRuntimeState.OrchestrationInstance, taskScheduledEvent);
+                    TaskScheduledEvent? taskScheduledEvent = workItem.OrchestrationRuntimeState.Events.OfType<TaskScheduledEvent>().LastOrDefault(x => x.EventId == taskCompletedEvent.TaskScheduledId);
+                    if (taskScheduledEvent != null)
+                    {
+                        TraceHelper.EmitTraceActivityForTaskCompleted(workItem.OrchestrationRuntimeState.OrchestrationInstance, taskScheduledEvent);
+                    }
                 }
                 else if (message.Event is TaskFailedEvent taskFailedEvent)
                 {
-                    TaskScheduledEvent taskScheduledEvent = workItem.OrchestrationRuntimeState.Events.OfType<TaskScheduledEvent>().LastOrDefault(x => x.EventId == taskFailedEvent.TaskScheduledId);
-                    TraceHelper.EmitTraceActivityForTaskFailed(workItem.OrchestrationRuntimeState.OrchestrationInstance, taskScheduledEvent, taskFailedEvent, errorPropagationMode);
+                    TaskScheduledEvent? taskScheduledEvent = workItem.OrchestrationRuntimeState.Events.OfType<TaskScheduledEvent>().LastOrDefault(x => x.EventId == taskFailedEvent.TaskScheduledId);
+                    if (taskScheduledEvent != null)
+                    {
+                        TraceHelper.EmitTraceActivityForTaskFailed(workItem.OrchestrationRuntimeState.OrchestrationInstance, taskScheduledEvent, taskFailedEvent, errorPropagationMode);
+                    }
                 }
 
                 // In this case, the ExecutionRewoundEvent has already been added to the history and is just sent as a way to trigger the failed deepest suborchestrations to rerun.
@@ -1036,7 +1051,9 @@ namespace DurableTask.Core
 
             runtimeState.AddEvent(executionCompletedEvent);
 
-            if (completeOrchestratorAction.Tags.TryGetValue(OrchestrationTags.CompleteOrchestrationLogWarning, out string warningMessage))
+            if (completeOrchestratorAction.Tags != null &&
+                completeOrchestratorAction.Tags.TryGetValue(OrchestrationTags.CompleteOrchestrationLogWarning, out string? warningMessage) &&
+                warningMessage != null)
             {
                 this.logHelper.OrchestrationCompletedWithWarning(runtimeState.OrchestrationInstance!, completeOrchestratorAction.OrchestrationStatus, warningMessage);
             }
@@ -1315,11 +1332,12 @@ namespace DurableTask.Core
 
             // If a parent trace context was provided via the CreateSubOrchestrationAction.Tags, we will use this as the parent trace context of the suborchestration execution Activity rather than Activity.Current.Context.
             if (createSubOrchestrationAction.Tags != null
-                && createSubOrchestrationAction.Tags.TryGetValue(OrchestrationTags.TraceParent, out string traceParent))
+                && createSubOrchestrationAction.Tags.TryGetValue(OrchestrationTags.TraceParent, out string? traceParent)
+                && traceParent != null)
             {
                 // If a parent trace context was provided but we fail to parse it, we don't want to attach any parent trace context to the start event since that will incorrectly link the trace corresponding to the orchestration execution
                 // as a child of Activity.Current, which is not truly the parent of the request
-                if (createSubOrchestrationAction.Tags.TryGetValue(OrchestrationTags.TraceState, out string traceState)
+                if (createSubOrchestrationAction.Tags.TryGetValue(OrchestrationTags.TraceState, out string? traceState)
                     && ActivityContext.TryParse(traceParent, traceState, out ActivityContext parentTraceContext))
                 {
                     startedEvent.SetParentTraceContext(parentTraceContext);

--- a/src/DurableTask.Core/TaskOrchestrationExecutor.cs
+++ b/src/DurableTask.Core/TaskOrchestrationExecutor.cs
@@ -137,7 +137,7 @@ namespace DurableTask.Core
 
         OrchestratorExecutionResult ExecuteCore(IEnumerable<HistoryEvent> pastEvents, IEnumerable<HistoryEvent> newEvents)
         {
-            SynchronizationContext prevCtx = SynchronizationContext.Current;
+            SynchronizationContext? prevCtx = SynchronizationContext.Current;
 
             try
             {
@@ -290,7 +290,7 @@ namespace DurableTask.Core
                 this.scheduler = scheduler;
             }
 
-            public override void Post(SendOrPostCallback sendOrPostCallback, object state)
+            public override void Post(SendOrPostCallback sendOrPostCallback, object? state)
             {
                 Task.Factory.StartNew(() => sendOrPostCallback(state),
                     CancellationToken.None,
@@ -298,7 +298,7 @@ namespace DurableTask.Core
                     this.scheduler);
             }
 
-            public override void Send(SendOrPostCallback sendOrPostCallback, object state)
+            public override void Send(SendOrPostCallback sendOrPostCallback, object? state)
             {
                 var t = new Task(() => sendOrPostCallback(state));
                 t.RunSynchronously(this.scheduler);

--- a/src/DurableTask.Core/Tracing/TraceHelper.cs
+++ b/src/DurableTask.Core/Tracing/TraceHelper.cs
@@ -59,14 +59,17 @@ namespace DurableTask.Core.Tracing
                 startTime = requestTime;
             }
 
-            Activity? newActivity = ActivityTraceSource.StartActivity(
+            Activity? newActivity = ActivityTraceSource.CreateActivity(
                 CreateSpanName(TraceActivityConstants.CreateOrchestration, startEvent.Name, startEvent.Version),
                 kind: ActivityKind.Producer,
                 parentContext: parentTraceContext,
-                startTime: startTime);
+                idFormat: ActivityIdFormat.W3C);
 
             if (newActivity != null)
             {
+                // This ID is persisted as a W3C traceparent, independent of process-wide Activity defaults.
+                newActivity.SetStartTime(startTime.UtcDateTime);
+                newActivity.Start();
                 newActivity.SetTag(Schema.Task.Type, TraceActivityConstants.Orchestration);
                 newActivity.SetTag(Schema.Task.Name, startEvent.Name);
                 newActivity.SetTag(Schema.Task.InstanceId, startEvent.OrchestrationInstance.InstanceId);

--- a/src/DurableTask.Emulator/DurableTask.Emulator.csproj
+++ b/src/DurableTask.Emulator/DurableTask.Emulator.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472;net48</TargetFrameworks>
     <PackageId>Microsoft.Azure.DurableTask.Emulator</PackageId>
     <NoWarn>NU5125</NoWarn>
   </PropertyGroup>

--- a/src/DurableTask.ServiceBus/Common/Abstraction/ServiceBusAbstraction.cs
+++ b/src/DurableTask.ServiceBus/Common/Abstraction/ServiceBusAbstraction.cs
@@ -9,7 +9,7 @@ namespace DurableTask.ServiceBus.Common.Abstraction
     using System.Threading.Tasks;
     using System.Xml;
     using DurableTask.ServiceBus.Tracking;
-#if !NETSTANDARD2_0
+#if !USE_AZURE_MESSAGING_SERVICEBUS
     using Microsoft.ServiceBus.Messaging;
 
     public class DataContractBinarySerializer<T>
@@ -116,7 +116,7 @@ namespace DurableTask.ServiceBus.Common.Abstraction
     }
 #endif
 
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
     /// <inheritdoc />
     public class IMessageSession
     {
@@ -249,7 +249,7 @@ namespace DurableTask.ServiceBus.Common.Abstraction
 
     }
 
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
     public abstract class Union<A, B>
     {
         public abstract T Match<T>(Func<A, T> f, Func<B, T> g);
@@ -553,7 +553,7 @@ namespace DurableTask.ServiceBus.Common.Abstraction
 #endif
     }
 
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
     /// <inheritdoc />
     public abstract class RetryPolicy : Azure.Messaging.ServiceBus.ServiceBusRetryPolicy
     {
@@ -583,7 +583,7 @@ namespace DurableTask.ServiceBus.Common.Abstraction
 #endif
     }
 
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
     /// <inheritdoc />
     public class ServiceBusConnection
     {
@@ -643,7 +643,7 @@ namespace DurableTask.ServiceBus.Common.Abstraction
 #endif
     }
 
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
     /// <inheritdoc />
     public class ServiceBusConnectionStringBuilder
     {
@@ -675,7 +675,7 @@ namespace DurableTask.ServiceBus.Common.Abstraction
 #endif
     }
 
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
 #else
     public class TokenProvider
     {
@@ -703,7 +703,7 @@ namespace DurableTask.ServiceBus.Common.Abstraction
     }
 #endif
 
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
     /// <inheritdoc />
     public class MessageSender
     {
@@ -802,7 +802,7 @@ namespace DurableTask.ServiceBus.Common.Abstraction
 #endif
     }
 
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
     /// <inheritdoc />
     public class MessageReceiver
     {
@@ -909,7 +909,7 @@ namespace DurableTask.ServiceBus.Common.Abstraction
 #endif
     }
 
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
     /// <inheritdoc />
     public class QueueClient
     {
@@ -993,7 +993,7 @@ namespace DurableTask.ServiceBus.Common.Abstraction
 #endif
     }
 
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
     public class QueueDescription
     {
         private readonly Union<Azure.Messaging.ServiceBus.Administration.QueueProperties, Azure.Messaging.ServiceBus.Administration.QueueRuntimeProperties> propertiesUnion;
@@ -1106,7 +1106,7 @@ namespace DurableTask.ServiceBus.Common.Abstraction
 #endif
     }
 
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
     public class SessionClient
     {
         private readonly Azure.Messaging.ServiceBus.ServiceBusClient serviceBusClient;

--- a/src/DurableTask.ServiceBus/Common/ServiceBusUtils.cs
+++ b/src/DurableTask.ServiceBus/Common/ServiceBusUtils.cs
@@ -54,7 +54,7 @@ namespace DurableTask.ServiceBus.Common.Abstraction
 
             if (compressionSettings.Style == CompressionStyle.Legacy)
             {
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
                 using (var ms = new MemoryStream())
                 {
                     var serialiser = (XmlObjectSerializer)typeof(DataContractSerializer)
@@ -137,7 +137,7 @@ namespace DurableTask.ServiceBus.Common.Abstraction
 
         static Message GenerateBrokeredMessageWithCompressionTypeProperty(Stream stream, string compressionType)
         {
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
             Message brokeredMessage;
             using (var ms = new MemoryStream())
             {
@@ -212,7 +212,7 @@ namespace DurableTask.ServiceBus.Common.Abstraction
             if (string.IsNullOrWhiteSpace(compressionType))
             {
                 // no compression, legacy style
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
                 var dataContractSerializer = new DataContractSerializer(typeof(T));
                 using (var ms = new MemoryStream(message.Body))
                     deserializedObject = (T)dataContractSerializer.ReadObject(ms);
@@ -300,7 +300,7 @@ namespace DurableTask.ServiceBus.Common.Abstraction
             {
                 // load the stream from the message directly if the blob key property is not set,
                 // i.e., it is not stored externally
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
                 return Task.Run(() => new System.IO.MemoryStream(message.Body) as Stream);
 #else
                 return Task.Run(() => message.GetBody<Stream>());

--- a/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
+++ b/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
@@ -2,9 +2,10 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472;net48</TargetFrameworks>
     <PackageId>Microsoft.Azure.DurableTask.ServiceBus</PackageId>
     <Platforms>AnyCPU;x64</Platforms>
+    <DefineConstants Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net472'">$(DefineConstants);USE_AZURE_MESSAGING_SERVICEBUS</DefineConstants>
   </PropertyGroup>
 
     <!-- Version Info -->
@@ -25,18 +26,25 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="ImpromptuInterface" />
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" />
     <PackageReference Include="Microsoft.Data.Edm" />
     <PackageReference Include="Microsoft.Data.OData" />
     <PackageReference Include="Microsoft.Data.Services.Client" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" />
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" />
     <PackageReference Include="System.Spatial" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
     <PackageReference Include="WindowsAzure.ServiceBus" />
     <Reference Include="System.Transactions" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <Reference Include="System.Transactions" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net472'">
     <PackageReference Include="Azure.Messaging.ServiceBus" />
   </ItemGroup>
 

--- a/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
+++ b/src/DurableTask.ServiceBus/ServiceBusOrchestrationService.cs
@@ -42,7 +42,7 @@ namespace DurableTask.ServiceBus
     using ServiceBusConnection = DurableTask.ServiceBus.Common.Abstraction.ServiceBusConnection;
     using ManagementClient = DurableTask.ServiceBus.Common.Abstraction.ManagementClient;
     using ServiceBusConnectionStringBuilder = DurableTask.ServiceBus.Common.Abstraction.ServiceBusConnectionStringBuilder;
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
     using Azure.Core;
     using ReceiveMode = Azure.Messaging.ServiceBus.ServiceBusReceiveMode;
 #else
@@ -109,7 +109,7 @@ namespace DurableTask.ServiceBus
 
         ServiceBusConnection serviceBusConnection;
 
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
 
         /// <summary>
         ///     Create a new ServiceBusOrchestrationService to the given service bus namespace and hub name
@@ -187,7 +187,7 @@ namespace DurableTask.ServiceBus
             if (!string.IsNullOrEmpty(connectionSettings.ConnectionString))
             {
                 var sbConnectionStringBuilder = new ServiceBusConnectionStringBuilder(connectionSettings.ConnectionString);
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
                 this.serviceBusConnection = new ServiceBusConnection(sbConnectionStringBuilder);
 #else
                 this.serviceBusConnection = new ServiceBusConnection(sbConnectionStringBuilder)
@@ -197,7 +197,7 @@ namespace DurableTask.ServiceBus
                 };
 #endif
             }
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
             else if (connectionSettings.Endpoint != null && connectionSettings.TokenCredential != null)
             {
 
@@ -248,7 +248,7 @@ namespace DurableTask.ServiceBus
             this.orchestratorSender = new MessageSender(this.serviceBusConnection, this.orchestratorEntityName, this.workerEntityName);
             this.workerSender = new MessageSender(this.serviceBusConnection, this.workerEntityName, this.orchestratorEntityName);
             this.trackingSender = new MessageSender(this.serviceBusConnection, this.trackingEntityName, this.orchestratorEntityName);
-#if !NETSTANDARD2_0
+#if !USE_AZURE_MESSAGING_SERVICEBUS
             this.orchestratorQueueClient = new QueueClient(this.serviceBusConnection, this.orchestratorEntityName, ReceiveMode.PeekLock, RetryPolicy.Default);
 #else
             this.orchestratorQueueClient = new QueueClient(this.serviceBusConnection, this.orchestratorEntityName);
@@ -1333,7 +1333,7 @@ namespace DurableTask.ServiceBus
         static bool IsTransientException(Exception exception)
         {
             // TODO : Once we change the exception model, check for inner exception
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
             return (exception as Azure.Messaging.ServiceBus.ServiceBusException)?.IsTransient ?? false;
 #else
             return (exception as MessagingException)?.IsTransient ?? false;
@@ -1729,7 +1729,7 @@ namespace DurableTask.ServiceBus
                     {
                         await managementClient.DeleteQueueAsync(path);
                     }
-#if !NETSTANDARD2_0
+#if !USE_AZURE_MESSAGING_SERVICEBUS
                     catch (MessagingEntityAlreadyExistsException)
 #else
                     catch (Azure.Messaging.ServiceBus.ServiceBusException e) when (e.Reason.Equals(Azure.Messaging.ServiceBus.ServiceBusFailureReason.MessagingEntityAlreadyExists))
@@ -1737,7 +1737,7 @@ namespace DurableTask.ServiceBus
                     {
                         await Task.FromResult(0);
                     }
-#if !NETSTANDARD2_0
+#if !USE_AZURE_MESSAGING_SERVICEBUS
                     catch (MessagingEntityNotFoundException)
 #else
                     catch (Azure.Messaging.ServiceBus.ServiceBusException e) when (e.Reason.Equals(Azure.Messaging.ServiceBus.ServiceBusFailureReason.MessagingEntityNotFound))
@@ -1762,7 +1762,7 @@ namespace DurableTask.ServiceBus
                     {
                         await CreateQueueAsync(managementClient, path, requiresSessions, requiresDuplicateDetection, maxDeliveryCount, maxSizeInMegabytes);
                     }
-#if !NETSTANDARD2_0
+#if !USE_AZURE_MESSAGING_SERVICEBUS
                     catch (MessagingEntityAlreadyExistsException)
 #else
                     catch (Azure.Messaging.ServiceBus.ServiceBusException e) when (e.Reason.Equals(Azure.Messaging.ServiceBus.ServiceBusFailureReason.MessagingEntityAlreadyExists))
@@ -1800,7 +1800,7 @@ namespace DurableTask.ServiceBus
                 throw new ArgumentException($"The specified value {maxSizeInMegabytes} is invalid for the maximum queue size in megabytes.\r\nIt must be one of the following values:\r\n{string.Join(";", ValidQueueSizes)}", nameof(maxSizeInMegabytes));
             }
 
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
             var description = new Azure.Messaging.ServiceBus.Administration.CreateQueueOptions(path)
 #else
             var description = new QueueDescription(path)
@@ -1849,7 +1849,7 @@ namespace DurableTask.ServiceBus
             {
                 return new ManagementClient(this.connectionSettings.ConnectionString);
             }
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
             else if (connectionSettings.Endpoint != null && connectionSettings.TokenCredential != null)
             {
                 return new ManagementClient(connectionSettings.Endpoint.Host, connectionSettings.TokenCredential);

--- a/src/DurableTask.ServiceBus/Settings/ServiceBusConnectionSettings.cs
+++ b/src/DurableTask.ServiceBus/Settings/ServiceBusConnectionSettings.cs
@@ -13,7 +13,7 @@
 
 namespace DurableTask.ServiceBus.Settings
 {
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
     using Azure.Core;
 #endif
     using System;
@@ -36,7 +36,7 @@ namespace DurableTask.ServiceBus.Settings
             };
         }
 
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
 
         /// <summary>
         /// Creates an instance of <see cref="ServiceBusConnectionSettings"/>
@@ -83,7 +83,7 @@ namespace DurableTask.ServiceBus.Settings
         /// </summary>
         public string ConnectionString { get; private set; }
 
-#if NETSTANDARD2_0
+#if USE_AZURE_MESSAGING_SERVICEBUS
 
         /// <summary>
         /// Service Bus endpoint

--- a/test/DurableTask.AzureServiceFabric.Integration.Tests/DurableTask.AzureServiceFabric.Integration.Tests.csproj
+++ b/test/DurableTask.AzureServiceFabric.Integration.Tests/DurableTask.AzureServiceFabric.Integration.Tests.csproj
@@ -12,7 +12,7 @@
 	<PackageReference Include="Microsoft.NET.Test.Sdk" VersionOverride="15.0.0" />
 	<PackageReference Include="MSTest.TestAdapter" VersionOverride="1.4.0" />
 	<PackageReference Include="MSTest.TestFramework" VersionOverride="1.4.0" />
-    <PackageReference Include="System.Collections.Immutable" VersionOverride="1.5.0" />
+    <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Net.Http" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" />
     <PackageReference Include="Moq" />

--- a/test/DurableTask.AzureStorage.Tests/AsyncAutoResetEventTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AsyncAutoResetEventTests.cs
@@ -21,14 +21,14 @@ namespace DurableTask.AzureStorage.Tests
     [TestClass]
     public class AsyncAutoResetEventTests
     {
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(false, false)]
         [DataRow(true, true)]
         public async Task InitialState(bool initiallySignaled, bool expectedResult)
         {
             var resetEvent = new AsyncAutoResetEvent(initiallySignaled);
             bool result = await resetEvent.WaitAsync(TimeSpan.Zero);
-            Assert.AreEqual<bool>(result, expectedResult);
+            Assert.AreEqual<bool>(expectedResult, result);
         }
 
         [TestMethod]

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScaleTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScaleTests.cs
@@ -210,7 +210,7 @@ namespace DurableTask.AzureStorage.Tests
         /// REQUIREMENT: Workers can be added or removed at any time and control-queue partitions are load-balanced automatically.
         /// REQUIREMENT: No two workers will ever process the same control queue.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(PartitionManagerType.V1Legacy, 30)]
         [DataRow(PartitionManagerType.V2Safe, 180)]
         public async Task MultiWorkerLeaseMovement(PartitionManagerType partitionManagerType, int timeoutInSeconds)
@@ -589,7 +589,7 @@ namespace DurableTask.AzureStorage.Tests
                 await service2.CompleteTaskOrchestrationWorkItemAsync(workItem2, runtimeState, new List<TaskMessage>(), new List<TaskMessage>(), new List<TaskMessage>(), null, null);
                 // Now worker 1 will attempt to complete the same work item. Since this is the first attempt to complete a work item and add a history for the orchestration (by worker 1),
                 // there is no etag stored for the OrchestrationSession, and so the a "conflict" exception will be thrown as worker 2 already created a history for the orchestration.
-                SessionAbortedException exception = await Assert.ThrowsExceptionAsync<SessionAbortedException>(async () =>
+                SessionAbortedException exception = await Assert.ThrowsExactlyAsync<SessionAbortedException>(async () =>
                     await service1.CompleteTaskOrchestrationWorkItemAsync(workItem1, runtimeState, new List<TaskMessage>(), new List<TaskMessage>(), new List<TaskMessage>(), null, null)
                 );
                 Assert.IsInstanceOfType(exception.InnerException, typeof(DurableTaskStorageException));
@@ -632,7 +632,7 @@ namespace DurableTask.AzureStorage.Tests
                 await service1.CompleteTaskOrchestrationWorkItemAsync(workItem1, runtimeState, new List<TaskMessage>(), new List<TaskMessage>(), new List<TaskMessage>(), null, null);
                 // Now worker 2 attempts to complete the same work item. Since this is not the first work item for the orchestration, now an etag exists for the OrchestrationSession, and the exception
                 // that is thrown will be "precondition failed" as the Etag is stale after worker 1 completed the work item.
-                exception = await Assert.ThrowsExceptionAsync<SessionAbortedException>(async () =>
+                exception = await Assert.ThrowsExactlyAsync<SessionAbortedException>(async () =>
                     await service2.CompleteTaskOrchestrationWorkItemAsync(workItem2, runtimeState, new List<TaskMessage>(), new List<TaskMessage>(), new List<TaskMessage>(), null, null)
                 );
                 Assert.IsInstanceOfType(exception.InnerException, typeof(DurableTaskStorageException));

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -47,10 +47,26 @@ namespace DurableTask.AzureStorage.Tests
     {
         public static readonly TimeSpan StandardTimeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(30);
 
+        static void AssertJsonTokenEquals(JToken expected, string actual)
+        {
+            JToken actualToken = JToken.Parse(actual);
+            Assert.IsTrue(
+                JToken.DeepEquals(expected, actualToken),
+                $"Expected JSON token {expected} ({expected.Type}), but found {actualToken} ({actualToken.Type}).");
+        }
+
+        static void AssertJsonTokenNotEquals(JToken expected, string actual)
+        {
+            JToken actualToken = JToken.Parse(actual);
+            Assert.IsFalse(
+                JToken.DeepEquals(expected, actualToken),
+                $"Expected JSON token to differ from {expected} ({expected.Type}).");
+        }
+
         /// <summary>
         /// End-to-end test which validates a simple orchestrator function which doesn't call any activity functions.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task HelloWorldOrchestration_Inline(bool enableExtendedSessions)
@@ -63,8 +79,8 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(StandardTimeout);
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual("World", JToken.Parse(status?.Input));
-                Assert.AreEqual("Hello, World!", JToken.Parse(status?.Output));
+                AssertJsonTokenEquals("World", status?.Input);
+                AssertJsonTokenEquals("Hello, World!", status?.Output);
 
                 await host.StopAsync();
             }
@@ -73,7 +89,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which runs a simple orchestrator function that calls a single activity function.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task HelloWorldOrchestration_Activity(bool enableExtendedSessions)
@@ -86,8 +102,8 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(StandardTimeout);
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual("World", JToken.Parse(status?.Input));
-                Assert.AreEqual("Hello, World!", JToken.Parse(status?.Output));
+                AssertJsonTokenEquals("World", status?.Input);
+                AssertJsonTokenEquals("Hello, World!", status?.Output);
 
                 await host.StopAsync();
             }
@@ -107,8 +123,8 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(StandardTimeout);
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(10, JToken.Parse(status?.Input));
-                Assert.AreEqual(3628800, JToken.Parse(status?.Output));
+                AssertJsonTokenEquals(10, status?.Input);
+                AssertJsonTokenEquals(3628800, status?.Output);
 
                 await host.StopAsync();
             }
@@ -129,8 +145,8 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(StandardTimeout);
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(10, JToken.Parse(status?.Input));
-                Assert.AreEqual(3628800, JToken.Parse(status?.Output));
+                AssertJsonTokenEquals(10, status?.Input);
+                AssertJsonTokenEquals(3628800, status?.Output);
 
                 await host.StopAsync();
             }
@@ -147,8 +163,8 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(10, JToken.Parse(status?.Input));
-                Assert.AreEqual(3628800, JToken.Parse(status?.Output));
+                AssertJsonTokenEquals(10, status?.Input);
+                AssertJsonTokenEquals(3628800, status?.Output);
 
                 await host.StopAsync();
             }
@@ -157,7 +173,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which runs a slow orchestrator that causes work item renewal
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task LongRunningOrchestrator(bool enableExtendedSessions)
@@ -176,7 +192,7 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(StandardTimeout);
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual("ok", JToken.Parse(status?.Output));
+                AssertJsonTokenEquals("ok", status?.Output);
 
                 await host.StopAsync();
             }
@@ -266,7 +282,7 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(false, false)]
         [DataRow(true, false)]
         [DataRow(false, true)]
@@ -281,13 +297,13 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual("OK", JToken.Parse(status?.Output));
+                AssertJsonTokenEquals("OK", status?.Output);
 
                 await host.StopAsync();
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(false)]
         [DataRow(true)]
         public async Task AutoStart(bool enableExtendedSessions)
@@ -302,13 +318,13 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual("OK", JToken.Parse(status?.Output));
+                AssertJsonTokenEquals("OK", status?.Output);
 
                 await host.StopAsync();
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(false)]
         [DataRow(true)]
         public async Task ContinueAsNewThenTimer(bool enableExtendedSessions)
@@ -321,7 +337,7 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual("OK", JToken.Parse(status?.Output));
+                AssertJsonTokenEquals("OK", status?.Output);
 
                 await host.StopAsync();
             }
@@ -396,7 +412,7 @@ namespace DurableTask.AzureStorage.Tests
                 var state = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, state?.OrchestrationStatus);
-                Assert.AreEqual(customStatus, JToken.Parse(state?.Status));
+                AssertJsonTokenEquals(customStatus, state?.Status);
 
                 await host.StopAsync();
             }
@@ -956,7 +972,7 @@ namespace DurableTask.AzureStorage.Tests
         /// End-to-end test which validates parallel function execution by enumerating all files in the current directory 
         /// in parallel and getting the sum total of all file sizes.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task ParallelOrchestration(bool enableExtendedSessions)
@@ -969,14 +985,14 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(90));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(Environment.CurrentDirectory, JToken.Parse(status?.Input));
+                AssertJsonTokenEquals(Environment.CurrentDirectory, status?.Input);
                 Assert.IsTrue(long.Parse(status?.Output) > 0L);
 
                 await host.StopAsync();
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task LargeFanOutOrchestration(bool enableExtendedSessions)
@@ -1015,7 +1031,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates the ContinueAsNew functionality by implementing a counter actor pattern.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task ActorOrchestration(bool enableExtendedSessions)
@@ -1051,10 +1067,10 @@ namespace DurableTask.AzureStorage.Tests
                 status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(10));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(3, JToken.Parse(status?.Output));
+                AssertJsonTokenEquals(3, status?.Output);
 
                 // When using ContinueAsNew, the original input is discarded and replaced with the most recent state.
-                Assert.AreNotEqual(initialValue, JToken.Parse(status?.Input));
+                AssertJsonTokenNotEquals(initialValue, status?.Input);
 
                 await host.StopAsync();
             }
@@ -1063,7 +1079,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates the ContinueAsNew functionality by implementing character counter actor pattern.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task ActorOrchestrationForLargeInput(bool enableExtendedSessions)
@@ -1074,7 +1090,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates the deletion of all data generated by the ContinueAsNew functionality in the character counter actor pattern.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task ActorOrchestrationDeleteAllLargeMessageBlobs(bool enableExtendedSessions)
@@ -1188,7 +1204,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates the Terminate functionality.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task TerminateOrchestration(bool enableExtendedSessions)
@@ -1218,7 +1234,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates the Suspend-Resume functionality.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task SuspendResumeOrchestration(bool enableExtendedSessions)
@@ -1242,13 +1258,13 @@ namespace DurableTask.AzureStorage.Tests
                 // Test case 2: external event does not go through
                 await client.RaiseEventAsync("changeStatusNow", changedStatus);
                 status = await client.GetStatusAsync();
-                Assert.AreEqual(originalStatus, JToken.Parse(status?.Status));
+                AssertJsonTokenEquals(originalStatus, status?.Status);
 
                 // Test case 3: external event now goes through
                 await client.ResumeAsync("wakeUp");
                 status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(10));
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(changedStatus, JToken.Parse(status?.Status));
+                AssertJsonTokenEquals(changedStatus, status?.Status);
 
                 await host.StopAsync();
             }
@@ -1257,7 +1273,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// Test that a suspended orchestration can be terminated.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task TerminateSuspendedOrchestration(bool enableExtendedSessions)
@@ -1286,7 +1302,7 @@ namespace DurableTask.AzureStorage.Tests
         /// Test that a pending orchestration can be terminated (including tests with a large termination reason that will need to be
         /// stored in blob storage).
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true, true)]
         [DataRow(false, true)]
         [DataRow(true, false)]
@@ -1593,7 +1609,7 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task TimerCancellation(bool enableExtendedSessions)
@@ -1612,7 +1628,7 @@ namespace DurableTask.AzureStorage.Tests
 
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual("Approved", JToken.Parse(status?.Output));
+                AssertJsonTokenEquals("Approved", status?.Output);
 
                 await host.StopAsync();
             }
@@ -1621,7 +1637,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates the handling of durable timer expiration.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task TimerExpiration(bool enableExtendedSessions)
@@ -1641,13 +1657,13 @@ namespace DurableTask.AzureStorage.Tests
 
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(20));
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual("Expired", JToken.Parse(status?.Output));
+                AssertJsonTokenEquals("Expired", status?.Output);
 
                 await host.StopAsync();
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task TimerDelay(bool useUtc)
@@ -1675,7 +1691,7 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(false)]
         [DataRow(true)]
         public async Task OrchestratorStartAtAcceptsAllDateTimeKinds(bool useUtc)
@@ -1715,7 +1731,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that orchestrations run concurrently of each other (up to 100 by default).
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task OrchestrationConcurrency(bool enableExtendedSessions)
@@ -1754,7 +1770,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates the orchestrator's exception handling behavior.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task HandledActivityException(bool enableExtendedSessions)
@@ -1768,7 +1784,7 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(15));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(5, JToken.Parse(status?.Output));
+                AssertJsonTokenEquals(5, status?.Output);
 
                 await host.StopAsync();
             }
@@ -1777,7 +1793,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates the handling of unhandled exceptions generated from orchestrator code.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task UnhandledOrchestrationException(bool enableExtendedSessions)
@@ -1800,7 +1816,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates the handling of unhandled exceptions generated from activity code.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task UnhandledActivityException(bool enableExtendedSessions)
@@ -1823,7 +1839,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// Fan-out/fan-in test which ensures each operation is run only once.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task FanOutToTableStorage(bool enableExtendedSessions)
@@ -1867,7 +1883,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that orchestrations with <=60KB text message sizes can run successfully.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task SmallTextMessagePayloads(bool enableExtendedSessions)
@@ -1894,7 +1910,7 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(message, JToken.Parse(status?.Output));
+                AssertJsonTokenEquals(message, status?.Output);
 
                 await host.StopAsync();
             }
@@ -1903,7 +1919,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that orchestrations with > 60KB text message sizes can run successfully.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task LargeQueueTextMessagePayloads_BlobUrl(bool enableExtendedSessions)
@@ -1920,8 +1936,8 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromMinutes(2));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(message, JToken.Parse(status?.Output));
-                Assert.AreEqual(message, JToken.Parse(status.Input));
+                AssertJsonTokenEquals(message, status?.Output);
+                AssertJsonTokenEquals(message, status.Input);
 
                 await host.StopAsync();
             }
@@ -1930,7 +1946,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that orchestrations with > 60KB text message sizes can run successfully.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task LargeTableTextMessagePayloads_SizeViolation_BlobUrl(bool enableExtendedSessions)
@@ -2014,7 +2030,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that orchestrations with > 60KB text message sizes can run successfully.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task LargeOverallTextMessagePayloads_BlobUrl(bool enableExtendedSessions)
@@ -2051,7 +2067,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that orchestrations with > 60KB text message sizes can run successfully.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task LargeTextMessagePayloads_FetchLargeMessages(bool enableExtendedSessions)
@@ -2065,8 +2081,8 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromMinutes(2));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(message, JToken.Parse(status?.Input));
-                Assert.AreEqual(message, JToken.Parse(status?.Output));
+                AssertJsonTokenEquals(message, status?.Input);
+                AssertJsonTokenEquals(message, status?.Output);
 
                 await host.StopAsync();
             }
@@ -2075,7 +2091,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that orchestrations with > 60KB text message sizes can run successfully.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task LargeTableTextMessagePayloads_FetchLargeMessages(bool enableExtendedSessions)
@@ -2091,8 +2107,8 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromMinutes(2));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(message, JToken.Parse(status?.Input));
-                Assert.AreEqual(message, JToken.Parse(status?.Output));
+                AssertJsonTokenEquals(message, status?.Input);
+                AssertJsonTokenEquals(message, status?.Output);
 
                 await host.StopAsync();
             }
@@ -2127,7 +2143,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that orchestrations with > 60KB text message sizes can run successfully.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task NonBlobUriPayload_FetchLargeMessages_RetainsOriginalPayload(bool enableExtendedSessions)
@@ -2141,8 +2157,8 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromMinutes(2));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(message, JToken.Parse(status?.Input));
-                Assert.AreEqual(message, JToken.Parse(status?.Output));
+                AssertJsonTokenEquals(message, status?.Input);
+                AssertJsonTokenEquals(message, status?.Output);
 
                 await host.StopAsync();
             }
@@ -2151,7 +2167,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that orchestrations with > 60KB text message sizes can run successfully.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task LargeTextMessagePayloads_FetchLargeMessages_QueryState(bool enableExtendedSessions)
@@ -2168,8 +2184,8 @@ namespace DurableTask.AzureStorage.Tests
                 status = (await client.GetStateAsync(status.OrchestrationInstance.InstanceId)).First();
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(message, JToken.Parse(status?.Input));
-                Assert.AreEqual(message, JToken.Parse(status?.Output));
+                AssertJsonTokenEquals(message, status?.Input);
+                AssertJsonTokenEquals(message, status?.Output);
 
                 await host.StopAsync();
             }
@@ -2179,7 +2195,7 @@ namespace DurableTask.AzureStorage.Tests
         /// End-to-end test which validates that exception messages that are considered valid Urls in the Uri.TryCreate() method
         /// are handled with an additional Uri format check
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task LargeTextMessagePayloads_URIFormatCheck(bool enableExtendedSessions)
@@ -2243,7 +2259,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that orchestrations with > 60KB binary bytes message sizes can run successfully.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task LargeBinaryByteMessagePayloads(bool enableExtendedSessions)
@@ -2273,7 +2289,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that orchestrations with > 60KB binary string message sizes can run successfully.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task LargeBinaryStringMessagePayloads(bool enableExtendedSessions)
@@ -2305,7 +2321,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that a completed singleton instance can be recreated.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task RecreateCompletedInstance(bool enableExtendedSessions)
@@ -2323,8 +2339,8 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual("One", JToken.Parse(status?.Input));
-                Assert.AreEqual("Hello, One!", JToken.Parse(status?.Output));
+                AssertJsonTokenEquals("One", status?.Input);
+                AssertJsonTokenEquals("Hello, One!", status?.Output);
 
                 client = await host.StartOrchestrationAsync(
                     typeof(Orchestrations.SayHelloWithActivity),
@@ -2333,8 +2349,8 @@ namespace DurableTask.AzureStorage.Tests
                 status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual("Two", JToken.Parse(status?.Input));
-                Assert.AreEqual("Hello, Two!", JToken.Parse(status?.Output));
+                AssertJsonTokenEquals("Two", status?.Input);
+                AssertJsonTokenEquals("Hello, Two!", status?.Output);
 
                 await host.StopAsync();
             }
@@ -2343,7 +2359,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that a failed singleton instance can be recreated.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task RecreateFailedInstance(bool enableExtendedSessions)
@@ -2369,7 +2385,7 @@ namespace DurableTask.AzureStorage.Tests
                 status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual("Hello, NotNull!", JToken.Parse(status?.Output));
+                AssertJsonTokenEquals("Hello, NotNull!", status?.Output);
 
                 await host.StopAsync();
             }
@@ -2378,7 +2394,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that a terminated orchestration can be recreated.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task RecreateTerminatedInstance(bool enableExtendedSessions)
@@ -2422,7 +2438,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that a running orchestration can be recreated.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task RecreateRunningInstance(bool enableExtendedSessions)
@@ -2509,7 +2525,7 @@ namespace DurableTask.AzureStorage.Tests
                 status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(10));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(1, JToken.Parse(status?.Output));
+                AssertJsonTokenEquals(1, status?.Output);
 
                 await host.StopAsync();
             }
@@ -2519,7 +2535,7 @@ namespace DurableTask.AzureStorage.Tests
         /// Tests an orchestration that does two consecutive fan-out, fan-ins.
         /// This is a regression test for https://github.com/Azure/durabletask/issues/241.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task DoubleFanOut(bool enableExtendedSessions)
@@ -2567,7 +2583,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// Tests the behavior of <see cref="SessionAbortedException"/> from orchestrations and activities.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task AbortOrchestrationAndActivity(bool enableExtendedSessions)
@@ -2582,7 +2598,7 @@ namespace DurableTask.AzureStorage.Tests
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
                 Assert.IsNotNull(status.Output);
-                Assert.AreEqual("True", JToken.Parse(status.Output));
+                AssertJsonTokenEquals("True", status.Output);
                 await host.StopAsync();
             }
         }
@@ -2592,7 +2608,7 @@ namespace DurableTask.AzureStorage.Tests
         /// </summary>
         /// <param name="enableExtendedSessions"></param>
         /// <returns></returns>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task ScheduledStart_Inline(bool enableExtendedSessions)
@@ -2611,11 +2627,11 @@ namespace DurableTask.AzureStorage.Tests
                 await Task.WhenAll(statusStartingNow, statusStartingIn30Seconds);
 
                 Assert.AreEqual(OrchestrationStatus.Completed, statusStartingNow.Result?.OrchestrationStatus);
-                Assert.AreEqual("Current Time!", JToken.Parse(statusStartingNow.Result?.Input));
+                AssertJsonTokenEquals("Current Time!", statusStartingNow.Result?.Input);
                 Assert.IsNull(statusStartingNow.Result.ScheduledStartTime);
 
                 Assert.AreEqual(OrchestrationStatus.Completed, statusStartingIn30Seconds.Result?.OrchestrationStatus);
-                Assert.AreEqual("Current Time!", JToken.Parse(statusStartingIn30Seconds.Result?.Input));
+                AssertJsonTokenEquals("Current Time!", statusStartingIn30Seconds.Result?.Input);
                 Assert.AreEqual(expectedStartTime, statusStartingIn30Seconds.Result.ScheduledStartTime);
 
                 var startNowResult = (DateTime)JToken.Parse(statusStartingNow.Result?.Output);
@@ -2633,7 +2649,7 @@ namespace DurableTask.AzureStorage.Tests
         /// </summary>
         /// <param name="enableExtendedSessions"></param>
         /// <returns></returns>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task ScheduledStart_Activity(bool enableExtendedSessions)
@@ -2652,11 +2668,11 @@ namespace DurableTask.AzureStorage.Tests
                 await Task.WhenAll(statusStartingNow, statusStartingIn30Seconds);
 
                 Assert.AreEqual(OrchestrationStatus.Completed, statusStartingNow.Result?.OrchestrationStatus);
-                Assert.AreEqual("Current Time!", JToken.Parse(statusStartingNow.Result?.Input));
+                AssertJsonTokenEquals("Current Time!", statusStartingNow.Result?.Input);
                 Assert.IsNull(statusStartingNow.Result.ScheduledStartTime);
 
                 Assert.AreEqual(OrchestrationStatus.Completed, statusStartingIn30Seconds.Result?.OrchestrationStatus);
-                Assert.AreEqual("Current Time!", JToken.Parse(statusStartingIn30Seconds.Result?.Input));
+                AssertJsonTokenEquals("Current Time!", statusStartingIn30Seconds.Result?.Input);
                 Assert.AreEqual(expectedStartTime, statusStartingIn30Seconds.Result.ScheduledStartTime);
 
                 var startNowResult = (DateTime)JToken.Parse(statusStartingNow.Result?.Output);
@@ -2674,7 +2690,7 @@ namespace DurableTask.AzureStorage.Tests
         /// </summary>
         /// <param name="enableExtendedSessions"></param>
         /// <returns></returns>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task ScheduledStart_Activity_GetStatus_Returns_ScheduledStart(bool enableExtendedSessions)
@@ -2719,7 +2735,7 @@ namespace DurableTask.AzureStorage.Tests
         /// To recover from this, users may set `AllowReplayingTerminalInstances` to true. When this is set, DTFx will not discard
         /// events for terminal orchestrators, forcing a replay which eventually updates the instances table to the right state.
         /// </remarks>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true, true, true)]
         [DataRow(true, true, false)]
         [DataRow(true, false, true)]
@@ -2817,7 +2833,7 @@ namespace DurableTask.AzureStorage.Tests
         /// the tracking store context object that is part of the orchestration session state which keeps track of the blobs.
         /// </summary>
         /// <returns></returns>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true, true)]
         [DataRow(false, true)]
         [DataRow(true, false)]
@@ -2909,7 +2925,7 @@ namespace DurableTask.AzureStorage.Tests
         /// Same as <see cref="TestWorkerFailingDuringCompleteWorkItemCallCompletedOrchestration"/> but for a failed orchestration.
         /// </summary>
         /// <returns></returns>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true, true)]
         [DataRow(false, true)]
         [DataRow(true, false)]
@@ -3001,7 +3017,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// Same as <see cref="TestWorkerFailingDuringCompleteWorkItemCallCompletedOrchestration"/> but for a terminated orchestration.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true, true)]
         [DataRow(false, true)]
         [DataRow(true, false)]
@@ -3095,7 +3111,7 @@ namespace DurableTask.AzureStorage.Tests
         /// Same as <see cref="TestWorkerFailingDuringCompleteWorkItemCallCompletedOrchestration"/> but for an orchestration with large input
         /// and output, which will need to be stored in blob storage.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true, true)]
         [DataRow(false, true)]
         [DataRow(true, false)]
@@ -3188,7 +3204,7 @@ namespace DurableTask.AzureStorage.Tests
         /// Same as <see cref="TestWorkerFailingDuringCompleteWorkItemCallTerminatedOrchestration"/> but for a large termination reason that
         /// will need to be stored in blob storage.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true, true)]
         [DataRow(false, true)]
         [DataRow(true, false)]
@@ -3285,7 +3301,7 @@ namespace DurableTask.AzureStorage.Tests
         /// Same as <see cref="TestWorkerFailingDuringCompleteWorkItemCallFailedOrchestration"/> but for a large exception message that will need
         /// to be stored in blob storage.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true, true)]
         [DataRow(false, true)]
         [DataRow(true, false)]
@@ -3477,7 +3493,7 @@ namespace DurableTask.AzureStorage.Tests
         /// </remarks>
         /// <param name="useInstanceEtag">The value to use for <see cref="AzureStorageOrchestrationServiceSettings.UseInstanceTableEtag"/></param>
         /// <returns></returns>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task WorkerAttemptingToUpdateInstanceTableAfterStalling(bool useInstanceEtag)
@@ -3541,7 +3557,7 @@ namespace DurableTask.AzureStorage.Tests
                 if (useInstanceEtag)
                 {
                     // Confirm an exception is thrown due to the etag mismatch for the instance table when the worker attempts to complete the work item
-                    SessionAbortedException exception = await Assert.ThrowsExceptionAsync<SessionAbortedException>(async () =>
+                    SessionAbortedException exception = await Assert.ThrowsExactlyAsync<SessionAbortedException>(async () =>
                         await service.CompleteTaskOrchestrationWorkItemAsync(workItem, runtimeState, new List<TaskMessage>(), new List<TaskMessage>(), new List<TaskMessage>(), null, null)
                     );
                     Assert.IsInstanceOfType(exception.InnerException, typeof(DurableTaskStorageException));
@@ -3592,7 +3608,7 @@ namespace DurableTask.AzureStorage.Tests
         /// </remarks>
         /// <param name="useInstanceEtag">The value to use for <see cref="AzureStorageOrchestrationServiceSettings.UseInstanceTableEtag"/></param>
         /// <returns></returns>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task WorkerAttemptingToUpdateInstanceTableAfterStallingForSubOrchestration(bool useInstanceEtag)
@@ -3699,7 +3715,7 @@ namespace DurableTask.AzureStorage.Tests
                 {
                     // Confirm an exception is thrown because the worker attempts to insert a new entity for the suborchestration into the instance table
                     // when one already exists
-                    SessionAbortedException exception = await Assert.ThrowsExceptionAsync<SessionAbortedException>(async () =>
+                    SessionAbortedException exception = await Assert.ThrowsExactlyAsync<SessionAbortedException>(async () =>
                         await service.CompleteTaskOrchestrationWorkItemAsync(workItem, runtimeState, new List<TaskMessage>(), new List<TaskMessage>(), new List<TaskMessage>(), null, null)
                     );
                     Assert.IsInstanceOfType(exception.InnerException, typeof(DurableTaskStorageException));
@@ -3733,7 +3749,7 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task WorkerAttemptingToDequeueMessageForNonExistentInstance(bool extendedSessionsEnabled)
@@ -3785,7 +3801,7 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true, true)]
         [DataRow(false, true)]
         [DataRow(true, false)]
@@ -3878,7 +3894,7 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true, true)]
         [DataRow(false, true)]
         [DataRow(true, false)]
@@ -3991,7 +4007,7 @@ namespace DurableTask.AzureStorage.Tests
         /// End-to-end test which validates a simple orchestrator function that calls an activity function
         /// and checks the OpenTelemetry trace information
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task OpenTelemetry_SayHelloWithActivity(bool enableExtendedSessions)
@@ -4061,7 +4077,7 @@ namespace DurableTask.AzureStorage.Tests
         /// End-to-end test which validates a simple orchestrator function that waits for an external event
         /// raised through the RaiseEvent API and checks the OpenTelemetry trace information
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task OpenTelemetry_ExternalEvent_RaiseEvent(bool enableExtendedSessions)
@@ -4131,7 +4147,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates a simple orchestrator function that fires a timer and checks the OpenTelemetry trace information
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task OpenTelemetry_TimerFired(bool enableExtendedSessions)
@@ -4198,7 +4214,7 @@ namespace DurableTask.AzureStorage.Tests
         /// End-to-end test which validates a simple orchestrator function that waits for an external event
         /// raised by calling SendEvent and checks the OpenTelemetry trace information
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task OpenTelemetry_ExternalEvent_SendEvent(bool enableExtendedSessions)

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -1935,8 +1935,9 @@ namespace DurableTask.AzureStorage.Tests
                 var client = await host.StartOrchestrationAsync(typeof(Orchestrations.Echo), message);
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromMinutes(2));
 
-                Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                AssertJsonTokenEquals(message, status?.Output);
+                Assert.IsNotNull(status);
+                Assert.AreEqual(OrchestrationStatus.Completed, status.OrchestrationStatus);
+                AssertJsonTokenEquals(message, status.Output);
                 AssertJsonTokenEquals(message, status.Input);
 
                 await host.StopAsync();

--- a/test/DurableTask.AzureStorage.Tests/AzureTableQueryFilterTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureTableQueryFilterTests.cs
@@ -21,7 +21,7 @@ namespace DurableTask.AzureStorage.Tests
     {
         // PartitionKeyEquals applies KeySanitation.EscapePartitionKey (storage-key characters) and then
         // OData quote-escaping (single quotes doubled).
-        [DataTestMethod]
+        [TestMethod]
         [DataRow("instance1", "PartitionKey eq 'instance1'")]
         [DataRow("inst'ance", "PartitionKey eq 'inst''ance'")]
         [DataRow("in#st'ance", "PartitionKey eq 'in^2st''ance'")]
@@ -31,7 +31,7 @@ namespace DurableTask.AzureStorage.Tests
         }
 
         // ColumnEquals OData-escapes the value (single quotes doubled); the column name is literal text.
-        [DataTestMethod]
+        [TestMethod]
         [DataRow("ExecutionId", "abc", "ExecutionId eq 'abc'")]
         [DataRow("ExecutionId", "a'b", "ExecutionId eq 'a''b'")]
         [DataRow("RowKey", "", "RowKey eq ''")]
@@ -40,7 +40,7 @@ namespace DurableTask.AzureStorage.Tests
             Assert.AreEqual(expectedFilter, AzureTableQueryFilter.ColumnEquals(columnName, value));
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow("prefix", "PartitionKey ge 'prefix'")]
         [DataRow("pre'fix", "PartitionKey ge 'pre''fix'")]
         public void PartitionKeyGreaterOrEqual(string sanitizedPartitionKey, string expectedFilter)
@@ -48,7 +48,7 @@ namespace DurableTask.AzureStorage.Tests
             Assert.AreEqual(expectedFilter, AzureTableQueryFilter.PartitionKeyGreaterOrEqual(sanitizedPartitionKey));
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow("prefix", "PartitionKey lt 'prefix'")]
         [DataRow("pre'fix", "PartitionKey lt 'pre''fix'")]
         public void PartitionKeyLessThan(string sanitizedPartitionKey, string expectedFilter)

--- a/test/DurableTask.AzureStorage.Tests/Correlation/CorrelationScenarioTest.cs
+++ b/test/DurableTask.AzureStorage.Tests/Correlation/CorrelationScenarioTest.cs
@@ -31,7 +31,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
     [TestClass]
     public class CorrelationScenarioTest
     {
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(Protocol.W3CTraceContext, false)]
         [DataRow(Protocol.HttpCorrelationProtocol, false)]
         [DataRow(Protocol.W3CTraceContext, true)]
@@ -78,7 +78,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(Protocol.W3CTraceContext, false)]
         [DataRow(Protocol.HttpCorrelationProtocol, false)]
         [DataRow(Protocol.W3CTraceContext, true)]
@@ -113,7 +113,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
                 );
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(Protocol.W3CTraceContext, false)]
         [DataRow(Protocol.HttpCorrelationProtocol, false)]
         [DataRow(Protocol.W3CTraceContext, true)]
@@ -173,7 +173,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(Protocol.W3CTraceContext, false)]
         [DataRow(Protocol.HttpCorrelationProtocol, false)]
         [DataRow(Protocol.W3CTraceContext, true)]
@@ -217,7 +217,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(Protocol.W3CTraceContext, false)]
         [DataRow(Protocol.HttpCorrelationProtocol, false)]
         [DataRow(Protocol.W3CTraceContext, true)]
@@ -274,7 +274,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(Protocol.W3CTraceContext, false)]
         [DataRow(Protocol.HttpCorrelationProtocol, false)]
         [DataRow(Protocol.W3CTraceContext, true)]
@@ -338,7 +338,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(Protocol.W3CTraceContext, false)]
         [DataRow(Protocol.HttpCorrelationProtocol, false)]
         [DataRow(Protocol.W3CTraceContext, true)]
@@ -447,7 +447,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
 
         //[TestMethod] ContinueAsNew
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(Protocol.W3CTraceContext, false)]
         [DataRow(Protocol.HttpCorrelationProtocol, false)]
         [DataRow(Protocol.W3CTraceContext, true)]
@@ -502,7 +502,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(Protocol.W3CTraceContext, false)]
         [DataRow(Protocol.HttpCorrelationProtocol, false)]
         [DataRow(Protocol.W3CTraceContext, true)]
@@ -576,7 +576,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(Protocol.W3CTraceContext, false)]
         [DataRow(Protocol.HttpCorrelationProtocol, false)]
         [DataRow(Protocol.W3CTraceContext, true)]
@@ -718,7 +718,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(Protocol.W3CTraceContext, false)]
         [DataRow(Protocol.HttpCorrelationProtocol, false)]
         [DataRow(Protocol.W3CTraceContext, true)]

--- a/test/DurableTask.AzureStorage.Tests/Correlation/StringExtensionsTest.cs
+++ b/test/DurableTask.AzureStorage.Tests/Correlation/StringExtensionsTest.cs
@@ -35,7 +35,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
         public void TestParseTraceParentThrowsException()
         {
             string wrongTraceparentString = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7";
-            Assert.ThrowsException<ArgumentException>(
+            Assert.ThrowsExactly<ArgumentException>(
                 () => { wrongTraceparentString.ToTraceParent(); });
         }
 

--- a/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
+++ b/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
@@ -10,13 +10,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
-    <!-- Increasing Azure.Monitor.OpenTelemetry.Exporter to 1.0.0-beta.5 or beyond brings Systems.DiagnosticSource 7.x, which is uncompatible with netcoreapp3.1.
-    The warning reads:
-	  "System.Diagnostics.DiagnosticSource 7.0.0-rc.1.22426.10 doesn't support netcoreapp3.1 and has not been tested with it
-	  Consider upgrading your TargetFramework to net6.0 or later. You may also set <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings> 
-	  in the project file to ignore this warning and attempt to run in this unsupported configuration at your own risk."-->
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
     <PackageReference Include="System.Configuration.ConfigurationManager" />
+    <PackageReference Include="System.Net.Http" />
+    <PackageReference Include="System.Text.RegularExpressions" />
   </ItemGroup>
 
   <!-- Common package dependencies -->

--- a/test/DurableTask.AzureStorage.Tests/KeySanitationTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/KeySanitationTests.cs
@@ -24,7 +24,7 @@ namespace DurableTask.AzureStorage.Tests
     [TestClass]
     public class KeySanitationTests
     {
-        [DataTestMethod]
+        [TestMethod]
         [DataRow("\r")]
         [DataRow("")]
         [DataRow("hello")]

--- a/test/DurableTask.AzureStorage.Tests/MessageManagerTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/MessageManagerTests.cs
@@ -23,7 +23,7 @@ namespace DurableTask.AzureStorage.Tests
     [TestClass]
     public class MessageManagerTests
     {
-        [DataTestMethod]
+        [TestMethod]
         [DataRow("System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib],[System.String, System.Private.CoreLib]]")]
         [DataRow("System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.String, mscorlib]]")]
         public void DeserializesStandardTypes(string dictionaryType)
@@ -49,7 +49,7 @@ namespace DurableTask.AzureStorage.Tests
             var messageManager = SetupMessageManager(new KnownTypeBinder());
 
             // When/Then
-            Assert.ThrowsException<JsonSerializationException>(() => messageManager.DeserializeMessageData(message));
+            Assert.ThrowsExactly<JsonSerializationException>(() => messageManager.DeserializeMessageData(message));
         }
 
 
@@ -69,7 +69,7 @@ namespace DurableTask.AzureStorage.Tests
             Assert.AreEqual("tagValue", startedEvent.Tags["tag1"]);
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow("blob.bin", "blob.bin")]
         [DataRow("@#$%!", "%40%23%24%25%21")]
         [DataRow("foo/bar/b@z.tar.gz", "foo/bar/b%40z.tar.gz")]

--- a/test/DurableTask.AzureStorage.Tests/Net/UriPathTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/Net/UriPathTests.cs
@@ -18,7 +18,7 @@ namespace DurableTask.AzureStorage.Net
     [TestClass]
     public class UriPathTests
     {
-        [DataTestMethod]
+        [TestMethod]
         [DataRow("", "", "")]
         [DataRow("", "bar/baz", "bar/baz")]
         [DataRow("foo", "", "foo")]

--- a/test/DurableTask.AzureStorage.Tests/Storage/TableDeleteBatchParallelTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/Storage/TableDeleteBatchParallelTests.cs
@@ -250,7 +250,7 @@ namespace DurableTask.AzureStorage.Tests.Storage
                     return Task.FromResult(CreateMockBatchResponse(batch.Count()));
                 });
 
-            await Assert.ThrowsExceptionAsync<OperationCanceledException>(
+            await Assert.ThrowsExactlyAsync<OperationCanceledException>(
                 () => table.DeleteBatchParallelAsync(entities, cts.Token));
         }
 

--- a/test/DurableTask.AzureStorage.Tests/StressTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/StressTests.cs
@@ -49,7 +49,7 @@ namespace DurableTask.AzureStorage.Tests
         /// both in the case where they all share the same instance ID and when they have unique
         /// instance IDs.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task ConcurrentOrchestrationStarts(bool useSameInstanceId)

--- a/test/DurableTask.AzureStorage.Tests/TestTablePartitionManager.cs
+++ b/test/DurableTask.AzureStorage.Tests/TestTablePartitionManager.cs
@@ -702,7 +702,7 @@ namespace DurableTask.AzureStorage.Tests
             // read the partition table
             var results = partitionTable.ExecuteQueryAsync<TablePartitionLease>();
             var numResults = await results.CountAsync();
-            Assert.AreEqual(numResults, 1); // there should only be 1 partition
+            Assert.AreEqual(1, numResults); // there should only be 1 partition
 
             // We want to test that worker 0 starts listening to the control queue without claiming the lease.
             // Therefore, we force the table to be in a state where worker 0 is still the current owner of the partition.
@@ -716,8 +716,8 @@ namespace DurableTask.AzureStorage.Tests
             // guarantee table is corrrectly updated
             results = partitionTable.ExecuteQueryAsync<TablePartitionLease>();
             numResults = await results.CountAsync();
-            Assert.AreEqual(numResults, 1); // there should only be 1 partition
-            Assert.AreEqual((await results.FirstAsync()).CurrentOwner, "0"); // ensure current owner is partition "0"
+            Assert.AreEqual(1, numResults); // there should only be 1 partition
+            Assert.AreEqual("0", (await results.FirstAsync()).CurrentOwner); // ensure current owner is partition "0"
 
             // create and start new worker with the same settings, ensure it is actively listening to the queue
             worker = new TaskHubWorker(service);

--- a/test/DurableTask.Core.Tests/ContinueAsNewTraceBehaviorTests.cs
+++ b/test/DurableTask.Core.Tests/ContinueAsNewTraceBehaviorTests.cs
@@ -61,6 +61,7 @@ namespace DurableTask.Core.Tests
             {
                 ShouldListenTo = source => source.Name == "DurableTask.Core",
                 Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
+                SampleUsingParentId = (ref ActivityCreationOptions<string> options) => ActivitySamplingResult.AllDataAndRecorded,
             };
             ActivitySource.AddActivityListener(listener);
         }
@@ -473,6 +474,7 @@ namespace DurableTask.Core.Tests
             {
                 ShouldListenTo = source => source.Name == "DurableTask.Core",
                 Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.None,
+                SampleUsingParentId = (ref ActivityCreationOptions<string> options) => ActivitySamplingResult.None,
             };
             ActivitySource.AddActivityListener(listener);
 
@@ -622,12 +624,12 @@ namespace DurableTask.Core.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void Context_ContinueAsNew_NullOptions_Throws()
         {
             var instance = new OrchestrationInstance { InstanceId = "test", ExecutionId = Guid.NewGuid().ToString() };
             var context = new TestableTaskOrchestrationContext(instance, TaskScheduler.Default);
-            context.ContinueAsNew(null, "input", (ContinueAsNewOptions)null!);
+            Assert.ThrowsExactly<ArgumentNullException>(
+                () => context.ContinueAsNew(null, "input", (ContinueAsNewOptions)null!));
         }
 
         #endregion
@@ -635,11 +637,11 @@ namespace DurableTask.Core.Tests
         #region Base class — NotSupportedException for unsupported implementations
 
         [TestMethod]
-        [ExpectedException(typeof(NotSupportedException))]
         public void BaseClass_ContinueAsNewWithOptions_ThrowsNotSupported()
         {
             var ctx = new MinimalOrchestrationContext();
-            ctx.ContinueAsNew("1.0", "input", new ContinueAsNewOptions());
+            Assert.ThrowsExactly<NotSupportedException>(
+                () => ctx.ContinueAsNew("1.0", "input", new ContinueAsNewOptions()));
         }
 
         #endregion

--- a/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
+++ b/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
@@ -339,7 +339,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual("Value", executionContext?.OrchestrationTags?["Test"]);
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(OrchestrationStatus.Completed)]
         [DataRow(OrchestrationStatus.Failed)]
         [DataRow(OrchestrationStatus.Terminated)]

--- a/test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
+++ b/test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
@@ -49,7 +49,7 @@ namespace DurableTask.Core.Tests
             this.client = new TaskHubClient(service, loggerFactory: loggerFactory);
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(ErrorPropagationMode.SerializeExceptions)]
         [DataRow(ErrorPropagationMode.UseFailureDetails)]
         public async Task CatchInvalidOperationException(ErrorPropagationMode mode)
@@ -123,7 +123,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual(1, retryPolicyInvokedCount);
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(ErrorPropagationMode.SerializeExceptions)]
         [DataRow(ErrorPropagationMode.UseFailureDetails)]
         public async Task FailureDetailsOnUnhandled(ErrorPropagationMode mode)

--- a/test/DurableTask.Core.Tests/RetryInterceptorTests.cs
+++ b/test/DurableTask.Core.Tests/RetryInterceptorTests.cs
@@ -28,10 +28,10 @@ namespace DurableTask.Core.Tests
             var interceptor = new RetryInterceptor<object>(this.context, new RetryOptions(TimeSpan.FromMilliseconds(100), 1), () => throw new IOException());
             async Task Invoke() => await interceptor.Invoke();
 
-            await Assert.ThrowsExceptionAsync<IOException>(Invoke, "Interceptor should throw the original exception after exceeding max retry attempts.");
+            await Assert.ThrowsExactlyAsync<IOException>(Invoke, "Interceptor should throw the original exception after exceeding max retry attempts.");
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(1)]
         [DataRow(2)]
         [DataRow(3)]
@@ -59,7 +59,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual(maxAttempts, callCount, 0, $"There should be {maxAttempts} function calls for {maxAttempts} max attempts.");
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(1)]
         [DataRow(2)]
         [DataRow(3)]

--- a/test/DurableTask.Core.Tests/TraceContextBaseTest.cs
+++ b/test/DurableTask.Core.Tests/TraceContextBaseTest.cs
@@ -121,7 +121,7 @@ namespace DurableTask.Core.Tests
         public void GetCurrentOrchestrationRequestTraceContextWithNoRequestTraceContextScenario()
         {
             TraceContextBase currentContext = new Foo();
-            Assert.ThrowsException<InvalidOperationException>(() => currentContext.GetCurrentOrchestrationRequestTraceContext());
+            Assert.ThrowsExactly<InvalidOperationException>(() => currentContext.GetCurrentOrchestrationRequestTraceContext());
         }
 
         private static Foo GetNewRequestContext(string comment)

--- a/test/DurableTask.Core.Tests/WorkItemDispatcherTests.cs
+++ b/test/DurableTask.Core.Tests/WorkItemDispatcherTests.cs
@@ -404,11 +404,7 @@ namespace DurableTask.Core.Tests
                 this.logs = logs;
             }
 
-#if NET8_0_OR_GREATER
             public IDisposable? BeginScope<TState>(TState state) where TState : notnull => NoOpDisposable.Instance;
-#else
-            public IDisposable BeginScope<TState>(TState state) => NoOpDisposable.Instance;
-#endif
 
             public bool IsEnabled(LogLevel logLevel) => true;
 

--- a/test/DurableTask.Emulator.Tests/EmulatorFunctionalTests.cs
+++ b/test/DurableTask.Emulator.Tests/EmulatorFunctionalTests.cs
@@ -76,9 +76,9 @@ namespace DurableTask.Emulator.Tests
             OrchestrationState result = await client.WaitForOrchestrationAsync(id, TimeSpan.FromSeconds(30), new CancellationToken());
             Assert.AreEqual(OrchestrationStatus.Completed, result.OrchestrationStatus);
 
-            await Assert.ThrowsExceptionAsync<OrchestrationAlreadyExistsException>(() => client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null));
+            await Assert.ThrowsExactlyAsync<OrchestrationAlreadyExistsException>(() => client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null));
 
-            await Assert.ThrowsExceptionAsync<OrchestrationAlreadyExistsException>(() => client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null, new[] { OrchestrationStatus.Completed }));
+            await Assert.ThrowsExactlyAsync<OrchestrationAlreadyExistsException>(() => client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null, new[] { OrchestrationStatus.Completed }));
 
             SimplestGreetingsOrchestration.Result = String.Empty;
 

--- a/test/DurableTask.ServiceBus.Tests/ErrorHandlingTests.cs
+++ b/test/DurableTask.ServiceBus.Tests/ErrorHandlingTests.cs
@@ -475,7 +475,7 @@ namespace DurableTask.ServiceBus.Tests
         }
 
         [Ignore]
-        ////[TestMethod]
+        [TestMethod]
         // Disabled until bug https://github.com/Azure/durabletask/issues/47 is fixed
         // Also the test does not work as expected due to debug mode suppressing UnobservedTaskException's
         public async Task ParallelInterfaceExceptionsTest()

--- a/test/DurableTask.ServiceBus.Tests/InstanceStoreQueryTests.cs
+++ b/test/DurableTask.ServiceBus.Tests/InstanceStoreQueryTests.cs
@@ -464,16 +464,9 @@ namespace DurableTask.ServiceBus.Tests
         }
 
         static void AssertException<T>(Action action)
+            where T : Exception
         {
-            try
-            {
-                action();
-                Assert.IsTrue(false);
-            }
-            catch (Exception ex)
-            {
-                Assert.IsTrue(ex is T);
-            }
+            Assert.ThrowsExactly<T>(action);
         }
 
         [TestMethod]

--- a/test/DurableTask.ServiceBus.Tests/OrchestrationHubTableClientTests.cs
+++ b/test/DurableTask.ServiceBus.Tests/OrchestrationHubTableClientTests.cs
@@ -67,13 +67,13 @@ namespace DurableTask.ServiceBus.Tests
             bool isCompleted = await TestHelpers.WaitForInstanceAsync(this.client, id, 60);
             Assert.IsTrue(isCompleted, TestHelpers.GetInstanceNotCompletedMessage(this.client, id, 60));
             OrchestrationState runtimeState = await this.client.GetOrchestrationStateAsync(id);
-            Assert.AreEqual(runtimeState.OrchestrationStatus, OrchestrationStatus.Completed);
-            Assert.AreEqual(runtimeState.OrchestrationInstance.InstanceId, id.InstanceId);
-            Assert.AreEqual(runtimeState.OrchestrationInstance.ExecutionId, id.ExecutionId);
+            Assert.AreEqual(OrchestrationStatus.Completed, runtimeState.OrchestrationStatus);
+            Assert.AreEqual(id.InstanceId, runtimeState.OrchestrationInstance.InstanceId);
+            Assert.AreEqual(id.ExecutionId, runtimeState.OrchestrationInstance.ExecutionId);
             Assert.AreEqual("DurableTask.ServiceBus.Tests.OrchestrationHubTableClientTests+InstanceStoreTestOrchestration", runtimeState.Name);
-            Assert.AreEqual(runtimeState.Version, string.Empty);
-            Assert.AreEqual(runtimeState.Input, "\"DONT_THROW\"");
-            Assert.AreEqual(runtimeState.Output, "\"Spartacus\"");
+            Assert.AreEqual(string.Empty, runtimeState.Version);
+            Assert.AreEqual("\"DONT_THROW\"", runtimeState.Input);
+            Assert.AreEqual("\"Spartacus\"", runtimeState.Output);
 
             string history = await this.client.GetOrchestrationHistoryAsync(id);
             Assert.IsTrue(!string.IsNullOrWhiteSpace(history));
@@ -147,14 +147,14 @@ namespace DurableTask.ServiceBus.Tests
             Assert.AreEqual(id.InstanceId, runtimeState.OrchestrationInstance.InstanceId);
             Assert.AreEqual(id.ExecutionId, runtimeState.OrchestrationInstance.ExecutionId);
             Assert.AreEqual("DurableTask.ServiceBus.Tests.OrchestrationHubTableClientTests+InstanceStoreTestOrchestration", runtimeState.Name);
-            Assert.AreEqual(runtimeState.Version, string.Empty);
-            Assert.AreEqual(runtimeState.Input, "\"WAIT\"");
-            Assert.AreEqual(runtimeState.Output, null);
+            Assert.AreEqual(string.Empty, runtimeState.Version);
+            Assert.AreEqual("\"WAIT\"", runtimeState.Input);
+            Assert.IsNull(runtimeState.Output);
 
             bool isCompleted = await TestHelpers.WaitForInstanceAsync(this.client, id, 60);
             Assert.IsTrue(isCompleted, TestHelpers.GetInstanceNotCompletedMessage(this.client, id, 60));
             runtimeState = await this.client.GetOrchestrationStateAsync(id);
-            Assert.AreEqual(runtimeState.OrchestrationStatus, OrchestrationStatus.Completed);
+            Assert.AreEqual(OrchestrationStatus.Completed, runtimeState.OrchestrationStatus);
         }
 
         [TestMethod]

--- a/test/DurableTask.ServiceBus.Tests/SampleScenarioTests.cs
+++ b/test/DurableTask.ServiceBus.Tests/SampleScenarioTests.cs
@@ -104,11 +104,11 @@ namespace DurableTask.ServiceBus.Tests
             Assert.AreEqual("Greeting send to Gabbar", SimplestGreetingsOrchestration.Result,
                 "Orchestration Result is wrong!!!");
 
-            await Assert.ThrowsExceptionAsync<OrchestrationAlreadyExistsException>(() => this.client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null));
+            await Assert.ThrowsExactlyAsync<OrchestrationAlreadyExistsException>(() => this.client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null));
 
-            await Assert.ThrowsExceptionAsync<OrchestrationAlreadyExistsException>(() => this.client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null, null));
+            await Assert.ThrowsExactlyAsync<OrchestrationAlreadyExistsException>(() => this.client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null, null));
 
-            await Assert.ThrowsExceptionAsync<OrchestrationAlreadyExistsException>(() => this.client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null, new[] { OrchestrationStatus.Completed, OrchestrationStatus.Terminated }));
+            await Assert.ThrowsExactlyAsync<OrchestrationAlreadyExistsException>(() => this.client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null, new[] { OrchestrationStatus.Completed, OrchestrationStatus.Terminated }));
 
             SimplestGreetingsOrchestration.Result = string.Empty;
 

--- a/test/DurableTask.ServiceBus.Tests/ServiceBusOrchestrationServiceTests.cs
+++ b/test/DurableTask.ServiceBus.Tests/ServiceBusOrchestrationServiceTests.cs
@@ -28,6 +28,22 @@ namespace DurableTask.ServiceBus.Tests
         TaskHubClient client;
         TaskHubWorker taskHub;
 
+        static void AssertJsonTokenEquals(JToken expected, string actual)
+        {
+            JToken actualToken = JToken.Parse(actual);
+            Assert.IsTrue(
+                JToken.DeepEquals(expected, actualToken),
+                $"Expected JSON token {expected} ({expected.Type}), but found {actualToken} ({actualToken.Type}).");
+        }
+
+        static void AssertJsonTokenNotEquals(JToken expected, string actual)
+        {
+            JToken actualToken = JToken.Parse(actual);
+            Assert.IsFalse(
+                JToken.DeepEquals(expected, actualToken),
+                $"Expected JSON token to differ from {expected} ({expected.Type}).");
+        }
+
         public TestContext TestContext { get; set; }
 
         [TestInitialize]
@@ -110,10 +126,10 @@ namespace DurableTask.ServiceBus.Tests
             status = await client.WaitForOrchestrationAsync(temp, TimeSpan.FromSeconds(10));
 
             Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-            Assert.AreEqual(3, JToken.Parse(status?.Output));
+            AssertJsonTokenEquals(3, status?.Output);
 
             // When using ContinueAsNew, the original input is discarded and replaced with the most recent state.
-            Assert.AreNotEqual(initialValue, JToken.Parse(status?.Input));
+            AssertJsonTokenNotEquals(initialValue, status?.Input);
         }
 
         [TestMethod]

--- a/test/DurableTask.Test.Orchestrations/DurableTask.Test.Orchestrations.csproj
+++ b/test/DurableTask.Test.Orchestrations/DurableTask.Test.Orchestrations.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),DurableTask.sln))\tools\DurableTask.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472;net48</TargetFrameworks>
   </PropertyGroup>
   
   <ItemGroup>

--- a/test/DurableTask.Test.Orchestrations/SimpleOrchestrations.cs
+++ b/test/DurableTask.Test.Orchestrations/SimpleOrchestrations.cs
@@ -381,7 +381,7 @@ namespace DurableTask.Test.Orchestrations
     public sealed class EventConversationOrchestration : TaskOrchestration<string, bool>
     {
         private readonly TaskCompletionSource<string> tcs
-            = new TaskCompletionSource<string>(TaskContinuationOptions.ExecuteSynchronously);
+            = new TaskCompletionSource<string>(TaskCreationOptions.None);
 
         // HACK: This is just a hack to communicate result of orchestration back to test
         public static bool OkResult;
@@ -450,7 +450,7 @@ namespace DurableTask.Test.Orchestrations
         public class Responder : TaskOrchestration<string, string>
         {
             private readonly TaskCompletionSource<string> tcs
-                = new TaskCompletionSource<string>(TaskContinuationOptions.ExecuteSynchronously);
+                = new TaskCompletionSource<string>(TaskCreationOptions.None);
 
             public async override Task<string> RunTask(OrchestrationContext context, string input)
             {


### PR DESCRIPTION
## Summary
- raise the minimum modern runtime to .NET 8 and recommend .NET 10 while preserving .NET Framework 4.7.2+
- publish explicit `net8.0`/`net472` assets, retaining `net48` only where provider behavior differs
- modernize the dependency graph, including patched Framework-compatible overrides for legacy Service Bus and Storage paths
- update installation guidance, samples, official builds, CodeQL, MSTest usage, serialization compatibility, and W3C tracing behavior

## Compatibility
- Core, Azure Storage, Application Insights: `net8.0;net472`
- Emulator, Service Bus: `net8.0;net472;net48`
- Azure Service Fabric: `net472;net48`
- Service Bus uses `Azure.Messaging.ServiceBus` on `net8.0`/`net472` and preserves `WindowsAzure.ServiceBus` on `net48`

## Validation
- full solution builds cleanly with SDK 8.0.300 and SDK 10.0.302
- Core and Emulator test matrices pass on `net8.0` and `net48`
- Azure Storage targeted and isolated retry coverage passes on both runtime paths
- Service Bus infrastructure-independent tests pass on `net8.0` and `net48`
- all 23 PackageReference projects report no vulnerable or deprecated direct/transitive packages
- all six shipping NuGet packages were packed and their target/dependency groups verified