### PR TITLE
Release abandoned orchestrator tasks when an executor is retired

### DIFF
--- a/Test/DurableTask.Core.Tests/TaskOrchestrationExecutorTests.cs
+++ b/Test/DurableTask.Core.Tests/TaskOrchestrationExecutorTests.cs
@@ -31,7 +31,7 @@ namespace DurableTask.Core.Tests
     /// sub-orchestration, and timer it is waiting on, and those tasks are abandoned in a pending state when
     /// the episode ends. When a debugger is attached, the CLR keeps every awaited task in the process-wide
     /// <c>Task.s_currentActiveTasks</c> dictionary until the task completes, so abandoned awaits permanently
-    /// root the orchestration object graph. Disposing the executor cancels the open tasks, which lets those
+    /// root the orchestration object graph. Releasing the executor cancels the open tasks, which lets those
     /// awaiter continuations run and unregister themselves.
     /// Regression coverage for https://github.com/Azure/azure-functions-durable-extension/issues/340.
     /// </remarks>
@@ -41,25 +41,25 @@ namespace DurableTask.Core.Tests
         const string ActivityName = "SayHello";
 
         [TestMethod]
-        public void Dispose_ResumesAbandonedOrchestratorContinuations()
+        public void Release_ResumesAbandonedOrchestratorContinuations()
         {
             var orchestration = new FanOutOrchestration(fanOut: 3);
-            using (var executor = CreateExecutor(orchestration))
-            {
-                executor.Execute();
+            TaskOrchestrationExecutor executor = CreateExecutor(orchestration);
+            executor.Execute();
 
-                Assert.AreEqual(3, orchestration.StartedTaskCount, "The orchestrator should have scheduled 3 activities.");
-                Assert.AreEqual(0, orchestration.ReleasedTaskCount, "Abandoned awaits should still be pending at the end of the episode.");
-            }
+            Assert.AreEqual(3, orchestration.StartedTaskCount, "The orchestrator should have scheduled 3 activities.");
+            Assert.AreEqual(0, orchestration.ReleasedTaskCount, "Abandoned awaits should still be pending at the end of the episode.");
+
+            executor.Release();
 
             Assert.AreEqual(
                 3,
                 orchestration.ReleasedTaskCount,
-                "Disposing the executor should resume every abandoned await so its continuation can unregister itself.");
+                "Releasing the executor should resume every abandoned await so its continuation can unregister itself.");
         }
 
         [TestMethod]
-        public void Dispose_WithAsyncDebuggingEnabled_DoesNotLeakActiveTasks()
+        public void Release_WithAsyncDebuggingEnabled_DoesNotLeakActiveTasks()
         {
             // This is the actual bug: with a debugger attached, every abandoned await stays in
             // Task.s_currentActiveTasks forever, which roots the entire orchestration object graph.
@@ -75,20 +75,20 @@ namespace DurableTask.Core.Tests
             using (AsyncDebuggingScope.Enable())
             {
                 // Warm up so that one-time allocations aren't counted against the measurement.
-                RunEpisodes(Episodes, SmallFanOut, dispose: true);
+                RunEpisodes(Episodes, SmallFanOut, release: true);
 
-                int leakySensitivity = MeasureFanOutSensitivity(Episodes, SmallFanOut, LargeFanOut, dispose: false);
+                int leakySensitivity = MeasureFanOutSensitivity(Episodes, SmallFanOut, LargeFanOut, release: false);
                 Assert.IsTrue(
                     leakySensitivity > Episodes * (LargeFanOut - SmallFanOut),
-                    "Undisposed executors are expected to leak one entry per abandoned await; if they no longer " +
+                    "Unreleased executors are expected to leak one entry per abandoned await; if they no longer " +
                     $"do, this test can no longer detect the regression. Measured {leakySensitivity}.");
 
-                int fixedSensitivity = MeasureFanOutSensitivity(Episodes, SmallFanOut, LargeFanOut, dispose: true);
+                int fixedSensitivity = MeasureFanOutSensitivity(Episodes, SmallFanOut, LargeFanOut, release: true);
                 Assert.IsTrue(
                     fixedSensitivity * 20 < leakySensitivity,
-                    "Disposing the executor must stop Task.s_currentActiveTasks from growing with the number of " +
+                    "Releasing the executor must stop Task.s_currentActiveTasks from growing with the number of " +
                     $"abandoned awaits, but growth was still {fixedSensitivity} against {leakySensitivity} when " +
-                    "the executors were left undisposed.");
+                    "the executors were left unreleased.");
             }
         }
 
@@ -97,23 +97,23 @@ namespace DurableTask.Core.Tests
         /// awaits per episode than it does for <paramref name="smallFanOut"/>. Constant per-episode overhead
         /// and unrelated test host activity cancel out, leaving only growth caused by abandoned awaits.
         /// </summary>
-        static int MeasureFanOutSensitivity(int episodes, int smallFanOut, int largeFanOut, bool dispose)
+        static int MeasureFanOutSensitivity(int episodes, int smallFanOut, int largeFanOut, bool release)
         {
-            int small = RunEpisodes(episodes, smallFanOut, dispose);
-            int large = RunEpisodes(episodes, largeFanOut, dispose);
+            int small = RunEpisodes(episodes, smallFanOut, release);
+            int large = RunEpisodes(episodes, largeFanOut, release);
             return large - small;
         }
 
-        static int RunEpisodes(int episodes, int fanOut, bool dispose)
+        static int RunEpisodes(int episodes, int fanOut, bool release)
         {
             int before = AsyncDebuggingScope.ActiveTaskCount;
             for (int i = 0; i < episodes; i++)
             {
                 TaskOrchestrationExecutor executor = CreateExecutor(new FanOutOrchestration(fanOut));
                 executor.Execute();
-                if (dispose)
+                if (release)
                 {
-                    executor.Dispose();
+                    executor.Release();
                 }
             }
 
@@ -121,31 +121,30 @@ namespace DurableTask.Core.Tests
         }
 
         [TestMethod]
-        public void Dispose_DoesNotChangeTheDecisionsAlreadyProduced()
+        public void Release_DoesNotChangeTheDecisionsAlreadyProduced()
         {
             var orchestration = new FanOutOrchestration(fanOut: 3);
-            using (var executor = CreateExecutor(orchestration))
-            {
-                OrchestratorExecutionResult result = executor.Execute();
-                List<OrchestratorAction> before = result.Actions.ToList();
+            TaskOrchestrationExecutor executor = CreateExecutor(orchestration);
 
-                executor.Dispose();
+            OrchestratorExecutionResult result = executor.Execute();
+            List<OrchestratorAction> before = result.Actions.ToList();
 
-                CollectionAssert.AreEqual(
-                    before,
-                    result.Actions.ToList(),
-                    "Releasing abandoned tasks must not add or remove orchestrator actions.");
-            }
+            executor.Release();
+
+            CollectionAssert.AreEqual(
+                before,
+                result.Actions.ToList(),
+                "Releasing abandoned tasks must not add or remove orchestrator actions.");
         }
 
         [TestMethod]
-        public void Dispose_OrchestratorThatSwallowsCancellation_CannotScheduleMoreWork()
+        public void Release_OrchestratorThatSwallowsCancellation_CannotScheduleMoreWork()
         {
             var orchestration = new SwallowsCancellationOrchestration();
-            using (var executor = CreateExecutor(orchestration))
-            {
-                executor.Execute();
-            }
+            TaskOrchestrationExecutor executor = CreateExecutor(orchestration);
+            executor.Execute();
+
+            executor.Release();
 
             Assert.IsInstanceOfType(
                 orchestration.RescheduleFailure,
@@ -154,16 +153,16 @@ namespace DurableTask.Core.Tests
         }
 
         [TestMethod]
-        public void Dispose_IsIdempotent()
+        public void Release_IsIdempotent()
         {
             var orchestration = new FanOutOrchestration(fanOut: 2);
-            var executor = CreateExecutor(orchestration);
+            TaskOrchestrationExecutor executor = CreateExecutor(orchestration);
             executor.Execute();
 
-            executor.Dispose();
-            executor.Dispose();
+            executor.Release();
+            executor.Release();
 
-            Assert.AreEqual(2, orchestration.ReleasedTaskCount, "Repeated disposal should not resume continuations more than once.");
+            Assert.AreEqual(2, orchestration.ReleasedTaskCount, "Repeated release should not resume continuations more than once.");
         }
 
         [TestMethod]
@@ -174,24 +173,23 @@ namespace DurableTask.Core.Tests
             var orchestration = new FanOutOrchestration(fanOut: 1);
             OrchestrationRuntimeState runtimeState = CreateRuntimeState();
 
-            using (var executor = new TaskOrchestrationExecutor(runtimeState, orchestration, BehaviorOnContinueAsNew.Carryover))
-            {
-                OrchestratorExecutionResult firstEpisode = executor.Execute();
-                Assert.AreEqual(1, firstEpisode.Actions.Count(), "The first episode should schedule the activity.");
-                Assert.IsFalse(executor.IsCompleted);
+            var executor = new TaskOrchestrationExecutor(runtimeState, orchestration, BehaviorOnContinueAsNew.Carryover);
 
-                runtimeState.NewEvents.Clear();
-                runtimeState.AddEvent(new OrchestratorStartedEvent(-1));
-                runtimeState.AddEvent(new TaskCompletedEvent(-1, taskScheduledId: 0, result: JsonDataConverter.Default.Serialize("Hello")));
+            OrchestratorExecutionResult firstEpisode = executor.Execute();
+            Assert.AreEqual(1, firstEpisode.Actions.Count(), "The first episode should schedule the activity.");
+            Assert.IsFalse(executor.IsCompleted);
 
-                OrchestratorExecutionResult secondEpisode = executor.ExecuteNewEvents();
+            runtimeState.NewEvents.Clear();
+            runtimeState.AddEvent(new OrchestratorStartedEvent(-1));
+            runtimeState.AddEvent(new TaskCompletedEvent(-1, taskScheduledId: 0, result: JsonDataConverter.Default.Serialize("Hello")));
 
-                Assert.IsTrue(executor.IsCompleted, "The activity result should have been delivered to the still-open task.");
-                Assert.AreEqual(1, orchestration.ReleasedTaskCount, "The await should have been resumed by its result, not by cancellation.");
-                Assert.IsTrue(
-                    secondEpisode.Actions.OfType<OrchestrationCompleteOrchestratorAction>().Any(),
-                    "The orchestration should have completed on the second episode.");
-            }
+            OrchestratorExecutionResult secondEpisode = executor.ExecuteNewEvents();
+
+            Assert.IsTrue(executor.IsCompleted, "The activity result should have been delivered to the still-open task.");
+            Assert.AreEqual(1, orchestration.ReleasedTaskCount, "The await should have been resumed by its result, not by cancellation.");
+            Assert.IsTrue(
+                secondEpisode.Actions.OfType<OrchestrationCompleteOrchestratorAction>().Any(),
+                "The orchestration should have completed on the second episode.");
         }
 
         static TaskOrchestrationExecutor CreateExecutor(TaskOrchestration orchestration) =>

--- a/Test/DurableTask.Core.Tests/TaskOrchestrationExecutorTests.cs
+++ b/Test/DurableTask.Core.Tests/TaskOrchestrationExecutorTests.cs
@@ -1,0 +1,344 @@
+//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Threading.Tasks;
+    using DurableTask.Core.Command;
+    using DurableTask.Core.History;
+    using DurableTask.Core.Serializing;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// Tests for <see cref="TaskOrchestrationExecutor"/> lifetime management.
+    /// </summary>
+    /// <remarks>
+    /// An orchestrator parks on a <see cref="TaskCompletionSource{TResult}"/> for every activity,
+    /// sub-orchestration, and timer it is waiting on, and those tasks are abandoned in a pending state when
+    /// the episode ends. When a debugger is attached, the CLR keeps every awaited task in the process-wide
+    /// <c>Task.s_currentActiveTasks</c> dictionary until the task completes, so abandoned awaits permanently
+    /// root the orchestration object graph. Disposing the executor cancels the open tasks, which lets those
+    /// awaiter continuations run and unregister themselves.
+    /// Regression coverage for https://github.com/Azure/azure-functions-durable-extension/issues/340.
+    /// </remarks>
+    [TestClass]
+    public class TaskOrchestrationExecutorTests
+    {
+        const string ActivityName = "SayHello";
+
+        [TestMethod]
+        public void Dispose_ResumesAbandonedOrchestratorContinuations()
+        {
+            var orchestration = new FanOutOrchestration(fanOut: 3);
+            using (var executor = CreateExecutor(orchestration))
+            {
+                executor.Execute();
+
+                Assert.AreEqual(3, orchestration.StartedTaskCount, "The orchestrator should have scheduled 3 activities.");
+                Assert.AreEqual(0, orchestration.ReleasedTaskCount, "Abandoned awaits should still be pending at the end of the episode.");
+            }
+
+            Assert.AreEqual(
+                3,
+                orchestration.ReleasedTaskCount,
+                "Disposing the executor should resume every abandoned await so its continuation can unregister itself.");
+        }
+
+        [TestMethod]
+        public void Dispose_WithAsyncDebuggingEnabled_DoesNotLeakActiveTasks()
+        {
+            // This is the actual bug: with a debugger attached, every abandoned await stays in
+            // Task.s_currentActiveTasks forever, which roots the entire orchestration object graph.
+            //
+            // Task.s_currentActiveTasks is process-wide, so the test host's own async plumbing shows up in
+            // it as well. Rather than trying to subtract that noise, this measures how the growth scales
+            // with the number of abandoned awaits: a leak is proportional to the fan-out, while unrelated
+            // noise is not.
+            const int Episodes = 20;
+            const int SmallFanOut = 1;
+            const int LargeFanOut = 25;
+
+            using (AsyncDebuggingScope.Enable())
+            {
+                // Warm up so that one-time allocations aren't counted against the measurement.
+                RunEpisodes(Episodes, SmallFanOut, dispose: true);
+
+                int leakySensitivity = MeasureFanOutSensitivity(Episodes, SmallFanOut, LargeFanOut, dispose: false);
+                Assert.IsTrue(
+                    leakySensitivity > Episodes * (LargeFanOut - SmallFanOut),
+                    "Undisposed executors are expected to leak one entry per abandoned await; if they no longer " +
+                    $"do, this test can no longer detect the regression. Measured {leakySensitivity}.");
+
+                int fixedSensitivity = MeasureFanOutSensitivity(Episodes, SmallFanOut, LargeFanOut, dispose: true);
+                Assert.IsTrue(
+                    fixedSensitivity * 20 < leakySensitivity,
+                    "Disposing the executor must stop Task.s_currentActiveTasks from growing with the number of " +
+                    $"abandoned awaits, but growth was still {fixedSensitivity} against {leakySensitivity} when " +
+                    "the executors were left undisposed.");
+            }
+        }
+
+        /// <summary>
+        /// Returns how much more the active task table grows for <paramref name="largeFanOut"/> abandoned
+        /// awaits per episode than it does for <paramref name="smallFanOut"/>. Constant per-episode overhead
+        /// and unrelated test host activity cancel out, leaving only growth caused by abandoned awaits.
+        /// </summary>
+        static int MeasureFanOutSensitivity(int episodes, int smallFanOut, int largeFanOut, bool dispose)
+        {
+            int small = RunEpisodes(episodes, smallFanOut, dispose);
+            int large = RunEpisodes(episodes, largeFanOut, dispose);
+            return large - small;
+        }
+
+        static int RunEpisodes(int episodes, int fanOut, bool dispose)
+        {
+            int before = AsyncDebuggingScope.ActiveTaskCount;
+            for (int i = 0; i < episodes; i++)
+            {
+                TaskOrchestrationExecutor executor = CreateExecutor(new FanOutOrchestration(fanOut));
+                executor.Execute();
+                if (dispose)
+                {
+                    executor.Dispose();
+                }
+            }
+
+            return AsyncDebuggingScope.ActiveTaskCount - before;
+        }
+
+        [TestMethod]
+        public void Dispose_DoesNotChangeTheDecisionsAlreadyProduced()
+        {
+            var orchestration = new FanOutOrchestration(fanOut: 3);
+            using (var executor = CreateExecutor(orchestration))
+            {
+                OrchestratorExecutionResult result = executor.Execute();
+                List<OrchestratorAction> before = result.Actions.ToList();
+
+                executor.Dispose();
+
+                CollectionAssert.AreEqual(
+                    before,
+                    result.Actions.ToList(),
+                    "Releasing abandoned tasks must not add or remove orchestrator actions.");
+            }
+        }
+
+        [TestMethod]
+        public void Dispose_OrchestratorThatSwallowsCancellation_CannotScheduleMoreWork()
+        {
+            var orchestration = new SwallowsCancellationOrchestration();
+            using (var executor = CreateExecutor(orchestration))
+            {
+                executor.Execute();
+            }
+
+            Assert.IsInstanceOfType(
+                orchestration.RescheduleFailure,
+                typeof(OperationCanceledException),
+                "A released context must refuse to open new tasks, otherwise resumed orchestrator code can leak again.");
+        }
+
+        [TestMethod]
+        public void Dispose_IsIdempotent()
+        {
+            var orchestration = new FanOutOrchestration(fanOut: 2);
+            var executor = CreateExecutor(orchestration);
+            executor.Execute();
+
+            executor.Dispose();
+            executor.Dispose();
+
+            Assert.AreEqual(2, orchestration.ReleasedTaskCount, "Repeated disposal should not resume continuations more than once.");
+        }
+
+        [TestMethod]
+        public void ExtendedSession_OpenTasksSurviveBetweenEpisodes()
+        {
+            // Extended sessions reuse the executor across episodes, so open tasks must stay pending
+            // until their results arrive. Only the end of the session may release them.
+            var orchestration = new FanOutOrchestration(fanOut: 1);
+            OrchestrationRuntimeState runtimeState = CreateRuntimeState();
+
+            using (var executor = new TaskOrchestrationExecutor(runtimeState, orchestration, BehaviorOnContinueAsNew.Carryover))
+            {
+                OrchestratorExecutionResult firstEpisode = executor.Execute();
+                Assert.AreEqual(1, firstEpisode.Actions.Count(), "The first episode should schedule the activity.");
+                Assert.IsFalse(executor.IsCompleted);
+
+                runtimeState.NewEvents.Clear();
+                runtimeState.AddEvent(new OrchestratorStartedEvent(-1));
+                runtimeState.AddEvent(new TaskCompletedEvent(-1, taskScheduledId: 0, result: JsonDataConverter.Default.Serialize("Hello")));
+
+                OrchestratorExecutionResult secondEpisode = executor.ExecuteNewEvents();
+
+                Assert.IsTrue(executor.IsCompleted, "The activity result should have been delivered to the still-open task.");
+                Assert.AreEqual(1, orchestration.ReleasedTaskCount, "The await should have been resumed by its result, not by cancellation.");
+                Assert.IsTrue(
+                    secondEpisode.Actions.OfType<OrchestrationCompleteOrchestratorAction>().Any(),
+                    "The orchestration should have completed on the second episode.");
+            }
+        }
+
+        static TaskOrchestrationExecutor CreateExecutor(TaskOrchestration orchestration) =>
+            new TaskOrchestrationExecutor(CreateRuntimeState(), orchestration, BehaviorOnContinueAsNew.Carryover);
+
+        static OrchestrationRuntimeState CreateRuntimeState()
+        {
+            var runtimeState = new OrchestrationRuntimeState();
+            runtimeState.AddEvent(new OrchestratorStartedEvent(-1));
+            runtimeState.AddEvent(new ExecutionStartedEvent(-1, null)
+            {
+                OrchestrationInstance = new OrchestrationInstance
+                {
+                    InstanceId = Guid.NewGuid().ToString("N"),
+                    ExecutionId = Guid.NewGuid().ToString("N"),
+                },
+                Name = "TestOrchestration",
+                Version = string.Empty,
+            });
+
+            return runtimeState;
+        }
+
+        /// <summary>
+        /// Fans out to several activities and then parks, which is the state an orchestrator is in at the
+        /// end of a typical episode. Each await records whether it was ever resumed.
+        /// </summary>
+        class FanOutOrchestration : TaskOrchestration<string, string>
+        {
+            readonly int fanOut;
+
+            public FanOutOrchestration(int fanOut)
+            {
+                this.fanOut = fanOut;
+            }
+
+            public int StartedTaskCount { get; private set; }
+
+            public int ReleasedTaskCount { get; private set; }
+
+            public override async Task<string> RunTask(OrchestrationContext context, string input)
+            {
+                var tasks = new List<Task<string>>(this.fanOut);
+                for (int i = 0; i < this.fanOut; i++)
+                {
+                    this.StartedTaskCount++;
+                    tasks.Add(this.AwaitActivityAsync(context));
+                }
+
+                await Task.WhenAll(tasks);
+                return string.Empty;
+            }
+
+            async Task<string> AwaitActivityAsync(OrchestrationContext context)
+            {
+                try
+                {
+                    return await context.ScheduleTask<string>(ActivityName, string.Empty);
+                }
+                finally
+                {
+                    this.ReleasedTaskCount++;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Mimics orchestrator code with a catch-all handler: it swallows the cancellation raised while the
+        /// executor is being released and then tries to schedule more work.
+        /// </summary>
+        class SwallowsCancellationOrchestration : TaskOrchestration<string, string>
+        {
+            public Exception RescheduleFailure { get; private set; }
+
+            public override async Task<string> RunTask(OrchestrationContext context, string input)
+            {
+                try
+                {
+                    return await context.ScheduleTask<string>(ActivityName, string.Empty);
+                }
+                catch (Exception)
+                {
+                    try
+                    {
+                        return await context.ScheduleTask<string>(ActivityName, string.Empty);
+                    }
+                    catch (Exception e)
+                    {
+                        this.RescheduleFailure = e;
+                        throw;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Turns on the CLR's async debugging bookkeeping for the duration of a test, which is what a
+        /// attached debugger does, and exposes the size of the tracking dictionary.
+        /// </summary>
+        sealed class AsyncDebuggingScope : IDisposable
+        {
+            const BindingFlags StaticFlags = BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public;
+
+            static readonly FieldInfo EnabledField = typeof(Task).GetField("s_asyncDebuggingEnabled", StaticFlags);
+            static readonly FieldInfo ActiveTasksField = typeof(Task).GetField("s_currentActiveTasks", StaticFlags);
+
+            readonly bool previousValue;
+
+            AsyncDebuggingScope(bool previousValue)
+            {
+                this.previousValue = previousValue;
+            }
+
+            public static AsyncDebuggingScope Enable()
+            {
+                if (EnabledField == null || ActiveTasksField == null)
+                {
+                    Assert.Inconclusive("This runtime does not expose the async debugging state that this test relies on.");
+                }
+
+                var scope = new AsyncDebuggingScope((bool)EnabledField.GetValue(null));
+                EnabledField.SetValue(null, true);
+                return scope;
+            }
+
+            /// <summary>
+            /// The size of the process-wide <c>Task.s_currentActiveTasks</c> table.
+            /// </summary>
+            public static int ActiveTaskCount
+            {
+                get
+                {
+                    object activeTasks = ActiveTasksField.GetValue(null);
+                    if (activeTasks == null)
+                    {
+                        return 0;
+                    }
+
+                    PropertyInfo count = activeTasks.GetType().GetProperty("Count");
+                    lock (activeTasks)
+                    {
+                        return (int)count.GetValue(activeTasks);
+                    }
+                }
+            }
+
+            public void Dispose() => EnabledField.SetValue(null, this.previousValue);
+        }
+    }
+}

--- a/Test/DurableTask.Core.Tests/TaskOrchestrationExecutorTests.cs
+++ b/Test/DurableTask.Core.Tests/TaskOrchestrationExecutorTests.cs
@@ -32,7 +32,9 @@ namespace DurableTask.Core.Tests
     /// the episode ends. When a debugger is attached, the CLR keeps every awaited task in the process-wide
     /// <c>Task.s_currentActiveTasks</c> dictionary until the task completes, so abandoned awaits permanently
     /// root the orchestration object graph. Releasing the executor cancels the open tasks, which lets those
-    /// awaiter continuations run and unregister themselves.
+    /// awaiter continuations run and unregister themselves. The dispatcher only does that when a debugger is
+    /// attached, since the cancellation resumes user code; these tests drive the internal entry points
+    /// directly so both branches are covered without an attached debugger.
     /// Regression coverage for https://github.com/Azure/azure-functions-durable-extension/issues/340.
     /// </remarks>
     [TestClass]
@@ -146,10 +148,24 @@ namespace DurableTask.Core.Tests
 
             executor.Release();
 
+            // The first failure has to be an OperationCanceledException: that is simply what a cancelled
+            // TaskCompletionSource raises at the await that was abandoned.
+            Assert.IsInstanceOfType(
+                orchestration.FirstFailure,
+                typeof(OperationCanceledException),
+                "Releasing an open task must surface as cancellation at the await that was abandoned.");
+
+            // The retry must not. If retirement also looked like cancellation, the extremely common
+            // 'catch (OperationCanceledException) { retry; }' shape would treat a permanently retired
+            // executor as a transient failure and loop.
             Assert.IsInstanceOfType(
                 orchestration.RescheduleFailure,
-                typeof(OperationCanceledException),
+                typeof(InvalidOperationException),
                 "A released context must refuse to open new tasks, otherwise resumed orchestrator code can leak again.");
+            Assert.IsNotInstanceOfType(
+                orchestration.RescheduleFailure,
+                typeof(OperationCanceledException),
+                "Retirement must not be reported as cancellation, or cancellation-specific retry loops will spin.");
         }
 
         [TestMethod]
@@ -163,6 +179,43 @@ namespace DurableTask.Core.Tests
             executor.Release();
 
             Assert.AreEqual(2, orchestration.ReleasedTaskCount, "Repeated release should not resume continuations more than once.");
+        }
+
+        [TestMethod]
+        public void ReleaseCursor_WithTeardownEnabled_ClearsCursorAndResumesContinuations()
+        {
+            var orchestration = new FanOutOrchestration(fanOut: 3);
+            TaskOrchestrationExecutor executor = CreateExecutor(orchestration);
+            executor.Execute();
+
+            OrchestrationExecutionCursor cursor = CreateCursor(executor);
+            TaskOrchestrationDispatcher.ReleaseCursor(ref cursor, runContinuationTeardown: true);
+
+            Assert.IsNull(cursor, "Retiring a cursor must always clear the reference.");
+            Assert.AreEqual(
+                3,
+                orchestration.ReleasedTaskCount,
+                "With teardown enabled the abandoned awaits should be resumed so they can unregister themselves.");
+        }
+
+        [TestMethod]
+        public void ReleaseCursor_WithTeardownDisabled_ClearsCursorWithoutRunningContinuations()
+        {
+            // Teardown is gated on Debugger.IsAttached because cancelling the open tasks necessarily runs
+            // user catch/finally blocks. Without a debugger there is no leak to fix, so production keeps the
+            // pre-existing behavior: the executor is simply dropped and collected.
+            var orchestration = new FanOutOrchestration(fanOut: 3);
+            TaskOrchestrationExecutor executor = CreateExecutor(orchestration);
+            executor.Execute();
+
+            OrchestrationExecutionCursor cursor = CreateCursor(executor);
+            TaskOrchestrationDispatcher.ReleaseCursor(ref cursor, runContinuationTeardown: false);
+
+            Assert.IsNull(cursor, "The cursor must be cleared whether or not continuation teardown runs.");
+            Assert.AreEqual(
+                0,
+                orchestration.ReleasedTaskCount,
+                "With teardown disabled no orchestrator continuation may run, so user code is unaffected.");
         }
 
         [TestMethod]
@@ -194,6 +247,13 @@ namespace DurableTask.Core.Tests
 
         static TaskOrchestrationExecutor CreateExecutor(TaskOrchestration orchestration) =>
             new TaskOrchestrationExecutor(CreateRuntimeState(), orchestration, BehaviorOnContinueAsNew.Carryover);
+
+        static OrchestrationExecutionCursor CreateCursor(TaskOrchestrationExecutor executor) =>
+            new OrchestrationExecutionCursor(
+                CreateRuntimeState(),
+                orchestration: null,
+                executor: executor,
+                latestDecisions: Enumerable.Empty<OrchestratorAction>());
 
         static OrchestrationRuntimeState CreateRuntimeState()
         {
@@ -257,11 +317,14 @@ namespace DurableTask.Core.Tests
         }
 
         /// <summary>
-        /// Mimics orchestrator code with a catch-all handler: it swallows the cancellation raised while the
-        /// executor is being released and then tries to schedule more work.
+        /// Mimics orchestrator code that retries on cancellation: it catches the
+        /// <see cref="OperationCanceledException"/> raised while the executor is being released and then
+        /// tries to schedule more work.
         /// </summary>
         class SwallowsCancellationOrchestration : TaskOrchestration<string, string>
         {
+            public Exception FirstFailure { get; private set; }
+
             public Exception RescheduleFailure { get; private set; }
 
             public override async Task<string> RunTask(OrchestrationContext context, string input)
@@ -270,8 +333,10 @@ namespace DurableTask.Core.Tests
                 {
                     return await context.ScheduleTask<string>(ActivityName, string.Empty);
                 }
-                catch (Exception)
+                catch (OperationCanceledException firstFailure)
                 {
+                    this.FirstFailure = firstFailure;
+
                     try
                     {
                         return await context.ScheduleTask<string>(ActivityName, string.Empty);

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -35,6 +35,7 @@ namespace DurableTask.Core
         private OrchestrationCompleteOrchestratorAction continueAsNew;
         private static readonly ContinueAsNewOptions DefaultContinueAsNewOptions = new ContinueAsNewOptions();
         private bool executionCompletedOrTerminated;
+        private bool isReleased;
         private int idCounter;
         private readonly Queue<HistoryEvent> eventsWhileSuspended;
         private readonly IDictionary<int, OrchestratorAction> suspendedActionsMap;
@@ -74,6 +75,76 @@ namespace DurableTask.Core
         public IEnumerable<OrchestratorAction> OrchestratorActions => this.orchestratorActionsMap.Values;
 
         public bool HasOpenTasks => this.openTasks.Count > 0;
+
+        /// <summary>
+        /// Cancels every open task so that the orchestrator's abandoned <c>await</c> continuations are released.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Orchestrator code parks on a <see cref="TaskCompletionSource{TResult}"/> for every activity,
+        /// sub-orchestration, and timer it is waiting on. When an episode ends, those tasks are simply
+        /// abandoned in a pending state, because their results are not yet known. That is harmless to the
+        /// garbage collector on its own, but when a debugger is attached the CLR records every awaited task
+        /// in the process-wide <c>Task.s_currentActiveTasks</c> dictionary and only removes the entry when
+        /// the awaited task completes. Abandoned tasks therefore stay rooted forever, and with them the
+        /// entire orchestration object graph (context, history, inputs, and outputs).
+        /// </para>
+        /// <para>
+        /// Cancelling the open tasks lets each awaiter continuation run and unregister itself, which is what
+        /// allows the graph to be collected. This is only safe once the executor is guaranteed never to be
+        /// used again, since a cancelled task can no longer receive a result on a subsequent episode.
+        /// </para>
+        /// </remarks>
+        internal void ReleaseOpenTasks()
+        {
+            if (this.isReleased)
+            {
+                return;
+            }
+
+            // Set this before cancelling anything: cancellation resumes orchestrator code, and that code must
+            // not be able to open new tasks that would leak in exactly the same way.
+            this.isReleased = true;
+
+            if (this.openTasks.Count == 0)
+            {
+                return;
+            }
+
+            // Resumed orchestrator code can mutate openTasks (for example via a timer cancellation callback),
+            // so cancel from a snapshot rather than while enumerating the live dictionary.
+            List<OpenTaskInfo> abandonedTasks = this.openTasks.Values.ToList();
+            this.openTasks.Clear();
+
+            foreach (OpenTaskInfo info in abandonedTasks)
+            {
+                try
+                {
+                    info.Result.TrySetCanceled();
+                }
+                catch (Exception e) when (!Utils.IsFatal(e))
+                {
+                    // Orchestrator code observed the cancellation and threw. The episode is already over and
+                    // its decisions have already been captured, so there is nothing to report. Swallow the
+                    // exception and keep going so the remaining tasks still get released.
+                    TraceHelper.TraceSession(
+                        TraceEventType.Warning,
+                        "TaskOrchestrationContext-ReleaseOpenTasks",
+                        OrchestrationInstance?.InstanceId,
+                        "Exception while releasing abandoned orchestrator tasks: {0}",
+                        e);
+                }
+            }
+        }
+
+        private void ThrowIfReleased()
+        {
+            if (this.isReleased)
+            {
+                throw new OperationCanceledException(
+                    "This orchestration episode has ended and the orchestration context can no longer schedule work.");
+            }
+        }
 
         internal void ClearPendingActions()
         {
@@ -126,6 +197,8 @@ namespace DurableTask.Core
         public async Task<object> ScheduleTaskInternal(string name, string version, string taskList, Type resultType,
             ScheduleTaskOptions options, params object[] parameters)
         {
+            ThrowIfReleased();
+
             int id = this.idCounter++;
             string serializedInput = this.MessageDataConverter.SerializeInternal(parameters);
             var scheduleTaskTaskAction = new ScheduleTaskOrchestratorAction
@@ -189,6 +262,8 @@ namespace DurableTask.Core
             object input,
             IDictionary<string, string> tags)
         {
+            ThrowIfReleased();
+
             int id = this.idCounter++;
             string serializedInput = this.MessageDataConverter.SerializeInternal(input);
 
@@ -294,6 +369,8 @@ namespace DurableTask.Core
                     "The state parameter cannot be a CancellationToken. Did you mean to use a different overload?",
                     paramName: nameof(state));
             }
+
+            ThrowIfReleased();
 
             int id = this.idCounter++;
             var createTimerOrchestratorAction = new CreateTimerOrchestratorAction

--- a/src/DurableTask.Core/TaskOrchestrationContext.cs
+++ b/src/DurableTask.Core/TaskOrchestrationContext.cs
@@ -94,6 +94,13 @@ namespace DurableTask.Core
         /// allows the graph to be collected. This is only safe once the executor is guaranteed never to be
         /// used again, since a cancelled task can no longer receive a result on a subsequent episode.
         /// </para>
+        /// <para>
+        /// Cancellation is not side-effect free: resuming an abandoned await runs the orchestrator's
+        /// <c>catch</c> and <c>finally</c> blocks. There is no supported way to drop the CLR's active-task
+        /// roots without running those continuations, so callers gate this on debugger presence rather than
+        /// paying the cost in production. See dotnet/runtime#26565 for the upstream proposal to make the
+        /// active-task table weak, which would remove the need for this teardown entirely.
+        /// </para>
         /// </remarks>
         internal void ReleaseOpenTasks()
         {
@@ -141,8 +148,12 @@ namespace DurableTask.Core
         {
             if (this.isReleased)
             {
-                throw new OperationCanceledException(
-                    "This orchestration episode has ended and the orchestration context can no longer schedule work.");
+                // Deliberately not an OperationCanceledException. The first cancellation surfaced at the
+                // abandoned await necessarily is one, and orchestrator code that catches it and retries would
+                // otherwise treat permanent retirement as a transient cancellation and loop.
+                throw new InvalidOperationException(
+                    "This orchestration executor has been retired and its context can no longer schedule work. " +
+                    "The orchestration episode has ended and any work scheduled now would never run.");
             }
         }
 

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -310,10 +310,10 @@ namespace DurableTask.Core
             }
             finally
             {
-                // The session is over and the executor will never run again, so release the orchestrator
-                // continuations it abandoned while waiting on activities, sub-orchestrations, and timers.
-                // Leaving them pending leaks the whole orchestration object graph when a debugger is
-                // attached. See https://github.com/Azure/azure-functions-durable-extension/issues/340.
+                // The session is over and the executor will never run again. Always drop the cursor; only tear
+                // down the abandoned orchestrator continuations when a debugger is attached, because that
+                // teardown necessarily runs user catch/finally blocks and the leak it prevents is
+                // debugger-only. See https://github.com/Azure/azure-functions-durable-extension/issues/340.
                 ReleaseCursor(ref workItem.Cursor);
             }
         }
@@ -321,10 +321,37 @@ namespace DurableTask.Core
         /// <summary>
         /// Retires the executor held by <paramref name="cursor"/> and clears the reference.
         /// </summary>
+        /// <remarks>
+        /// Continuation teardown is gated on <see cref="Debugger.IsAttached"/>. The leak this guards against
+        /// only exists when a debugger is attached, and the teardown is not free of side effects: cancelling
+        /// the abandoned tasks resumes orchestrator code, so user <c>catch</c> and <c>finally</c> blocks run.
+        /// There is no supported way to drop the CLR's active-task roots without running those continuations,
+        /// so the cost is confined to the situation that actually needs it.
+        /// </remarks>
         static void ReleaseCursor(ref OrchestrationExecutionCursor? cursor)
+        {
+            ReleaseCursor(ref cursor, runContinuationTeardown: Debugger.IsAttached);
+        }
+
+        /// <summary>
+        /// Retirement logic behind <see cref="ReleaseCursor(ref OrchestrationExecutionCursor?)"/>, with the
+        /// debugger check lifted into <paramref name="runContinuationTeardown"/> so both branches are testable.
+        /// </summary>
+        /// <param name="cursor">The cursor to retire. Always cleared, whatever the second argument is.</param>
+        /// <param name="runContinuationTeardown">
+        /// Whether to also cancel the executor's abandoned orchestrator continuations. When false the executor
+        /// is simply dropped, which is what this dispatcher did before the leak fix.
+        /// </param>
+        internal static void ReleaseCursor(ref OrchestrationExecutionCursor? cursor, bool runContinuationTeardown)
         {
             OrchestrationExecutionCursor? retiredCursor = cursor;
             cursor = null;
+
+            if (!runContinuationTeardown)
+            {
+                return;
+            }
+
             retiredCursor?.OrchestrationExecutor?.Release();
         }
 

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -308,6 +308,24 @@ namespace DurableTask.Core
                 TraceHelper.TraceInstance(TraceEventType.Warning, "TaskOrchestrationDispatcher-ExecutionAborted", instance, "{0}", e.Message);
                 await this.orchestrationService.AbandonTaskOrchestrationWorkItemAsync(workItem);
             }
+            finally
+            {
+                // The session is over and the executor will never run again, so release the orchestrator
+                // continuations it abandoned while waiting on activities, sub-orchestrations, and timers.
+                // Leaving them pending leaks the whole orchestration object graph when a debugger is
+                // attached. See https://github.com/Azure/azure-functions-durable-extension/issues/340.
+                ReleaseCursor(ref workItem.Cursor);
+            }
+        }
+
+        /// <summary>
+        /// Retires the executor held by <paramref name="cursor"/> and clears the reference.
+        /// </summary>
+        static void ReleaseCursor(ref OrchestrationExecutionCursor? cursor)
+        {
+            OrchestrationExecutionCursor? retiredCursor = cursor;
+            cursor = null;
+            retiredCursor?.OrchestrationExecutor?.Dispose();
         }
 
         /// <summary>
@@ -669,7 +687,9 @@ namespace DurableTask.Core
                                 runtimeState.AddEvent(new OrchestratorCompletedEvent(-1));
                                 workItem.OrchestrationRuntimeState = runtimeState;
 
-                                workItem.Cursor = null;
+                                // The continued-as-new execution gets a brand new executor, so retire this
+                                // one instead of just dropping the reference.
+                                ReleaseCursor(ref workItem.Cursor);
 
                                 traceActivity = RestartTraceActivityForContinueAsNewIfNeeded(
                                     traceActivity,

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -325,7 +325,7 @@ namespace DurableTask.Core
         {
             OrchestrationExecutionCursor? retiredCursor = cursor;
             cursor = null;
-            retiredCursor?.OrchestrationExecutor?.Dispose();
+            retiredCursor?.OrchestrationExecutor?.Release();
         }
 
         /// <summary>

--- a/src/DurableTask.Core/TaskOrchestrationExecutor.cs
+++ b/src/DurableTask.Core/TaskOrchestrationExecutor.cs
@@ -157,6 +157,12 @@ namespace DurableTask.Core
         /// component that knows when an executor will never run again, so exposing this externally would
         /// add public surface that no caller outside this assembly can use correctly.
         /// </para>
+        /// <para>
+        /// This is not side-effect free: cancelling the open tasks resumes orchestrator code, so the
+        /// orchestrator's <c>catch</c> and <c>finally</c> blocks run. There is no supported way to drop the
+        /// CLR's active-task roots without running those continuations, so the dispatcher only calls this
+        /// when a debugger is attached, which is the only situation in which the leak exists.
+        /// </para>
         /// </remarks>
         internal void Release()
         {

--- a/src/DurableTask.Core/TaskOrchestrationExecutor.cs
+++ b/src/DurableTask.Core/TaskOrchestrationExecutor.cs
@@ -28,7 +28,7 @@ namespace DurableTask.Core
     /// <summary>
     /// Utility for executing task orchestrators.
     /// </summary>
-    public class TaskOrchestrationExecutor : IDisposable
+    public class TaskOrchestrationExecutor
     {
         readonly TaskOrchestrationContext context;
         readonly TaskScheduler decisionScheduler;
@@ -151,8 +151,14 @@ namespace DurableTask.Core
         /// completes, so abandoned orchestrator awaits permanently root the orchestration object graph.
         /// See https://github.com/Azure/azure-functions-durable-extension/issues/340.
         /// </para>
+        /// <para>
+        /// This is intentionally internal rather than an <see cref="IDisposable"/> implementation.
+        /// Executor lifetime is owned by <see cref="TaskOrchestrationDispatcher"/>, which is the only
+        /// component that knows when an executor will never run again, so exposing this externally would
+        /// add public surface that no caller outside this assembly can use correctly.
+        /// </para>
         /// </remarks>
-        public void Dispose()
+        internal void Release()
         {
             SynchronizationContext prevCtx = SynchronizationContext.Current;
             bool prevIsOrchestratorThread = OrchestrationContext.IsOrchestratorThread;

--- a/src/DurableTask.Core/TaskOrchestrationExecutor.cs
+++ b/src/DurableTask.Core/TaskOrchestrationExecutor.cs
@@ -28,7 +28,7 @@ namespace DurableTask.Core
     /// <summary>
     /// Utility for executing task orchestrators.
     /// </summary>
-    public class TaskOrchestrationExecutor
+    public class TaskOrchestrationExecutor : IDisposable
     {
         readonly TaskOrchestrationContext context;
         readonly TaskScheduler decisionScheduler;
@@ -133,6 +133,52 @@ namespace DurableTask.Core
             return this.ExecuteCore(
                 pastEvents: Enumerable.Empty<HistoryEvent>(),
                 newEvents: this.orchestrationRuntimeState.NewEvents);
+        }
+
+        /// <summary>
+        /// Releases the orchestrator continuations that this executor abandoned while waiting on
+        /// activities, sub-orchestrations, or timers.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Call this once the executor is guaranteed never to run again, i.e. when the orchestration
+        /// session ends. It must not be called between episodes of an extended session, because an open
+        /// task still needs to be able to receive its result on a later episode.
+        /// </para>
+        /// <para>
+        /// Skipping this call is not a correctness problem, but it leaks memory whenever a debugger is
+        /// attached: the CLR keeps every awaited task in a process-wide dictionary until that task
+        /// completes, so abandoned orchestrator awaits permanently root the orchestration object graph.
+        /// See https://github.com/Azure/azure-functions-durable-extension/issues/340.
+        /// </para>
+        /// </remarks>
+        public void Dispose()
+        {
+            SynchronizationContext prevCtx = SynchronizationContext.Current;
+            bool prevIsOrchestratorThread = OrchestrationContext.IsOrchestratorThread;
+
+            try
+            {
+                // Cancelling the open tasks resumes orchestrator code, so give it the same ambient
+                // environment it sees during a normal episode.
+                SynchronizationContext.SetSynchronizationContext(
+                    new TaskOrchestrationSynchronizationContext(this.decisionScheduler));
+                OrchestrationContext.IsOrchestratorThread = true;
+
+                this.context.ReleaseOpenTasks();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(prevCtx);
+                OrchestrationContext.IsOrchestratorThread = prevIsOrchestratorThread;
+
+                // Unwinding may have faulted the orchestrator's top-level task. Nothing observes it at this
+                // point, so observe it here to keep it from surfacing as an unobserved task exception.
+                if (this.result?.IsFaulted == true)
+                {
+                    _ = this.result.Exception;
+                }
+            }
         }
 
         OrchestratorExecutionResult ExecuteCore(IEnumerable<HistoryEvent> pastEvents, IEnumerable<HistoryEvent> newEvents)


### PR DESCRIPTION
## Problem

`TaskOrchestrationContext` creates a `TaskCompletionSource<string>` for every activity, sub-orchestration, and timer, registers it in `openTasks`, and awaits `tcs.Task`. When an episode ends while the orchestrator is parked on one of those awaits, the TCS is deliberately abandoned in a pending state — that is inherent to the replay model.

**When a debugger is attached**, `TaskAwaiter.OnCompletedInternal` calls `OutputWaitEtwEvents`, which calls `Task.AddToActiveTasks(task)` because `Task.s_asyncDebuggingEnabled` is true. That inserts the task into the process-wide, strongly-referenced static dictionary `Task.s_currentActiveTasks`. The matching `Task.RemoveFromActiveTasks` only runs inside the awaiter continuation wrapper, i.e. **only when the awaited task completes**.

Abandoned tasks are therefore rooted forever, and each rooted `Task` pins its continuation → async state machine → `TaskOrchestrationContext` → history, inputs, and outputs. Only the `AddToActiveTasks` branch roots the task (the ETW branch does not), which is exactly why the leak is debugger-specific.

Fixes the root cause behind Azure/azure-functions-durable-extension#340 ("Memory leak when debugger attached"), which is filed on the extension repo but labeled `dtfx`/`external` because the defect lives here in DurableTask.Core.

## The fix

**`TaskOrchestrationContext`** gains `internal void ReleaseOpenTasks()`, which cancels every open task so the abandoned awaiter continuations run and unregister themselves. It is idempotent, sets `isReleased = true` *before* cancelling, and snapshots `openTasks.Values.ToList()` before iterating, because resumed user code can mutate the dictionary (concretely, `CreateTimer`'s cancellation-token callback calls `openTasks.Remove`). A new private `ThrowIfReleased()` guard runs at the top of `ScheduleTaskInternal`, `CreateSubOrchestrationInstanceCore`, and `CreateTimer` so orchestrator code that swallows the cancellation cannot schedule new work that would leak the same way.

**`TaskOrchestrationExecutor`** gains `internal void Release()`. It restores the orchestrator ambient environment (`TaskOrchestrationSynchronizationContext` + `OrchestrationContext.IsOrchestratorThread`) because cancelling resumes orchestrator code synchronously, calls `context.ReleaseOpenTasks()`, and observes `this.result.Exception` if faulted so nothing surfaces as an `UnobservedTaskException`.

**`TaskOrchestrationDispatcher`** owns executor lifetime via `workItem.Cursor`, so it is the only component that knows when an executor will never run again. A new `ReleaseCursor` helper is called from a new `finally` on the outer `try` of `OnProcessWorkItemSessionAsync` (covering both the legacy `Session == null` path and the session path — `workItem.Cursor` is only ever assigned in `OnProcessWorkItemAsync`, which both paths call), and it replaces the bare `workItem.Cursor = null;` at the continue-as-new site.

## ⚠️ Continuation teardown is gated on `Debugger.IsAttached`

This is the part reviewers should look at hardest, and it is a deliberate trade-off rather than a free win.

Cancelling the abandoned tasks is *what makes the CLR drop its roots* — the entry is only removed when the awaiter continuation runs. There is **no supported way to remove a `s_currentActiveTasks` root without running the async state-machine continuation**. Running that continuation means the orchestrator's `catch` and `finally` blocks execute. So an unconditional release would change user-visible behavior in production to fix a bug that only exists under a debugger.

`ReleaseCursor` therefore **always clears `workItem.Cursor`**, but only calls `TaskOrchestrationExecutor.Release()` when `System.Diagnostics.Debugger.IsAttached`:

```csharp
static void ReleaseCursor(ref OrchestrationExecutionCursor? cursor)
{
    ReleaseCursor(ref cursor, runContinuationTeardown: Debugger.IsAttached);
}

internal static void ReleaseCursor(ref OrchestrationExecutionCursor? cursor, bool runContinuationTeardown)
{
    OrchestrationExecutionCursor? retiredCursor = cursor;
    cursor = null;

    if (!runContinuationTeardown)
    {
        return;
    }

    retiredCursor?.OrchestrationExecutor?.Release();
}
```

The gate lives in the dispatcher because the dispatcher owns executor lifetime, and it is lifted into an internal overload taking the flag so **both branches are unit-tested without needing an attached debugger in CI**. No public API, no private-CLR reflection.

To be candid about what this does and does not claim:

- **No debugger attached (i.e. production): behavior is exactly what it was before this PR.** The executor is dropped and collected; no orchestrator continuation runs. The only cost is one `Debugger.IsAttached` check per retired cursor.
- **Debugger attached: this is *not* a zero-behavior-change fix.** The abandoned await is resumed with an `OperationCanceledException`, so orchestrator `catch`/`finally` blocks run during teardown. That is unavoidable with the public `Task` API. The compromise is now confined to the dev/debug session where the leak actually occurs.
- **Escape hatch:** run without a debugger attached. There is no `AppContext` switch convention in this repository, so this PR deliberately does not invent a settings surface for a single debug-only branch.
- **Upstream fix:** [dotnet/runtime#26565](https://github.com/dotnet/runtime/issues/26565) proposes making the active-task table weak. If that lands, this teardown becomes unnecessary and can be deleted outright.

### Retirement is reported as `InvalidOperationException`, not cancellation

`ThrowIfReleased()` throws `InvalidOperationException`. The *first* failure at the abandoned await necessarily remains an `OperationCanceledException` — that is simply what a cancelled TCS raises. But a retired executor is **permanent**, so the extremely common

```csharp
catch (OperationCanceledException) { /* retry */ }
```

shape must not treat it as a transient cancellation and spin. With `InvalidOperationException`, such a loop terminates on the retry.

A `catch (Exception)` infinite loop remains fundamentally impossible to prevent with any managed exception type — but it is now restricted to debugger teardown, and the guard still stops any new work from being scheduled.

## Evidence

Direct-executor harness, 2000 episodes × fan-out 100, debugger simulated by setting `Task.s_asyncDebuggingEnabled`:

| | Retained after full blocking GC | Entries leaked into `Task.s_currentActiveTasks` |
|---|---|---|
| Before | **400.76 MB** | **1,006,000** (~210 KB/episode) |
| After | **0.01 MB** | **0** |

With no debugger, both before and after are 0 — confirming the debugger-specific mechanism.

End-to-end through the real `TaskHubWorker`/`TaskOrchestrationDispatcher` with `LocalOrchestrationService`, 200 instances × 3 activities:

- **Before:** 4,200 leaked orchestrator tasks — 600 each of `TaskOrchestration'4.<Execute>`, the user orchestrator's `<RunTask>`, `ScheduleTask`, both `ScheduleTaskToWorker` overloads, `ScheduleTaskInternal`, plus ~600 TCS tasks. Exactly 3 abandoned awaits per instance.
- **After:** 0.

(A residual ~1,200 `Task.Delay` promises appear identically in both runs; that is the emulator's own queue polling, unrelated to this change.)

## Public API

**No public API change.** `TaskOrchestrationExecutor` does not implement `IDisposable` and exposes no new members; the cleanup hook is `internal void Release()`, and the dispatcher gate is `internal static void ReleaseCursor(ref OrchestrationExecutionCursor?, bool)`. Verified by reflecting over the built `DurableTask.Core.dll` rather than by reading source:

```
== DurableTask.Core.TaskOrchestrationExecutor  IsPublic=True
   interfaces: []
   PUBLIC   Constructor .ctor  (×3)
   PUBLIC   Method Execute
   PUBLIC   Method ExecuteNewEvents
   PUBLIC   Property IsCompleted
   internal method Release
```

Executor lifetime is owned by the dispatcher, which is the only component that knows when an executor will never run again, so there is nothing a caller outside this assembly could do with a public hook except use it incorrectly.

## Extended sessions are explicitly unaffected

Release happens **only at permanent executor retirement**, never between episodes. Cancelling at the end of every episode would break extended sessions: `HandleTaskCompletedEvent` calls `info.Result.SetResult(...)`, which throws `InvalidOperationException` on an already-cancelled TCS. There is a regression test, `ExtendedSession_OpenTasksSurviveBetweenEpisodes`, proving that an open task still survives across episodes and is resumed by its *result* rather than by cancellation.

## Alternatives rejected

- **Cancel at the end of every episode inside `ExecuteCore`** — breaks extended sessions, as above.
- **A custom awaitable that avoids registration** — only fixes the innermost await; user-code awaits (`Task.WhenAll`, awaiting the returned `Task<T>`) still register.
- **Reflectively removing entries from `s_currentActiveTasks`** — private API, and it cannot reach the intermediate async-method tasks.

## Tests

New file `Test/DurableTask.Core.Tests/TaskOrchestrationExecutorTests.cs`, 8 tests:

| Test | Guarantee |
|---|---|
| `Release_ResumesAbandonedOrchestratorContinuations` | Every abandoned await is resumed so it can unregister itself |
| `Release_WithAsyncDebuggingEnabled_DoesNotLeakActiveTasks` | The leak itself is gone |
| `Release_DoesNotChangeTheDecisionsAlreadyProduced` | Teardown adds/removes no orchestrator actions |
| `Release_OrchestratorThatSwallowsCancellation_CannotScheduleMoreWork` | First failure is `OperationCanceledException`; the retry faults with `InvalidOperationException`, so cancellation-specific retry loops terminate |
| `Release_IsIdempotent` | Repeated release does not resume continuations twice |
| `ReleaseCursor_WithTeardownEnabled_ClearsCursorAndResumesContinuations` | Debugger branch: cursor cleared **and** continuations resumed |
| `ReleaseCursor_WithTeardownDisabled_ClearsCursorWithoutRunningContinuations` | Production branch: cursor cleared, **zero** user continuations run |
| `ExtendedSession_OpenTasksSurviveBetweenEpisodes` | The safety boundary — open tasks survive between episodes |

Note on `Release_WithAsyncDebuggingEnabled_DoesNotLeakActiveTasks`: it deliberately measures how `Task.s_currentActiveTasks` growth **scales** with fan-out (1 vs 25 abandoned awaits over 20 episodes) rather than asserting an absolute count. The dictionary is process-wide and the test host's own async plumbing pollutes it, and on .NET Framework an async method's task is not an `AsyncStateMachineBox<T>`, so entries cannot be attributed by type there. The test is self-validating: it first asserts that *unreleased* executors DO leak proportionally, so it can never silently stop detecting the regression.

### Results (Debug — test projects only build in Debug, since `SIGN_ASSEMBLY` disables `InternalsVisibleTo`)

- Full solution build: **0 warnings, 0 errors**
- `TaskOrchestrationExecutorTests`: **8/8 net8.0, 8/8 net48**
- `DurableTask.Core.Tests`: **147/147 net8.0**; net48 128 passed / 7 failed
- `DurableTask.Emulator.Tests`: **5/5 net8.0, 5/5 net48**

The 7 net48 failures are all in `ContinueAsNewTraceBehaviorTests` and are **pre-existing on `main`**, verified by stashing this change and re-running the same test class at baseline — identical 7 failures. No new failures.

## Known follow-up (not fixed here)

`azure-functions-durable-extension` has its own secondary TCS leaks of the same shape that this change does not cover, because an orchestrator parked purely on an external event has no DTFx open tasks:

- `DurableOrchestrationContext.pendingExternalEvents` (`EventTaskCompletionSource<T>`)
- `TaskCommonShim.timeoutTaskCompletionSource`
