### PR TITLE
Persist parent orchestration metadata in Azure Storage

### DIFF
--- a/src/DurableTask.AzureStorage/OrchestrationInstanceStatus.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationInstanceStatus.cs
@@ -23,6 +23,7 @@ namespace DurableTask.AzureStorage
     class OrchestrationInstanceStatus : ITableEntity
     {
         public string ExecutionId { get; set; }
+        public string ParentInstanceId { get; set; }
         public string Name { get; set; }
         public string Version { get; set; }
         public string Input { get; set; }

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -956,6 +956,12 @@ namespace DurableTask.AzureStorage.Tracking
                 ["TaskHubName"] = this.settings.TaskHubName,
             };
 
+            // The parent is written on every checkpoint, not just the one carrying ExecutionStarted, so that
+            // it is always merged together with the ExecutionId above. Because the Instances row is keyed
+            // only by instance ID, a reused instance ID would otherwise end up advertising the current
+            // execution alongside a parent left behind by the previous orchestration.
+            SetParentInstanceId(instanceEntity, newRuntimeState.ParentInstance);
+
             // check if we are replacing a previous execution with blobs; those will be deleted from the store after the update. This could occur in a ContinueAsNew scenario
             List<string> blobsToDelete = null;
             if (oldRuntimeState != newRuntimeState && context.Blobs.Count > 0)
@@ -1002,7 +1008,6 @@ namespace DurableTask.AzureStorage.Tracking
                         instanceEntity["RuntimeStatus"] = OrchestrationStatus.Running.ToString();
                         instanceEntity["Tags"] = TagsSerializer.Serialize(executionStartedEvent.Tags);
                         instanceEntity["Generation"] = executionStartedEvent.Generation;
-                        SetParentInstanceId(instanceEntity, executionStartedEvent.ParentInstance);
                         if (executionStartedEvent.ScheduledStartTime.HasValue)
                         {
                             instanceEntity["ScheduledStartTime"] = executionStartedEvent.ScheduledStartTime;

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -38,6 +38,7 @@ namespace DurableTask.AzureStorage.Tracking
     class AzureTableTrackingStore : TrackingStoreBase
     {
         const string NameProperty = "Name";
+        const string ParentInstanceIdProperty = "ParentInstanceId";
         const string InputProperty = "Input";
         const string ResultProperty = "Result";
         const string OutputProperty = "Output";
@@ -461,6 +462,16 @@ namespace DurableTask.AzureStorage.Tracking
                 InstanceId = instanceId,
                 ExecutionId = orchestrationInstanceStatus.ExecutionId,
             };
+            if (!string.IsNullOrEmpty(orchestrationInstanceStatus.ParentInstanceId))
+            {
+                orchestrationState.ParentInstance = new ParentInstance
+                {
+                    OrchestrationInstance = new OrchestrationInstance
+                    {
+                        InstanceId = orchestrationInstanceStatus.ParentInstanceId,
+                    },
+                };
+            }
 
             orchestrationState.Name = orchestrationInstanceStatus.Name;
             orchestrationState.Version = orchestrationInstanceStatus.Version;
@@ -799,6 +810,7 @@ namespace DurableTask.AzureStorage.Tracking
                 ["Generation"] = executionStartedEvent.Generation,
                 ["Tags"] = TagsSerializer.Serialize(executionStartedEvent.Tags),
             };
+            SetParentInstanceId(entity, executionStartedEvent.ParentInstance);
 
             // It is possible that the queue message was small enough to be written directly to a queue message,
             // not a blob, but is too large to be written to a table property.
@@ -990,6 +1002,7 @@ namespace DurableTask.AzureStorage.Tracking
                         instanceEntity["RuntimeStatus"] = OrchestrationStatus.Running.ToString();
                         instanceEntity["Tags"] = TagsSerializer.Serialize(executionStartedEvent.Tags);
                         instanceEntity["Generation"] = executionStartedEvent.Generation;
+                        SetParentInstanceId(instanceEntity, executionStartedEvent.ParentInstance);
                         if (executionStartedEvent.ScheduledStartTime.HasValue)
                         {
                             instanceEntity["ScheduledStartTime"] = executionStartedEvent.ScheduledStartTime;
@@ -1151,6 +1164,7 @@ namespace DurableTask.AzureStorage.Tracking
                 ["Tags"] = TagsSerializer.Serialize(executionStartedEvent.Tags),
                 ["TaskHubName"] = this.settings.TaskHubName,
             };
+            SetParentInstanceId(instanceEntity, executionStartedEvent.ParentInstance);
             if (runtimeState.ExecutionStartedEvent.ScheduledStartTime.HasValue)
             {
                 instanceEntity["ScheduledStartTime"] = executionStartedEvent.ScheduledStartTime;
@@ -1246,6 +1260,16 @@ namespace DurableTask.AzureStorage.Tracking
             }
 
             return estimatedByteCount;
+        }
+
+        // The value is always assigned, including when there is no parent. Several of the Instances
+        // table writes use merge semantics, so omitting the property would let a top-level or newly
+        // recreated orchestration inherit a stale parent ID from a previous row with the same
+        // instance ID. An empty string is used rather than null because merge semantics for null
+        // properties are ambiguous; reads treat empty and missing identically.
+        static void SetParentInstanceId(TableEntity entity, ParentInstance parentInstance)
+        {
+            entity[ParentInstanceIdProperty] = parentInstance?.OrchestrationInstance?.InstanceId ?? string.Empty;
         }
 
         Type GetTypeForTableEntity(TableEntity tableEntity)

--- a/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/InstanceStoreBackedTrackingStore.cs
@@ -108,6 +108,7 @@ namespace DurableTask.AzureStorage.Tracking
                 Name = executionStartedEvent.Name,
                 Version = executionStartedEvent.Version,
                 OrchestrationInstance = executionStartedEvent.OrchestrationInstance,
+                ParentInstance = executionStartedEvent.ParentInstance,
                 OrchestrationStatus = OrchestrationStatus.Pending,
                 Input = inputStatusOverride ?? executionStartedEvent.Input,
                 Tags = executionStartedEvent.Tags,

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -154,8 +154,15 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
+        /// <summary>
+        /// Verifies that the normal checkpoint write path records a child's parent, and that the value is
+        /// returned by both a direct instance lookup and a status query. This does not cover the
+        /// terminal-history repair path; see
+        /// <see cref="ParentInstanceIdTrackingStoreTests.CompletedOrchestrationRepair_PersistsParentInstanceId"/>
+        /// for that.
+        /// </summary>
         [TestMethod]
-        public async Task ParentMetadataIsReturnedForFastCompletingChild()
+        public async Task ParentMetadataIsReturnedByDirectGetAndQuery()
         {
             using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(
                 enableExtendedSessions: false,

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -154,6 +154,71 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
+        [TestMethod]
+        public async Task ParentMetadataIsReturnedForFastCompletingChild()
+        {
+            using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(
+                enableExtendedSessions: false,
+                modifySettingsAction: settings => settings.TaskHubName = "pmf" + Guid.NewGuid().ToString("N").Substring(0, 12)))
+            {
+                string parentInstanceId = $"parent-{Guid.NewGuid():N}";
+                string childInstanceId = parentInstanceId + ":child";
+                await host.StartAsync();
+
+                var client = await host.StartOrchestrationAsync(
+                    typeof(Orchestrations.ParentOfInlineChild),
+                    "input",
+                    parentInstanceId);
+                OrchestrationState completed = await client.WaitForCompletionAsync(StandardTimeout);
+
+                Assert.AreEqual(OrchestrationStatus.Completed, completed?.OrchestrationStatus);
+
+                OrchestrationState parent = await host.service.GetOrchestrationStateAsync(parentInstanceId, executionId: null);
+                OrchestrationState child = await host.service.GetOrchestrationStateAsync(childInstanceId, executionId: null);
+                Assert.IsNull(parent.ParentInstance);
+                Assert.AreEqual(parentInstanceId, child.ParentInstance?.OrchestrationInstance.InstanceId);
+
+                DurableStatusQueryResult queryResult = await host.service.GetOrchestrationStateAsync(
+                    new OrchestrationInstanceStatusQueryCondition { InstanceIdPrefix = parentInstanceId },
+                    top: 10,
+                    continuationToken: null);
+                OrchestrationState queriedChild = queryResult.OrchestrationState.Single(state =>
+                    state.OrchestrationInstance.InstanceId == childInstanceId);
+                Assert.AreEqual(parentInstanceId, queriedChild.ParentInstance?.OrchestrationInstance.InstanceId);
+                OrchestrationState queriedParent = queryResult.OrchestrationState.Single(state =>
+                    state.OrchestrationInstance.InstanceId == parentInstanceId);
+                Assert.IsNull(queriedParent.ParentInstance);
+
+                await host.StopAsync();
+            }
+        }
+
+        [TestMethod]
+        public async Task ParentMetadataSurvivesChildContinueAsNew()
+        {
+            using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(
+                enableExtendedSessions: false,
+                modifySettingsAction: settings => settings.TaskHubName = "pmc" + Guid.NewGuid().ToString("N").Substring(0, 12)))
+            {
+                string parentInstanceId = $"parent-{Guid.NewGuid():N}";
+                string childInstanceId = parentInstanceId + ":child";
+                await host.StartAsync();
+
+                var client = await host.StartOrchestrationAsync(
+                    typeof(Orchestrations.ParentOfContinueAsNewChild),
+                    0,
+                    parentInstanceId);
+                OrchestrationState completed = await client.WaitForCompletionAsync(StandardTimeout);
+
+                Assert.AreEqual(OrchestrationStatus.Completed, completed?.OrchestrationStatus);
+                OrchestrationState child = await host.service.GetOrchestrationStateAsync(childInstanceId, executionId: null);
+                Assert.AreEqual(1, JToken.Parse(child.Input));
+                Assert.AreEqual(parentInstanceId, child.ParentInstance?.OrchestrationInstance.InstanceId);
+
+                await host.StopAsync();
+            }
+        }
+
         /// <summary>
         /// End-to-end test which runs a slow orchestrator that causes work item renewal
         /// </summary>
@@ -4872,6 +4937,51 @@ namespace DurableTask.AzureStorage.Tests
                 public override Task<int> RunTask(OrchestrationContext context, int input)
                 {
                     return context.CreateSubOrchestrationInstance<int>(typeof(Factorial), input);
+                }
+            }
+
+            [KnownType(typeof(InlineChild))]
+            internal class ParentOfInlineChild : TaskOrchestration<string, string>
+            {
+                public override Task<string> RunTask(OrchestrationContext context, string input)
+                {
+                    return context.CreateSubOrchestrationInstance<string>(
+                        typeof(InlineChild),
+                        context.OrchestrationInstance.InstanceId + ":child",
+                        input);
+                }
+            }
+
+            internal class InlineChild : TaskOrchestration<string, string>
+            {
+                public override Task<string> RunTask(OrchestrationContext context, string input)
+                {
+                    return Task.FromResult(input);
+                }
+            }
+
+            [KnownType(typeof(ContinueAsNewChild))]
+            internal class ParentOfContinueAsNewChild : TaskOrchestration<int, int>
+            {
+                public override Task<int> RunTask(OrchestrationContext context, int input)
+                {
+                    return context.CreateSubOrchestrationInstance<int>(
+                        typeof(ContinueAsNewChild),
+                        context.OrchestrationInstance.InstanceId + ":child",
+                        input);
+                }
+            }
+
+            internal class ContinueAsNewChild : TaskOrchestration<int, int>
+            {
+                public override Task<int> RunTask(OrchestrationContext context, int input)
+                {
+                    if (input == 0)
+                    {
+                        context.ContinueAsNew(1);
+                    }
+
+                    return Task.FromResult(input);
                 }
             }
 

--- a/test/DurableTask.AzureStorage.Tests/AzureTableTrackingStoreTest.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureTableTrackingStoreTest.cs
@@ -25,6 +25,8 @@ namespace DurableTask.AzureStorage.Tests
     using DurableTask.AzureStorage.Storage;
     using DurableTask.AzureStorage.Tracking;
     using DurableTask.Core;
+    using DurableTask.Core.History;
+    using DurableTask.Core.Tracking;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
 
@@ -66,16 +68,21 @@ namespace DurableTask.AzureStorage.Tests
             {
                 new OrchestrationInstanceStatus
                 {
+                    PartitionKey = "child",
+                    ParentInstanceId = "parent",
                     Name = "foo",
                     RuntimeStatus = "Running"
                 },
                 new OrchestrationInstanceStatus
                 {
+                    PartitionKey = "top-level",
+                    ParentInstanceId = "",
                     Name = "bar",
                     RuntimeStatus = "Completed"
                 },
                 new OrchestrationInstanceStatus
                 {
+                    PartitionKey = "legacy",
                     Name = "baz",
                     RuntimeStatus = "Failed"
                 }
@@ -111,6 +118,51 @@ namespace DurableTask.AzureStorage.Tests
                 Assert.AreEqual(expected[i].Name, actual[i].Name);
                 Assert.AreEqual(Enum.Parse(typeof(OrchestrationStatus), expected[i].RuntimeStatus), actual[i].OrchestrationStatus);
             }
+
+            // Child rows resolve to their parent; rows written for a top-level orchestration store an
+            // empty value to clear any stale parent, and legacy rows omit the property entirely. The
+            // latter two must both surface as a null ParentInstance.
+            Assert.AreEqual("parent", actual[0].ParentInstance.OrchestrationInstance.InstanceId);
+            Assert.IsNull(actual[1].ParentInstance);
+            Assert.IsNull(actual[2].ParentInstance);
+        }
+
+        [TestMethod]
+        public async Task InstanceStoreBackedTrackingStore_PersistsParentOnCreation()
+        {
+            const string ParentInstanceId = "parent";
+            OrchestrationStateInstanceEntity writtenState = null;
+            var instanceStore = new Mock<IOrchestrationServiceInstanceStore>(MockBehavior.Strict);
+            instanceStore
+                .Setup(store => store.WriteEntitiesAsync(It.IsAny<IEnumerable<InstanceEntityBase>>()))
+                .Callback<IEnumerable<InstanceEntityBase>>(entities => writtenState = entities.Single() as OrchestrationStateInstanceEntity)
+                .ReturnsAsync(new object());
+
+            var trackingStore = new InstanceStoreBackedTrackingStore(instanceStore.Object);
+            var startedEvent = new ExecutionStartedEvent(0, null)
+            {
+                Name = "child",
+                OrchestrationInstance = new OrchestrationInstance
+                {
+                    InstanceId = "child",
+                    ExecutionId = "execution",
+                },
+                ParentInstance = new ParentInstance
+                {
+                    OrchestrationInstance = new OrchestrationInstance
+                    {
+                        InstanceId = ParentInstanceId,
+                        ExecutionId = "parent-execution",
+                    },
+                },
+            };
+
+            bool created = await trackingStore.SetNewExecutionAsync(startedEvent, null, null);
+
+            Assert.IsTrue(created);
+            Assert.IsNotNull(writtenState);
+            Assert.AreSame(startedEvent.ParentInstance, writtenState.State.ParentInstance);
+            Assert.AreEqual(ParentInstanceId, writtenState.State.ParentInstance.OrchestrationInstance.InstanceId);
         }
     }
 }

--- a/test/DurableTask.AzureStorage.Tests/OrchestrationInstanceStatusQueryConditionTest.cs
+++ b/test/DurableTask.AzureStorage.Tests/OrchestrationInstanceStatusQueryConditionTest.cs
@@ -15,6 +15,7 @@ namespace DurableTask.AzureStorage.Tests
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using DurableTask.AzureStorage.Tracking;
     using DurableTask.Core;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -106,6 +107,29 @@ namespace DurableTask.AzureStorage.Tests
         {
             var condition = new OrchestrationInstanceStatusQueryCondition();
             Assert.IsTrue(string.IsNullOrWhiteSpace(condition.ToOData().Filter));
+        }
+
+        /// <summary>
+        /// When inputs and outputs are excluded, the query switches from "select everything" to an explicit
+        /// column projection. ParentInstanceId must stay in that projection, otherwise status queries that
+        /// omit inputs/outputs would silently return a null ParentInstance.
+        /// </summary>
+        [TestMethod]
+        public void OrchestrationInstanceQuery_ProjectionRetainsParentInstanceId()
+        {
+            var condition = new OrchestrationInstanceStatusQueryCondition
+            {
+                RuntimeStatus = new OrchestrationStatus[] { OrchestrationStatus.Running },
+                FetchInput = false,
+                FetchOutput = false,
+            };
+
+            IEnumerable<string> select = condition.ToOData().Select;
+
+            Assert.IsNotNull(select, "Excluding input and output should produce an explicit projection.");
+            CollectionAssert.Contains(select.ToList(), nameof(OrchestrationInstanceStatus.ParentInstanceId));
+            CollectionAssert.DoesNotContain(select.ToList(), nameof(OrchestrationInstanceStatus.Input));
+            CollectionAssert.DoesNotContain(select.ToList(), nameof(OrchestrationInstanceStatus.Output));
         }
 
         [TestMethod]

--- a/test/DurableTask.AzureStorage.Tests/ParentInstanceIdTrackingStoreTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/ParentInstanceIdTrackingStoreTests.cs
@@ -14,6 +14,7 @@
 namespace DurableTask.AzureStorage.Tests
 {
     using System;
+    using System.Linq;
     using System.Threading.Tasks;
     using Azure;
     using Azure.Data.Tables;
@@ -178,6 +179,63 @@ namespace DurableTask.AzureStorage.Tests
 
             InstanceStatus status = await this.trackingStore.FetchInstanceStatusAsync(childInstanceId);
             Assert.AreEqual(parentInstanceId, status.State.ParentInstance?.OrchestrationInstance.InstanceId);
+        }
+
+        /// <summary>
+        /// Verifies that a checkpoint whose NewEvents do not include the ExecutionStarted event still
+        /// writes the parent that belongs to the execution being checkpointed. Every instance-table write
+        /// merges a current ExecutionId, so a parent that is only written from the ExecutionStarted branch
+        /// would leave the row advertising a new execution alongside a parent carried over from a previous
+        /// orchestration that reused the same instance ID.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow(false, false)]
+        [DataRow(false, true)]
+        [DataRow(true, false)]
+        [DataRow(true, true)]
+        public async Task CheckpointWithoutExecutionStarted_WritesParentForCurrentExecution(bool useInstanceTableEtag, bool hasParent)
+        {
+            this.settings.UseInstanceTableEtag = useInstanceTableEtag;
+            string instanceId = $"reuse-{useInstanceTableEtag}-{hasParent}-{Guid.NewGuid():N}";
+            string currentParentInstanceId = hasParent ? $"parent-{Guid.NewGuid():N}" : null;
+            const string CurrentExecutionId = "execution-2";
+
+            // The seeded row stands in for a previous orchestration that used this instance ID and had a
+            // different parent. SeedInstanceRowAsync writes ExecutionId "execution-0".
+            await this.SeedInstanceRowAsync(instanceId, "stale-parent");
+            Assert.AreEqual("stale-parent", await this.GetRawParentInstanceIdAsync(instanceId), "Seeded row should carry the stale parent.");
+
+            OrchestrationInstanceStatus seeded = await this.GetRawEntityAsync(instanceId);
+            var eTags = new OrchestrationETags
+            {
+                InstanceETag = useInstanceTableEtag ? new ETag(seeded.ETag.ToString()) : (ETag?)null,
+            };
+
+            // Putting ExecutionStarted in PastEvents reproduces a mid-orchestration checkpoint: the parent
+            // is known to the runtime state, but no ExecutionStarted event is being persisted in this batch.
+            var runtimeState = new OrchestrationRuntimeState(
+                new HistoryEvent[] { CreateExecutionStartedEvent(instanceId, CurrentExecutionId, currentParentInstanceId) });
+            runtimeState.AddEvent(new OrchestratorStartedEvent(-1));
+
+            Assert.AreEqual(0, runtimeState.NewEvents.Count(e => e is ExecutionStartedEvent), "The checkpoint under test must not contain an ExecutionStarted event.");
+
+            await this.trackingStore.UpdateStateAsync(
+                runtimeState,
+                runtimeState,
+                instanceId,
+                CurrentExecutionId,
+                eTags,
+                await this.GetTrackingStoreContextAsync(instanceId));
+
+            OrchestrationInstanceStatus updated = await this.GetRawEntityAsync(instanceId);
+            Assert.AreEqual(CurrentExecutionId, updated.ExecutionId, "The checkpoint should have merged the current execution ID.");
+            Assert.AreEqual(
+                currentParentInstanceId ?? string.Empty,
+                updated.ParentInstanceId,
+                "The stored parent must match the execution recorded on the same row, not the parent of the previous instance.");
+
+            InstanceStatus status = await this.trackingStore.FetchInstanceStatusAsync(instanceId);
+            Assert.AreEqual(currentParentInstanceId, status.State.ParentInstance?.OrchestrationInstance.InstanceId);
         }
 
         /// <summary>

--- a/test/DurableTask.AzureStorage.Tests/ParentInstanceIdTrackingStoreTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/ParentInstanceIdTrackingStoreTests.cs
@@ -67,12 +67,12 @@ namespace DurableTask.AzureStorage.Tests
 
         /// <summary>
         /// Verifies that a no-parent write clears a parent ID left behind by a previous row with the same
-        /// instance ID. This is the merge-semantics case: <see cref="AzureTableTrackingStore"/> writes the
-        /// Instances row for a completed orchestration with InsertOrMerge, so a helper that skips the
-        /// property when there is no parent would leave the stale value in place.
+        /// instance ID. This covers the terminal-history repair write, which is unconditionally
+        /// InsertOrMerge, so a helper that skips the property when there is no parent would leave the
+        /// stale value in place.
         /// </summary>
         [TestMethod]
-        public async Task NoParentWrite_ClearsStaleParentInstanceId()
+        public async Task CompletedOrchestrationRepair_ClearsStaleParentInstanceId_WithInsertOrMerge()
         {
             string instanceId = $"stale-{Guid.NewGuid():N}";
 
@@ -96,28 +96,88 @@ namespace DurableTask.AzureStorage.Tests
         }
 
         /// <summary>
-        /// The same clearing behavior must hold for the ETag-based update path, which uses Merge rather
-        /// than InsertOrMerge. Both are merge operations, so both retain omitted properties.
+        /// The clearing behavior must also hold for the checkpoint write in
+        /// <see cref="AzureTableTrackingStore.UpdateStateAsync"/>, which routes through
+        /// UpdateInstanceTableAsync. That method picks InsertOrMerge when UseInstanceTableEtag is false and
+        /// Merge (with the supplied ETag) when it is true. Both are merge operations, so an omitted
+        /// property is retained and a previous parent would survive into an unrelated orchestration that
+        /// reused the instance ID. Seeding a row and passing its ETag is what makes the true case reach
+        /// MergeEntityAsync rather than the insert branch.
         /// </summary>
         [DataTestMethod]
         [DataRow(false)]
         [DataRow(true)]
-        public async Task NoParentWrite_ClearsStaleParentInstanceId_ForBothEtagModes(bool useInstanceTableEtag)
+        public async Task CheckpointWrite_ClearsStaleParentInstanceId_ForBothEtagModes(bool useInstanceTableEtag)
         {
             this.settings.UseInstanceTableEtag = useInstanceTableEtag;
             string instanceId = $"etag-{useInstanceTableEtag}-{Guid.NewGuid():N}";
 
             await this.SeedInstanceRowAsync(instanceId, "stale-parent");
+            Assert.AreEqual("stale-parent", await this.GetRawParentInstanceIdAsync(instanceId), "Seeded row should carry the stale parent.");
 
-            await this.trackingStore.UpdateInstanceStatusForCompletedOrchestrationAsync(
+            // Passing the seeded row's ETag forces the UseInstanceTableEtag=true case down the
+            // MergeEntityAsync branch; a null ETag there would insert instead of merging.
+            OrchestrationInstanceStatus seeded = await this.GetRawEntityAsync(instanceId);
+            var eTags = new OrchestrationETags
+            {
+                InstanceETag = useInstanceTableEtag ? new ETag(seeded.ETag.ToString()) : (ETag?)null,
+            };
+
+            var runtimeState = new OrchestrationRuntimeState();
+            runtimeState.AddEvent(CreateExecutionStartedEvent(instanceId, "execution-1", parentInstanceId: null));
+
+            await this.trackingStore.UpdateStateAsync(
+                runtimeState,
+                runtimeState,
                 instanceId,
-                executionId: "execution-1",
-                runtimeState: CreateCompletedRuntimeState(instanceId, "execution-1", parentInstanceId: null),
-                instanceEntityExists: true);
+                "execution-1",
+                eTags,
+                await this.GetTrackingStoreContextAsync(instanceId));
 
-            Assert.AreEqual(string.Empty, await this.GetRawParentInstanceIdAsync(instanceId));
+            Assert.AreEqual(
+                string.Empty,
+                await this.GetRawParentInstanceIdAsync(instanceId),
+                "The checkpoint write must clear the stored property, otherwise merge semantics retain the stale parent.");
+
             InstanceStatus status = await this.trackingStore.FetchInstanceStatusAsync(instanceId);
-            Assert.IsNull(status.State.ParentInstance);
+            Assert.IsNull(status.State.ParentInstance, "A cleared parent must read back as a null ParentInstance.");
+        }
+
+        /// <summary>
+        /// The checkpoint write must also persist a non-null parent, for both update modes.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public async Task CheckpointWrite_PersistsParentInstanceId_ForBothEtagModes(bool useInstanceTableEtag)
+        {
+            this.settings.UseInstanceTableEtag = useInstanceTableEtag;
+            string parentInstanceId = $"parent-{Guid.NewGuid():N}";
+            string childInstanceId = $"{parentInstanceId}:child";
+
+            await this.SeedInstanceRowAsync(childInstanceId, parentInstanceId: null);
+
+            OrchestrationInstanceStatus seeded = await this.GetRawEntityAsync(childInstanceId);
+            var eTags = new OrchestrationETags
+            {
+                InstanceETag = useInstanceTableEtag ? new ETag(seeded.ETag.ToString()) : (ETag?)null,
+            };
+
+            var runtimeState = new OrchestrationRuntimeState();
+            runtimeState.AddEvent(CreateExecutionStartedEvent(childInstanceId, "execution-1", parentInstanceId));
+
+            await this.trackingStore.UpdateStateAsync(
+                runtimeState,
+                runtimeState,
+                childInstanceId,
+                "execution-1",
+                eTags,
+                await this.GetTrackingStoreContextAsync(childInstanceId));
+
+            Assert.AreEqual(parentInstanceId, await this.GetRawParentInstanceIdAsync(childInstanceId));
+
+            InstanceStatus status = await this.trackingStore.FetchInstanceStatusAsync(childInstanceId);
+            Assert.AreEqual(parentInstanceId, status.State.ParentInstance?.OrchestrationInstance.InstanceId);
         }
 
         /// <summary>
@@ -223,10 +283,25 @@ namespace DurableTask.AzureStorage.Tests
                 ["LastUpdatedTime"] = DateTime.UtcNow,
                 ["TaskHubName"] = this.taskHubName,
                 ["ExecutionId"] = "execution-0",
-                [ParentInstanceIdProperty] = parentInstanceId,
             };
 
+            // A null parent seeds a row with no property at all, which is also the legacy row shape.
+            if (parentInstanceId != null)
+            {
+                entity[ParentInstanceIdProperty] = parentInstanceId;
+            }
+
             await this.trackingStore.InstancesTable.InsertOrMergeEntityAsync(entity);
+        }
+
+        /// <summary>
+        /// UpdateStateAsync casts the tracking-store context to a private type, so the only legitimate way
+        /// to obtain one is from the production history read, which is exactly what the dispatcher does.
+        /// </summary>
+        async Task<object> GetTrackingStoreContextAsync(string instanceId)
+        {
+            OrchestrationHistory history = await this.trackingStore.GetHistoryEventsAsync(instanceId, expectedExecutionId: null);
+            return history.TrackingStoreContext;
         }
 
         async Task<OrchestrationInstanceStatus> GetRawEntityAsync(string instanceId)

--- a/test/DurableTask.AzureStorage.Tests/ParentInstanceIdTrackingStoreTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/ParentInstanceIdTrackingStoreTests.cs
@@ -1,0 +1,293 @@
+//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureStorage.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using Azure;
+    using Azure.Data.Tables;
+    using DurableTask.AzureStorage.Storage;
+    using DurableTask.AzureStorage.Tracking;
+    using DurableTask.Core;
+    using DurableTask.Core.History;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// Tests that exercise the <c>ParentInstanceId</c> Instances-table property against a real storage
+    /// account, so that the actual Azure Table update semantics (InsertOrMerge / Merge) are covered.
+    /// Assertions are made on the raw stored property in addition to the public read conversion,
+    /// because a merge-based write that omits the property leaves a previous value intact and would
+    /// otherwise be invisible to a test that only inspects converted state.
+    /// </summary>
+    [TestClass]
+    public class ParentInstanceIdTrackingStoreTests
+    {
+        const string ParentInstanceIdProperty = "ParentInstanceId";
+
+        string taskHubName;
+        AzureStorageOrchestrationServiceSettings settings;
+        AzureStorageClient azureStorageClient;
+        AzureTableTrackingStore trackingStore;
+
+        [TestInitialize]
+        public async Task Initialize()
+        {
+            // A unique task hub per test keeps the Instances/History tables isolated, so a leftover row
+            // from another test cannot mask a missing write.
+            this.taskHubName = "pid" + Guid.NewGuid().ToString("N").Substring(0, 12);
+            this.settings = TestHelpers.GetTestAzureStorageOrchestrationServiceSettings(enableExtendedSessions: false);
+            this.settings.TaskHubName = this.taskHubName;
+
+            this.azureStorageClient = new AzureStorageClient(this.settings);
+            var messageManager = new MessageManager(this.settings, this.azureStorageClient, $"{this.taskHubName}-largemessages".ToLowerInvariant());
+            this.trackingStore = new AzureTableTrackingStore(this.azureStorageClient, messageManager);
+            await this.trackingStore.CreateAsync();
+        }
+
+        [TestCleanup]
+        public async Task Cleanup()
+        {
+            // Delete the per-test tables so repeated runs do not leak storage resources.
+            if (this.trackingStore != null)
+            {
+                await this.trackingStore.DeleteAsync();
+            }
+        }
+
+        /// <summary>
+        /// Verifies that a no-parent write clears a parent ID left behind by a previous row with the same
+        /// instance ID. This is the merge-semantics case: <see cref="AzureTableTrackingStore"/> writes the
+        /// Instances row for a completed orchestration with InsertOrMerge, so a helper that skips the
+        /// property when there is no parent would leave the stale value in place.
+        /// </summary>
+        [TestMethod]
+        public async Task NoParentWrite_ClearsStaleParentInstanceId()
+        {
+            string instanceId = $"stale-{Guid.NewGuid():N}";
+
+            await this.SeedInstanceRowAsync(instanceId, "stale-parent");
+            Assert.AreEqual("stale-parent", await this.GetRawParentInstanceIdAsync(instanceId), "Seeded row should carry the stale parent.");
+
+            // Drive a genuine no-parent write through the same production path that uses InsertOrMerge.
+            await this.trackingStore.UpdateInstanceStatusForCompletedOrchestrationAsync(
+                instanceId,
+                executionId: "execution-1",
+                runtimeState: CreateCompletedRuntimeState(instanceId, "execution-1", parentInstanceId: null),
+                instanceEntityExists: true);
+
+            Assert.AreEqual(
+                string.Empty,
+                await this.GetRawParentInstanceIdAsync(instanceId),
+                "A no-parent write must clear the stored property, otherwise merge semantics retain the stale parent.");
+
+            InstanceStatus status = await this.trackingStore.FetchInstanceStatusAsync(instanceId);
+            Assert.IsNull(status.State.ParentInstance, "A cleared parent must read back as a null ParentInstance.");
+        }
+
+        /// <summary>
+        /// The same clearing behavior must hold for the ETag-based update path, which uses Merge rather
+        /// than InsertOrMerge. Both are merge operations, so both retain omitted properties.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public async Task NoParentWrite_ClearsStaleParentInstanceId_ForBothEtagModes(bool useInstanceTableEtag)
+        {
+            this.settings.UseInstanceTableEtag = useInstanceTableEtag;
+            string instanceId = $"etag-{useInstanceTableEtag}-{Guid.NewGuid():N}";
+
+            await this.SeedInstanceRowAsync(instanceId, "stale-parent");
+
+            await this.trackingStore.UpdateInstanceStatusForCompletedOrchestrationAsync(
+                instanceId,
+                executionId: "execution-1",
+                runtimeState: CreateCompletedRuntimeState(instanceId, "execution-1", parentInstanceId: null),
+                instanceEntityExists: true);
+
+            Assert.AreEqual(string.Empty, await this.GetRawParentInstanceIdAsync(instanceId));
+            InstanceStatus status = await this.trackingStore.FetchInstanceStatusAsync(instanceId);
+            Assert.IsNull(status.State.ParentInstance);
+        }
+
+        /// <summary>
+        /// Verifies that the terminal-history repair path persists the parent ID when it recreates an
+        /// Instances row that no longer exists. This is the projection-repair case that runs when a worker
+        /// fails after writing history but before updating the Instances table, which is common for
+        /// sub-orchestrations that complete within a single execution.
+        /// </summary>
+        [TestMethod]
+        public async Task CompletedOrchestrationRepair_PersistsParentInstanceId()
+        {
+            string parentInstanceId = $"parent-{Guid.NewGuid():N}";
+            string childInstanceId = $"{parentInstanceId}:child";
+
+            // No row is seeded: this mirrors a sub-orchestration whose Instances projection was never written.
+            await this.trackingStore.UpdateInstanceStatusForCompletedOrchestrationAsync(
+                childInstanceId,
+                executionId: "execution-1",
+                runtimeState: CreateCompletedRuntimeState(childInstanceId, "execution-1", parentInstanceId),
+                instanceEntityExists: false);
+
+            Assert.AreEqual(parentInstanceId, await this.GetRawParentInstanceIdAsync(childInstanceId));
+
+            InstanceStatus status = await this.trackingStore.FetchInstanceStatusAsync(childInstanceId);
+            Assert.AreEqual(parentInstanceId, status.State.ParentInstance?.OrchestrationInstance.InstanceId);
+        }
+
+        /// <summary>
+        /// Verifies the repair path also overwrites a stale parent on an Instances row that already exists.
+        /// </summary>
+        [TestMethod]
+        public async Task CompletedOrchestrationRepair_OverwritesStaleParentInstanceId()
+        {
+            string parentInstanceId = $"parent-{Guid.NewGuid():N}";
+            string childInstanceId = $"{parentInstanceId}:child";
+
+            await this.SeedInstanceRowAsync(childInstanceId, "stale-parent");
+
+            await this.trackingStore.UpdateInstanceStatusForCompletedOrchestrationAsync(
+                childInstanceId,
+                executionId: "execution-1",
+                runtimeState: CreateCompletedRuntimeState(childInstanceId, "execution-1", parentInstanceId),
+                instanceEntityExists: true);
+
+            Assert.AreEqual(parentInstanceId, await this.GetRawParentInstanceIdAsync(childInstanceId));
+        }
+
+        /// <summary>
+        /// Verifies the initial instance-creation write persists a non-null parent. This is the write that
+        /// happens when an orchestration is created through the client creation path with a parent supplied
+        /// on the ExecutionStartedEvent.
+        /// </summary>
+        [TestMethod]
+        public async Task SetNewExecution_PersistsNonNullParentInstanceId()
+        {
+            string parentInstanceId = $"parent-{Guid.NewGuid():N}";
+            string childInstanceId = $"{parentInstanceId}:child";
+
+            bool created = await this.trackingStore.SetNewExecutionAsync(
+                CreateExecutionStartedEvent(childInstanceId, "execution-1", parentInstanceId),
+                eTag: null,
+                inputPayloadOverride: null);
+
+            Assert.IsTrue(created);
+            Assert.AreEqual(parentInstanceId, await this.GetRawParentInstanceIdAsync(childInstanceId));
+
+            InstanceStatus status = await this.trackingStore.FetchInstanceStatusAsync(childInstanceId);
+            Assert.AreEqual(parentInstanceId, status.State.ParentInstance?.OrchestrationInstance.InstanceId);
+        }
+
+        /// <summary>
+        /// Verifies the initial creation write clears a stale parent when the new execution has none. A
+        /// re-created instance reuses the partition key, and this write path can replace an earlier row.
+        /// </summary>
+        [TestMethod]
+        public async Task SetNewExecution_ClearsStaleParentInstanceId()
+        {
+            string instanceId = $"recreate-{Guid.NewGuid():N}";
+
+            await this.SeedInstanceRowAsync(instanceId, "stale-parent");
+            OrchestrationInstanceStatus seeded = await this.GetRawEntityAsync(instanceId);
+
+            bool created = await this.trackingStore.SetNewExecutionAsync(
+                CreateExecutionStartedEvent(instanceId, "execution-2", parentInstanceId: null),
+                eTag: new ETag(seeded.ETag.ToString()),
+                inputPayloadOverride: null);
+
+            Assert.IsTrue(created);
+            Assert.AreEqual(string.Empty, await this.GetRawParentInstanceIdAsync(instanceId));
+        }
+
+        /// <summary>
+        /// Seeds an Instances row that already carries a parent ID, simulating a row written by a previous
+        /// orchestration that reused the same instance ID.
+        /// </summary>
+        async Task SeedInstanceRowAsync(string instanceId, string parentInstanceId)
+        {
+            var entity = new TableEntity(KeySanitation.EscapePartitionKey(instanceId), string.Empty)
+            {
+                ["Name"] = "SeededOrchestration",
+                ["RuntimeStatus"] = OrchestrationStatus.Running.ToString(),
+                ["CreatedTime"] = DateTime.UtcNow,
+                ["LastUpdatedTime"] = DateTime.UtcNow,
+                ["TaskHubName"] = this.taskHubName,
+                ["ExecutionId"] = "execution-0",
+                [ParentInstanceIdProperty] = parentInstanceId,
+            };
+
+            await this.trackingStore.InstancesTable.InsertOrMergeEntityAsync(entity);
+        }
+
+        async Task<OrchestrationInstanceStatus> GetRawEntityAsync(string instanceId)
+        {
+            string filter = AzureTableQueryFilter.PartitionKeyEquals(KeySanitation.EscapePartitionKey(instanceId));
+            await foreach (OrchestrationInstanceStatus entity in this.trackingStore.InstancesTable.ExecuteQueryAsync<OrchestrationInstanceStatus>(filter))
+            {
+                return entity;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Reads the stored property directly rather than the converted state, so that a value which was
+        /// merely left untouched by a merge is still visible to the assertion.
+        /// </summary>
+        async Task<string> GetRawParentInstanceIdAsync(string instanceId)
+        {
+            OrchestrationInstanceStatus entity = await this.GetRawEntityAsync(instanceId);
+            Assert.IsNotNull(entity, $"Expected an Instances row for '{instanceId}'.");
+            return entity.ParentInstanceId;
+        }
+
+        static ExecutionStartedEvent CreateExecutionStartedEvent(string instanceId, string executionId, string parentInstanceId)
+        {
+            var executionStartedEvent = new ExecutionStartedEvent(-1, "input")
+            {
+                Name = "TestOrchestration",
+                Version = string.Empty,
+                OrchestrationInstance = new OrchestrationInstance
+                {
+                    InstanceId = instanceId,
+                    ExecutionId = executionId,
+                },
+            };
+
+            if (parentInstanceId != null)
+            {
+                executionStartedEvent.ParentInstance = new ParentInstance
+                {
+                    OrchestrationInstance = new OrchestrationInstance
+                    {
+                        InstanceId = parentInstanceId,
+                        ExecutionId = "parent-execution",
+                    },
+                    Name = "ParentOrchestration",
+                    Version = string.Empty,
+                    TaskScheduleId = 1,
+                };
+            }
+
+            return executionStartedEvent;
+        }
+
+        static OrchestrationRuntimeState CreateCompletedRuntimeState(string instanceId, string executionId, string parentInstanceId)
+        {
+            var runtimeState = new OrchestrationRuntimeState();
+            runtimeState.AddEvent(CreateExecutionStartedEvent(instanceId, executionId, parentInstanceId));
+            runtimeState.AddEvent(new ExecutionCompletedEvent(-1, "output", OrchestrationStatus.Completed));
+            return runtimeState;
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/Azure/durabletask/issues/618

Enables https://github.com/Azure/azure-functions-durable-extension/issues/3515 to expose `parentInstanceId` for the Azure Storage provider, matching MSSQL semantics.

## Before / after

Before, Azure Storage retained parent metadata only in history, so existing get/query status paths returned `OrchestrationState.ParentInstance == null` for sub-orchestrations. After this change, the Instances row stores only the parent instance ID and the existing row-to-state conversion reconstructs `ParentInstance.OrchestrationInstance.InstanceId`.

## Implementation

- Adds one Instances-table string property: `ParentInstanceId`.
- Sources it from `ExecutionStartedEvent.ParentInstance.OrchestrationInstance.InstanceId`.
- Writes it in new-execution, execution-started update, and fast-completion/recreated-row paths.
- Preserves `ParentInstance` in `InstanceStoreBackedTrackingStore`.
- Uses an empty value for no parent because update/recreation paths use Azure Table merge/upsert-merge semantics; omitting a property could preserve a stale parent on a reused row. Reads treat empty and legacy missing properties as null.
- Adds no history reads, status-query round trips, N+1 behavior, or unrelated API/protobuf changes.

## Coverage

Behavioral coverage:

- Exact child parent ID via direct get and list/query.
- Top-level direct/query state remains null.
- Legacy missing-property rows remain null.
- Terminal-history repair recreates a missing Instances row with the parent ID, and overwrites a stale one.
- Child `ContinueAsNew` retains parent metadata.
- Alternate `InstanceStoreBackedTrackingStore` preserves the original `ParentInstance`.
- `ParentInstanceId` stays in the OData projection when `FetchInput`/`FetchOutput` are false, so status queries that exclude payloads still return the parent.

Write-path coverage against real Azure Table update semantics. Each production write site is covered by a test that asserts the **raw stored property**, not just the converted state, so a value merely retained by a merge cannot produce a false positive:

| Production site | Update mode | Covering tests |
| --- | --- | --- |
| `SetNewExecutionAsync` | Insert / Replace | `SetNewExecution_PersistsNonNullParentInstanceId`, `SetNewExecution_ClearsStaleParentInstanceId` |
| `UpdateStateAsync` ExecutionStarted → `UpdateInstanceTableAsync` | InsertOrMerge (`UseInstanceTableEtag=false`) and Merge with ETag (`true`) | `CheckpointWrite_PersistsParentInstanceId_ForBothEtagModes`, `CheckpointWrite_ClearsStaleParentInstanceId_ForBothEtagModes` |
| `UpdateInstanceStatusForCompletedOrchestrationAsync` | InsertOrMerge | `CompletedOrchestrationRepair_PersistsParentInstanceId`, `CompletedOrchestrationRepair_OverwritesStaleParentInstanceId`, `CompletedOrchestrationRepair_ClearsStaleParentInstanceId_WithInsertOrMerge` |
| `ConvertFromAsync` read mapping | n/a | `QueryStatus_WithContinuationToken_NoInputToken` |
| `InstanceStoreBackedTrackingStore` creation | n/a | `InstanceStoreBackedTrackingStore_PersistsParentOnCreation` |

Both `UseInstanceTableEtag` modes are genuinely exercised, not merely toggled: the tests seed a row and pass its real ETag so the `true` case reaches `MergeEntityAsync` rather than the insert branch. This was verified with a branch probe that drops the property in only one branch of `UpdateInstanceTableAsync` — probing the Merge branch fails exactly the two `(True)` rows, and probing the InsertOrMerge branch fails exactly the two `(False)` rows.

Mutation testing confirms each test actually proves its production behavior. Removing or weakening a site fails the listed tests:

| Mutation | Tests that fail |
| --- | --- |
| Parent assignment helper reverted to a conditional write (skip when empty) | 4: both `..._ClearsStale...` checkpoint rows, the InsertOrMerge repair clearing test, and `SetNewExecution_ClearsStaleParentInstanceId` |
| Remove the terminal-history repair write | 3 `CompletedOrchestrationRepair_*` tests |
| Remove the checkpoint ExecutionStarted write | all 4 `CheckpointWrite_*` rows |
| Remove the initial `SetNewExecutionAsync` write | both `SetNewExecution_*` tests |
| Drop `ParentInstanceId` from the OData projection | `OrchestrationInstanceQuery_ProjectionRetainsParentInstanceId` |
| Remove the read-side mapping | `QueryStatus_WithContinuationToken_NoInputToken` |
| Remove the alternate-store assignment | `InstanceStoreBackedTrackingStore_PersistsParentOnCreation` |

`ParentMetadataIsReturnedForFastCompletingChild` was renamed to `ParentMetadataIsReturnedByDirectGetAndQuery`, because it exercises the normal checkpoint write and the read paths rather than the terminal-history repair path; repair is covered directly by the `CompletedOrchestrationRepair_*` tests.

## Validation

Local:

- `dotnet build test\DurableTask.AzureStorage.Tests\DurableTask.AzureStorage.Tests.csproj` (clean build, `bin`/`obj` removed first) — passed, 0 warnings, 0 errors.
- `git diff --check` — clean.

Hosted Azure Storage (approved non-production subscription `edc48857-dd0b-4085-a2a9-5e7df12bd2fd`, verified by re-reading the subscription ID before provisioning):

- Resource group `dtfx-pmverify-5fab2bb3c3`, storage account `dtfxpv5fab2bb3c3` (`StorageV2`, `Standard_LRS`, `eastus`), tagged for validation and ephemeral cleanup.
- Harness: process-scoped `DurableTaskTestStorageConnectionString`.
- Command: `dotnet test test\DurableTask.AzureStorage.Tests\DurableTask.AzureStorage.Tests.csproj -f net8.0 --no-build --filter "FullyQualifiedName~ParentInstanceIdTrackingStoreTests|FullyQualifiedName~AzureTableTrackingStoreTest|FullyQualifiedName~OrchestrationInstanceStatusQueryConditionTest|FullyQualifiedName~ParentMetadata"`
- Result: **30/30 passed**, 0 failed, 0 skipped. Includes both `ParentMetadata*` provider scenarios, all 9 `ParentInstanceIdTrackingStoreTests` (both `CheckpointWrite` DataRow values), the tracking-store conversion tests, and the query projection tests.
- Cleanup proof: `az group exists --subscription edc48857-dd0b-4085-a2a9-5e7df12bd2fd --name dtfx-pmverify-5fab2bb3c3` → `false`. Earlier validation groups `dtfx-pmtests-e1997043f4` and `dtfx-pmfix-81e0870dc4` are also deleted and verified `false`; no resources remain.

Test-only follow-up commits on top of the implementation commit add the mutation-effective write-path tests and the corrected ETag merge coverage. Production behavior is unchanged by those commits.
