### PR TITLE
Fix RewindAsync non-determinism when the failed step is not the last executed step

### DIFF
--- a/Test/DurableTask.Core.Tests/RewindTests.cs
+++ b/Test/DurableTask.Core.Tests/RewindTests.cs
@@ -1,0 +1,537 @@
+//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.Core.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using DurableTask.Core.Command;
+    using DurableTask.Core.History;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// Tests for the history scrubbing performed by
+    /// <see cref="TaskOrchestrationDispatcher.ProcessRewindOrchestrationDecision"/>.
+    /// </summary>
+    /// <remarks>
+    /// Each test drives a real <see cref="TaskOrchestration"/> through real episodes with
+    /// <see cref="TaskOrchestrationExecutor"/> until it fails, rewinds the resulting history, then
+    /// replays the rewound history and asserts on the actions the orchestrator produces. A rewound
+    /// history that is not replayable surfaces as a fail-orchestration action carrying a
+    /// "Non-Deterministic workflow detected" message, because
+    /// <see cref="TaskOrchestrationExecutor.ExecuteCore"/> converts
+    /// <see cref="Exceptions.NonDeterministicOrchestrationException"/> into that action.
+    /// </remarks>
+    [TestClass]
+    public class RewindTests
+    {
+        const string FailingActivity = "FailingActivity";
+
+        /// <summary>
+        /// Regression test for https://github.com/Azure/azure-functions-durable-extension/issues/444.
+        /// The orchestrator catches the activity failure and schedules another activity before
+        /// rethrowing. That second activity only exists because the orchestrator observed the
+        /// failure, so it must not survive the rewind.
+        /// </summary>
+        [TestMethod]
+        public void Rewind_CatchBlockSchedulesActivity_ProducesReplayableHistory()
+        {
+            RewindResult result = RunRewindTest(() => new CatchAndScheduleActivityOrchestration());
+
+            AssertReplayable(result);
+
+            // 'Cleanup' was scheduled from the catch block, so neither it nor its result may survive.
+            Assert.IsFalse(
+                result.RewoundHistory.OfType<TaskScheduledEvent>().Any(e => e.Name == "Cleanup"),
+                "The activity scheduled from the catch block should have been removed from the history.");
+            Assert.AreEqual(
+                0,
+                result.RewoundHistory.OfType<TaskCompletedEvent>().Count(e => e.TaskScheduledId == 3),
+                "The result of the activity scheduled from the catch block should have been removed too.");
+
+            // The two activities that succeeded before the failure are retained, so only the failed
+            // activity is rescheduled.
+            CollectionAssert.AreEqual(
+                new[] { "First", "Second" },
+                result.RewoundHistory.OfType<TaskScheduledEvent>().Select(e => e.Name).ToArray());
+            CollectionAssert.AreEqual(
+                new[] { FailingActivity },
+                result.ReplayScheduledActivities);
+        }
+
+        /// <summary>
+        /// An activity scheduled through <see cref="OrchestrationContext.ScheduleWithRetry{T}(string, string, RetryOptions, object[])"/>
+        /// always leaves a delay timer in the history (see <see cref="RetryInterceptor"/>), including
+        /// one created after the final failed attempt. Those timers are created only because the
+        /// orchestrator observed a failure, so they must not survive the rewind either.
+        /// </summary>
+        [TestMethod]
+        public void Rewind_ScheduleWithRetry_RemovesRetryTimers()
+        {
+            RewindResult result = RunRewindTest(() => new RetryOrchestration());
+
+            AssertReplayable(result);
+
+            Assert.AreEqual(
+                0,
+                result.RewoundHistory.OfType<TimerCreatedEvent>().Count(),
+                "Retry timers should have been removed from the history.");
+            Assert.AreEqual(
+                0,
+                result.RewoundHistory.OfType<TimerFiredEvent>().Count(),
+                "Retry timer results should have been removed from the history.");
+            Assert.AreEqual(
+                0,
+                result.RewoundHistory.OfType<TaskScheduledEvent>().Count(),
+                "Every attempt of the failed activity should have been removed from the history.");
+            CollectionAssert.AreEqual(
+                new[] { FailingActivity },
+                result.ReplayScheduledActivities);
+        }
+
+        /// <summary>
+        /// Same as <see cref="Rewind_CatchBlockSchedulesActivity_ProducesReplayableHistory"/>, but the
+        /// catch block creates a sub-orchestration rather than scheduling an activity.
+        /// </summary>
+        [TestMethod]
+        public void Rewind_CatchBlockCreatesSubOrchestration_ProducesReplayableHistory()
+        {
+            RewindResult result = RunRewindTest(() => new CatchAndCreateSubOrchestrationOrchestration());
+
+            AssertReplayable(result);
+
+            Assert.AreEqual(
+                0,
+                result.RewoundHistory.OfType<SubOrchestrationInstanceCreatedEvent>().Count(),
+                "The sub-orchestration created from the catch block should have been removed.");
+            Assert.AreEqual(
+                0,
+                result.RewoundHistory.OfType<SubOrchestrationInstanceCompletedEvent>().Count(),
+                "The result of the sub-orchestration created from the catch block should have been removed.");
+            CollectionAssert.AreEqual(
+                new[] { FailingActivity },
+                result.ReplayScheduledActivities);
+
+            // No failed sub-orchestration means this is a terminal leaf, so a dummy rewind message is
+            // emitted to force the orchestration to rerun.
+            Assert.AreEqual(1, result.RewindMessages.Count);
+            Assert.IsInstanceOfType(result.RewindMessages[0].Event, typeof(ExecutionRewoundEvent));
+        }
+
+        /// <summary>
+        /// Same as <see cref="Rewind_CatchBlockSchedulesActivity_ProducesReplayableHistory"/>, but the
+        /// catch block sends an external event, which is also matched against the orchestrator's
+        /// sequence-ID counter during replay.
+        /// </summary>
+        [TestMethod]
+        public void Rewind_CatchBlockSendsEvent_ProducesReplayableHistory()
+        {
+            RewindResult result = RunRewindTest(() => new CatchAndSendEventOrchestration());
+
+            AssertReplayable(result);
+
+            Assert.AreEqual(
+                0,
+                result.RewoundHistory.OfType<EventSentEvent>().Count(),
+                "The event sent from the catch block should have been removed from the history.");
+            CollectionAssert.AreEqual(
+                new[] { FailingActivity },
+                result.ReplayScheduledActivities);
+        }
+
+        /// <summary>
+        /// Control case: an orchestration that does no work in response to the failure must rewind
+        /// exactly as it did before this change.
+        /// </summary>
+        [TestMethod]
+        public void Rewind_SimpleActivityFailure_ReschedulesOnlyTheFailedActivity()
+        {
+            RewindResult result = RunRewindTest(() => new SimpleFailureOrchestration());
+
+            AssertReplayable(result);
+
+            CollectionAssert.AreEqual(
+                new[] { "First" },
+                result.RewoundHistory.OfType<TaskScheduledEvent>().Select(e => e.Name).ToArray());
+            CollectionAssert.AreEqual(
+                new[] { FailingActivity },
+                result.ReplayScheduledActivities);
+        }
+
+        /// <summary>
+        /// Fan-out/fan-in: the parallel branches are all scheduled in an episode before the failure is
+        /// observed, so they must be retained and only the failed branch rescheduled.
+        /// </summary>
+        [TestMethod]
+        public void Rewind_FanOutFanIn_RetainsSuccessfulBranches()
+        {
+            RewindResult result = RunRewindTest(() => new FanOutFanInOrchestration());
+
+            AssertReplayable(result);
+
+            CollectionAssert.AreEquivalent(
+                new[] { "Branch1", "Branch3" },
+                result.RewoundHistory.OfType<TaskScheduledEvent>().Select(e => e.Name).ToArray());
+            CollectionAssert.AreEqual(
+                new[] { FailingActivity },
+                result.ReplayScheduledActivities);
+        }
+
+        /// <summary>
+        /// A sub-orchestration is always created in an episode before the one that delivers its
+        /// failure, so its creation event is retained and a rewind message is emitted for the child.
+        /// </summary>
+        [TestMethod]
+        public void Rewind_FailedSubOrchestration_RetainsCreationAndEmitsChildRewindMessage()
+        {
+            RewindResult result = RunRewindTest(() => new SubOrchestrationFailureOrchestration());
+
+            AssertReplayable(result);
+
+            SubOrchestrationInstanceCreatedEvent createdEvent =
+                result.RewoundHistory.OfType<SubOrchestrationInstanceCreatedEvent>().SingleOrDefault();
+            Assert.IsNotNull(createdEvent, "The failed sub-orchestration's creation event should be retained.");
+            Assert.AreEqual("ChildInstance", createdEvent.InstanceId);
+
+            Assert.AreEqual(1, result.RewindMessages.Count);
+            Assert.AreEqual("ChildInstance", result.RewindMessages[0].OrchestrationInstance.InstanceId);
+            Assert.IsInstanceOfType(result.RewindMessages[0].Event, typeof(ExecutionRewoundEvent));
+
+            // The parent replays up to the sub-orchestration and then waits for the rewound child.
+            Assert.AreEqual(0, result.ReplayScheduledActivities.Count);
+        }
+
+        /// <summary>
+        /// The rewound history must always carry a fresh execution ID.
+        /// </summary>
+        [TestMethod]
+        public void Rewind_AssignsNewExecutionId()
+        {
+            RewindResult result = RunRewindTest(() => new SimpleFailureOrchestration());
+
+            ExecutionStartedEvent executionStartedEvent =
+                result.RewoundHistory.OfType<ExecutionStartedEvent>().Single();
+            Assert.AreNotEqual(
+                InitialExecutionId,
+                executionStartedEvent.OrchestrationInstance.ExecutionId,
+                "The rewound history should carry a new execution ID.");
+            Assert.AreEqual(0, result.RewoundHistory.OfType<ExecutionCompletedEvent>().Count());
+        }
+
+        #region Test orchestrations
+
+        class SimpleFailureOrchestration : TaskOrchestration<string, string>
+        {
+            public override async Task<string> RunTask(OrchestrationContext context, string input)
+            {
+                await context.ScheduleTask<string>("First", string.Empty);
+                await context.ScheduleTask<string>(FailingActivity, string.Empty);
+                return "done";
+            }
+        }
+
+        class CatchAndScheduleActivityOrchestration : TaskOrchestration<string, string>
+        {
+            public override async Task<string> RunTask(OrchestrationContext context, string input)
+            {
+                await context.ScheduleTask<string>("First", string.Empty);
+                await context.ScheduleTask<string>("Second", string.Empty);
+                try
+                {
+                    await context.ScheduleTask<string>(FailingActivity, string.Empty);
+                }
+                catch (Exception)
+                {
+                    await context.ScheduleTask<string>("Cleanup", string.Empty);
+                    throw;
+                }
+
+                return "done";
+            }
+        }
+
+        class CatchAndCreateSubOrchestrationOrchestration : TaskOrchestration<string, string>
+        {
+            public override async Task<string> RunTask(OrchestrationContext context, string input)
+            {
+                try
+                {
+                    await context.ScheduleTask<string>(FailingActivity, string.Empty);
+                }
+                catch (Exception)
+                {
+                    await context.CreateSubOrchestrationInstance<string>("Notify", string.Empty, "NotifyInstance", null);
+                    throw;
+                }
+
+                return "done";
+            }
+        }
+
+        class CatchAndSendEventOrchestration : TaskOrchestration<string, string>
+        {
+            public override async Task<string> RunTask(OrchestrationContext context, string input)
+            {
+                try
+                {
+                    await context.ScheduleTask<string>(FailingActivity, string.Empty);
+                }
+                catch (Exception)
+                {
+                    context.SendEvent(
+                        new OrchestrationInstance { InstanceId = "Listener" },
+                        "Failed",
+                        "payload");
+                    throw;
+                }
+
+                return "done";
+            }
+        }
+
+        class RetryOrchestration : TaskOrchestration<string, string>
+        {
+            public override async Task<string> RunTask(OrchestrationContext context, string input)
+            {
+                var retryOptions = new RetryOptions(TimeSpan.FromSeconds(1), 2);
+                return await context.ScheduleWithRetry<string>(FailingActivity, string.Empty, retryOptions);
+            }
+        }
+
+        class FanOutFanInOrchestration : TaskOrchestration<string, string>
+        {
+            public override async Task<string> RunTask(OrchestrationContext context, string input)
+            {
+                var tasks = new List<Task<string>>
+                {
+                    context.ScheduleTask<string>("Branch1", string.Empty),
+                    context.ScheduleTask<string>(FailingActivity, string.Empty),
+                    context.ScheduleTask<string>("Branch3", string.Empty),
+                };
+
+                await Task.WhenAll(tasks);
+                return "done";
+            }
+        }
+
+        class SubOrchestrationFailureOrchestration : TaskOrchestration<string, string>
+        {
+            public override async Task<string> RunTask(OrchestrationContext context, string input)
+            {
+                return await context.CreateSubOrchestrationInstance<string>(
+                    FailingActivity,
+                    string.Empty,
+                    "ChildInstance",
+                    null);
+            }
+        }
+
+        #endregion
+
+        #region Harness
+
+        const string InstanceId = "TestInstance";
+        const string InitialExecutionId = "TestExecution";
+
+        class RewindResult
+        {
+            public List<HistoryEvent> HistoryAtFailure { get; set; }
+
+            public List<HistoryEvent> RewoundHistory { get; set; }
+
+            public List<TaskMessage> RewindMessages { get; set; }
+
+            public IReadOnlyList<OrchestratorAction> ReplayActions { get; set; }
+
+            public List<string> ReplayScheduledActivities { get; set; }
+
+            public string ReplayFailureReason { get; set; }
+        }
+
+        static void AssertReplayable(RewindResult result)
+        {
+            Assert.IsNull(
+                result.ReplayFailureReason,
+                "Replaying the rewound history should not fail the orchestration. Actual failure: "
+                    + result.ReplayFailureReason);
+        }
+
+        static RewindResult RunRewindTest(Func<TaskOrchestration> orchestrationFactory)
+        {
+            List<HistoryEvent> historyAtFailure = RunToFailure(orchestrationFactory());
+
+            var runtimeState = new OrchestrationRuntimeState(historyAtFailure);
+            runtimeState.AddEvent(new OrchestratorStartedEvent(-1));
+            runtimeState.AddEvent(new ExecutionRewoundEvent(-1, "rewind requested"));
+
+            TaskOrchestrationDispatcher.ProcessRewindOrchestrationDecision(
+                runtimeState,
+                out List<TaskMessage> rewindMessages,
+                out OrchestrationRuntimeState rewoundState);
+
+            List<HistoryEvent> rewoundHistory = rewoundState.Events.ToList();
+
+            // The dispatcher persists the rewound history and the orchestration is then picked up by a
+            // fresh work item.
+            var replayState = new OrchestrationRuntimeState(rewoundHistory);
+            replayState.AddEvent(new OrchestratorStartedEvent(-1));
+
+            var executor = new TaskOrchestrationExecutor(
+                replayState,
+                orchestrationFactory(),
+                BehaviorOnContinueAsNew.Carryover);
+            OrchestratorExecutionResult replayResult = executor.Execute();
+
+            OrchestrationCompleteOrchestratorAction failureAction = replayResult.Actions
+                .OfType<OrchestrationCompleteOrchestratorAction>()
+                .FirstOrDefault(a => a.OrchestrationStatus == OrchestrationStatus.Failed);
+
+            return new RewindResult
+            {
+                HistoryAtFailure = historyAtFailure,
+                RewoundHistory = rewoundHistory,
+                RewindMessages = rewindMessages,
+                ReplayActions = replayResult.Actions.ToList(),
+                ReplayScheduledActivities = replayResult.Actions
+                    .OfType<ScheduleTaskOrchestratorAction>()
+                    .Select(a => a.Name)
+                    .ToList(),
+                ReplayFailureReason = failureAction == null
+                    ? null
+                    : failureAction.FailureDetails?.ErrorMessage ?? failureAction.Result,
+            };
+        }
+
+        /// <summary>
+        /// Drives the orchestration through real episodes until it completes, failing every task named
+        /// <see cref="FailingActivity"/> and completing everything else.
+        /// </summary>
+        static List<HistoryEvent> RunToFailure(TaskOrchestration orchestration)
+        {
+            var instance = new OrchestrationInstance
+            {
+                InstanceId = InstanceId,
+                ExecutionId = InitialExecutionId,
+            };
+
+            var history = new List<HistoryEvent>();
+            var inbox = new List<HistoryEvent>
+            {
+                new ExecutionStartedEvent(-1, "\"input\"")
+                {
+                    OrchestrationInstance = instance,
+                    Name = "TestOrchestration",
+                    Version = string.Empty,
+                },
+            };
+
+            for (int episode = 0; episode < 25; episode++)
+            {
+                var runtimeState = new OrchestrationRuntimeState(history);
+                runtimeState.AddEvent(new OrchestratorStartedEvent(-1));
+                foreach (HistoryEvent inboundEvent in inbox)
+                {
+                    runtimeState.AddEvent(inboundEvent);
+                }
+
+                inbox = new List<HistoryEvent>();
+
+                var executor = new TaskOrchestrationExecutor(
+                    runtimeState,
+                    orchestration,
+                    BehaviorOnContinueAsNew.Carryover);
+                OrchestratorExecutionResult result = executor.Execute();
+
+                bool completed = false;
+                foreach (OrchestratorAction action in result.Actions)
+                {
+                    switch (action)
+                    {
+                        case ScheduleTaskOrchestratorAction scheduleTask:
+                            runtimeState.AddEvent(new TaskScheduledEvent(
+                                scheduleTask.Id,
+                                scheduleTask.Name,
+                                scheduleTask.Version,
+                                scheduleTask.Input));
+                            inbox.Add(scheduleTask.Name == FailingActivity
+                                ? (HistoryEvent)new TaskFailedEvent(-1, scheduleTask.Id, "failure", "details")
+                                : new TaskCompletedEvent(-1, scheduleTask.Id, "\"ok\""));
+                            break;
+
+                        case CreateSubOrchestrationAction createSubOrchestration:
+                            runtimeState.AddEvent(new SubOrchestrationInstanceCreatedEvent(createSubOrchestration.Id)
+                            {
+                                Name = createSubOrchestration.Name,
+                                Version = createSubOrchestration.Version,
+                                InstanceId = createSubOrchestration.InstanceId,
+                                Input = createSubOrchestration.Input,
+                            });
+                            inbox.Add(createSubOrchestration.Name == FailingActivity
+                                ? (HistoryEvent)new SubOrchestrationInstanceFailedEvent(
+                                    -1,
+                                    createSubOrchestration.Id,
+                                    "failure",
+                                    "details")
+                                : new SubOrchestrationInstanceCompletedEvent(-1, createSubOrchestration.Id, "\"ok\""));
+                            break;
+
+                        case CreateTimerOrchestratorAction createTimer:
+                            runtimeState.AddEvent(new TimerCreatedEvent(createTimer.Id)
+                            {
+                                FireAt = createTimer.FireAt,
+                            });
+                            inbox.Add(new TimerFiredEvent(-1, createTimer.FireAt)
+                            {
+                                TimerId = createTimer.Id,
+                            });
+                            break;
+
+                        case SendEventOrchestratorAction sendEvent:
+                            runtimeState.AddEvent(new EventSentEvent(sendEvent.Id)
+                            {
+                                InstanceId = sendEvent.Instance.InstanceId,
+                                Name = sendEvent.EventName,
+                                Input = sendEvent.EventData,
+                            });
+                            break;
+
+                        case OrchestrationCompleteOrchestratorAction complete:
+                            runtimeState.AddEvent(new ExecutionCompletedEvent(
+                                -1,
+                                complete.Result,
+                                complete.OrchestrationStatus,
+                                complete.FailureDetails));
+                            completed = true;
+                            break;
+
+                        default:
+                            throw new InvalidOperationException(
+                                "Unexpected orchestrator action: " + action.GetType().Name);
+                    }
+                }
+
+                history = runtimeState.Events.ToList();
+                if (completed)
+                {
+                    return history;
+                }
+            }
+
+            throw new InvalidOperationException("The test orchestration never completed.");
+        }
+
+        #endregion
+    }
+}

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -276,12 +276,16 @@ namespace DurableTask.AzureStorage.Tracking
             // REWIND ALGORITHM:
             // 1. Finds failed execution of specified orchestration instance to rewind
             // 2. Finds failure entities to clear and over-writes them (as well as corresponding trigger events)
-            // 3. Identifies sub-orchestration failure(s) from parent instance and calls RewindHistoryAsync recursively on failed sub-orchestration child instance(s)
-            // 4. Resets orchestration status of rewound instance in instance store table to prepare it to be restarted
-            // 5. Returns "failedLeaves", a list of the deepest failed instances on each failed branch to revive with RewindEvent messages
+            // 3. Over-writes everything the orchestrator scheduled at or after the episode in which it first observed a failure,
+            //    together with the entities carrying those results, since the replayed orchestrator can no longer reach them
+            // 4. Identifies sub-orchestration failure(s) from parent instance and calls RewindHistoryAsync recursively on failed sub-orchestration child instance(s)
+            // 5. Resets orchestration status of rewound instance in instance store table to prepare it to be restarted
+            // 6. Returns "failedLeaves", a list of the deepest failed instances on each failed branch to revive with RewindEvent messages
+            //
+            // NOTE: this must be kept in sync with TaskOrchestrationDispatcher.ProcessRewindOrchestrationDecision, which performs the
+            // equivalent scrub over an OrchestrationRuntimeState for backends that rewind at the SDK layer.
             ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-            bool hasFailedSubOrchestrations = false;
             string partitionFilter = AzureTableQueryFilter.PartitionKeyEquals(instanceId);
 
             string orchestratorStartedFilter = $"{partitionFilter} and {nameof(HistoryEvent.EventType)} eq '{nameof(EventType.OrchestratorStarted)}'";
@@ -296,84 +300,174 @@ namespace DurableTask.AzureStorage.Tracking
             // Use parameterized filter to prevent OData injection via crafted execution IDs
             string executionIdFilter = AzureTableQueryFilter.ColumnEquals(nameof(OrchestrationInstance.ExecutionId), executionId);
 
-            var updateFilterBuilder = new StringBuilder();
-            updateFilterBuilder.Append($"{partitionFilter}");
-            updateFilterBuilder.Append($" and {executionIdFilter}");
-            updateFilterBuilder.Append(" and (");
-            updateFilterBuilder.Append($"{nameof(ExecutionCompletedEvent.OrchestrationStatus)} eq '{nameof(OrchestrationStatus.Failed)}'");
-            updateFilterBuilder.Append($" or {nameof(HistoryEvent.EventType)} eq '{nameof(EventType.TaskFailed)}'");
-            updateFilterBuilder.Append($" or {nameof(HistoryEvent.EventType)} eq '{nameof(EventType.SubOrchestrationInstanceFailed)}'");
-            updateFilterBuilder.Append(')');
+            // The full history of the current execution. Row keys are the chronological sequence number of the event formatted as
+            // fixed-width hex, and Azure Table Storage returns entities ordered by row key within a partition, so this list is in
+            // chronological order.
+            IReadOnlyList<TableEntity> historyEntities = await this.QueryHistoryAsync(
+                $"{partitionFilter} and {executionIdFilter}",
+                instanceId,
+                cancellationToken);
 
-            IReadOnlyList<TableEntity> entitiesToClear = await this.QueryHistoryAsync(updateFilterBuilder.ToString(), instanceId, cancellationToken);
-            foreach (TableEntity entity in entitiesToClear)
+            // Determine the task IDs of the failed tasks and suborchestrations, along with the earliest episode in which the
+            // orchestrator observed one of those failures. Episodes are delimited by OrchestratorStarted events.
+            var failedTaskIds = new HashSet<int>();
+            int failureEpisode = int.MaxValue;
+            int episode = -1;
+
+            foreach (TableEntity entity in historyEntities)
             {
-                if (entity.GetString(nameof(OrchestrationInstance.ExecutionId)) != executionId)
+                string eventType = entity.GetString(nameof(HistoryEvent.EventType));
+                if (eventType == nameof(EventType.OrchestratorStarted))
                 {
-                    // the remaining entities are from a previous generation and can be discarded.
-                    break;
+                    episode++;
                 }
+                else if (eventType == nameof(EventType.TaskFailed) || eventType == nameof(EventType.SubOrchestrationInstanceFailed))
+                {
+                    failedTaskIds.Add(entity.GetInt32(nameof(TaskFailedEvent.TaskScheduledId)).GetValueOrDefault());
+                    failureEpisode = Math.Min(failureEpisode, episode);
+                }
+            }
 
+            // Anything the orchestrator scheduled from the failure episode onwards was scheduled only because the orchestrator
+            // observed the failure (for example an activity invoked from a catch block, or the delay timer that RetryInterceptor
+            // creates between attempts). After the rewind the failure is no longer visible, so the replayed orchestrator can never
+            // reach those sequence IDs and would fail with a NonDeterministicOrchestrationException. Note that this deliberately
+            // errs on the side of removing too much: within the failure episode we cannot tell a consequence of the failure apart
+            // from unrelated work that happened to be batched into the same work item without replaying the orchestrator code. The
+            // cost is that a small number of already-successful tasks may be re-executed; the benefit is a history that replays.
+            var consequenceTaskIds = new HashSet<int>();
+            episode = -1;
+
+            foreach (TableEntity entity in historyEntities)
+            {
+                string eventType = entity.GetString(nameof(HistoryEvent.EventType));
+                if (eventType == nameof(EventType.OrchestratorStarted))
+                {
+                    episode++;
+                }
+                else if (episode >= failureEpisode && IsScheduledEventType(eventType))
+                {
+                    consequenceTaskIds.Add(entity.GetInt32(nameof(HistoryEvent.EventId)).GetValueOrDefault());
+                }
+            }
+
+            // Decide what to do with each entity before touching the table, so that no entity is written twice.
+            var entitiesToClear = new List<TableEntity>();
+            var failedSubOrchestrationEntities = new List<TableEntity>();
+
+            foreach (TableEntity entity in historyEntities)
+            {
                 if (entity.RowKey == SentinelRowKey)
                 {
                     continue;
                 }
 
-                int? taskScheduledId = entity.GetInt32(nameof(TaskCompletedEvent.TaskScheduledId));
-
-                var eventFilterBuilder = new StringBuilder();
-                eventFilterBuilder.Append($"{partitionFilter}");
-                eventFilterBuilder.Append($" and {executionIdFilter}");
-                eventFilterBuilder.Append($" and {nameof(HistoryEvent.EventId)} eq {taskScheduledId.GetValueOrDefault()}");
-
-                switch (entity.GetString(nameof(HistoryEvent.EventType)))
+                if (entity.GetString(nameof(OrchestrationInstance.ExecutionId)) != executionId)
                 {
-                    // delete TaskScheduled corresponding to TaskFailed event
-                    case nameof(EventType.TaskFailed):
-                        eventFilterBuilder.Append($" and {nameof(HistoryEvent.EventType)} eq '{nameof(EventType.TaskScheduled)}'");
-                        IReadOnlyList<TableEntity> taskScheduledEntities = await this.QueryHistoryAsync(eventFilterBuilder.ToString(), instanceId, cancellationToken);
-
-                        TableEntity tsEntity = taskScheduledEntities[0];
-                        tsEntity[nameof(TaskFailedEvent.Reason)] = "Rewound: " + tsEntity.GetString(nameof(HistoryEvent.EventType));
-                        tsEntity[nameof(TaskFailedEvent.EventType)] = nameof(EventType.GenericEvent);
-                        await this.HistoryTable.ReplaceEntityAsync(tsEntity, tsEntity.ETag, cancellationToken);
-                        break;
-
-                    // delete SubOrchestratorCreated corresponding to SubOrchestraionInstanceFailed event
-                    case nameof(EventType.SubOrchestrationInstanceFailed):
-                        hasFailedSubOrchestrations = true;
-
-                        eventFilterBuilder.Append($" and {nameof(HistoryEvent.EventType)} eq '{nameof(EventType.SubOrchestrationInstanceCreated)}'");
-                        IReadOnlyList<TableEntity> subOrchesratrationEntities = await this.QueryHistoryAsync(eventFilterBuilder.ToString(), instanceId, cancellationToken);
-
-                        // the SubOrchestrationCreatedEvent is still healthy and will not be overwritten, just marked as rewound
-                        TableEntity soEntity = subOrchesratrationEntities[0];
-                        soEntity[nameof(SubOrchestrationInstanceFailedEvent.Reason)] = "Rewound: " + soEntity.GetString(nameof(HistoryEvent.EventType));
-                        await this.HistoryTable.ReplaceEntityAsync(soEntity, soEntity.ETag, cancellationToken);
-
-                        // recursive call to clear out failure events on child instances
-                        await foreach (string childInstanceId in this.RewindHistoryAsync(soEntity.GetString(nameof(OrchestrationInstance.InstanceId)), cancellationToken))
-                        {
-                            yield return childInstanceId;
-                        }
-
-                        break;
+                    // the entity is from a previous generation and can be discarded.
+                    continue;
                 }
 
-                // "clear" failure event by making RewindEvent: replay ignores row while dummy event preserves rowKey
+                string eventType = entity.GetString(nameof(HistoryEvent.EventType));
+                int eventId = entity.GetInt32(nameof(HistoryEvent.EventId)).GetValueOrDefault();
+
+                // the failure events themselves, including the failed ExecutionCompleted event
+                if (eventType == nameof(EventType.TaskFailed)
+                    || eventType == nameof(EventType.SubOrchestrationInstanceFailed)
+                    || entity.GetString(nameof(ExecutionCompletedEvent.OrchestrationStatus)) == nameof(OrchestrationStatus.Failed))
+                {
+                    entitiesToClear.Add(entity);
+                }
+
+                // the TaskScheduled event corresponding to a TaskFailed event, so that the task gets rescheduled
+                else if (eventType == nameof(EventType.TaskScheduled) && failedTaskIds.Contains(eventId))
+                {
+                    entitiesToClear.Add(entity);
+                }
+
+                // the SubOrchestrationInstanceCreated event corresponding to a SubOrchestrationInstanceFailed event is still
+                // healthy and will not be overwritten, just marked as rewound, so long as it is not itself being removed
+                else if (eventType == nameof(EventType.SubOrchestrationInstanceCreated)
+                    && failedTaskIds.Contains(eventId)
+                    && !consequenceTaskIds.Contains(eventId))
+                {
+                    failedSubOrchestrationEntities.Add(entity);
+                }
+
+                // everything the orchestrator scheduled as a consequence of observing the failure
+                else if (IsScheduledEventType(eventType) && consequenceTaskIds.Contains(eventId))
+                {
+                    entitiesToClear.Add(entity);
+                }
+
+                // and the results of those scheduled events. Leaving them behind would allow a stale result to satisfy a different
+                // task that gets assigned the same sequence ID once the orchestration resumes.
+                else if (TryGetCompletedTaskId(entity, eventType, out int completedTaskId) && consequenceTaskIds.Contains(completedTaskId))
+                {
+                    entitiesToClear.Add(entity);
+                }
+            }
+
+            foreach (TableEntity entity in entitiesToClear)
+            {
+                // "clear" the event by making it a GenericEvent: replay ignores the row while the dummy event preserves the rowKey
                 entity[nameof(TaskFailedEvent.Reason)] = "Rewound: " + entity.GetString(nameof(HistoryEvent.EventType));
                 entity[nameof(TaskFailedEvent.EventType)] = nameof(EventType.GenericEvent);
 
                 await this.HistoryTable.ReplaceEntityAsync(entity, entity.ETag, cancellationToken);
             }
 
+            foreach (TableEntity entity in failedSubOrchestrationEntities)
+            {
+                entity[nameof(SubOrchestrationInstanceFailedEvent.Reason)] = "Rewound: " + entity.GetString(nameof(HistoryEvent.EventType));
+                await this.HistoryTable.ReplaceEntityAsync(entity, entity.ETag, cancellationToken);
+
+                // recursive call to clear out failure events on child instances
+                await foreach (string childInstanceId in this.RewindHistoryAsync(entity.GetString(nameof(OrchestrationInstance.InstanceId)), cancellationToken))
+                {
+                    yield return childInstanceId;
+                }
+            }
+
             // reset orchestration status in instance store table
             await this.UpdateStatusForRewindAsync(instanceId, cancellationToken);
 
-            if (!hasFailedSubOrchestrations)
+            if (failedSubOrchestrationEntities.Count == 0)
             {
                 yield return instanceId;
             }
+        }
+
+        /// <summary>
+        /// Determines whether the event type is one that replay matches against the orchestrator's sequence-ID counter. If one of
+        /// these events has no counterpart in the replayed execution, the orchestration fails with a
+        /// <see cref="Core.Exceptions.NonDeterministicOrchestrationException"/>.
+        /// </summary>
+        static bool IsScheduledEventType(string eventType) =>
+            eventType == nameof(EventType.TaskScheduled)
+            || eventType == nameof(EventType.SubOrchestrationInstanceCreated)
+            || eventType == nameof(EventType.TimerCreated)
+            || eventType == nameof(EventType.EventSent);
+
+        /// <summary>
+        /// Gets the sequence ID of the scheduled task whose result the entity carries.
+        /// </summary>
+        static bool TryGetCompletedTaskId(TableEntity entity, string eventType, out int taskId)
+        {
+            if (eventType == nameof(EventType.TaskCompleted) || eventType == nameof(EventType.SubOrchestrationInstanceCompleted))
+            {
+                taskId = entity.GetInt32(nameof(TaskCompletedEvent.TaskScheduledId)).GetValueOrDefault();
+                return true;
+            }
+
+            if (eventType == nameof(EventType.TimerFired))
+            {
+                taskId = entity.GetInt32(nameof(TimerFiredEvent.TimerId)).GetValueOrDefault();
+                return true;
+            }
+
+            taskId = -1;
+            return false;
         }
 
         /// <inheritdoc />

--- a/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
+++ b/src/DurableTask.AzureStorage/Tracking/AzureTableTrackingStore.cs
@@ -409,15 +409,11 @@ namespace DurableTask.AzureStorage.Tracking
                 }
             }
 
-            foreach (TableEntity entity in entitiesToClear)
-            {
-                // "clear" the event by making it a GenericEvent: replay ignores the row while the dummy event preserves the rowKey
-                entity[nameof(TaskFailedEvent.Reason)] = "Rewound: " + entity.GetString(nameof(HistoryEvent.EventType));
-                entity[nameof(TaskFailedEvent.EventType)] = nameof(EventType.GenericEvent);
-
-                await this.HistoryTable.ReplaceEntityAsync(entity, entity.ETag, cancellationToken);
-            }
-
+            // Rewind the failed children before clearing this orchestration's own failure rows. The two loops touch disjoint
+            // entities, but the ordering matters for retryability: the SubOrchestrationInstanceFailed rows are what identify the
+            // children that still need rewinding, so if a child rewind fails part way through, leaving those rows intact lets a
+            // retry rediscover the children. Clearing them first would let a retry mistake this orchestration for a leaf and
+            // revive it while a child is still failed, leaving it waiting forever on the retained sub-orchestration creation.
             foreach (TableEntity entity in failedSubOrchestrationEntities)
             {
                 entity[nameof(SubOrchestrationInstanceFailedEvent.Reason)] = "Rewound: " + entity.GetString(nameof(HistoryEvent.EventType));
@@ -428,6 +424,15 @@ namespace DurableTask.AzureStorage.Tracking
                 {
                     yield return childInstanceId;
                 }
+            }
+
+            foreach (TableEntity entity in entitiesToClear)
+            {
+                // "clear" the event by making it a GenericEvent: replay ignores the row while the dummy event preserves the rowKey
+                entity[nameof(TaskFailedEvent.Reason)] = "Rewound: " + entity.GetString(nameof(HistoryEvent.EventType));
+                entity[nameof(TaskFailedEvent.EventType)] = nameof(EventType.GenericEvent);
+
+                await this.HistoryTable.ReplaceEntityAsync(entity, entity.ETag, cancellationToken);
             }
 
             // reset orchestration status in instance store table

--- a/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
+++ b/src/DurableTask.Core/TaskOrchestrationDispatcher.cs
@@ -551,7 +551,7 @@ namespace DurableTask.Core
                                     isCompleted = !continuedAsNew;
                                     break;
                                 case OrchestratorActionType.RewindOrchestration:
-                                    this.ProcessRewindOrchestrationDecision(
+                                    ProcessRewindOrchestrationDecision(
                                         runtimeState,
                                         out List<TaskMessage> subOrchestrationRewindMessages,
                                         out OrchestrationRuntimeState newRuntimeState);
@@ -1379,7 +1379,57 @@ namespace DurableTask.Core
             };
         }
 
-        void ProcessRewindOrchestrationDecision(
+        /// <summary>
+        /// Gets the sequence ID of a history event that the orchestrator matches against its own
+        /// sequence-ID counter during replay. If one of these events has no counterpart in the
+        /// replayed execution, <see cref="TaskOrchestrationContext"/> throws a
+        /// <see cref="Exceptions.NonDeterministicOrchestrationException"/>.
+        /// </summary>
+        static bool TryGetScheduledTaskId(HistoryEvent historyEvent, out int taskId)
+        {
+            switch (historyEvent)
+            {
+                case TaskScheduledEvent taskScheduledEvent:
+                    taskId = taskScheduledEvent.EventId;
+                    return true;
+                case SubOrchestrationInstanceCreatedEvent subOrchestrationInstanceCreatedEvent:
+                    taskId = subOrchestrationInstanceCreatedEvent.EventId;
+                    return true;
+                case TimerCreatedEvent timerCreatedEvent:
+                    taskId = timerCreatedEvent.EventId;
+                    return true;
+                case EventSentEvent eventSentEvent:
+                    taskId = eventSentEvent.EventId;
+                    return true;
+                default:
+                    taskId = -1;
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Gets the sequence ID of the scheduled task that a history event carries the result of.
+        /// </summary>
+        static bool TryGetCompletedTaskId(HistoryEvent historyEvent, out int taskId)
+        {
+            switch (historyEvent)
+            {
+                case TaskCompletedEvent taskCompletedEvent:
+                    taskId = taskCompletedEvent.TaskScheduledId;
+                    return true;
+                case SubOrchestrationInstanceCompletedEvent subOrchestrationInstanceCompletedEvent:
+                    taskId = subOrchestrationInstanceCompletedEvent.TaskScheduledId;
+                    return true;
+                case TimerFiredEvent timerFiredEvent:
+                    taskId = timerFiredEvent.TimerId;
+                    return true;
+                default:
+                    taskId = -1;
+                    return false;
+            }
+        }
+
+        internal static void ProcessRewindOrchestrationDecision(
             OrchestrationRuntimeState runtimeState,
             out List<TaskMessage> subOrchestrationRewindMessages,
             out OrchestrationRuntimeState newRuntimeState)
@@ -1388,9 +1438,15 @@ namespace DurableTask.Core
             /* WARNING!!!:
              * If any changes are made to how this method modifies the orchestration's history, then corresponding changes *must* 
              * be made in the backend implementations that rely on this method for executing a rewind.
+             *
+             * The rewind is "episode-aware": history is divided into episodes delimited by OrchestratorStartedEvent, and every
+             * task the orchestrator scheduled at or after the episode in which a failure was first observed is removed along with
+             * the failure itself. Backends replicating this logic must remove all four of the event types that replay matches
+             * against the orchestrator's sequence-ID counter (TaskScheduled, SubOrchestrationInstanceCreated, TimerCreated and
+             * EventSent), plus their result events. See AzureTableTrackingStore.RewindHistoryAsync for the equivalent
+             * implementation over Azure Table rows.
              */
 
-            HashSet<int> failedTaskIds = new();
             subOrchestrationRewindMessages = new();
 
             newRuntimeState = new()
@@ -1398,16 +1454,50 @@ namespace DurableTask.Core
                 Status = runtimeState.Status
             };
 
-            // Determine the task IDs of the failed tasks and suborchestrations
+            // Determine the task IDs of the failed tasks and suborchestrations, along with the earliest episode in which the
+            // orchestrator observed one of those failures.
+            HashSet<int> failedTaskIds = new();
+            int failureEpisode = int.MaxValue;
+            int episode = -1;
+
             foreach (var evt in runtimeState.Events)
             {
-                if (evt is TaskFailedEvent taskFailedEvent)
+                if (evt is OrchestratorStartedEvent)
+                {
+                    episode++;
+                }
+                else if (evt is TaskFailedEvent taskFailedEvent)
                 {
                     failedTaskIds.Add(taskFailedEvent.TaskScheduledId);
+                    failureEpisode = Math.Min(failureEpisode, episode);
                 }
                 else if (evt is SubOrchestrationInstanceFailedEvent subOrchestrationInstanceFailedEvent)
                 {
                     failedTaskIds.Add(subOrchestrationInstanceFailedEvent.TaskScheduledId);
+                    failureEpisode = Math.Min(failureEpisode, episode);
+                }
+            }
+
+            // Anything the orchestrator scheduled from the failure episode onwards was scheduled only because the orchestrator
+            // observed the failure (for example an activity invoked from a catch block, or the delay timer that
+            // RetryInterceptor creates between attempts). After the rewind the failure is no longer visible, so the replayed
+            // orchestrator can never reach those sequence IDs and would fail with a NonDeterministicOrchestrationException.
+            // Note that this deliberately errs on the side of removing too much: within the failure episode we cannot tell a
+            // consequence of the failure apart from unrelated work that happened to be batched into the same work item without
+            // replaying the orchestrator code, which the rewind path (and the backends replicating it) cannot do. The cost is
+            // that a small number of already-successful tasks may be re-executed; the benefit is a history that always replays.
+            HashSet<int> consequenceTaskIds = new();
+            episode = -1;
+
+            foreach (var evt in runtimeState.Events)
+            {
+                if (evt is OrchestratorStartedEvent)
+                {
+                    episode++;
+                }
+                else if (episode >= failureEpisode && TryGetScheduledTaskId(evt, out int scheduledTaskId))
+                {
+                    consequenceTaskIds.Add(scheduledTaskId);
                 }
             }
 
@@ -1417,74 +1507,87 @@ namespace DurableTask.Core
             // Copy the existing history, removing the failed task/suborchestration events and generating rewind events for each of the failed suborchestrations.
             foreach (var evt in runtimeState.Events)
             {
-                // Do not add the TaskScheduledEvents for the failed tasks so that they get rescheduled, and do not add any of
-                // the failed task/suborchestration/execution events to the new history.
-                if (!(evt is TaskScheduledEvent taskScheduledEvent && failedTaskIds.Contains(taskScheduledEvent.EventId))
-                    && evt is not TaskFailedEvent
-                    && evt is not SubOrchestrationInstanceFailedEvent
-                    && evt is not ExecutionCompletedEvent)
+                // Do not add any of the failed task/suborchestration/execution events to the new history.
+                if (evt is TaskFailedEvent || evt is SubOrchestrationInstanceFailedEvent || evt is ExecutionCompletedEvent)
                 {
-                    HistoryEvent eventToAdd = evt;
-
-                    if (evt is ExecutionStartedEvent executionStartedEvent)
-                    {
-                        // Copy all information from the old ExecutionStartedEvent except for the ExecutionId, since we create a new one
-                        var newExecutionStartedEvent = new ExecutionStartedEvent(executionStartedEvent);
-                        newExecutionStartedEvent.OrchestrationInstance.ExecutionId = newExecutionId;
-
-                        // If this is a suborchestration, we also need to update the ParentInstance's ExecutionId to match the new ExecutionId of the rewinding parent orchestration
-                        if (!string.IsNullOrEmpty(executionRewoundEvent.ParentExecutionId))
-                        {
-                            newExecutionStartedEvent.ParentInstance.OrchestrationInstance.ExecutionId = executionRewoundEvent.ParentExecutionId;
-                        }
-                        eventToAdd = newExecutionStartedEvent;
-                    }
-
-                    // For each of the failed suborchestrations, generate a rewind event
-                    else if (evt is SubOrchestrationInstanceCreatedEvent subOrchestrationInstanceCreatedEvent
-                        && failedTaskIds.Contains(subOrchestrationInstanceCreatedEvent.EventId))
-                    {   
-                        var childExecutionRewoundEvent = new ExecutionRewoundEvent(-1, executionRewoundEvent!.Reason)
-                        {
-                            ParentExecutionId = newExecutionId,
-                            InstanceId = subOrchestrationInstanceCreatedEvent.InstanceId
-                        };
-
-                        if (runtimeState.ExecutionStartedEvent.TryGetParentTraceContext(out ActivityContext parentTraceContext))
-                        {
-                            // We set a new client span ID here so that the execution of the rewound suborchestration is not tied to the 
-                            // old parent.
-                            var newClientSpanId = ActivitySpanId.CreateRandom();
-                            var newSubOrchestrationInstanceCreatedEvent = new SubOrchestrationInstanceCreatedEvent(subOrchestrationInstanceCreatedEvent)
-                            {
-                                ClientSpanId = newClientSpanId.ToString()
-                            };
-                            eventToAdd = newSubOrchestrationInstanceCreatedEvent;
-
-                            ActivityContext childActivityContext = new(
-                                parentTraceContext.TraceId,
-                                newClientSpanId,
-                                parentTraceContext.TraceFlags,
-                                parentTraceContext.TraceState);
-                            childExecutionRewoundEvent.SetParentTraceContext(childActivityContext);
-                        }
-
-                        subOrchestrationRewindMessages.Add
-                            (
-                                new TaskMessage
-                                {
-                                    Event = childExecutionRewoundEvent,
-                                    OrchestrationInstance = new OrchestrationInstance
-                                    {
-                                        InstanceId = subOrchestrationInstanceCreatedEvent.InstanceId
-                                    },
-                                }
-                            );
-                    }
-
-                    // Finally, add the event to the new history
-                    newRuntimeState.AddEvent(eventToAdd);
+                    continue;
                 }
+
+                // Do not add the TaskScheduledEvents for the failed tasks so that they get rescheduled, and do not add anything
+                // the orchestrator scheduled as a consequence of observing the failure.
+                if (TryGetScheduledTaskId(evt, out int taskId)
+                    && (consequenceTaskIds.Contains(taskId) || (evt is TaskScheduledEvent && failedTaskIds.Contains(taskId))))
+                {
+                    continue;
+                }
+
+                // Do not add the results of the removed tasks either. Leaving them behind would allow a stale result to satisfy
+                // a different task that gets assigned the same sequence ID once the orchestration resumes.
+                if (TryGetCompletedTaskId(evt, out int completedTaskId) && consequenceTaskIds.Contains(completedTaskId))
+                {
+                    continue;
+                }
+
+                HistoryEvent eventToAdd = evt;
+
+                if (evt is ExecutionStartedEvent executionStartedEvent)
+                {
+                    // Copy all information from the old ExecutionStartedEvent except for the ExecutionId, since we create a new one
+                    var newExecutionStartedEvent = new ExecutionStartedEvent(executionStartedEvent);
+                    newExecutionStartedEvent.OrchestrationInstance.ExecutionId = newExecutionId;
+
+                    // If this is a suborchestration, we also need to update the ParentInstance's ExecutionId to match the new ExecutionId of the rewinding parent orchestration
+                    if (!string.IsNullOrEmpty(executionRewoundEvent.ParentExecutionId))
+                    {
+                        newExecutionStartedEvent.ParentInstance.OrchestrationInstance.ExecutionId = executionRewoundEvent.ParentExecutionId;
+                    }
+                    eventToAdd = newExecutionStartedEvent;
+                }
+
+                // For each of the failed suborchestrations we are keeping, generate a rewind event
+                else if (evt is SubOrchestrationInstanceCreatedEvent subOrchestrationInstanceCreatedEvent
+                    && failedTaskIds.Contains(subOrchestrationInstanceCreatedEvent.EventId))
+                {   
+                    var childExecutionRewoundEvent = new ExecutionRewoundEvent(-1, executionRewoundEvent!.Reason)
+                    {
+                        ParentExecutionId = newExecutionId,
+                        InstanceId = subOrchestrationInstanceCreatedEvent.InstanceId
+                    };
+
+                    if (runtimeState.ExecutionStartedEvent.TryGetParentTraceContext(out ActivityContext parentTraceContext))
+                    {
+                        // We set a new client span ID here so that the execution of the rewound suborchestration is not tied to the 
+                        // old parent.
+                        var newClientSpanId = ActivitySpanId.CreateRandom();
+                        var newSubOrchestrationInstanceCreatedEvent = new SubOrchestrationInstanceCreatedEvent(subOrchestrationInstanceCreatedEvent)
+                        {
+                            ClientSpanId = newClientSpanId.ToString()
+                        };
+                        eventToAdd = newSubOrchestrationInstanceCreatedEvent;
+
+                        ActivityContext childActivityContext = new(
+                            parentTraceContext.TraceId,
+                            newClientSpanId,
+                            parentTraceContext.TraceFlags,
+                            parentTraceContext.TraceState);
+                        childExecutionRewoundEvent.SetParentTraceContext(childActivityContext);
+                    }
+
+                    subOrchestrationRewindMessages.Add
+                        (
+                            new TaskMessage
+                            {
+                                Event = childExecutionRewoundEvent,
+                                OrchestrationInstance = new OrchestrationInstance
+                                {
+                                    InstanceId = subOrchestrationInstanceCreatedEvent.InstanceId
+                                },
+                            }
+                        );
+                }
+
+                // Finally, add the event to the new history
+                newRuntimeState.AddEvent(eventToAdd);
             }
 
             // If this is a "terminal leaf" with no suborchestrations, we need to add an outbound message to it to force it to rerun.

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -1438,6 +1438,79 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
+        /// <summary>
+        /// End-to-end test which validates that an orchestration that schedules more work in response to an activity
+        /// failure can be rewound. Regression test for
+        /// https://github.com/Azure/azure-functions-durable-extension/issues/444.
+        /// </summary>
+        [TestMethod]
+        public async Task RewindActivityFailWithCleanupActivity()
+        {
+            using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(enableExtendedSessions: true))
+            {
+                Activities.HelloFailCleanupActivity.ShouldFail = true;
+                await host.StartAsync();
+
+                string singletonInstanceId = $"Test_{Guid.NewGuid():N}";
+
+                var client = await host.StartOrchestrationAsync(
+                    typeof(Orchestrations.SayHelloWithActivityFailAndCleanup),
+                    input: "World",
+                    instanceId: singletonInstanceId);
+
+                var statusFail = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+
+                Assert.AreEqual(OrchestrationStatus.Failed, statusFail?.OrchestrationStatus);
+
+                Activities.HelloFailCleanupActivity.ShouldFail = false;
+
+                await client.RewindAsync("Rewind orchestrator that scheduled an activity from its catch block.");
+
+                var statusRewind = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+
+                Assert.AreEqual(OrchestrationStatus.Completed, statusRewind?.OrchestrationStatus);
+                Assert.AreEqual("\"Hello, World!\"", statusRewind?.Output);
+
+                await host.StopAsync();
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which validates that an orchestration whose retried activity ultimately failed can be rewound.
+        /// The retry delay timers are also a consequence of the failure and must not survive the rewind.
+        /// </summary>
+        [TestMethod]
+        public async Task RewindActivityFailWithRetry()
+        {
+            using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(enableExtendedSessions: true))
+            {
+                Activities.HelloFailRetryActivity.ShouldFail = true;
+                await host.StartAsync();
+
+                string singletonInstanceId = $"Test_{Guid.NewGuid():N}";
+
+                var client = await host.StartOrchestrationAsync(
+                    typeof(Orchestrations.SayHelloWithActivityFailAndRetry),
+                    input: "World",
+                    instanceId: singletonInstanceId);
+
+                var statusFail = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
+
+                Assert.AreEqual(OrchestrationStatus.Failed, statusFail?.OrchestrationStatus);
+
+                Activities.HelloFailRetryActivity.ShouldFail = false;
+
+                await client.RewindAsync("Rewind orchestrator with a retried activity.");
+
+                var statusRewind = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
+
+                Assert.AreEqual(OrchestrationStatus.Completed, statusRewind?.OrchestrationStatus);
+                Assert.AreEqual("\"Hello, World!\"", statusRewind?.Output);
+
+                await host.StopAsync();
+            }
+        }
+
         [TestMethod]
         public async Task RewindMultipleActivityFail()
         {
@@ -4303,6 +4376,38 @@ namespace DurableTask.AzureStorage.Tests
                 }
             }
 
+            [KnownType(typeof(Activities.HelloFailCleanupActivity))]
+            [KnownType(typeof(Activities.Hello))]
+            internal class SayHelloWithActivityFailAndCleanup : TaskOrchestration<string, string>
+            {
+                public override async Task<string> RunTask(OrchestrationContext context, string input)
+                {
+                    try
+                    {
+                        return await context.ScheduleTask<string>(typeof(Activities.HelloFailCleanupActivity), input);
+                    }
+                    catch (Exception)
+                    {
+                        // The cleanup activity exists only because the orchestrator observed the failure, so rewind has to
+                        // remove it from the history. See https://github.com/Azure/azure-functions-durable-extension/issues/444.
+                        await context.ScheduleTask<string>(typeof(Activities.Hello), "Cleanup");
+                        throw;
+                    }
+                }
+            }
+
+            [KnownType(typeof(Activities.HelloFailRetryActivity))]
+            internal class SayHelloWithActivityFailAndRetry : TaskOrchestration<string, string>
+            {
+                public override Task<string> RunTask(OrchestrationContext context, string input)
+                {
+                    // Retries leave delay timers in the history, including one created after the final failed attempt, which
+                    // rewind has to remove along with the failed attempts themselves.
+                    var retryOptions = new RetryOptions(TimeSpan.FromSeconds(1), maxNumberOfAttempts: 2);
+                    return context.ScheduleWithRetry<string>(typeof(Activities.HelloFailRetryActivity), retryOptions, input);
+                }
+            }
+
             [KnownType(typeof(Activities.Multiply))]
             internal class Factorial : TaskOrchestration<long, int>
             {
@@ -5069,6 +5174,44 @@ namespace DurableTask.AzureStorage.Tests
         static class Activities
         {
             internal class HelloFailActivity : TaskActivity<string, string>
+            {
+                public static bool ShouldFail = true;
+                protected override string Execute(TaskContext context, string input)
+                {
+                    if (string.IsNullOrEmpty(input))
+                    {
+                        throw new ArgumentNullException(nameof(input));
+                    }
+
+                    if (ShouldFail)
+                    {
+                        throw new Exception("Simulating unhandled activity function failure...");
+                    }
+
+                    return $"Hello, {input}!";
+                }
+            }
+
+            internal class HelloFailCleanupActivity : TaskActivity<string, string>
+            {
+                public static bool ShouldFail = true;
+                protected override string Execute(TaskContext context, string input)
+                {
+                    if (string.IsNullOrEmpty(input))
+                    {
+                        throw new ArgumentNullException(nameof(input));
+                    }
+
+                    if (ShouldFail)
+                    {
+                        throw new Exception("Simulating unhandled activity function failure...");
+                    }
+
+                    return $"Hello, {input}!";
+                }
+            }
+
+            internal class HelloFailRetryActivity : TaskActivity<string, string>
             {
                 public static bool ShouldFail = true;
                 protected override string Execute(TaskContext context, string input)

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -1448,30 +1448,39 @@ namespace DurableTask.AzureStorage.Tests
         {
             using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(enableExtendedSessions: true))
             {
-                Activities.HelloFailCleanupActivity.ShouldFail = true;
-                await host.StartAsync();
+                bool originalShouldFail = Activities.HelloFailCleanupActivity.ShouldFail;
+                try
+                {
+                    Activities.HelloFailCleanupActivity.ShouldFail = true;
+                    await host.StartAsync();
 
-                string singletonInstanceId = $"Test_{Guid.NewGuid():N}";
+                    string singletonInstanceId = $"Test_{Guid.NewGuid():N}";
 
-                var client = await host.StartOrchestrationAsync(
-                    typeof(Orchestrations.SayHelloWithActivityFailAndCleanup),
-                    input: "World",
-                    instanceId: singletonInstanceId);
+                    var client = await host.StartOrchestrationAsync(
+                        typeof(Orchestrations.SayHelloWithActivityFailAndCleanup),
+                        input: "World",
+                        instanceId: singletonInstanceId);
 
-                var statusFail = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+                    var statusFail = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
-                Assert.AreEqual(OrchestrationStatus.Failed, statusFail?.OrchestrationStatus);
+                    Assert.AreEqual(OrchestrationStatus.Failed, statusFail?.OrchestrationStatus);
 
-                Activities.HelloFailCleanupActivity.ShouldFail = false;
+                    Activities.HelloFailCleanupActivity.ShouldFail = false;
 
-                await client.RewindAsync("Rewind orchestrator that scheduled an activity from its catch block.");
+                    await client.RewindAsync("Rewind orchestrator that scheduled an activity from its catch block.");
 
-                var statusRewind = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+                    var statusRewind = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
-                Assert.AreEqual(OrchestrationStatus.Completed, statusRewind?.OrchestrationStatus);
-                Assert.AreEqual("\"Hello, World!\"", statusRewind?.Output);
-
-                await host.StopAsync();
+                    Assert.AreEqual(OrchestrationStatus.Completed, statusRewind?.OrchestrationStatus);
+                    Assert.AreEqual("\"Hello, World!\"", statusRewind?.Output);
+                }
+                finally
+                {
+                    // Restore the shared flag and stop the host even if an assertion above threw, so that
+                    // a failure here cannot cascade into unrelated tests.
+                    Activities.HelloFailCleanupActivity.ShouldFail = originalShouldFail;
+                    await host.StopAsync();
+                }
             }
         }
 
@@ -1484,30 +1493,39 @@ namespace DurableTask.AzureStorage.Tests
         {
             using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(enableExtendedSessions: true))
             {
-                Activities.HelloFailRetryActivity.ShouldFail = true;
-                await host.StartAsync();
+                bool originalShouldFail = Activities.HelloFailRetryActivity.ShouldFail;
+                try
+                {
+                    Activities.HelloFailRetryActivity.ShouldFail = true;
+                    await host.StartAsync();
 
-                string singletonInstanceId = $"Test_{Guid.NewGuid():N}";
+                    string singletonInstanceId = $"Test_{Guid.NewGuid():N}";
 
-                var client = await host.StartOrchestrationAsync(
-                    typeof(Orchestrations.SayHelloWithActivityFailAndRetry),
-                    input: "World",
-                    instanceId: singletonInstanceId);
+                    var client = await host.StartOrchestrationAsync(
+                        typeof(Orchestrations.SayHelloWithActivityFailAndRetry),
+                        input: "World",
+                        instanceId: singletonInstanceId);
 
-                var statusFail = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
+                    var statusFail = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
 
-                Assert.AreEqual(OrchestrationStatus.Failed, statusFail?.OrchestrationStatus);
+                    Assert.AreEqual(OrchestrationStatus.Failed, statusFail?.OrchestrationStatus);
 
-                Activities.HelloFailRetryActivity.ShouldFail = false;
+                    Activities.HelloFailRetryActivity.ShouldFail = false;
 
-                await client.RewindAsync("Rewind orchestrator with a retried activity.");
+                    await client.RewindAsync("Rewind orchestrator with a retried activity.");
 
-                var statusRewind = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
+                    var statusRewind = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
 
-                Assert.AreEqual(OrchestrationStatus.Completed, statusRewind?.OrchestrationStatus);
-                Assert.AreEqual("\"Hello, World!\"", statusRewind?.Output);
-
-                await host.StopAsync();
+                    Assert.AreEqual(OrchestrationStatus.Completed, statusRewind?.OrchestrationStatus);
+                    Assert.AreEqual("\"Hello, World!\"", statusRewind?.Output);
+                }
+                finally
+                {
+                    // Restore the shared flag and stop the host even if an assertion above threw, so that
+                    // a failure here cannot cascade into unrelated tests.
+                    Activities.HelloFailRetryActivity.ShouldFail = originalShouldFail;
+                    await host.StopAsync();
+                }
             }
         }
 

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -1715,7 +1715,8 @@ namespace DurableTask.AzureStorage.Tests
 
                     var statusFail = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
 
-                    Assert.AreEqual(OrchestrationStatus.Failed, statusFail?.OrchestrationStatus);
+                    Assert.IsNotNull(statusFail, "The orchestration did not complete within the timeout, so no status was returned.");
+                    Assert.AreEqual(OrchestrationStatus.Failed, statusFail.OrchestrationStatus);
 
                     // A sub-orchestration created without an explicit instance ID is assigned "<parent execution ID>:<sequence
                     // ID>", and the cleanup child is the first one the orchestrator creates, so it occupies sequence ID 1.

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -1617,6 +1617,63 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
+        /// <summary>
+        /// End-to-end test which validates that rewinding an orchestration whose catch block created a sub-orchestration leaves
+        /// the orchestrator able to create a *different* sub-orchestration at the same sequence ID on the success path. Because
+        /// the Azure Storage rewind keeps the parent's execution ID, the replayed child is assigned the default instance ID
+        /// "&lt;parent execution ID&gt;:&lt;sequence ID&gt;", which the cleanup child from the failed attempt already occupies.
+        /// </summary>
+        [TestMethod]
+        public async Task RewindActivityFailWithSubOrchestrationIdReuse()
+        {
+            using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(enableExtendedSessions: true))
+            {
+                bool originalShouldFail = Activities.HelloFailSubOrchestrationIdReuseActivity.ShouldFail;
+                try
+                {
+                    Activities.HelloFailSubOrchestrationIdReuseActivity.ShouldFail = true;
+                    await host.StartAsync();
+
+                    string singletonInstanceId = $"Test_{Guid.NewGuid():N}";
+
+                    var client = await host.StartOrchestrationAsync(
+                        typeof(Orchestrations.SayHelloWithActivityFailAndSubOrchestrationIdReuse),
+                        input: "World",
+                        instanceId: singletonInstanceId);
+
+                    var statusFail = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
+
+                    Assert.AreEqual(OrchestrationStatus.Failed, statusFail?.OrchestrationStatus);
+
+                    Activities.HelloFailSubOrchestrationIdReuseActivity.ShouldFail = false;
+
+                    await client.RewindAsync("Rewind orchestrator whose success path reuses the cleanup child's sequence ID.");
+
+                    var statusRewind = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
+
+                    Assert.AreEqual(OrchestrationStatus.Completed, statusRewind?.OrchestrationStatus);
+                    Assert.AreEqual("\"Hello, World! Child says World.\"", statusRewind?.Output);
+
+                    // Guard the premise of this test: if the two sub-orchestrations ever stop colliding on the same default
+                    // instance ID, the scenario is no longer covered and the assertions above would pass for the wrong reason.
+                    Assert.IsNotNull(
+                        Orchestrations.IdReuseCleanupChildWorkflow.LastInstanceId,
+                        "The cleanup sub-orchestration never ran, so the failed attempt did not set up the ID collision.");
+                    Assert.AreEqual(
+                        Orchestrations.IdReuseCleanupChildWorkflow.LastInstanceId,
+                        Orchestrations.IdReuseSuccessChildWorkflow.LastInstanceId,
+                        "The two sub-orchestrations were assigned different instance IDs, so this test no longer covers child instance ID reuse across a rewind.");
+                }
+                finally
+                {
+                    Activities.HelloFailSubOrchestrationIdReuseActivity.ShouldFail = originalShouldFail;
+                    Orchestrations.IdReuseCleanupChildWorkflow.LastInstanceId = null;
+                    Orchestrations.IdReuseSuccessChildWorkflow.LastInstanceId = null;
+                    await host.StopAsync();
+                }
+            }
+        }
+
         [TestMethod]
         public async Task RewindMultipleActivityFail()
         {
@@ -4566,6 +4623,56 @@ namespace DurableTask.AzureStorage.Tests
                 }
             }
 
+            [KnownType(typeof(Activities.HelloFailSubOrchestrationIdReuseActivity))]
+            [KnownType(typeof(IdReuseCleanupChildWorkflow))]
+            [KnownType(typeof(IdReuseSuccessChildWorkflow))]
+            internal class SayHelloWithActivityFailAndSubOrchestrationIdReuse : TaskOrchestration<string, string>
+            {
+                public override async Task<string> RunTask(OrchestrationContext context, string input)
+                {
+                    string greeting;
+                    try
+                    {
+                        greeting = await context.ScheduleTask<string>(typeof(Activities.HelloFailSubOrchestrationIdReuseActivity), input);
+                    }
+                    catch (Exception)
+                    {
+                        // Consequence sub-orchestration. It takes sequence ID 1, so its default child instance ID is
+                        // "<parent execution ID>:1".
+                        await context.CreateSubOrchestrationInstance<string>(typeof(IdReuseCleanupChildWorkflow), "Cleanup");
+                        throw;
+                    }
+
+                    // On the post-rewind success path this is the first sub-orchestration, so it also takes sequence ID 1 and
+                    // therefore the same default child instance ID that the cleanup child already occupies. Rewind must leave the
+                    // parent able to start this child anyway.
+                    string child = await context.CreateSubOrchestrationInstance<string>(typeof(IdReuseSuccessChildWorkflow), input);
+                    return $"{greeting} {child}";
+                }
+            }
+
+            internal class IdReuseCleanupChildWorkflow : TaskOrchestration<string, string>
+            {
+                public static string LastInstanceId;
+
+                public override Task<string> RunTask(OrchestrationContext context, string input)
+                {
+                    LastInstanceId = context.OrchestrationInstance.InstanceId;
+                    return Task.FromResult($"Cleaned up {input}");
+                }
+            }
+
+            internal class IdReuseSuccessChildWorkflow : TaskOrchestration<string, string>
+            {
+                public static string LastInstanceId;
+
+                public override Task<string> RunTask(OrchestrationContext context, string input)
+                {
+                    LastInstanceId = context.OrchestrationInstance.InstanceId;
+                    return Task.FromResult($"Child says {input}.");
+                }
+            }
+
             [KnownType(typeof(Activities.Multiply))]
             internal class Factorial : TaskOrchestration<long, int>
             {
@@ -5389,6 +5496,25 @@ namespace DurableTask.AzureStorage.Tests
             }
 
             internal class HelloFailSendEventActivity : TaskActivity<string, string>
+            {
+                public static bool ShouldFail = true;
+                protected override string Execute(TaskContext context, string input)
+                {
+                    if (string.IsNullOrEmpty(input))
+                    {
+                        throw new ArgumentNullException(nameof(input));
+                    }
+
+                    if (ShouldFail)
+                    {
+                        throw new Exception("Simulating unhandled activity function failure...");
+                    }
+
+                    return $"Hello, {input}!";
+                }
+            }
+
+            internal class HelloFailSubOrchestrationIdReuseActivity : TaskActivity<string, string>
             {
                 public static bool ShouldFail = true;
                 protected override string Execute(TaskContext context, string input)

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -1717,6 +1717,14 @@ namespace DurableTask.AzureStorage.Tests
 
                     Assert.AreEqual(OrchestrationStatus.Failed, statusFail?.OrchestrationStatus);
 
+                    // A sub-orchestration created without an explicit instance ID is assigned "<parent execution ID>:<sequence
+                    // ID>", and the cleanup child is the first one the orchestrator creates, so it occupies sequence ID 1.
+                    string reusedChildInstanceId = $"{statusFail.OrchestrationInstance.ExecutionId}:1";
+                    Assert.AreNotEqual(
+                        0,
+                        (await client.GetOrchestrationHistoryAsync(reusedChildInstanceId)).Count,
+                        $"The cleanup sub-orchestration did not run as '{reusedChildInstanceId}', so the failed attempt did not set up the instance ID collision this test exists to cover.");
+
                     Activities.HelloFailSubOrchestrationIdReuseActivity.ShouldFail = false;
 
                     await client.RewindAsync("Rewind orchestrator whose success path reuses the cleanup child's sequence ID.");
@@ -1724,23 +1732,15 @@ namespace DurableTask.AzureStorage.Tests
                     var statusRewind = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
 
                     Assert.AreEqual(OrchestrationStatus.Completed, statusRewind?.OrchestrationStatus);
-                    Assert.AreEqual("\"Hello, World! Child says World.\"", statusRewind?.Output);
 
-                    // Guard the premise of this test: if the two sub-orchestrations ever stop colliding on the same default
-                    // instance ID, the scenario is no longer covered and the assertions above would pass for the wrong reason.
-                    Assert.IsNotNull(
-                        Orchestrations.IdReuseCleanupChildWorkflow.LastInstanceId,
-                        "The cleanup sub-orchestration never ran, so the failed attempt did not set up the ID collision.");
-                    Assert.AreEqual(
-                        Orchestrations.IdReuseCleanupChildWorkflow.LastInstanceId,
-                        Orchestrations.IdReuseSuccessChildWorkflow.LastInstanceId,
-                        "The two sub-orchestrations were assigned different instance IDs, so this test no longer covers child instance ID reuse across a rewind.");
+                    // The success child returns its own instance ID, so this asserts both that it ran to completion and that it
+                    // was assigned the instance ID the cleanup child already occupied. Had its start message been dropped or
+                    // deferred as a duplicate, the parent would still be awaiting it and the test would have timed out above.
+                    Assert.AreEqual($"\"Hello, World! {reusedChildInstanceId}\"", statusRewind?.Output);
                 }
                 finally
                 {
                     Activities.HelloFailSubOrchestrationIdReuseActivity.ShouldFail = originalShouldFail;
-                    Orchestrations.IdReuseCleanupChildWorkflow.LastInstanceId = null;
-                    Orchestrations.IdReuseSuccessChildWorkflow.LastInstanceId = null;
                     await host.StopAsync();
                 }
             }
@@ -4725,23 +4725,18 @@ namespace DurableTask.AzureStorage.Tests
 
             internal class IdReuseCleanupChildWorkflow : TaskOrchestration<string, string>
             {
-                public static string LastInstanceId;
-
                 public override Task<string> RunTask(OrchestrationContext context, string input)
                 {
-                    LastInstanceId = context.OrchestrationInstance.InstanceId;
                     return Task.FromResult($"Cleaned up {input}");
                 }
             }
 
             internal class IdReuseSuccessChildWorkflow : TaskOrchestration<string, string>
             {
-                public static string LastInstanceId;
-
                 public override Task<string> RunTask(OrchestrationContext context, string input)
                 {
-                    LastInstanceId = context.OrchestrationInstance.InstanceId;
-                    return Task.FromResult($"Child says {input}.");
+                    // Returning the instance ID lets the test observe which instance actually ran without any shared state.
+                    return Task.FromResult(context.OrchestrationInstance.InstanceId);
                 }
             }
 

--- a/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/AzureStorageScenarioTests.cs
@@ -1529,6 +1529,94 @@ namespace DurableTask.AzureStorage.Tests
             }
         }
 
+        /// <summary>
+        /// End-to-end test which validates that an orchestration that creates a sub-orchestration in response to an activity
+        /// failure can be rewound. This covers the <see cref="EventType.SubOrchestrationInstanceCreated"/> branch of the
+        /// Azure Storage scrub, which is a separate implementation from the one in DurableTask.Core.
+        /// </summary>
+        [TestMethod]
+        public async Task RewindActivityFailWithCleanupSubOrchestration()
+        {
+            using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(enableExtendedSessions: true))
+            {
+                bool originalShouldFail = Activities.HelloFailCleanupSubOrchestrationActivity.ShouldFail;
+                try
+                {
+                    Activities.HelloFailCleanupSubOrchestrationActivity.ShouldFail = true;
+                    await host.StartAsync();
+
+                    string singletonInstanceId = $"Test_{Guid.NewGuid():N}";
+
+                    var client = await host.StartOrchestrationAsync(
+                        typeof(Orchestrations.SayHelloWithActivityFailAndCleanupSubOrchestration),
+                        input: "World",
+                        instanceId: singletonInstanceId);
+
+                    var statusFail = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
+
+                    Assert.AreEqual(OrchestrationStatus.Failed, statusFail?.OrchestrationStatus);
+
+                    Activities.HelloFailCleanupSubOrchestrationActivity.ShouldFail = false;
+
+                    await client.RewindAsync("Rewind orchestrator that created a sub-orchestration from its catch block.");
+
+                    var statusRewind = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
+
+                    Assert.AreEqual(OrchestrationStatus.Completed, statusRewind?.OrchestrationStatus);
+                    Assert.AreEqual("\"Hello, World!\"", statusRewind?.Output);
+                }
+                finally
+                {
+                    Activities.HelloFailCleanupSubOrchestrationActivity.ShouldFail = originalShouldFail;
+                    await host.StopAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// End-to-end test which validates that an orchestration that sends an event in response to an activity failure can be
+        /// rewound. This covers the <see cref="EventType.EventSent"/> branch of the Azure Storage scrub, which is a separate
+        /// implementation from the one in DurableTask.Core.
+        /// </summary>
+        [TestMethod]
+        public async Task RewindActivityFailWithSendEvent()
+        {
+            using (TestOrchestrationHost host = TestHelpers.GetTestOrchestrationHost(enableExtendedSessions: true))
+            {
+                bool originalShouldFail = Activities.HelloFailSendEventActivity.ShouldFail;
+                try
+                {
+                    Activities.HelloFailSendEventActivity.ShouldFail = true;
+                    await host.StartAsync();
+
+                    string singletonInstanceId = $"Test_{Guid.NewGuid():N}";
+
+                    var client = await host.StartOrchestrationAsync(
+                        typeof(Orchestrations.SayHelloWithActivityFailAndSendEvent),
+                        input: "World",
+                        instanceId: singletonInstanceId);
+
+                    var statusFail = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
+
+                    Assert.AreEqual(OrchestrationStatus.Failed, statusFail?.OrchestrationStatus);
+
+                    Activities.HelloFailSendEventActivity.ShouldFail = false;
+
+                    await client.RewindAsync("Rewind orchestrator that sent an event from its catch block.");
+
+                    var statusRewind = await client.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
+
+                    Assert.AreEqual(OrchestrationStatus.Completed, statusRewind?.OrchestrationStatus);
+                    Assert.AreEqual("\"Hello, World!\"", statusRewind?.Output);
+                }
+                finally
+                {
+                    Activities.HelloFailSendEventActivity.ShouldFail = originalShouldFail;
+                    await host.StopAsync();
+                }
+            }
+        }
+
         [TestMethod]
         public async Task RewindMultipleActivityFail()
         {
@@ -4426,6 +4514,58 @@ namespace DurableTask.AzureStorage.Tests
                 }
             }
 
+            [KnownType(typeof(Activities.HelloFailCleanupSubOrchestrationActivity))]
+            [KnownType(typeof(CleanupChildWorkflow))]
+            internal class SayHelloWithActivityFailAndCleanupSubOrchestration : TaskOrchestration<string, string>
+            {
+                public override async Task<string> RunTask(OrchestrationContext context, string input)
+                {
+                    try
+                    {
+                        return await context.ScheduleTask<string>(typeof(Activities.HelloFailCleanupSubOrchestrationActivity), input);
+                    }
+                    catch (Exception)
+                    {
+                        // The sub-orchestration exists only because the orchestrator observed the failure, so rewind has to
+                        // remove its SubOrchestrationInstanceCreated event (and its result) from the history.
+                        await context.CreateSubOrchestrationInstance<string>(typeof(CleanupChildWorkflow), "Cleanup");
+                        throw;
+                    }
+                }
+            }
+
+            internal class CleanupChildWorkflow : TaskOrchestration<string, string>
+            {
+                public override Task<string> RunTask(OrchestrationContext context, string input)
+                {
+                    // Deliberately schedules no work of its own. The events this test cares about
+                    // (SubOrchestrationInstanceCreated and its result) live in the *parent's* history and are produced
+                    // regardless of what the child does, so keeping the child trivial avoids depending on activity
+                    // registration, which TestOrchestrationHost only resolves one KnownType level deep.
+                    return Task.FromResult($"Cleaned up {input}");
+                }
+            }
+
+            [KnownType(typeof(Activities.HelloFailSendEventActivity))]
+            internal class SayHelloWithActivityFailAndSendEvent : TaskOrchestration<string, string>
+            {
+                public override async Task<string> RunTask(OrchestrationContext context, string input)
+                {
+                    try
+                    {
+                        return await context.ScheduleTask<string>(typeof(Activities.HelloFailSendEventActivity), input);
+                    }
+                    catch (Exception)
+                    {
+                        // The event is sent only because the orchestrator observed the failure, so rewind has to remove the
+                        // resulting EventSent event from the history. It is addressed to this same instance so that the test
+                        // does not depend on the lifetime of some other orchestration.
+                        context.SendEvent(context.OrchestrationInstance, "ActivityFailed", "cleanup");
+                        throw;
+                    }
+                }
+            }
+
             [KnownType(typeof(Activities.Multiply))]
             internal class Factorial : TaskOrchestration<long, int>
             {
@@ -5211,6 +5351,44 @@ namespace DurableTask.AzureStorage.Tests
             }
 
             internal class HelloFailCleanupActivity : TaskActivity<string, string>
+            {
+                public static bool ShouldFail = true;
+                protected override string Execute(TaskContext context, string input)
+                {
+                    if (string.IsNullOrEmpty(input))
+                    {
+                        throw new ArgumentNullException(nameof(input));
+                    }
+
+                    if (ShouldFail)
+                    {
+                        throw new Exception("Simulating unhandled activity function failure...");
+                    }
+
+                    return $"Hello, {input}!";
+                }
+            }
+
+            internal class HelloFailCleanupSubOrchestrationActivity : TaskActivity<string, string>
+            {
+                public static bool ShouldFail = true;
+                protected override string Execute(TaskContext context, string input)
+                {
+                    if (string.IsNullOrEmpty(input))
+                    {
+                        throw new ArgumentNullException(nameof(input));
+                    }
+
+                    if (ShouldFail)
+                    {
+                        throw new Exception("Simulating unhandled activity function failure...");
+                    }
+
+                    return $"Hello, {input}!";
+                }
+            }
+
+            internal class HelloFailSendEventActivity : TaskActivity<string, string>
             {
                 public static bool ShouldFail = true;
                 protected override string Execute(TaskContext context, string input)

--- a/test/DurableTask.Core.Tests/RewindTests.cs
+++ b/test/DurableTask.Core.Tests/RewindTests.cs
@@ -53,12 +53,19 @@ namespace DurableTask.Core.Tests
             AssertReplayable(result);
 
             // 'Cleanup' was scheduled from the catch block, so neither it nor its result may survive.
+            // The sequence ID is read back from the pre-rewind history rather than hard-coded so that
+            // the assertion keeps testing the cleanup activity even if the history layout changes.
+            int cleanupTaskId = result.HistoryAtFailure
+                .OfType<TaskScheduledEvent>()
+                .Single(e => e.Name == "Cleanup")
+                .EventId;
+
             Assert.IsFalse(
                 result.RewoundHistory.OfType<TaskScheduledEvent>().Any(e => e.Name == "Cleanup"),
                 "The activity scheduled from the catch block should have been removed from the history.");
             Assert.AreEqual(
                 0,
-                result.RewoundHistory.OfType<TaskCompletedEvent>().Count(e => e.TaskScheduledId == 3),
+                result.RewoundHistory.OfType<TaskCompletedEvent>().Count(e => e.TaskScheduledId == cleanupTaskId),
                 "The result of the activity scheduled from the catch block should have been removed too.");
 
             // The two activities that succeeded before the failure are retained, so only the failed
@@ -366,6 +373,64 @@ namespace DurableTask.Core.Tests
                 result.ReplayFailureReason,
                 "Replaying the rewound history should not fail the orchestration. Actual failure: "
                     + result.ReplayFailureReason);
+
+            AssertNoOrphanedResultEvents(result.RewoundHistory);
+        }
+
+        /// <summary>
+        /// Asserts that every result event in the rewound history still refers to a scheduling event
+        /// that survived the scrub. An orphaned result event is dangerous rather than merely untidy:
+        /// during replay it can satisfy a completely different task that happens to be assigned the
+        /// same sequence ID, silently feeding the orchestrator a result it never asked for.
+        /// </summary>
+        static void AssertNoOrphanedResultEvents(List<HistoryEvent> history)
+        {
+            AssertNoOrphans(
+                history.OfType<TaskScheduledEvent>().Select(e => e.EventId),
+                history.OfType<TaskCompletedEvent>().Select(e => e.TaskScheduledId),
+                nameof(TaskCompletedEvent),
+                nameof(TaskScheduledEvent));
+
+            AssertNoOrphans(
+                history.OfType<TaskScheduledEvent>().Select(e => e.EventId),
+                history.OfType<TaskFailedEvent>().Select(e => e.TaskScheduledId),
+                nameof(TaskFailedEvent),
+                nameof(TaskScheduledEvent));
+
+            AssertNoOrphans(
+                history.OfType<SubOrchestrationInstanceCreatedEvent>().Select(e => e.EventId),
+                history.OfType<SubOrchestrationInstanceCompletedEvent>().Select(e => e.TaskScheduledId),
+                nameof(SubOrchestrationInstanceCompletedEvent),
+                nameof(SubOrchestrationInstanceCreatedEvent));
+
+            AssertNoOrphans(
+                history.OfType<SubOrchestrationInstanceCreatedEvent>().Select(e => e.EventId),
+                history.OfType<SubOrchestrationInstanceFailedEvent>().Select(e => e.TaskScheduledId),
+                nameof(SubOrchestrationInstanceFailedEvent),
+                nameof(SubOrchestrationInstanceCreatedEvent));
+
+            AssertNoOrphans(
+                history.OfType<TimerCreatedEvent>().Select(e => e.EventId),
+                history.OfType<TimerFiredEvent>().Select(e => e.TimerId),
+                nameof(TimerFiredEvent),
+                nameof(TimerCreatedEvent));
+        }
+
+        static void AssertNoOrphans(
+            IEnumerable<int> scheduledIds,
+            IEnumerable<int> resultIds,
+            string resultEventName,
+            string schedulingEventName)
+        {
+            var surviving = new HashSet<int>(scheduledIds);
+            int[] orphans = resultIds.Where(id => !surviving.Contains(id)).ToArray();
+
+            Assert.AreEqual(
+                0,
+                orphans.Length,
+                $"Found {resultEventName} event(s) with no matching {schedulingEventName} in the rewound "
+                    + $"history (sequence ID(s): {string.Join(", ", orphans)}). A stale result event can be "
+                    + "mistaken for the result of a different task assigned the same sequence ID on replay.");
         }
 
         static RewindResult RunRewindTest(Func<TaskOrchestration> orchestrationFactory)


### PR DESCRIPTION
Fixes Azure/azure-functions-durable-extension#444

## Problem

`RewindAsync` fails with `Non-Deterministic workflow detected` whenever the failed step was **not** the last thing the orchestrator did before failing. The most common shape is a `try/catch` where the catch block schedules something (a cleanup activity, a sub-orchestration, an external event) before rethrowing:

```csharp
try
{
    await context.ScheduleTask<string>(nameof(Foo), "");   // fails
}
catch (Exception)
{
    await context.ScheduleTask<string>(nameof(Cleanup), ""); // <-- scheduled *because* of the failure
    throw;
}
```

This was confirmed by @kashimiz back in 2018 ("the rewind process's cleanup phase fails to scrub the history events of the first `FN.DispatchSignalREvent` ... the failed step in the orchestrator must be the **last** step executed before the orchestrator itself fails. This is due to a logical oversight in our implementation") and reactivated by @cgillum "so that we don't forget to actually fix this."

## Root cause

`ProcessRewindOrchestrationDecision` rebuilt the history by filtering only on **event type + failed task IDs**:

```csharp
if (!(evt is TaskScheduledEvent ts && failedTaskIds.Contains(ts.EventId))
    && evt is not TaskFailedEvent
    && evt is not SubOrchestrationInstanceFailedEvent
    && evt is not ExecutionCompletedEvent)
```

That correctly removes the failed task, but it **retains every event the orchestrator scheduled as a consequence of observing that failure**. After rewind the failure is no longer visible in the history, so on replay the orchestrator takes the success path and blocks awaiting the re-scheduled activity. It never reaches the sequence ID of the leftover `TaskScheduledEvent`, and `TaskOrchestrationContext.HandleTaskScheduledEvent` throws `NonDeterministicOrchestrationException`.

This is exactly why the failure only shows up when the failed step isn't the last one — if nothing was scheduled after the failure, there is nothing left over to trip on.

## Fix

Make the scrub **episode-aware**. History is divided into episodes delimited by `OrchestratorStartedEvent`; an episode boundary is precisely where the orchestrator observed new results and reacted to them.

1. Collect `failedTaskIds` and `failureEpisode` = the earliest episode in which any failure is delivered.
2. Collect `consequenceTaskIds` = sequence IDs of everything scheduled at episode >= `failureEpisode`.
3. Rebuild, dropping the failed/consequence scheduling events **and their corresponding result events**.

Dropping the result events matters: a stale result left behind could otherwise satisfy a *different* task that later gets assigned the same sequence ID.

Two details that are easy to miss and are handled here:

- Replay matches the orchestrator's sequence-ID counter for **four** event types, not just task scheduling: `TaskScheduledEvent`, `SubOrchestrationInstanceCreatedEvent`, `TimerCreatedEvent`, `EventSentEvent`. All four are scrubbed.
- `RetryInterceptor` always creates a **delay timer after the final failed attempt**, so `ScheduleWithRetry` leaves behind a `TimerCreatedEvent` that is itself a consequence of the failure. Without removing it, rewinding a retried activity produces the timer variant of the same error (`scheduled a timer task with sequence number 1 ...`).

The same rule is applied to the Azure Storage rewind path in `AzureTableTrackingStore.RewindHistoryAsync`, which is what `AzureStorageOrchestrationService.RewindTaskOrchestrationAsync` actually calls.

### Behaviors deliberately preserved

- **Fan-out/fan-in**: parallel branches are all scheduled in an episode *before* the failure is observed, so they are retained and not re-executed.
- **Failed sub-orchestrations**: the `SubOrchestrationInstanceCreatedEvent` precedes the episode that delivers the failure, so it is retained and the child rewind message is still emitted.

### Known tradeoff

Within the failure episode the scrub errs on the side of removing too much. Without re-running orchestrator code there is no way to distinguish "scheduled because of the failure" from "unrelated work that happened to be batched into the same episode". The cost is that a small number of successful tasks may be re-executed on rewind; the benefit is a history that always replays. Given that rewind is an explicit, manual recovery operation on an already-failed instance, and that the alternative is rewind failing outright, this is the right trade. Activities should already be idempotent for rewind to be meaningful at all.

## Note for other backends

`ProcessRewindOrchestrationDecision` is not the only implementation of this scrub — some backends (notably the Durable Task Scheduler) replicate it server-side. The `WARNING` comment above the method has been expanded into an explicit contract describing the rule so those implementations can be kept in sync. **They will still exhibit this bug until updated.**

## Tests

New `Test/DurableTask.Core.Tests/RewindTests.cs` (8 tests) drives real orchestrations through real episodes, rewinds, and replays the result.

Regression tests (fail without the fix):
- `Rewind_CatchBlockSchedulesActivity_ProducesReplayableHistory`
- `Rewind_CatchBlockCreatesSubOrchestration_ProducesReplayableHistory`
- `Rewind_CatchBlockSendsEvent_ProducesReplayableHistory`
- `Rewind_ScheduleWithRetry_RemovesRetryTimers`

Guard tests (protect existing behavior):
- `Rewind_SimpleActivityFailure_ReschedulesOnlyTheFailedActivity`
- `Rewind_FanOutFanIn_RetainsSuccessfulBranches`
- `Rewind_FailedSubOrchestration_RetainsCreationAndEmitsChildRewindMessage`
- `Rewind_AssignsNewExecutionId`

Two end-to-end tests in `AzureStorageScenarioTests.cs` cover the Azure Storage path against real storage: `RewindActivityFailWithCleanupActivity` and `RewindActivityFailWithRetry`.

## Verification

Both halves of the change were validated with A/B controls rather than by assuming the tests are meaningful.

| Check | Result |
|---|---|
| New Core tests, net8.0 + net48 | 8/8 pass |
| Core tests with the new logic surgically neutralized | **4 fail** — the regression tests genuinely catch the bug |
| Full Core suite, net8.0 | 147/147 pass |
| E2E tests with `AzureTableTrackingStore` reverted to pre-fix | **both fail** with the exact issue #444 message |
| E2E tests with the fix | both pass |

The pre-fix E2E failures reproduce the original 2018 report verbatim:

```
Non-Deterministic workflow detected: A previous execution of this orchestration scheduled
an activity task with sequence ID 1 and name '...Hello' (version ''), but the current replay
execution hasn't (yet?) scheduled this task.
```

and, for the retry variant:

```
Non-Deterministic workflow detected: A previous execution of this orchestration scheduled
a timer task with sequence number 1 but the current replay execution hasn't (yet?) scheduled this task.
```

Note: net48 has 7 pre-existing failures in the Core suite (all `TraceHelper_*` / `Dispatcher_RestartsTraceActivity_ForContinueAsNewStartNewTrace`). These were confirmed against a baseline with this change removed (7/127 before vs 7/135 after) and are unrelated to rewind.
