### PR TITLE
Upgrade dependencies for .NET 8

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,112 +9,104 @@
 
   <!-- Product dependencies -->
   <ItemGroup>
-    <PackageVersion Include="Azure.Core" Version="1.44.1" />
+    <PackageVersion Include="Azure.Core" Version="1.61.0" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
-    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
-    <PackageVersion Include="Azure.Storage.Queues" Version="12.22.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.21.0" />
+    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.2" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.1" />
+    <PackageVersion Include="Azure.Storage.Queues" Version="12.27.1" />
     <PackageVersion Include="Castle.Core" Version="5.2.1" />
-    <PackageVersion Include="ImpromptuInterface" Version="6.2.2" Condition="'$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'net472'" />
-    <PackageVersion Include="ImpromptuInterface" Version="7.0.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageVersion Include="ImpromptuInterface" Version="8.0.6" />
+    <!-- Application Insights 3.x removes the telemetry module APIs exposed by DurableTask.ApplicationInsights. -->
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Services.Client" Version="5.8.5" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-    <PackageVersion Include="Microsoft.ServiceFabric" Version="6.4.617" />
-    <PackageVersion Include="Microsoft.ServiceFabric.Data" Version="3.3.617" />
-    <PackageVersion Include="Microsoft.ServiceFabric.Services" Version="3.3.617" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
-    <PackageVersion Include="System.Collections.Immutable" Version="1.2.0" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
-    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-    <PackageVersion Include="System.Reactive.Compatibility" Version="4.4.1" />
-    <PackageVersion Include="System.Reactive.Core" Version="4.4.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.ServiceFabric" Version="11.6.239" />
+    <PackageVersion Include="Microsoft.ServiceFabric.Data" Version="8.6.239" />
+    <PackageVersion Include="Microsoft.ServiceFabric.Services" Version="8.6.239" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.17.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="10.0.10" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.10" />
+    <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
+    <!-- System.Reactive 7.0.0's analyzer requires Roslyn 4.12 and cannot build with the .NET 8 SDK. -->
+    <PackageVersion Include="System.Reactive" Version="6.1.0" />
   </ItemGroup>
   
   <!-- Product dependencies with net48 only-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-    <PackageVersion Include="Microsoft.Azure.KeyVault.Core" Version="1.0.0" />
+    <PackageVersion Include="Microsoft.Azure.KeyVault.Core" Version="3.0.5" />
     <PackageVersion Include="Microsoft.Data.Edm" Version="5.8.5" />
     <PackageVersion Include="Microsoft.Data.OData" Version="5.8.5" />
-    <PackageVersion Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.2.1" />
+    <PackageVersion Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
+    <PackageVersion Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.19" />
+    <PackageVersion Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.2.3" />
     <PackageVersion Include="System.Spatial" Version="5.8.5" />
-    <PackageVersion Include="WindowsAzure.ServiceBus" Version="4.1.3" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="6.36.0" />
+    <PackageVersion Include="WindowsAzure.ServiceBus" Version="7.0.1" />
   </ItemGroup>
   
   <!-- Test dependencies -->
   <ItemGroup>
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.1" />
-    <PackageVersion Include="CommandLineParser" Version="2.9.1" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageVersion Include="CommandLineParser" Version="1.9.71" Condition="'$(TargetFramework)' == 'net48'" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.3" />
+    <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer.NetCore" Version="2.0.1406.4" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Core" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.Diagnostics.EventFlow.Core" Version="1.5.6" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageVersion Include="Moq" Version="4.10.0" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.5.0" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.5.0" />
-    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
-    <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageVersion Include="Microsoft.Diagnostics.EventFlow.Core" Version="1.13.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="4.3.3" />
+    <PackageVersion Include="MSTest.TestFramework" Version="4.3.3" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
+    <PackageVersion Include="System.Data.SqlClient" Version="4.9.1" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.8" />
-    <PackageVersion Include="WindowsAzure.Storage" Version="9.3.3" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageVersion Include="WindowsAzure.Storage" Version="8.7.0" Condition="'$(TargetFramework)' == 'net48'" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.10" />
+    <PackageVersion Include="WindowsAzure.Storage" Version="9.3.3" />
   </ItemGroup>
 
   <!-- Test dependencies with net8.0-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Include="EnterpriseLibrary.SemanticLogging.NetCore" Version="2.0.1406.4" />
-    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
   </ItemGroup>
 
   <!-- Test dependencies with net472-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Owin" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.Owin.Hosting" Version="4.2.2" />
+    <PackageVersion Include="Microsoft.Owin.Hosting" Version="4.2.3" />
   </ItemGroup>
 
   <!-- Test dependencies with net48-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+    <!-- NuGet reports 6.0.1302 as newer, but it predates the 2.0.1406 release line. -->
     <PackageVersion Include="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" />
     <PackageVersion Include="EnterpriseLibrary.SemanticLogging.TextFile" version="2.0.1406.1" />
-    <PackageVersion Include="Microsoft.Owin.Hosting" Version="4.2.2" />
-    <PackageVersion Include="Microsoft.Tpl.Dataflow" version="4.5.24" />
+    <PackageVersion Include="Microsoft.Owin.Hosting" Version="4.2.3" />
+    <PackageVersion Include="Microsoft.Tpl.Dataflow" Version="4.5.24" />
   </ItemGroup>
 
   <!-- Samples dependencies -->
   <ItemGroup>
-    <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.23.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
-    <PackageVersion Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.17.3" />
+    <PackageVersion Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.17.5" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.14.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
     <PackageVersion Include="Vio.DurableTask.Hosting" Version="2.2.17" />
   </ItemGroup>
-
-  <!-- Dependencies specific to net8.0-->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-  </ItemGroup>
-  
 
   <!-- Samples dependencies with net48-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">

--- a/Test/DurableTask.AzureServiceFabric.Tests/AllowedTypesSerializationBinderTests.cs
+++ b/Test/DurableTask.AzureServiceFabric.Tests/AllowedTypesSerializationBinderTests.cs
@@ -81,14 +81,14 @@ namespace DurableTask.AzureServiceFabric.Tests
         [TestMethod]
         public void BindToType_RejectsArbitraryAssembly()
         {
-            Assert.ThrowsException<InvalidOperationException>(() =>
+            Assert.ThrowsExactly<InvalidOperationException>(() =>
                 this.binder.BindToType("Evil.Assembly", "Evil.PwnedDescriptor"));
         }
 
         [TestMethod]
         public void BindToType_RejectsQualifiedArbitraryAssembly()
         {
-            Assert.ThrowsException<InvalidOperationException>(() =>
+            Assert.ThrowsExactly<InvalidOperationException>(() =>
                 this.binder.BindToType("Evil.Assembly, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null", "Evil.PwnedDescriptor"));
         }
 
@@ -97,7 +97,7 @@ namespace DurableTask.AzureServiceFabric.Tests
         {
             // A common gadget type — must be rejected
             var type = typeof(System.Diagnostics.Process);
-            Assert.ThrowsException<InvalidOperationException>(() =>
+            Assert.ThrowsExactly<InvalidOperationException>(() =>
                 this.binder.BindToType(type.Assembly.GetName().Name, type.FullName));
         }
 
@@ -105,7 +105,7 @@ namespace DurableTask.AzureServiceFabric.Tests
         public void BindToType_RejectsNonAllowlistedMscorlibType()
         {
             // System.Type is from mscorlib but not in the type allowlist
-            Assert.ThrowsException<InvalidOperationException>(() =>
+            Assert.ThrowsExactly<InvalidOperationException>(() =>
                 this.binder.BindToType("mscorlib", typeof(Type).FullName));
         }
 
@@ -113,7 +113,7 @@ namespace DurableTask.AzureServiceFabric.Tests
         public void BindToType_RejectsUnresolvableType()
         {
             // A type name that cannot be resolved should throw a controlled exception, not NullReferenceException
-            var ex = Assert.ThrowsException<JsonSerializationException>(() =>
+            var ex = Assert.ThrowsExactly<JsonSerializationException>(() =>
                 this.binder.BindToType("DurableTask.Core", "DurableTask.Core.NonExistentType"));
             StringAssert.Contains(ex.Message, "NonExistentType");
         }
@@ -123,7 +123,7 @@ namespace DurableTask.AzureServiceFabric.Tests
         {
             // TaskOrchestration is a DurableTask.Core type but not in the proxy endpoint allowlist
             var type = typeof(TaskOrchestration);
-            Assert.ThrowsException<InvalidOperationException>(() =>
+            Assert.ThrowsExactly<InvalidOperationException>(() =>
                 this.binder.BindToType(type.Assembly.GetName().Name, type.FullName));
         }
 
@@ -208,7 +208,7 @@ namespace DurableTask.AzureServiceFabric.Tests
             };
 
             // Newtonsoft wraps the binder's InvalidOperationException in a JsonSerializationException
-            var ex = Assert.ThrowsException<JsonSerializationException>(() =>
+            var ex = Assert.ThrowsExactly<JsonSerializationException>(() =>
                 JsonConvert.DeserializeObject<object>(maliciousJson, settings));
             Assert.IsInstanceOfType(ex.InnerException, typeof(InvalidOperationException));
             StringAssert.Contains(ex.InnerException.Message, "is not allowed");

--- a/Test/DurableTask.AzureStorage.Tests/Storage/DurableTaskStorageExceptionTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/Storage/DurableTaskStorageExceptionTests.cs
@@ -30,7 +30,7 @@ namespace DurableTask.AzureStorage.Tests.Storage
             Assert.IsFalse(exception.LeaseLost);
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true, HttpStatusCode.Conflict, nameof(BlobErrorCode.LeaseLost))]
         [DataRow(false, HttpStatusCode.Conflict, nameof(BlobErrorCode.LeaseNotPresentWithBlobOperation))]
         [DataRow(false, HttpStatusCode.NotFound, nameof(BlobErrorCode.BlobNotFound))]

--- a/samples/DistributedTraceSample/ApplicationInsights/README.md
+++ b/samples/DistributedTraceSample/ApplicationInsights/README.md
@@ -4,7 +4,7 @@ This sample demonstrates direct integration with Azure Application Insights for 
 
 ## Prerequisites
 
-- .NET 6.0 SDK or later
+- .NET 8.0 SDK or later
 - Azure Storage Emulator (Azurite) or Azure Storage account
 - Azure Application Insights resource
 

--- a/samples/DistributedTraceSample/README.md
+++ b/samples/DistributedTraceSample/README.md
@@ -44,7 +44,7 @@ services.TryAddEnumerable(
 
 ## Prerequisites
 
-- .NET 6.0 SDK or later
+- .NET 8.0 SDK or later
 - Azure Storage Emulator (Azurite) or Azure Storage account
 - (Optional) Application Insights resource
 - (Optional) Zipkin instance for OpenTelemetry sample

--- a/samples/DurableTask.Samples/Options.cs
+++ b/samples/DurableTask.Samples/Options.cs
@@ -13,16 +13,17 @@
 
 namespace DurableTask.Samples
 {
+    using System.Collections.Generic;
     using CommandLine;
     using CommandLine.Text;
 
     internal class Options
     {
-        [Option('c', "create-hub", DefaultValue = false,
+        [Option('c', "create-hub", Default = false,
             HelpText = "Create Orchestration Hub.")]
         public bool CreateHub { get; set; }
 
-        [Option('s', "start-instance", DefaultValue = null,
+        [Option('s', "start-instance", Default = null,
             HelpText = "Start new instance.  Supported Orchestrations: 'Greetings, Cron, Average, ErrorHandling Signal'.")]
         public string StartInstance { get; set; }
 
@@ -30,20 +31,19 @@ namespace DurableTask.Samples
             HelpText = "Instance id for new orchestration instance.")]
         public string InstanceId { get; set; }
 
-        [OptionArray('p', "params",
+        [Option('p', "params",
             HelpText = "Parameters for new instance.")]
-        public string[] Parameters { get; set; }
+        public IEnumerable<string> Parameters { get; set; }
 
         [Option('n', "signal-name",
             HelpText = "Instance id to send signal")]
         public string Signal { get; set; }
 
-        [Option('w', "skip-worker", DefaultValue = false,
+        [Option('w', "skip-worker", Default = false,
             HelpText = "Don't start worker")]
         public bool SkipWorker { get; set; }
 
-        [HelpOption]
-        public string GetUsage()
+        public static string GetUsage(ParserResult<Options> options)
         {
             // this without using CommandLine.Text
             //  or using HelpText.AutoBuild
@@ -63,7 +63,7 @@ namespace DurableTask.Samples
             help.AddPreOptionsLine("Usage: DurableTaskSamples.exe -c -s SumOfSquares");
             help.AddPreOptionsLine("Usage: DurableTaskSamples.exe -c -s Signal -i 1");
             help.AddPreOptionsLine("Usage: DurableTaskSamples.exe -w -n User -i 1 -p MyName");
-            help.AddOptions(this);
+            help.AddOptions(options);
             return help;
         }
     }

--- a/samples/DurableTask.Samples/Program.cs
+++ b/samples/DurableTask.Samples/Program.cs
@@ -22,6 +22,7 @@ namespace DurableTask.Samples
     using System.IO;
     using System.Linq;
     using System.Threading;
+    using CommandLine;
     using DurableTask.AzureStorage;
     using DurableTask.Core;
     using DurableTask.Core.Tracing;
@@ -38,7 +39,6 @@ namespace DurableTask.Samples
 
     internal class Program
     {
-        static readonly Options ArgumentOptions = new Options();
         static ObservableEventListener eventListener;
 
         [STAThread]
@@ -48,8 +48,15 @@ namespace DurableTask.Samples
             eventListener.LogToConsole();
             eventListener.EnableEvents(DefaultEventSource.Log, EventLevel.LogAlways);
 
-            if (CommandLine.Parser.Default.ParseArgumentsStrict(args, ArgumentOptions))
+            Options argumentOptions = null;
+            ParserResult<Options> parserResult = Parser.Default.ParseArguments<Options>(args);
+            parserResult
+                .WithParsed(options => argumentOptions = options)
+                .WithNotParsed(errors => Console.Error.WriteLine(Options.GetUsage(parserResult)));
+
+            if (argumentOptions != null)
             {
+                string[] parameters = argumentOptions.Parameters?.ToArray();
                 string storageConnectionString = GetSetting("StorageConnectionString");
                 string taskHubName = ConfigurationManager.AppSettings["taskHubName"];
 
@@ -63,44 +70,44 @@ namespace DurableTask.Samples
                 var taskHubClient = new TaskHubClient(orchestrationServiceAndClient);
                 var taskHubWorker = new TaskHubWorker(orchestrationServiceAndClient);
                 
-                if (ArgumentOptions.CreateHub)
+                if (argumentOptions.CreateHub)
                 {
                     orchestrationServiceAndClient.CreateIfNotExistsAsync().Wait();
                 }
 
                 OrchestrationInstance instance = null;
 
-                if (!string.IsNullOrWhiteSpace(ArgumentOptions.StartInstance))
+                if (!string.IsNullOrWhiteSpace(argumentOptions.StartInstance))
                 {
-                    string instanceId = ArgumentOptions.InstanceId ?? Guid.NewGuid().ToString();
-                    Console.WriteLine($"Start Orchestration: {ArgumentOptions.StartInstance}");
-                    switch (ArgumentOptions.StartInstance)
+                    string instanceId = argumentOptions.InstanceId ?? Guid.NewGuid().ToString();
+                    Console.WriteLine($"Start Orchestration: {argumentOptions.StartInstance}");
+                    switch (argumentOptions.StartInstance)
                     {
                         case "Greetings":
                             instance = taskHubClient.CreateOrchestrationInstanceAsync(typeof(GreetingsOrchestration), instanceId, null).Result;
                             break;
                         case "Greetings2":
-                            if (ArgumentOptions.Parameters == null || ArgumentOptions.Parameters.Length != 1)
+                            if (parameters == null || parameters.Length != 1)
                             {
                                 throw new ArgumentException("parameters");
                             }
 
                             instance = taskHubClient.CreateOrchestrationInstanceAsync(typeof(GreetingsOrchestration2), instanceId, 
-                                int.Parse(ArgumentOptions.Parameters[0])).Result;
+                                int.Parse(parameters[0])).Result;
                             break;
                         case "Cron":
                             // Sample Input: "0 12 * */2 Mon"
                             instance = taskHubClient.CreateOrchestrationInstanceAsync(typeof(CronOrchestration), instanceId, 
-                                (ArgumentOptions.Parameters != null && ArgumentOptions.Parameters.Length > 0) ? ArgumentOptions.Parameters[0] : null).Result;
+                                (parameters != null && parameters.Length > 0) ? parameters[0] : null).Result;
                             break;
                         case "Average":
                             // Sample Input: "1 50 10"
-                            if (ArgumentOptions.Parameters == null || ArgumentOptions.Parameters.Length != 3)
+                            if (parameters == null || parameters.Length != 3)
                             {
                                 throw new ArgumentException("parameters");
                             }
 
-                            int[] input = ArgumentOptions.Parameters.Select(p => int.Parse(p)).ToArray();
+                            int[] input = parameters.Select(p => int.Parse(p)).ToArray();
                             instance = taskHubClient.CreateOrchestrationInstanceAsync(typeof(AverageCalculatorOrchestration), instanceId, input).Result;
                             break;
                         case "ErrorHandling":
@@ -118,46 +125,46 @@ namespace DurableTask.Samples
                             instance = taskHubClient.CreateOrchestrationInstanceAsync(typeof(SignalOrchestration), instanceId, null).Result;
                             break;
                         case "SignalAndRaise":
-                            if (ArgumentOptions.Parameters == null || ArgumentOptions.Parameters.Length != 1)
+                            if (parameters == null || parameters.Length != 1)
                             {
                                 throw new ArgumentException("parameters");
                             }
 
-                            instance = taskHubClient.CreateOrchestrationInstanceWithRaisedEventAsync(typeof(SignalOrchestration), instanceId, null, ArgumentOptions.Signal, ArgumentOptions.Parameters[0]).Result;
+                            instance = taskHubClient.CreateOrchestrationInstanceWithRaisedEventAsync(typeof(SignalOrchestration), instanceId, null, argumentOptions.Signal, parameters[0]).Result;
                             break;
                         case "Replat":
                             instance = taskHubClient.CreateOrchestrationInstanceAsync(typeof(MigrateOrchestration), instanceId,
                                 new MigrateOrchestrationData { SubscriptionId = "03a1cd39-47ac-4a57-9ff5-a2c2a2a76088", IsDisabled = false }).Result;
                             break;
                         default:
-                            throw new Exception("Unsupported Orchestration Name: " + ArgumentOptions.StartInstance);
+                            throw new Exception("Unsupported Orchestration Name: " + argumentOptions.StartInstance);
                     }
 
                     Console.WriteLine("Workflow Instance Started: " + instance);
                 }
-                else if (!string.IsNullOrWhiteSpace(ArgumentOptions.Signal))
+                else if (!string.IsNullOrWhiteSpace(argumentOptions.Signal))
                 {
                     Console.WriteLine("Run RaiseEvent");
 
-                    if (string.IsNullOrWhiteSpace(ArgumentOptions.InstanceId)) 
+                    if (string.IsNullOrWhiteSpace(argumentOptions.InstanceId))
                     {
                         throw new ArgumentException("instanceId");
                     }
 
-                    if (ArgumentOptions.Parameters == null || ArgumentOptions.Parameters.Length != 1)
+                    if (parameters == null || parameters.Length != 1)
                     {
                         throw new ArgumentException("parameters");
                     }
 
-                    string instanceId = ArgumentOptions.InstanceId;
+                    string instanceId = argumentOptions.InstanceId;
                     instance = new OrchestrationInstance { InstanceId = instanceId };
-                    taskHubClient.RaiseEventAsync(instance, ArgumentOptions.Signal, ArgumentOptions.Parameters[0]).Wait();
+                    taskHubClient.RaiseEventAsync(instance, argumentOptions.Signal, parameters[0]).Wait();
 
                     Console.WriteLine("Press any key to quit.");
                     Console.ReadLine();
                 }
 
-                if (!ArgumentOptions.SkipWorker)
+                if (!argumentOptions.SkipWorker)
                 {
                     try
                     {

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -277,7 +277,9 @@ namespace DurableTask.AzureStorage
             // "Remote" -> the instance ID info comes from the Instances table that we're querying
             IAsyncEnumerable<InstanceStatus> instances = this.trackingStore.FetchInstanceStatusAsync(instanceIds, cancellationToken);
             IDictionary<string, InstanceStatus> remoteOrchestrationsById = 
-                await instances.ToDictionaryAsync(o => o.State.OrchestrationInstance.InstanceId, cancellationToken);
+                await instances.ToDictionaryAsync(
+                    o => o.State.OrchestrationInstance.InstanceId,
+                    cancellationToken: cancellationToken);
 
             foreach (MessageData message in executionStartedMessages)
             {

--- a/src/DurableTask.Core/DurableTask.Core.csproj
+++ b/src/DurableTask.Core/DurableTask.Core.csproj
@@ -39,8 +39,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
-    <PackageReference Include="System.Reactive.Core" />
-    <PackageReference Include="System.Reactive.Compatibility" />
+    <PackageReference Include="System.Reactive" />
     <PackageReference Include="Castle.Core" />
   </ItemGroup>
 

--- a/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
+++ b/src/DurableTask.ServiceBus/DurableTask.ServiceBus.csproj
@@ -25,11 +25,16 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="ImpromptuInterface" />
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" />
     <PackageReference Include="Microsoft.Data.Edm" />
     <PackageReference Include="Microsoft.Data.OData" />
     <PackageReference Include="Microsoft.Data.Services.Client" />
+    <!-- Pin patched versions within the legacy Service Bus SDK's compatible major versions. -->
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" />
     <PackageReference Include="System.Spatial" />
     <PackageReference Include="WindowsAzure.ServiceBus" />

--- a/test/DurableTask.AzureServiceFabric.Integration.Tests/App.config
+++ b/test/DurableTask.AzureServiceFabric.Integration.Tests/App.config
@@ -7,22 +7,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="6.0.0.1" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="6.0.0.1" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.1.2" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.0.1" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>

--- a/test/DurableTask.AzureServiceFabric.Integration.Tests/DeploymentUtil/DeploymentHelper.cs
+++ b/test/DurableTask.AzureServiceFabric.Integration.Tests/DeploymentUtil/DeploymentHelper.cs
@@ -54,7 +54,11 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests.DeploymentUtil
                     var replicas = (await client.QueryManager.GetDeployedReplicaListAsync(node.NodeName, application.ApplicationName)).OfType<DeployedStatefulServiceReplica>();
                     foreach (var replica in replicas)
                     {
-                        await client.ServiceManager.RemoveReplicaAsync(node.NodeName, replica.Partitionid, replica.ReplicaId);
+                        await client.ServiceManager.RemoveReplicaAsync(
+                            node.NodeName,
+                            replica.Partitionid,
+                            replica.ReplicaId,
+                            new RemoveReplicaOptions());
                     }
                 }
             }

--- a/test/DurableTask.AzureServiceFabric.Integration.Tests/DurableTask.AzureServiceFabric.Integration.Tests.csproj
+++ b/test/DurableTask.AzureServiceFabric.Integration.Tests/DurableTask.AzureServiceFabric.Integration.Tests.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
 	<!-- Override the centrally managed version -->
-	<PackageReference Include="Microsoft.NET.Test.Sdk" VersionOverride="15.0.0" />
-	<PackageReference Include="MSTest.TestAdapter" VersionOverride="1.4.0" />
-	<PackageReference Include="MSTest.TestFramework" VersionOverride="1.4.0" />
-    <PackageReference Include="System.Collections.Immutable" VersionOverride="1.5.0" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" />
+	<PackageReference Include="MSTest.TestAdapter" />
+	<PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Net.Http" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" />
     <PackageReference Include="Moq" />

--- a/test/DurableTask.AzureServiceFabric.Integration.Tests/FunctionalTests.cs
+++ b/test/DurableTask.AzureServiceFabric.Integration.Tests/FunctionalTests.cs
@@ -376,7 +376,6 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(OrchestrationAlreadyExistsException))]
         public async Task Duplicate_Orchestration_Instance_Fails_With_OrchestrationAlreadyExistsException()
         {
             var instanceId = nameof(Duplicate_Orchestration_Instance_Fails_With_OrchestrationAlreadyExistsException);
@@ -389,8 +388,9 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests
                 DelayUnit = TimeSpan.FromSeconds(1),
             };
 
-            var instance = await this.taskHubClient.CreateOrchestrationInstanceAsync(typeof(TestOrchestration), instanceId, input);
-            var instance2 = await this.taskHubClient.CreateOrchestrationInstanceAsync(typeof(TestOrchestration), instanceId, input);
+            await this.taskHubClient.CreateOrchestrationInstanceAsync(typeof(TestOrchestration), instanceId, input);
+            await Assert.ThrowsExactlyAsync<OrchestrationAlreadyExistsException>(
+                () => this.taskHubClient.CreateOrchestrationInstanceAsync(typeof(TestOrchestration), instanceId, input));
         }
 
         [TestMethod]
@@ -476,7 +476,7 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests
 
             var reason = "Testing terminatiom of already finished orchestration";
 
-            await Assert.ThrowsExceptionAsync<RemoteServiceException>(() => this.taskHubClient.TerminateInstanceAsync(instance, reason));
+            await Assert.ThrowsExactlyAsync<RemoteServiceException>(() => this.taskHubClient.TerminateInstanceAsync(instance, reason));
         }
 
         [TestMethod]
@@ -586,7 +586,7 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests
         public async Task ScheduledStartTest_NotSupported()
         {
             var expectedStartTime = DateTime.UtcNow.AddSeconds(30);
-            await Assert.ThrowsExceptionAsync<RemoteServiceException>(() => this.taskHubClient.CreateScheduledOrchestrationInstanceAsync(typeof(SimpleOrchestrationWithTasks), null, expectedStartTime));
+            await Assert.ThrowsExactlyAsync<RemoteServiceException>(() => this.taskHubClient.CreateScheduledOrchestrationInstanceAsync(typeof(SimpleOrchestrationWithTasks), null, expectedStartTime));
         }
 
         [TestMethod]
@@ -612,7 +612,7 @@ namespace DurableTask.AzureServiceFabric.Integration.Tests
                 serviceClient.HttpClient = httpClient;
             });
 
-            await Assert.ThrowsExceptionAsync<OrchestrationAlreadyExistsException>(async () =>
+            await Assert.ThrowsExactlyAsync<OrchestrationAlreadyExistsException>(async () =>
             {
                 await taskHubClient.CreateOrchestrationInstanceAsync(typeof(TestOrchestration), new TestOrchestrationData());
             });

--- a/test/DurableTask.AzureServiceFabric.Tests/App.config
+++ b/test/DurableTask.AzureServiceFabric.Tests/App.config
@@ -7,22 +7,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="6.0.0.1" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="6.0.0.1" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.1.2" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.0.1" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>

--- a/test/DurableTask.AzureServiceFabric.Tests/DurableTask.AzureServiceFabric.Tests.csproj
+++ b/test/DurableTask.AzureServiceFabric.Tests/DurableTask.AzureServiceFabric.Tests.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-	<PackageReference Include="Microsoft.NET.Test.Sdk" VersionOverride="15.0.0" />
-	<PackageReference Include="MSTest.TestAdapter" VersionOverride="1.4.0" />
-	<PackageReference Include="MSTest.TestFramework" VersionOverride="1.4.0" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" />
+	<PackageReference Include="MSTest.TestAdapter" />
+	<PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="System.Collections.Immutable" />
     </ItemGroup>
 

--- a/test/DurableTask.AzureStorage.Tests/AsyncAutoResetEventTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AsyncAutoResetEventTests.cs
@@ -21,14 +21,14 @@ namespace DurableTask.AzureStorage.Tests
     [TestClass]
     public class AsyncAutoResetEventTests
     {
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(false, false)]
         [DataRow(true, true)]
         public async Task InitialState(bool initiallySignaled, bool expectedResult)
         {
             var resetEvent = new AsyncAutoResetEvent(initiallySignaled);
             bool result = await resetEvent.WaitAsync(TimeSpan.Zero);
-            Assert.AreEqual<bool>(result, expectedResult);
+            Assert.AreEqual<bool>(expectedResult, result);
         }
 
         [TestMethod]

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScaleTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScaleTests.cs
@@ -210,7 +210,7 @@ namespace DurableTask.AzureStorage.Tests
         /// REQUIREMENT: Workers can be added or removed at any time and control-queue partitions are load-balanced automatically.
         /// REQUIREMENT: No two workers will ever process the same control queue.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(PartitionManagerType.V1Legacy, 30)]
         [DataRow(PartitionManagerType.V2Safe, 180)]
         public async Task MultiWorkerLeaseMovement(PartitionManagerType partitionManagerType, int timeoutInSeconds)
@@ -589,7 +589,7 @@ namespace DurableTask.AzureStorage.Tests
                 await service2.CompleteTaskOrchestrationWorkItemAsync(workItem2, runtimeState, new List<TaskMessage>(), new List<TaskMessage>(), new List<TaskMessage>(), null, null);
                 // Now worker 1 will attempt to complete the same work item. Since this is the first attempt to complete a work item and add a history for the orchestration (by worker 1),
                 // there is no etag stored for the OrchestrationSession, and so the a "conflict" exception will be thrown as worker 2 already created a history for the orchestration.
-                SessionAbortedException exception = await Assert.ThrowsExceptionAsync<SessionAbortedException>(async () =>
+                SessionAbortedException exception = await Assert.ThrowsExactlyAsync<SessionAbortedException>(async () =>
                     await service1.CompleteTaskOrchestrationWorkItemAsync(workItem1, runtimeState, new List<TaskMessage>(), new List<TaskMessage>(), new List<TaskMessage>(), null, null)
                 );
                 Assert.IsInstanceOfType(exception.InnerException, typeof(DurableTaskStorageException));
@@ -632,7 +632,7 @@ namespace DurableTask.AzureStorage.Tests
                 await service1.CompleteTaskOrchestrationWorkItemAsync(workItem1, runtimeState, new List<TaskMessage>(), new List<TaskMessage>(), new List<TaskMessage>(), null, null);
                 // Now worker 2 attempts to complete the same work item. Since this is not the first work item for the orchestration, now an etag exists for the OrchestrationSession, and the exception
                 // that is thrown will be "precondition failed" as the Etag is stale after worker 1 completed the work item.
-                exception = await Assert.ThrowsExceptionAsync<SessionAbortedException>(async () =>
+                exception = await Assert.ThrowsExactlyAsync<SessionAbortedException>(async () =>
                     await service2.CompleteTaskOrchestrationWorkItemAsync(workItem2, runtimeState, new List<TaskMessage>(), new List<TaskMessage>(), new List<TaskMessage>(), null, null)
                 );
                 Assert.IsInstanceOfType(exception.InnerException, typeof(DurableTaskStorageException));

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -50,7 +50,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates a simple orchestrator function which doesn't call any activity functions.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task HelloWorldOrchestration_Inline(bool enableExtendedSessions)
@@ -63,8 +63,8 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(StandardTimeout);
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual("World", JToken.Parse(status?.Input));
-                Assert.AreEqual("Hello, World!", JToken.Parse(status?.Output));
+                Assert.AreEqual("World", JToken.Parse(status?.Input).Value<string>());
+                Assert.AreEqual("Hello, World!", JToken.Parse(status?.Output).Value<string>());
 
                 await host.StopAsync();
             }
@@ -73,7 +73,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which runs a simple orchestrator function that calls a single activity function.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task HelloWorldOrchestration_Activity(bool enableExtendedSessions)
@@ -86,8 +86,8 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(StandardTimeout);
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual("World", JToken.Parse(status?.Input));
-                Assert.AreEqual("Hello, World!", JToken.Parse(status?.Output));
+                Assert.AreEqual("World", JToken.Parse(status?.Input).Value<string>());
+                Assert.AreEqual("Hello, World!", JToken.Parse(status?.Output).Value<string>());
 
                 await host.StopAsync();
             }
@@ -107,8 +107,8 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(StandardTimeout);
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(10, JToken.Parse(status?.Input));
-                Assert.AreEqual(3628800, JToken.Parse(status?.Output));
+                Assert.AreEqual(10, JToken.Parse(status?.Input).Value<int>());
+                Assert.AreEqual(3628800, JToken.Parse(status?.Output).Value<int>());
 
                 await host.StopAsync();
             }
@@ -129,8 +129,8 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(StandardTimeout);
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(10, JToken.Parse(status?.Input));
-                Assert.AreEqual(3628800, JToken.Parse(status?.Output));
+                Assert.AreEqual(10, JToken.Parse(status?.Input).Value<int>());
+                Assert.AreEqual(3628800, JToken.Parse(status?.Output).Value<int>());
 
                 await host.StopAsync();
             }
@@ -147,8 +147,8 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(10, JToken.Parse(status?.Input));
-                Assert.AreEqual(3628800, JToken.Parse(status?.Output));
+                Assert.AreEqual(10, JToken.Parse(status?.Input).Value<int>());
+                Assert.AreEqual(3628800, JToken.Parse(status?.Output).Value<int>());
 
                 await host.StopAsync();
             }
@@ -157,7 +157,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which runs a slow orchestrator that causes work item renewal
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task LongRunningOrchestrator(bool enableExtendedSessions)
@@ -176,7 +176,7 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(StandardTimeout);
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual("ok", JToken.Parse(status?.Output));
+                Assert.AreEqual("ok", JToken.Parse(status?.Output).Value<string>());
 
                 await host.StopAsync();
             }
@@ -266,7 +266,7 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(false, false)]
         [DataRow(true, false)]
         [DataRow(false, true)]
@@ -281,13 +281,13 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual("OK", JToken.Parse(status?.Output));
+                Assert.AreEqual("OK", JToken.Parse(status?.Output).Value<string>());
 
                 await host.StopAsync();
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(false)]
         [DataRow(true)]
         public async Task AutoStart(bool enableExtendedSessions)
@@ -302,13 +302,13 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual("OK", JToken.Parse(status?.Output));
+                Assert.AreEqual("OK", JToken.Parse(status?.Output).Value<string>());
 
                 await host.StopAsync();
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(false)]
         [DataRow(true)]
         public async Task ContinueAsNewThenTimer(bool enableExtendedSessions)
@@ -321,7 +321,7 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual("OK", JToken.Parse(status?.Output));
+                Assert.AreEqual("OK", JToken.Parse(status?.Output).Value<string>());
 
                 await host.StopAsync();
             }
@@ -396,7 +396,7 @@ namespace DurableTask.AzureStorage.Tests
                 var state = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, state?.OrchestrationStatus);
-                Assert.AreEqual(customStatus, JToken.Parse(state?.Status));
+                Assert.AreEqual(customStatus, JToken.Parse(state?.Status).Value<string>());
 
                 await host.StopAsync();
             }
@@ -956,7 +956,7 @@ namespace DurableTask.AzureStorage.Tests
         /// End-to-end test which validates parallel function execution by enumerating all files in the current directory 
         /// in parallel and getting the sum total of all file sizes.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task ParallelOrchestration(bool enableExtendedSessions)
@@ -969,14 +969,14 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(90));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(Environment.CurrentDirectory, JToken.Parse(status?.Input));
+                Assert.AreEqual(Environment.CurrentDirectory, JToken.Parse(status?.Input).Value<string>());
                 Assert.IsTrue(long.Parse(status?.Output) > 0L);
 
                 await host.StopAsync();
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task LargeFanOutOrchestration(bool enableExtendedSessions)
@@ -1015,7 +1015,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates the ContinueAsNew functionality by implementing a counter actor pattern.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task ActorOrchestration(bool enableExtendedSessions)
@@ -1051,10 +1051,10 @@ namespace DurableTask.AzureStorage.Tests
                 status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(10));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(3, JToken.Parse(status?.Output));
+                Assert.AreEqual(3, JToken.Parse(status?.Output).Value<int>());
 
                 // When using ContinueAsNew, the original input is discarded and replaced with the most recent state.
-                Assert.AreNotEqual(initialValue, JToken.Parse(status?.Input));
+                Assert.AreNotEqual(initialValue, JToken.Parse(status?.Input).Value<int>());
 
                 await host.StopAsync();
             }
@@ -1063,7 +1063,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates the ContinueAsNew functionality by implementing character counter actor pattern.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task ActorOrchestrationForLargeInput(bool enableExtendedSessions)
@@ -1074,7 +1074,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates the deletion of all data generated by the ContinueAsNew functionality in the character counter actor pattern.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task ActorOrchestrationDeleteAllLargeMessageBlobs(bool enableExtendedSessions)
@@ -1188,7 +1188,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates the Terminate functionality.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task TerminateOrchestration(bool enableExtendedSessions)
@@ -1218,7 +1218,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates the Suspend-Resume functionality.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task SuspendResumeOrchestration(bool enableExtendedSessions)
@@ -1242,13 +1242,13 @@ namespace DurableTask.AzureStorage.Tests
                 // Test case 2: external event does not go through
                 await client.RaiseEventAsync("changeStatusNow", changedStatus);
                 status = await client.GetStatusAsync();
-                Assert.AreEqual(originalStatus, JToken.Parse(status?.Status));
+                Assert.AreEqual(originalStatus, JToken.Parse(status?.Status).Value<string>());
 
                 // Test case 3: external event now goes through
                 await client.ResumeAsync("wakeUp");
                 status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(10));
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(changedStatus, JToken.Parse(status?.Status));
+                Assert.AreEqual(changedStatus, JToken.Parse(status?.Status).Value<string>());
 
                 await host.StopAsync();
             }
@@ -1257,7 +1257,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// Test that a suspended orchestration can be terminated.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task TerminateSuspendedOrchestration(bool enableExtendedSessions)
@@ -1286,7 +1286,7 @@ namespace DurableTask.AzureStorage.Tests
         /// Test that a pending orchestration can be terminated (including tests with a large termination reason that will need to be
         /// stored in blob storage).
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true, true)]
         [DataRow(false, true)]
         [DataRow(true, false)]
@@ -1593,7 +1593,7 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task TimerCancellation(bool enableExtendedSessions)
@@ -1612,7 +1612,7 @@ namespace DurableTask.AzureStorage.Tests
 
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual("Approved", JToken.Parse(status?.Output));
+                Assert.AreEqual("Approved", JToken.Parse(status?.Output).Value<string>());
 
                 await host.StopAsync();
             }
@@ -1621,7 +1621,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates the handling of durable timer expiration.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task TimerExpiration(bool enableExtendedSessions)
@@ -1641,13 +1641,13 @@ namespace DurableTask.AzureStorage.Tests
 
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(20));
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual("Expired", JToken.Parse(status?.Output));
+                Assert.AreEqual("Expired", JToken.Parse(status?.Output).Value<string>());
 
                 await host.StopAsync();
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task TimerDelay(bool useUtc)
@@ -1675,7 +1675,7 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(false)]
         [DataRow(true)]
         public async Task OrchestratorStartAtAcceptsAllDateTimeKinds(bool useUtc)
@@ -1715,7 +1715,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that orchestrations run concurrently of each other (up to 100 by default).
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task OrchestrationConcurrency(bool enableExtendedSessions)
@@ -1754,7 +1754,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates the orchestrator's exception handling behavior.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task HandledActivityException(bool enableExtendedSessions)
@@ -1768,7 +1768,7 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(15));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(5, JToken.Parse(status?.Output));
+                Assert.AreEqual(5, JToken.Parse(status?.Output).Value<int>());
 
                 await host.StopAsync();
             }
@@ -1777,7 +1777,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates the handling of unhandled exceptions generated from orchestrator code.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task UnhandledOrchestrationException(bool enableExtendedSessions)
@@ -1800,7 +1800,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates the handling of unhandled exceptions generated from activity code.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task UnhandledActivityException(bool enableExtendedSessions)
@@ -1823,7 +1823,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// Fan-out/fan-in test which ensures each operation is run only once.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task FanOutToTableStorage(bool enableExtendedSessions)
@@ -1867,7 +1867,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that orchestrations with <=60KB text message sizes can run successfully.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task SmallTextMessagePayloads(bool enableExtendedSessions)
@@ -1894,7 +1894,7 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(message, JToken.Parse(status?.Output));
+                Assert.AreEqual(message, JToken.Parse(status?.Output).Value<string>());
 
                 await host.StopAsync();
             }
@@ -1903,7 +1903,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that orchestrations with > 60KB text message sizes can run successfully.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task LargeQueueTextMessagePayloads_BlobUrl(bool enableExtendedSessions)
@@ -1920,8 +1920,8 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromMinutes(2));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(message, JToken.Parse(status?.Output));
-                Assert.AreEqual(message, JToken.Parse(status.Input));
+                Assert.AreEqual(message, JToken.Parse(status?.Output).Value<string>());
+                Assert.AreEqual(message, JToken.Parse(status.Input).Value<string>());
 
                 await host.StopAsync();
             }
@@ -1930,7 +1930,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that orchestrations with > 60KB text message sizes can run successfully.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task LargeTableTextMessagePayloads_SizeViolation_BlobUrl(bool enableExtendedSessions)
@@ -2014,7 +2014,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that orchestrations with > 60KB text message sizes can run successfully.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task LargeOverallTextMessagePayloads_BlobUrl(bool enableExtendedSessions)
@@ -2051,7 +2051,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that orchestrations with > 60KB text message sizes can run successfully.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task LargeTextMessagePayloads_FetchLargeMessages(bool enableExtendedSessions)
@@ -2065,8 +2065,8 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromMinutes(2));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(message, JToken.Parse(status?.Input));
-                Assert.AreEqual(message, JToken.Parse(status?.Output));
+                Assert.AreEqual(message, JToken.Parse(status?.Input).Value<string>());
+                Assert.AreEqual(message, JToken.Parse(status?.Output).Value<string>());
 
                 await host.StopAsync();
             }
@@ -2075,7 +2075,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that orchestrations with > 60KB text message sizes can run successfully.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task LargeTableTextMessagePayloads_FetchLargeMessages(bool enableExtendedSessions)
@@ -2091,8 +2091,8 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromMinutes(2));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(message, JToken.Parse(status?.Input));
-                Assert.AreEqual(message, JToken.Parse(status?.Output));
+                Assert.AreEqual(message, JToken.Parse(status?.Input).Value<string>());
+                Assert.AreEqual(message, JToken.Parse(status?.Output).Value<string>());
 
                 await host.StopAsync();
             }
@@ -2127,7 +2127,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that orchestrations with > 60KB text message sizes can run successfully.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task NonBlobUriPayload_FetchLargeMessages_RetainsOriginalPayload(bool enableExtendedSessions)
@@ -2141,8 +2141,8 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromMinutes(2));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(message, JToken.Parse(status?.Input));
-                Assert.AreEqual(message, JToken.Parse(status?.Output));
+                Assert.AreEqual(message, JToken.Parse(status?.Input).Value<string>());
+                Assert.AreEqual(message, JToken.Parse(status?.Output).Value<string>());
 
                 await host.StopAsync();
             }
@@ -2151,7 +2151,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that orchestrations with > 60KB text message sizes can run successfully.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task LargeTextMessagePayloads_FetchLargeMessages_QueryState(bool enableExtendedSessions)
@@ -2168,8 +2168,8 @@ namespace DurableTask.AzureStorage.Tests
                 status = (await client.GetStateAsync(status.OrchestrationInstance.InstanceId)).First();
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(message, JToken.Parse(status?.Input));
-                Assert.AreEqual(message, JToken.Parse(status?.Output));
+                Assert.AreEqual(message, JToken.Parse(status?.Input).Value<string>());
+                Assert.AreEqual(message, JToken.Parse(status?.Output).Value<string>());
 
                 await host.StopAsync();
             }
@@ -2179,7 +2179,7 @@ namespace DurableTask.AzureStorage.Tests
         /// End-to-end test which validates that exception messages that are considered valid Urls in the Uri.TryCreate() method
         /// are handled with an additional Uri format check
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task LargeTextMessagePayloads_URIFormatCheck(bool enableExtendedSessions)
@@ -2243,7 +2243,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that orchestrations with > 60KB binary bytes message sizes can run successfully.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task LargeBinaryByteMessagePayloads(bool enableExtendedSessions)
@@ -2273,7 +2273,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that orchestrations with > 60KB binary string message sizes can run successfully.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task LargeBinaryStringMessagePayloads(bool enableExtendedSessions)
@@ -2305,7 +2305,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that a completed singleton instance can be recreated.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task RecreateCompletedInstance(bool enableExtendedSessions)
@@ -2323,8 +2323,8 @@ namespace DurableTask.AzureStorage.Tests
                 var status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual("One", JToken.Parse(status?.Input));
-                Assert.AreEqual("Hello, One!", JToken.Parse(status?.Output));
+                Assert.AreEqual("One", JToken.Parse(status?.Input).Value<string>());
+                Assert.AreEqual("Hello, One!", JToken.Parse(status?.Output).Value<string>());
 
                 client = await host.StartOrchestrationAsync(
                     typeof(Orchestrations.SayHelloWithActivity),
@@ -2333,8 +2333,8 @@ namespace DurableTask.AzureStorage.Tests
                 status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual("Two", JToken.Parse(status?.Input));
-                Assert.AreEqual("Hello, Two!", JToken.Parse(status?.Output));
+                Assert.AreEqual("Two", JToken.Parse(status?.Input).Value<string>());
+                Assert.AreEqual("Hello, Two!", JToken.Parse(status?.Output).Value<string>());
 
                 await host.StopAsync();
             }
@@ -2343,7 +2343,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that a failed singleton instance can be recreated.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task RecreateFailedInstance(bool enableExtendedSessions)
@@ -2369,7 +2369,7 @@ namespace DurableTask.AzureStorage.Tests
                 status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual("Hello, NotNull!", JToken.Parse(status?.Output));
+                Assert.AreEqual("Hello, NotNull!", JToken.Parse(status?.Output).Value<string>());
 
                 await host.StopAsync();
             }
@@ -2378,7 +2378,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that a terminated orchestration can be recreated.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task RecreateTerminatedInstance(bool enableExtendedSessions)
@@ -2422,7 +2422,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates that a running orchestration can be recreated.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task RecreateRunningInstance(bool enableExtendedSessions)
@@ -2509,7 +2509,7 @@ namespace DurableTask.AzureStorage.Tests
                 status = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(10));
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-                Assert.AreEqual(1, JToken.Parse(status?.Output));
+                Assert.AreEqual(1, JToken.Parse(status?.Output).Value<int>());
 
                 await host.StopAsync();
             }
@@ -2519,7 +2519,7 @@ namespace DurableTask.AzureStorage.Tests
         /// Tests an orchestration that does two consecutive fan-out, fan-ins.
         /// This is a regression test for https://github.com/Azure/durabletask/issues/241.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task DoubleFanOut(bool enableExtendedSessions)
@@ -2567,7 +2567,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// Tests the behavior of <see cref="SessionAbortedException"/> from orchestrations and activities.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task AbortOrchestrationAndActivity(bool enableExtendedSessions)
@@ -2582,7 +2582,7 @@ namespace DurableTask.AzureStorage.Tests
 
                 Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
                 Assert.IsNotNull(status.Output);
-                Assert.AreEqual("True", JToken.Parse(status.Output));
+                Assert.AreEqual("True", JToken.Parse(status.Output).Value<string>());
                 await host.StopAsync();
             }
         }
@@ -2592,7 +2592,7 @@ namespace DurableTask.AzureStorage.Tests
         /// </summary>
         /// <param name="enableExtendedSessions"></param>
         /// <returns></returns>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task ScheduledStart_Inline(bool enableExtendedSessions)
@@ -2611,11 +2611,11 @@ namespace DurableTask.AzureStorage.Tests
                 await Task.WhenAll(statusStartingNow, statusStartingIn30Seconds);
 
                 Assert.AreEqual(OrchestrationStatus.Completed, statusStartingNow.Result?.OrchestrationStatus);
-                Assert.AreEqual("Current Time!", JToken.Parse(statusStartingNow.Result?.Input));
+                Assert.AreEqual("Current Time!", JToken.Parse(statusStartingNow.Result?.Input).Value<string>());
                 Assert.IsNull(statusStartingNow.Result.ScheduledStartTime);
 
                 Assert.AreEqual(OrchestrationStatus.Completed, statusStartingIn30Seconds.Result?.OrchestrationStatus);
-                Assert.AreEqual("Current Time!", JToken.Parse(statusStartingIn30Seconds.Result?.Input));
+                Assert.AreEqual("Current Time!", JToken.Parse(statusStartingIn30Seconds.Result?.Input).Value<string>());
                 Assert.AreEqual(expectedStartTime, statusStartingIn30Seconds.Result.ScheduledStartTime);
 
                 var startNowResult = (DateTime)JToken.Parse(statusStartingNow.Result?.Output);
@@ -2633,7 +2633,7 @@ namespace DurableTask.AzureStorage.Tests
         /// </summary>
         /// <param name="enableExtendedSessions"></param>
         /// <returns></returns>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task ScheduledStart_Activity(bool enableExtendedSessions)
@@ -2652,11 +2652,11 @@ namespace DurableTask.AzureStorage.Tests
                 await Task.WhenAll(statusStartingNow, statusStartingIn30Seconds);
 
                 Assert.AreEqual(OrchestrationStatus.Completed, statusStartingNow.Result?.OrchestrationStatus);
-                Assert.AreEqual("Current Time!", JToken.Parse(statusStartingNow.Result?.Input));
+                Assert.AreEqual("Current Time!", JToken.Parse(statusStartingNow.Result?.Input).Value<string>());
                 Assert.IsNull(statusStartingNow.Result.ScheduledStartTime);
 
                 Assert.AreEqual(OrchestrationStatus.Completed, statusStartingIn30Seconds.Result?.OrchestrationStatus);
-                Assert.AreEqual("Current Time!", JToken.Parse(statusStartingIn30Seconds.Result?.Input));
+                Assert.AreEqual("Current Time!", JToken.Parse(statusStartingIn30Seconds.Result?.Input).Value<string>());
                 Assert.AreEqual(expectedStartTime, statusStartingIn30Seconds.Result.ScheduledStartTime);
 
                 var startNowResult = (DateTime)JToken.Parse(statusStartingNow.Result?.Output);
@@ -2674,7 +2674,7 @@ namespace DurableTask.AzureStorage.Tests
         /// </summary>
         /// <param name="enableExtendedSessions"></param>
         /// <returns></returns>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task ScheduledStart_Activity_GetStatus_Returns_ScheduledStart(bool enableExtendedSessions)
@@ -2719,7 +2719,7 @@ namespace DurableTask.AzureStorage.Tests
         /// To recover from this, users may set `AllowReplayingTerminalInstances` to true. When this is set, DTFx will not discard
         /// events for terminal orchestrators, forcing a replay which eventually updates the instances table to the right state.
         /// </remarks>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true, true, true)]
         [DataRow(true, true, false)]
         [DataRow(true, false, true)]
@@ -2817,7 +2817,7 @@ namespace DurableTask.AzureStorage.Tests
         /// the tracking store context object that is part of the orchestration session state which keeps track of the blobs.
         /// </summary>
         /// <returns></returns>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true, true)]
         [DataRow(false, true)]
         [DataRow(true, false)]
@@ -2909,7 +2909,7 @@ namespace DurableTask.AzureStorage.Tests
         /// Same as <see cref="TestWorkerFailingDuringCompleteWorkItemCallCompletedOrchestration"/> but for a failed orchestration.
         /// </summary>
         /// <returns></returns>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true, true)]
         [DataRow(false, true)]
         [DataRow(true, false)]
@@ -3001,7 +3001,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// Same as <see cref="TestWorkerFailingDuringCompleteWorkItemCallCompletedOrchestration"/> but for a terminated orchestration.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true, true)]
         [DataRow(false, true)]
         [DataRow(true, false)]
@@ -3095,7 +3095,7 @@ namespace DurableTask.AzureStorage.Tests
         /// Same as <see cref="TestWorkerFailingDuringCompleteWorkItemCallCompletedOrchestration"/> but for an orchestration with large input
         /// and output, which will need to be stored in blob storage.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true, true)]
         [DataRow(false, true)]
         [DataRow(true, false)]
@@ -3188,7 +3188,7 @@ namespace DurableTask.AzureStorage.Tests
         /// Same as <see cref="TestWorkerFailingDuringCompleteWorkItemCallTerminatedOrchestration"/> but for a large termination reason that
         /// will need to be stored in blob storage.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true, true)]
         [DataRow(false, true)]
         [DataRow(true, false)]
@@ -3285,7 +3285,7 @@ namespace DurableTask.AzureStorage.Tests
         /// Same as <see cref="TestWorkerFailingDuringCompleteWorkItemCallFailedOrchestration"/> but for a large exception message that will need
         /// to be stored in blob storage.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true, true)]
         [DataRow(false, true)]
         [DataRow(true, false)]
@@ -3477,7 +3477,7 @@ namespace DurableTask.AzureStorage.Tests
         /// </remarks>
         /// <param name="useInstanceEtag">The value to use for <see cref="AzureStorageOrchestrationServiceSettings.UseInstanceTableEtag"/></param>
         /// <returns></returns>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task WorkerAttemptingToUpdateInstanceTableAfterStalling(bool useInstanceEtag)
@@ -3541,7 +3541,7 @@ namespace DurableTask.AzureStorage.Tests
                 if (useInstanceEtag)
                 {
                     // Confirm an exception is thrown due to the etag mismatch for the instance table when the worker attempts to complete the work item
-                    SessionAbortedException exception = await Assert.ThrowsExceptionAsync<SessionAbortedException>(async () =>
+                    SessionAbortedException exception = await Assert.ThrowsExactlyAsync<SessionAbortedException>(async () =>
                         await service.CompleteTaskOrchestrationWorkItemAsync(workItem, runtimeState, new List<TaskMessage>(), new List<TaskMessage>(), new List<TaskMessage>(), null, null)
                     );
                     Assert.IsInstanceOfType(exception.InnerException, typeof(DurableTaskStorageException));
@@ -3592,7 +3592,7 @@ namespace DurableTask.AzureStorage.Tests
         /// </remarks>
         /// <param name="useInstanceEtag">The value to use for <see cref="AzureStorageOrchestrationServiceSettings.UseInstanceTableEtag"/></param>
         /// <returns></returns>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task WorkerAttemptingToUpdateInstanceTableAfterStallingForSubOrchestration(bool useInstanceEtag)
@@ -3699,7 +3699,7 @@ namespace DurableTask.AzureStorage.Tests
                 {
                     // Confirm an exception is thrown because the worker attempts to insert a new entity for the suborchestration into the instance table
                     // when one already exists
-                    SessionAbortedException exception = await Assert.ThrowsExceptionAsync<SessionAbortedException>(async () =>
+                    SessionAbortedException exception = await Assert.ThrowsExactlyAsync<SessionAbortedException>(async () =>
                         await service.CompleteTaskOrchestrationWorkItemAsync(workItem, runtimeState, new List<TaskMessage>(), new List<TaskMessage>(), new List<TaskMessage>(), null, null)
                     );
                     Assert.IsInstanceOfType(exception.InnerException, typeof(DurableTaskStorageException));
@@ -3733,7 +3733,7 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task WorkerAttemptingToDequeueMessageForNonExistentInstance(bool extendedSessionsEnabled)
@@ -3785,7 +3785,7 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true, true)]
         [DataRow(false, true)]
         [DataRow(true, false)]
@@ -3878,7 +3878,7 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true, true)]
         [DataRow(false, true)]
         [DataRow(true, false)]
@@ -3991,7 +3991,7 @@ namespace DurableTask.AzureStorage.Tests
         /// End-to-end test which validates a simple orchestrator function that calls an activity function
         /// and checks the OpenTelemetry trace information
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task OpenTelemetry_SayHelloWithActivity(bool enableExtendedSessions)
@@ -4061,7 +4061,7 @@ namespace DurableTask.AzureStorage.Tests
         /// End-to-end test which validates a simple orchestrator function that waits for an external event
         /// raised through the RaiseEvent API and checks the OpenTelemetry trace information
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task OpenTelemetry_ExternalEvent_RaiseEvent(bool enableExtendedSessions)
@@ -4131,7 +4131,7 @@ namespace DurableTask.AzureStorage.Tests
         /// <summary>
         /// End-to-end test which validates a simple orchestrator function that fires a timer and checks the OpenTelemetry trace information
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task OpenTelemetry_TimerFired(bool enableExtendedSessions)
@@ -4198,7 +4198,7 @@ namespace DurableTask.AzureStorage.Tests
         /// End-to-end test which validates a simple orchestrator function that waits for an external event
         /// raised by calling SendEvent and checks the OpenTelemetry trace information
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task OpenTelemetry_ExternalEvent_SendEvent(bool enableExtendedSessions)

--- a/test/DurableTask.AzureStorage.Tests/AzureTableQueryFilterTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureTableQueryFilterTests.cs
@@ -21,7 +21,7 @@ namespace DurableTask.AzureStorage.Tests
     {
         // PartitionKeyEquals applies KeySanitation.EscapePartitionKey (storage-key characters) and then
         // OData quote-escaping (single quotes doubled).
-        [DataTestMethod]
+        [TestMethod]
         [DataRow("instance1", "PartitionKey eq 'instance1'")]
         [DataRow("inst'ance", "PartitionKey eq 'inst''ance'")]
         [DataRow("in#st'ance", "PartitionKey eq 'in^2st''ance'")]
@@ -31,7 +31,7 @@ namespace DurableTask.AzureStorage.Tests
         }
 
         // ColumnEquals OData-escapes the value (single quotes doubled); the column name is literal text.
-        [DataTestMethod]
+        [TestMethod]
         [DataRow("ExecutionId", "abc", "ExecutionId eq 'abc'")]
         [DataRow("ExecutionId", "a'b", "ExecutionId eq 'a''b'")]
         [DataRow("RowKey", "", "RowKey eq ''")]
@@ -40,7 +40,7 @@ namespace DurableTask.AzureStorage.Tests
             Assert.AreEqual(expectedFilter, AzureTableQueryFilter.ColumnEquals(columnName, value));
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow("prefix", "PartitionKey ge 'prefix'")]
         [DataRow("pre'fix", "PartitionKey ge 'pre''fix'")]
         public void PartitionKeyGreaterOrEqual(string sanitizedPartitionKey, string expectedFilter)
@@ -48,7 +48,7 @@ namespace DurableTask.AzureStorage.Tests
             Assert.AreEqual(expectedFilter, AzureTableQueryFilter.PartitionKeyGreaterOrEqual(sanitizedPartitionKey));
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow("prefix", "PartitionKey lt 'prefix'")]
         [DataRow("pre'fix", "PartitionKey lt 'pre''fix'")]
         public void PartitionKeyLessThan(string sanitizedPartitionKey, string expectedFilter)

--- a/test/DurableTask.AzureStorage.Tests/Correlation/CorrelationScenarioTest.cs
+++ b/test/DurableTask.AzureStorage.Tests/Correlation/CorrelationScenarioTest.cs
@@ -31,7 +31,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
     [TestClass]
     public class CorrelationScenarioTest
     {
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(Protocol.W3CTraceContext, false)]
         [DataRow(Protocol.HttpCorrelationProtocol, false)]
         [DataRow(Protocol.W3CTraceContext, true)]
@@ -78,7 +78,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(Protocol.W3CTraceContext, false)]
         [DataRow(Protocol.HttpCorrelationProtocol, false)]
         [DataRow(Protocol.W3CTraceContext, true)]
@@ -113,7 +113,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
                 );
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(Protocol.W3CTraceContext, false)]
         [DataRow(Protocol.HttpCorrelationProtocol, false)]
         [DataRow(Protocol.W3CTraceContext, true)]
@@ -173,7 +173,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(Protocol.W3CTraceContext, false)]
         [DataRow(Protocol.HttpCorrelationProtocol, false)]
         [DataRow(Protocol.W3CTraceContext, true)]
@@ -217,7 +217,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(Protocol.W3CTraceContext, false)]
         [DataRow(Protocol.HttpCorrelationProtocol, false)]
         [DataRow(Protocol.W3CTraceContext, true)]
@@ -274,7 +274,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(Protocol.W3CTraceContext, false)]
         [DataRow(Protocol.HttpCorrelationProtocol, false)]
         [DataRow(Protocol.W3CTraceContext, true)]
@@ -338,7 +338,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(Protocol.W3CTraceContext, false)]
         [DataRow(Protocol.HttpCorrelationProtocol, false)]
         [DataRow(Protocol.W3CTraceContext, true)]
@@ -447,7 +447,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
 
         //[TestMethod] ContinueAsNew
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(Protocol.W3CTraceContext, false)]
         [DataRow(Protocol.HttpCorrelationProtocol, false)]
         [DataRow(Protocol.W3CTraceContext, true)]
@@ -502,7 +502,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(Protocol.W3CTraceContext, false)]
         [DataRow(Protocol.HttpCorrelationProtocol, false)]
         [DataRow(Protocol.W3CTraceContext, true)]
@@ -576,7 +576,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(Protocol.W3CTraceContext, false)]
         [DataRow(Protocol.HttpCorrelationProtocol, false)]
         [DataRow(Protocol.W3CTraceContext, true)]
@@ -718,7 +718,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
             }
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(Protocol.W3CTraceContext, false)]
         [DataRow(Protocol.HttpCorrelationProtocol, false)]
         [DataRow(Protocol.W3CTraceContext, true)]

--- a/test/DurableTask.AzureStorage.Tests/Correlation/StringExtensionsTest.cs
+++ b/test/DurableTask.AzureStorage.Tests/Correlation/StringExtensionsTest.cs
@@ -35,7 +35,7 @@ namespace DurableTask.AzureStorage.Tests.Correlation
         public void TestParseTraceParentThrowsException()
         {
             string wrongTraceparentString = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7";
-            Assert.ThrowsException<ArgumentException>(
+            Assert.ThrowsExactly<ArgumentException>(
                 () => { wrongTraceparentString.ToTraceParent(); });
         }
 

--- a/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
+++ b/test/DurableTask.AzureStorage.Tests/DurableTask.AzureStorage.Tests.csproj
@@ -10,11 +10,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
-    <!-- Increasing Azure.Monitor.OpenTelemetry.Exporter to 1.0.0-beta.5 or beyond brings Systems.DiagnosticSource 7.x, which is uncompatible with netcoreapp3.1.
-    The warning reads:
-	  "System.Diagnostics.DiagnosticSource 7.0.0-rc.1.22426.10 doesn't support netcoreapp3.1 and has not been tested with it
-	  Consider upgrading your TargetFramework to net6.0 or later. You may also set <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings> 
-	  in the project file to ignore this warning and attempt to run in this unsupported configuration at your own risk."-->
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
     <PackageReference Include="System.Configuration.ConfigurationManager" />
   </ItemGroup>
@@ -34,6 +29,12 @@
 	Since this is just a test project, and to prevent "warning fatigue" so real CVEs stand out, we choose to upgrade the dependency explicitly to remove the false alarm.-->
     <PackageReference Include="System.Data.SqlClient" /> <!-- Version 4.3.1 was detected by default-->
     <PackageReference Include="Microsoft.Data.Services.Client" /> <!-- Without this, we resolve Microsoft.Data.OData 5.8.2, which is flagged-->
+    <PackageReference Include="System.Text.RegularExpressions" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <!-- Pin patched versions of vulnerable dependencies pulled in by WindowsAzure.Storage 9.x. -->
+    <PackageReference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>
@@ -49,10 +50,6 @@
 
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-    <PackageReference Include="System.Text.RegularExpressions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DurableTask.AzureStorage.Tests/KeySanitationTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/KeySanitationTests.cs
@@ -24,7 +24,7 @@ namespace DurableTask.AzureStorage.Tests
     [TestClass]
     public class KeySanitationTests
     {
-        [DataTestMethod]
+        [TestMethod]
         [DataRow("\r")]
         [DataRow("")]
         [DataRow("hello")]

--- a/test/DurableTask.AzureStorage.Tests/MessageManagerTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/MessageManagerTests.cs
@@ -23,7 +23,7 @@ namespace DurableTask.AzureStorage.Tests
     [TestClass]
     public class MessageManagerTests
     {
-        [DataTestMethod]
+        [TestMethod]
         [DataRow("System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib],[System.String, System.Private.CoreLib]]")]
         [DataRow("System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.String, mscorlib]]")]
         public void DeserializesStandardTypes(string dictionaryType)
@@ -49,7 +49,7 @@ namespace DurableTask.AzureStorage.Tests
             var messageManager = SetupMessageManager(new KnownTypeBinder());
 
             // When/Then
-            Assert.ThrowsException<JsonSerializationException>(() => messageManager.DeserializeMessageData(message));
+            Assert.ThrowsExactly<JsonSerializationException>(() => messageManager.DeserializeMessageData(message));
         }
 
 
@@ -69,7 +69,7 @@ namespace DurableTask.AzureStorage.Tests
             Assert.AreEqual("tagValue", startedEvent.Tags["tag1"]);
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow("blob.bin", "blob.bin")]
         [DataRow("@#$%!", "%40%23%24%25%21")]
         [DataRow("foo/bar/b@z.tar.gz", "foo/bar/b%40z.tar.gz")]

--- a/test/DurableTask.AzureStorage.Tests/Net/UriPathTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/Net/UriPathTests.cs
@@ -18,7 +18,7 @@ namespace DurableTask.AzureStorage.Net
     [TestClass]
     public class UriPathTests
     {
-        [DataTestMethod]
+        [TestMethod]
         [DataRow("", "", "")]
         [DataRow("", "bar/baz", "bar/baz")]
         [DataRow("foo", "", "foo")]

--- a/test/DurableTask.AzureStorage.Tests/Storage/TableDeleteBatchParallelTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/Storage/TableDeleteBatchParallelTests.cs
@@ -250,7 +250,7 @@ namespace DurableTask.AzureStorage.Tests.Storage
                     return Task.FromResult(CreateMockBatchResponse(batch.Count()));
                 });
 
-            await Assert.ThrowsExceptionAsync<OperationCanceledException>(
+            await Assert.ThrowsExactlyAsync<OperationCanceledException>(
                 () => table.DeleteBatchParallelAsync(entities, cts.Token));
         }
 

--- a/test/DurableTask.AzureStorage.Tests/StressTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/StressTests.cs
@@ -49,7 +49,7 @@ namespace DurableTask.AzureStorage.Tests
         /// both in the case where they all share the same instance ID and when they have unique
         /// instance IDs.
         /// </summary>
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public async Task ConcurrentOrchestrationStarts(bool useSameInstanceId)

--- a/test/DurableTask.AzureStorage.Tests/TestTablePartitionManager.cs
+++ b/test/DurableTask.AzureStorage.Tests/TestTablePartitionManager.cs
@@ -702,7 +702,7 @@ namespace DurableTask.AzureStorage.Tests
             // read the partition table
             var results = partitionTable.ExecuteQueryAsync<TablePartitionLease>();
             var numResults = await results.CountAsync();
-            Assert.AreEqual(numResults, 1); // there should only be 1 partition
+            Assert.AreEqual(1, numResults); // there should only be 1 partition
 
             // We want to test that worker 0 starts listening to the control queue without claiming the lease.
             // Therefore, we force the table to be in a state where worker 0 is still the current owner of the partition.
@@ -716,8 +716,8 @@ namespace DurableTask.AzureStorage.Tests
             // guarantee table is corrrectly updated
             results = partitionTable.ExecuteQueryAsync<TablePartitionLease>();
             numResults = await results.CountAsync();
-            Assert.AreEqual(numResults, 1); // there should only be 1 partition
-            Assert.AreEqual((await results.FirstAsync()).CurrentOwner, "0"); // ensure current owner is partition "0"
+            Assert.AreEqual(1, numResults); // there should only be 1 partition
+            Assert.AreEqual("0", (await results.FirstAsync()).CurrentOwner); // ensure current owner is partition "0"
 
             // create and start new worker with the same settings, ensure it is actively listening to the queue
             worker = new TaskHubWorker(service);

--- a/test/DurableTask.Core.Tests/ContinueAsNewTraceBehaviorTests.cs
+++ b/test/DurableTask.Core.Tests/ContinueAsNewTraceBehaviorTests.cs
@@ -622,12 +622,12 @@ namespace DurableTask.Core.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void Context_ContinueAsNew_NullOptions_Throws()
         {
             var instance = new OrchestrationInstance { InstanceId = "test", ExecutionId = Guid.NewGuid().ToString() };
             var context = new TestableTaskOrchestrationContext(instance, TaskScheduler.Default);
-            context.ContinueAsNew(null, "input", (ContinueAsNewOptions)null!);
+            Assert.ThrowsExactly<ArgumentNullException>(
+                () => context.ContinueAsNew(null, "input", (ContinueAsNewOptions)null!));
         }
 
         #endregion
@@ -635,11 +635,11 @@ namespace DurableTask.Core.Tests
         #region Base class — NotSupportedException for unsupported implementations
 
         [TestMethod]
-        [ExpectedException(typeof(NotSupportedException))]
         public void BaseClass_ContinueAsNewWithOptions_ThrowsNotSupported()
         {
             var ctx = new MinimalOrchestrationContext();
-            ctx.ContinueAsNew("1.0", "input", new ContinueAsNewOptions());
+            Assert.ThrowsExactly<NotSupportedException>(
+                () => ctx.ContinueAsNew("1.0", "input", new ContinueAsNewOptions()));
         }
 
         #endregion

--- a/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
+++ b/test/DurableTask.Core.Tests/DispatcherMiddlewareTests.cs
@@ -339,7 +339,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual("Value", executionContext?.OrchestrationTags?["Test"]);
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(OrchestrationStatus.Completed)]
         [DataRow(OrchestrationStatus.Failed)]
         [DataRow(OrchestrationStatus.Terminated)]

--- a/test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
+++ b/test/DurableTask.Core.Tests/ExceptionHandlingIntegrationTests.cs
@@ -49,7 +49,7 @@ namespace DurableTask.Core.Tests
             this.client = new TaskHubClient(service, loggerFactory: loggerFactory);
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(ErrorPropagationMode.SerializeExceptions)]
         [DataRow(ErrorPropagationMode.UseFailureDetails)]
         public async Task CatchInvalidOperationException(ErrorPropagationMode mode)
@@ -123,7 +123,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual(1, retryPolicyInvokedCount);
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(ErrorPropagationMode.SerializeExceptions)]
         [DataRow(ErrorPropagationMode.UseFailureDetails)]
         public async Task FailureDetailsOnUnhandled(ErrorPropagationMode mode)

--- a/test/DurableTask.Core.Tests/RetryInterceptorTests.cs
+++ b/test/DurableTask.Core.Tests/RetryInterceptorTests.cs
@@ -28,10 +28,10 @@ namespace DurableTask.Core.Tests
             var interceptor = new RetryInterceptor<object>(this.context, new RetryOptions(TimeSpan.FromMilliseconds(100), 1), () => throw new IOException());
             async Task Invoke() => await interceptor.Invoke();
 
-            await Assert.ThrowsExceptionAsync<IOException>(Invoke, "Interceptor should throw the original exception after exceeding max retry attempts.");
+            await Assert.ThrowsExactlyAsync<IOException>(Invoke, "Interceptor should throw the original exception after exceeding max retry attempts.");
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(1)]
         [DataRow(2)]
         [DataRow(3)]
@@ -59,7 +59,7 @@ namespace DurableTask.Core.Tests
             Assert.AreEqual(maxAttempts, callCount, 0, $"There should be {maxAttempts} function calls for {maxAttempts} max attempts.");
         }
 
-        [DataTestMethod]
+        [TestMethod]
         [DataRow(1)]
         [DataRow(2)]
         [DataRow(3)]

--- a/test/DurableTask.Core.Tests/TraceContextBaseTest.cs
+++ b/test/DurableTask.Core.Tests/TraceContextBaseTest.cs
@@ -121,7 +121,7 @@ namespace DurableTask.Core.Tests
         public void GetCurrentOrchestrationRequestTraceContextWithNoRequestTraceContextScenario()
         {
             TraceContextBase currentContext = new Foo();
-            Assert.ThrowsException<InvalidOperationException>(() => currentContext.GetCurrentOrchestrationRequestTraceContext());
+            Assert.ThrowsExactly<InvalidOperationException>(() => currentContext.GetCurrentOrchestrationRequestTraceContext());
         }
 
         private static Foo GetNewRequestContext(string comment)

--- a/test/DurableTask.Core.Tests/WorkItemDispatcherTests.cs
+++ b/test/DurableTask.Core.Tests/WorkItemDispatcherTests.cs
@@ -407,7 +407,7 @@ namespace DurableTask.Core.Tests
 #if NET8_0_OR_GREATER
             public IDisposable? BeginScope<TState>(TState state) where TState : notnull => NoOpDisposable.Instance;
 #else
-            public IDisposable BeginScope<TState>(TState state) => NoOpDisposable.Instance;
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NoOpDisposable.Instance;
 #endif
 
             public bool IsEnabled(LogLevel logLevel) => true;

--- a/test/DurableTask.Emulator.Tests/EmulatorFunctionalTests.cs
+++ b/test/DurableTask.Emulator.Tests/EmulatorFunctionalTests.cs
@@ -76,9 +76,9 @@ namespace DurableTask.Emulator.Tests
             OrchestrationState result = await client.WaitForOrchestrationAsync(id, TimeSpan.FromSeconds(30), new CancellationToken());
             Assert.AreEqual(OrchestrationStatus.Completed, result.OrchestrationStatus);
 
-            await Assert.ThrowsExceptionAsync<OrchestrationAlreadyExistsException>(() => client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null));
+            await Assert.ThrowsExactlyAsync<OrchestrationAlreadyExistsException>(() => client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null));
 
-            await Assert.ThrowsExceptionAsync<OrchestrationAlreadyExistsException>(() => client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null, new[] { OrchestrationStatus.Completed }));
+            await Assert.ThrowsExactlyAsync<OrchestrationAlreadyExistsException>(() => client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null, new[] { OrchestrationStatus.Completed }));
 
             SimplestGreetingsOrchestration.Result = String.Empty;
 

--- a/test/DurableTask.ServiceBus.Tests/DurableTask.ServiceBus.Tests.csproj
+++ b/test/DurableTask.ServiceBus.Tests/DurableTask.ServiceBus.Tests.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="System.Configuration.ConfigurationManager" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>

--- a/test/DurableTask.ServiceBus.Tests/ErrorHandlingTests.cs
+++ b/test/DurableTask.ServiceBus.Tests/ErrorHandlingTests.cs
@@ -475,7 +475,7 @@ namespace DurableTask.ServiceBus.Tests
         }
 
         [Ignore]
-        ////[TestMethod]
+        [TestMethod]
         // Disabled until bug https://github.com/Azure/durabletask/issues/47 is fixed
         // Also the test does not work as expected due to debug mode suppressing UnobservedTaskException's
         public async Task ParallelInterfaceExceptionsTest()

--- a/test/DurableTask.ServiceBus.Tests/InstanceStoreQueryTests.cs
+++ b/test/DurableTask.ServiceBus.Tests/InstanceStoreQueryTests.cs
@@ -468,7 +468,7 @@ namespace DurableTask.ServiceBus.Tests
             try
             {
                 action();
-                Assert.IsTrue(false);
+                Assert.Fail();
             }
             catch (Exception ex)
             {

--- a/test/DurableTask.ServiceBus.Tests/OrchestrationHubTableClientTests.cs
+++ b/test/DurableTask.ServiceBus.Tests/OrchestrationHubTableClientTests.cs
@@ -67,13 +67,13 @@ namespace DurableTask.ServiceBus.Tests
             bool isCompleted = await TestHelpers.WaitForInstanceAsync(this.client, id, 60);
             Assert.IsTrue(isCompleted, TestHelpers.GetInstanceNotCompletedMessage(this.client, id, 60));
             OrchestrationState runtimeState = await this.client.GetOrchestrationStateAsync(id);
-            Assert.AreEqual(runtimeState.OrchestrationStatus, OrchestrationStatus.Completed);
-            Assert.AreEqual(runtimeState.OrchestrationInstance.InstanceId, id.InstanceId);
-            Assert.AreEqual(runtimeState.OrchestrationInstance.ExecutionId, id.ExecutionId);
+            Assert.AreEqual(OrchestrationStatus.Completed, runtimeState.OrchestrationStatus);
+            Assert.AreEqual(id.InstanceId, runtimeState.OrchestrationInstance.InstanceId);
+            Assert.AreEqual(id.ExecutionId, runtimeState.OrchestrationInstance.ExecutionId);
             Assert.AreEqual("DurableTask.ServiceBus.Tests.OrchestrationHubTableClientTests+InstanceStoreTestOrchestration", runtimeState.Name);
-            Assert.AreEqual(runtimeState.Version, string.Empty);
-            Assert.AreEqual(runtimeState.Input, "\"DONT_THROW\"");
-            Assert.AreEqual(runtimeState.Output, "\"Spartacus\"");
+            Assert.AreEqual(string.Empty, runtimeState.Version);
+            Assert.AreEqual("\"DONT_THROW\"", runtimeState.Input);
+            Assert.AreEqual("\"Spartacus\"", runtimeState.Output);
 
             string history = await this.client.GetOrchestrationHistoryAsync(id);
             Assert.IsTrue(!string.IsNullOrWhiteSpace(history));
@@ -147,14 +147,14 @@ namespace DurableTask.ServiceBus.Tests
             Assert.AreEqual(id.InstanceId, runtimeState.OrchestrationInstance.InstanceId);
             Assert.AreEqual(id.ExecutionId, runtimeState.OrchestrationInstance.ExecutionId);
             Assert.AreEqual("DurableTask.ServiceBus.Tests.OrchestrationHubTableClientTests+InstanceStoreTestOrchestration", runtimeState.Name);
-            Assert.AreEqual(runtimeState.Version, string.Empty);
-            Assert.AreEqual(runtimeState.Input, "\"WAIT\"");
-            Assert.AreEqual(runtimeState.Output, null);
+            Assert.AreEqual(string.Empty, runtimeState.Version);
+            Assert.AreEqual("\"WAIT\"", runtimeState.Input);
+            Assert.IsNull(runtimeState.Output);
 
             bool isCompleted = await TestHelpers.WaitForInstanceAsync(this.client, id, 60);
             Assert.IsTrue(isCompleted, TestHelpers.GetInstanceNotCompletedMessage(this.client, id, 60));
             runtimeState = await this.client.GetOrchestrationStateAsync(id);
-            Assert.AreEqual(runtimeState.OrchestrationStatus, OrchestrationStatus.Completed);
+            Assert.AreEqual(OrchestrationStatus.Completed, runtimeState.OrchestrationStatus);
         }
 
         [TestMethod]

--- a/test/DurableTask.ServiceBus.Tests/SampleScenarioTests.cs
+++ b/test/DurableTask.ServiceBus.Tests/SampleScenarioTests.cs
@@ -104,11 +104,11 @@ namespace DurableTask.ServiceBus.Tests
             Assert.AreEqual("Greeting send to Gabbar", SimplestGreetingsOrchestration.Result,
                 "Orchestration Result is wrong!!!");
 
-            await Assert.ThrowsExceptionAsync<OrchestrationAlreadyExistsException>(() => this.client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null));
+            await Assert.ThrowsExactlyAsync<OrchestrationAlreadyExistsException>(() => this.client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null));
 
-            await Assert.ThrowsExceptionAsync<OrchestrationAlreadyExistsException>(() => this.client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null, null));
+            await Assert.ThrowsExactlyAsync<OrchestrationAlreadyExistsException>(() => this.client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null, null));
 
-            await Assert.ThrowsExceptionAsync<OrchestrationAlreadyExistsException>(() => this.client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null, new[] { OrchestrationStatus.Completed, OrchestrationStatus.Terminated }));
+            await Assert.ThrowsExactlyAsync<OrchestrationAlreadyExistsException>(() => this.client.CreateOrchestrationInstanceAsync(typeof(SimplestGreetingsOrchestration), id.InstanceId, null, new[] { OrchestrationStatus.Completed, OrchestrationStatus.Terminated }));
 
             SimplestGreetingsOrchestration.Result = string.Empty;
 

--- a/test/DurableTask.ServiceBus.Tests/ServiceBusOrchestrationServiceTests.cs
+++ b/test/DurableTask.ServiceBus.Tests/ServiceBusOrchestrationServiceTests.cs
@@ -110,10 +110,10 @@ namespace DurableTask.ServiceBus.Tests
             status = await client.WaitForOrchestrationAsync(temp, TimeSpan.FromSeconds(10));
 
             Assert.AreEqual(OrchestrationStatus.Completed, status?.OrchestrationStatus);
-            Assert.AreEqual(3, JToken.Parse(status?.Output));
+            Assert.AreEqual(3, JToken.Parse(status?.Output).Value<int>());
 
             // When using ContinueAsNew, the original input is discarded and replaced with the most recent state.
-            Assert.AreNotEqual(initialValue, JToken.Parse(status?.Input));
+            Assert.AreNotEqual(initialValue, JToken.Parse(status?.Input).Value<int>());
         }
 
         [TestMethod]

--- a/test/DurableTask.Stress.Tests/Options.cs
+++ b/test/DurableTask.Stress.Tests/Options.cs
@@ -18,7 +18,6 @@ namespace DurableTask.Stress.Tests
 
     internal class Options
     {
-#if NETCOREAPP
         [Option('c', "create-hub", Default = false,
             HelpText = "Create Orchestration Hub.")]
         public bool CreateHub { get; set; }
@@ -48,37 +47,5 @@ namespace DurableTask.Stress.Tests
             help.AddOptions(options);
             return help;
         }
-#else
-        [Option('c', "create-hub", DefaultValue = false,
-            HelpText = "Create Orchestration Hub.")]
-        public bool CreateHub { get; set; }
-
-        [Option('s', "start-instance", DefaultValue = null,
-            HelpText = "Start Driver Instance")]
-        public string StartInstance { get; set; }
-
-        [Option('i', "instance-id",
-            HelpText = "Instance id for new orchestration instance.")]
-        public string InstanceId { get; set; }
-
-        [HelpOption]
-        public string GetUsage()
-        {
-            // this without using CommandLine.Text
-            //  or using HelpText.AutoBuild
-
-            var help = new HelpText
-            {
-                Heading = new HeadingInfo("TaskHubStressTest", "1.0"),
-                AdditionalNewLineAfterOption = true,
-                AddDashesToOption = true
-            };
-            help.AddPreOptionsLine("Usage: TaskHubStressTest.exe -c");
-            help.AddPreOptionsLine("Usage: TaskHubStressTest.exe -c -s <id>");
-            help.AddPreOptionsLine("Usage: TaskHubStressTest.exe -i <id>");
-            help.AddOptions(this);
-            return help;
-        }
-#endif
     }
 }

--- a/test/DurableTask.Stress.Tests/Program.cs
+++ b/test/DurableTask.Stress.Tests/Program.cs
@@ -150,6 +150,7 @@ namespace DurableTask.Stress.Tests
     using System.Configuration;
     using System.Diagnostics;
     using System.Diagnostics.Tracing;
+    using CommandLine;
     using DurableTask.AzureStorage;
     using DurableTask.Core;
     using DurableTask.Core.Tracing;
@@ -158,7 +159,6 @@ namespace DurableTask.Stress.Tests
 
     internal class Program
     {
-        static readonly Options ArgumentOptions = new Options();
         static ObservableEventListener eventListener;
 
         // ReSharper disable once UnusedMember.Local
@@ -170,7 +170,13 @@ namespace DurableTask.Stress.Tests
 
             string tableConnectionString = ConfigurationManager.AppSettings["StorageConnectionString"];
 
-            if (CommandLine.Parser.Default.ParseArgumentsStrict(args, ArgumentOptions))
+            Options argumentOptions = null;
+            ParserResult<Options> parserResult = Parser.Default.ParseArguments<Options>(args);
+            parserResult
+                .WithParsed(options => argumentOptions = options)
+                .WithNotParsed(errors => Console.Error.WriteLine(Options.GetUsage(parserResult)));
+
+            if (argumentOptions != null)
             {
                 string connectionString = ConfigurationManager.ConnectionStrings["AzureStorage"].ConnectionString;
                 var settings = new AzureStorageOrchestrationServiceSettings
@@ -186,13 +192,13 @@ namespace DurableTask.Stress.Tests
                 var taskHubClient = new TaskHubClient(orchestrationServiceAndClient);
                 var taskHub = new TaskHubWorker(orchestrationServiceAndClient);
 
-                if (ArgumentOptions.CreateHub)
+                if (argumentOptions.CreateHub)
                 {
                     orchestrationServiceAndClient.CreateIfNotExistsAsync().Wait();
                 }
 
                 OrchestrationInstance instance;
-                string instanceId = ArgumentOptions.StartInstance;
+                string instanceId = argumentOptions.StartInstance;
 
                 if (!string.IsNullOrWhiteSpace(instanceId))
                 {
@@ -212,7 +218,7 @@ namespace DurableTask.Stress.Tests
                 }
                 else
                 {
-                    instance = new OrchestrationInstance { InstanceId = ArgumentOptions.InstanceId };
+                    instance = new OrchestrationInstance { InstanceId = argumentOptions.InstanceId };
                 }
 
                 Console.WriteLine($"Orchestration starting: {DateTime.Now}");

--- a/test/TestFabricApplication/TestApplication/TestApplication.sfproj
+++ b/test/TestFabricApplication/TestApplication/TestApplication.sfproj
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" InitialTargets=";ValidateMSBuildFiles">
-  <Import Project="..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.7\build\Microsoft.VisualStudio.Azure.Fabric.Application.props" Condition="Exists('..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.7\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" />
+  <Import Project="..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.props" Condition="Exists('..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>1d52f94e-933c-411f-96c4-4960b423586f</ProjectGuid>
     <ProjectVersion>2.4</ProjectVersion>
     <MinToolsVersion>1.5</MinToolsVersion>
-    <SupportedMSBuildNuGetPackageVersion>1.6.7</SupportedMSBuildNuGetPackageVersion>
+    <SupportedMSBuildNuGetPackageVersion>1.7.9</SupportedMSBuildNuGetPackageVersion>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
@@ -39,9 +39,9 @@
     <ApplicationProjectTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Service Fabric Tools\Microsoft.VisualStudio.Azure.Fabric.ApplicationProject.targets</ApplicationProjectTargetsPath>
   </PropertyGroup>
   <Import Project="$(ApplicationProjectTargetsPath)" Condition="Exists('$(ApplicationProjectTargetsPath)')" />
-  <Import Project="..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.7\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets" Condition="Exists('..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.7\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" />
+  <Import Project="..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets" Condition="Exists('..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" />
   <Target Name="ValidateMSBuildFiles" BeforeTargets="PrepareForBuild">
-    <Error Condition="!Exists('..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.7\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" Text="Unable to find the '..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.7\build\Microsoft.VisualStudio.Azure.Fabric.Application.props' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package." />
-    <Error Condition="!Exists('..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.7\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" Text="Unable to find the '..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.7\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package." />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" Text="Unable to find the '..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.props' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package." />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" Text="Unable to find the '..\..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package." />
   </Target>
 </Project>

--- a/test/TestFabricApplication/TestApplication/packages.config
+++ b/test/TestFabricApplication/TestApplication/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.VisualStudio.Azure.Fabric.MSBuild" version="1.6.7" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Azure.Fabric.MSBuild" version="1.7.9" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
## Summary

- Modernize product, test, sample, and Service Fabric dependencies while retaining `netstandard2.0`, `net472`, and `net48` support.
- Migrate breaking APIs for MSTest 4, CommandLineParser 2.9, System.Linq.Async, and consolidated System.Reactive packaging.
- Pin patched legacy Service Bus and storage transitives, and update distributed-tracing prerequisites to the .NET 8 SDK.

## Compatibility notes

- Application Insights remains on 2.23 because 3.x removes telemetry-module APIs exposed by this repository.
- System.Reactive remains on 6.1 because 7.0.0's analyzer requires Roslyn 4.12 and breaks builds with the .NET 8 SDK.
- Legacy Service Bus transitives remain within compatible major versions while taking patched releases.

## Validation

- Debug solution and Release product matrix build with the .NET 8 SDK across `netstandard2.0`, `net8.0`, `net472`, and `net48` surfaces.
- Core, Emulator, Service Fabric, and local Service Bus test coverage passes on the retained frameworks.
- PackageReference projects have no known vulnerable package findings.
- The existing .NET Framework tracing failures reproduce on the unchanged baseline; one Azure Storage scheduled-start timing assertion remains timing-sensitive.