### PR TITLE
Enforce safe JSON deserialization in ServiceFabric

### DIFF
--- a/Test/DurableTask.AzureServiceFabric.Tests/AllowedTypesSerializationBinderTests.cs
+++ b/Test/DurableTask.AzureServiceFabric.Tests/AllowedTypesSerializationBinderTests.cs
@@ -223,11 +223,11 @@ namespace DurableTask.AzureServiceFabric.Tests
         }
 
         [TestMethod]
-        public void Settings_BinderCanBeSetToNull()
+        public void Settings_NullBinderRestoresAllowedTypesBinder()
         {
             var providerSettings = new FabricOrchestrationProviderSettings();
             providerSettings.JsonSerializationBinder = null;
-            Assert.IsNull(providerSettings.JsonSerializationBinder);
+            Assert.IsInstanceOfType(providerSettings.JsonSerializationBinder, typeof(AllowedTypesSerializationBinder));
         }
 
         [TestMethod]

--- a/src/DurableTask.AzureServiceFabric/FabricOrchestrationProviderSettings.cs
+++ b/src/DurableTask.AzureServiceFabric/FabricOrchestrationProviderSettings.cs
@@ -26,6 +26,8 @@ namespace DurableTask.AzureServiceFabric
     /// </summary>
     public sealed class FabricOrchestrationProviderSettings
     {
+        ISerializationBinder jsonSerializationBinder = new AllowedTypesSerializationBinder();
+
         /// <summary>
         /// Constructor. Initializes all settings to their default values.
         /// </summary>
@@ -66,9 +68,13 @@ namespace DurableTask.AzureServiceFabric
         /// <para>
         /// Defaults to <see cref="AllowedTypesSerializationBinder"/>, which permits only known
         /// DurableTask and core system types. Set a custom <see cref="ISerializationBinder"/> to
-        /// override, or set to <c>null</c> to disable type restrictions (not recommended).
+        /// override. Setting this property to <c>null</c> restores the default binder.
         /// </para>
         /// </summary>
-        public ISerializationBinder JsonSerializationBinder { get; set; } = new AllowedTypesSerializationBinder();
+        public ISerializationBinder JsonSerializationBinder
+        {
+            get => this.jsonSerializationBinder;
+            set => this.jsonSerializationBinder = value ?? new AllowedTypesSerializationBinder();
+        }
     }
 }

--- a/src/DurableTask.AzureServiceFabric/Service/Startup.cs
+++ b/src/DurableTask.AzureServiceFabric/Service/Startup.cs
@@ -34,7 +34,7 @@ namespace DurableTask.AzureServiceFabric.Service
         {
             this.listeningAddress = listeningAddress ?? throw new ArgumentNullException(nameof(listeningAddress));
             this.fabricOrchestrationProvider = fabricOrchestrationProvider ?? throw new ArgumentNullException(nameof(fabricOrchestrationProvider));
-            this.serializationBinder = serializationBinder;
+            this.serializationBinder = serializationBinder ?? new AllowedTypesSerializationBinder();
         }
 
         public string GetListeningAddress()
@@ -64,10 +64,7 @@ namespace DurableTask.AzureServiceFabric.Service
             config.Formatters.Remove(config.Formatters.XmlFormatter);
             config.Formatters.Remove(config.Formatters.FormUrlEncodedFormatter);
             config.Formatters.JsonFormatter.SerializerSettings.TypeNameHandling = Newtonsoft.Json.TypeNameHandling.All;
-            if (this.serializationBinder != null)
-            {
-                config.Formatters.JsonFormatter.SerializerSettings.SerializationBinder = this.serializationBinder;
-            }
+            config.Formatters.JsonFormatter.SerializerSettings.SerializationBinder = this.serializationBinder;
 
             appBuilder.UseWebApi(config);
         }


### PR DESCRIPTION
Ensure the Service Fabric JSON formatter always uses the allowed-types binder. This prevents untrusted requests from deserializing arbitrary .NET types through type metadata. Tests are added.