### PR TITLE
Remove  durabletask-core-v2 branch from public build triggers

### DIFF
--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -6,7 +6,6 @@ trigger:
   branches:
     include:
     - main
-    - durabletask-core-v2
     - vabachu/v320-release
 
 # Run nightly to catch new CVEs and to report SDL often.
@@ -16,7 +15,6 @@ schedules:
     branches:
       include:
       - main
-      - durabletask-core-v2
     always: true # Run pipeline irrespective of no code changes since last successful run
 
 # Run on all PRs

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -6,7 +6,6 @@ trigger:
   branches:
     include:
     - main
-    - vabachu/v320-release
 
 # Run nightly to catch new CVEs and to report SDL often.
 schedules:


### PR DESCRIPTION
The durabletask-core-v2 branch has been inactive for ~2 years and no longer needs scheduled or CI builds. This removes it from the CI trigger: and nightly schedules: in the public build pipeline so it no longer runs.