### PR TITLE
Add structured abandonment details to Azure Storage logs

### DIFF
--- a/Test/DurableTask.AzureStorage.Tests/LoggingTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/LoggingTests.cs
@@ -94,6 +94,37 @@ namespace DurableTask.AzureStorage.Tests
         }
 
         [TestMethod]
+        public void AbandoningMessage_WriteEventSourceWritesDetailsToFinalPayloadSlot()
+        {
+            const string details = "The dispatcher abandoned the work item.";
+            const string messageId = "event-source-test-message-id";
+            var logEvent = new LogEvents.AbandoningMessage(
+                "test-account",
+                "test-hub",
+                "TaskScheduled",
+                42,
+                messageId,
+                "instance-id",
+                "execution-id",
+                "control-queue",
+                17,
+                "pop-receipt",
+                30,
+                details);
+
+            using (var listener = new AbandoningMessageEventListener(messageId))
+            {
+                listener.Enable();
+                ((IEventSourceEvent)logEvent).WriteEventSource();
+
+                Assert.AreEqual(EventIds.AbandoningMessage, listener.EventId);
+                Assert.AreEqual("Details", listener.PayloadNames.Last());
+                Assert.AreEqual(Utils.ExtensionVersion, listener.Payload[listener.Payload.Count - 2]);
+                Assert.AreEqual(details, listener.Payload.Last());
+            }
+        }
+
+        [TestMethod]
         public void AbandoningMessage_LogHelperPropagatesDetails()
         {
             var logger = new CapturingLogger();
@@ -133,6 +164,46 @@ namespace DurableTask.AzureStorage.Tests
                 Func<TState, Exception, string> formatter)
             {
                 this.State = state;
+            }
+        }
+
+        sealed class AbandoningMessageEventListener : EventListener
+        {
+            readonly string messageId;
+
+            public AbandoningMessageEventListener(string messageId)
+            {
+                this.messageId = messageId;
+            }
+
+            public int EventId { get; private set; } = -1;
+
+            public IReadOnlyList<string> PayloadNames { get; private set; } = Array.Empty<string>();
+
+            public IReadOnlyList<object> Payload { get; private set; } = Array.Empty<object>();
+
+            public void Enable()
+            {
+                this.EnableEvents(AnalyticsEventSource.Log, EventLevel.Verbose);
+            }
+
+            public override void Dispose()
+            {
+                this.DisableEvents(AnalyticsEventSource.Log);
+                base.Dispose();
+            }
+
+            protected override void OnEventWritten(EventWrittenEventArgs eventData)
+            {
+                if (eventData.EventSource == AnalyticsEventSource.Log &&
+                    eventData.EventId == EventIds.AbandoningMessage &&
+                    eventData.Payload.Count == 14 &&
+                    Equals(eventData.Payload[4], this.messageId))
+                {
+                    this.EventId = eventData.EventId;
+                    this.PayloadNames = eventData.PayloadNames.ToArray();
+                    this.Payload = eventData.Payload.ToArray();
+                }
             }
         }
 

--- a/Test/DurableTask.AzureStorage.Tests/LoggingTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/LoggingTests.cs
@@ -1,0 +1,148 @@
+﻿//  ----------------------------------------------------------------------------------
+//  Copyright Microsoft Corporation
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ----------------------------------------------------------------------------------
+
+namespace DurableTask.AzureStorage.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.Tracing;
+    using System.Linq;
+    using System.Reflection;
+    using DurableTask.AzureStorage.Logging;
+    using DurableTask.Core.Logging;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class LoggingTests
+    {
+        [TestMethod]
+        public void AbandoningMessage_HasExpectedStructuredFieldsAndMessage()
+        {
+            var logEvent = new LogEvents.AbandoningMessage(
+                "test-account",
+                "test-hub",
+                "TaskScheduled",
+                42,
+                "message-id",
+                "instance-id",
+                "execution-id",
+                "control-queue",
+                17,
+                "pop-receipt",
+                30,
+                "The activity work item could not be processed.");
+
+            var fields = (IReadOnlyDictionary<string, object>)logEvent;
+            Assert.AreEqual("test-account", fields["Account"]);
+            Assert.AreEqual("test-hub", fields["TaskHub"]);
+            Assert.AreEqual("TaskScheduled", fields["EventType"]);
+            Assert.AreEqual(42, fields["TaskEventId"]);
+            Assert.AreEqual("message-id", fields["MessageId"]);
+            Assert.AreEqual("instance-id", fields["InstanceId"]);
+            Assert.AreEqual("execution-id", fields["ExecutionId"]);
+            Assert.AreEqual("control-queue", fields["PartitionId"]);
+            Assert.AreEqual(17L, fields["SequenceNumber"]);
+            Assert.AreEqual("pop-receipt", fields["PopReceipt"]);
+            Assert.AreEqual(30, fields["VisibilityTimeoutSeconds"]);
+            Assert.AreEqual("The activity work item could not be processed.", fields["Details"]);
+            Assert.AreEqual(LogLevel.Warning, logEvent.Level);
+            Assert.AreEqual(EventIds.AbandoningMessage, logEvent.EventId.Id);
+            Assert.AreEqual(nameof(EventIds.AbandoningMessage), logEvent.EventId.Name);
+            Assert.AreEqual(
+                "instance-id: Abandoning [TaskScheduled#42] message back to control-queue and setting a visibility delay of 30ms: The activity work item could not be processed.",
+                ((ILogEvent)logEvent).FormattedMessage);
+        }
+
+        [TestMethod]
+        public void AbandoningMessage_EventSourceSchemaAppendsDetailsAndUsesVersionEight()
+        {
+            MethodInfo method = typeof(AnalyticsEventSource).GetMethod(nameof(AnalyticsEventSource.AbandoningMessage));
+            EventAttribute eventAttribute = method.GetCustomAttribute<EventAttribute>();
+            string[] parameterNames = method.GetParameters().Select(parameter => parameter.Name).ToArray();
+
+            Assert.AreEqual(8, eventAttribute.Version);
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    "Account",
+                    "TaskHub",
+                    "EventType",
+                    "TaskEventId",
+                    "MessageId",
+                    "InstanceId",
+                    "ExecutionId",
+                    "PartitionId",
+                    "SequenceNumber",
+                    "PopReceipt",
+                    "VisibilityTimeoutSeconds",
+                    "AppName",
+                    "ExtensionVersion",
+                    "Details",
+                },
+                parameterNames);
+        }
+
+        [TestMethod]
+        public void AbandoningMessage_LogHelperPropagatesDetails()
+        {
+            var logger = new CapturingLogger();
+            var logHelper = new LogHelper(logger);
+
+            logHelper.AbandoningMessage(
+                "test-account",
+                "test-hub",
+                "TaskScheduled",
+                42,
+                "message-id",
+                "instance-id",
+                "execution-id",
+                "control-queue",
+                17,
+                "pop-receipt",
+                30,
+                "The orchestration work item could not be processed.");
+
+            var fields = (IReadOnlyDictionary<string, object>)logger.State;
+            Assert.AreEqual("The orchestration work item could not be processed.", fields["Details"]);
+        }
+
+        sealed class CapturingLogger : ILogger
+        {
+            public object State { get; private set; }
+
+            public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception exception,
+                Func<TState, Exception, string> formatter)
+            {
+                this.State = state;
+            }
+        }
+
+        sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new NullScope();
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/Test/DurableTask.AzureStorage.Tests/LoggingTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/LoggingTests.cs
@@ -27,7 +27,7 @@ namespace DurableTask.AzureStorage.Tests
     public class LoggingTests
     {
         [TestMethod]
-        public void AbandoningMessage_HasExpectedStructuredFieldsAndPreservesMessage()
+        public void AbandoningMessage_HasExpectedStructuredFieldsAndMessage()
         {
             var logEvent = new LogEvents.AbandoningMessage(
                 "test-account",
@@ -60,7 +60,7 @@ namespace DurableTask.AzureStorage.Tests
             Assert.AreEqual(EventIds.AbandoningMessage, logEvent.EventId.Id);
             Assert.AreEqual(nameof(EventIds.AbandoningMessage), logEvent.EventId.Name);
             Assert.AreEqual(
-                "instance-id: Abandoning [TaskScheduled#42] message back to control-queue and setting a visibility delay of 30ms",
+                "instance-id: Abandoning [TaskScheduled#42] message back to control-queue and setting a visibility delay of 30ms: The activity work item could not be processed.",
                 ((ILogEvent)logEvent).FormattedMessage);
         }
 

--- a/Test/DurableTask.AzureStorage.Tests/LoggingTests.cs
+++ b/Test/DurableTask.AzureStorage.Tests/LoggingTests.cs
@@ -27,7 +27,7 @@ namespace DurableTask.AzureStorage.Tests
     public class LoggingTests
     {
         [TestMethod]
-        public void AbandoningMessage_HasExpectedStructuredFieldsAndMessage()
+        public void AbandoningMessage_HasExpectedStructuredFieldsAndPreservesMessage()
         {
             var logEvent = new LogEvents.AbandoningMessage(
                 "test-account",
@@ -60,7 +60,7 @@ namespace DurableTask.AzureStorage.Tests
             Assert.AreEqual(EventIds.AbandoningMessage, logEvent.EventId.Id);
             Assert.AreEqual(nameof(EventIds.AbandoningMessage), logEvent.EventId.Name);
             Assert.AreEqual(
-                "instance-id: Abandoning [TaskScheduled#42] message back to control-queue and setting a visibility delay of 30ms: The activity work item could not be processed.",
+                "instance-id: Abandoning [TaskScheduled#42] message back to control-queue and setting a visibility delay of 30ms",
                 ((ILogEvent)logEvent).FormattedMessage);
         }
 

--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -165,7 +165,7 @@ namespace DurableTask.AzureStorage
                 ExtensionVersion);
         }
 
-        [Event(EventIds.AbandoningMessage, Level = EventLevel.Warning, Version = 7)]
+        [Event(EventIds.AbandoningMessage, Level = EventLevel.Warning, Version = 8)]
         public void AbandoningMessage(
             string Account,
             string TaskHub,
@@ -179,7 +179,8 @@ namespace DurableTask.AzureStorage
             string PopReceipt,
             int VisibilityTimeoutSeconds,
             string AppName,
-            string ExtensionVersion)
+            string ExtensionVersion,
+            string Details)
         {
             this.WriteEvent(
                 EventIds.AbandoningMessage,
@@ -195,7 +196,8 @@ namespace DurableTask.AzureStorage
                 PopReceipt ?? string.Empty,
                 VisibilityTimeoutSeconds,
                 AppName,
-                ExtensionVersion);
+                ExtensionVersion,
+                Details);
         }
 
         [Event(EventIds.AssertFailure, Level = EventLevel.Warning, Message = "An unexpected condition was detected: {2}", Version = 2)]

--- a/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
+++ b/src/DurableTask.AzureStorage/AnalyticsEventSource.cs
@@ -197,7 +197,7 @@ namespace DurableTask.AzureStorage
                 VisibilityTimeoutSeconds,
                 AppName,
                 ExtensionVersion,
-                Details);
+                Details ?? string.Empty);
         }
 
         [Event(EventIds.AssertFailure, Level = EventLevel.Warning, Message = "An unexpected condition was detected: {2}", Version = 2)]

--- a/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
+++ b/src/DurableTask.AzureStorage/AzureStorageOrchestrationService.cs
@@ -726,7 +726,9 @@ namespace DurableTask.AzureStorage
                     // Make sure we still own the partition. If not, abandon the session.
                     if (session.ControlQueue.IsReleased)
                     {
-                        await this.AbandonAndReleaseSessionAsync(session);
+                        await this.AbandonAndReleaseSessionAsync(
+                            session,
+                            "The control queue was released.");
                         return null;
                     }
 
@@ -771,13 +773,18 @@ namespace DurableTask.AzureStorage
                     if (outOfOrderMessages?.Count > 0)
                     {
                         // This will also remove the messages from the current batch.
-                        await this.AbandonMessagesAsync(session, outOfOrderMessages);
+                        await this.AbandonMessagesAsync(
+                            session,
+                            outOfOrderMessages,
+                            "Message was received out of order.");
                     }
 
                     if (session.CurrentMessageBatch.Count == 0)
                     {
                         // All messages were removed. Release the work item.
-                        await this.AbandonAndReleaseSessionAsync(session);
+                        await this.AbandonAndReleaseSessionAsync(
+                            session,
+                            "No processable messages remained in the session.");
                         return null;
                     }
 
@@ -870,7 +877,9 @@ namespace DurableTask.AzureStorage
                     if (session != null)
                     {
                         // host is shutting down - release any queued messages
-                        await this.AbandonAndReleaseSessionAsync(session);
+                        await this.AbandonAndReleaseSessionAsync(
+                            session,
+                            "Message processing was canceled during shutdown or listener cancellation.");
                     }
 
                     return null;
@@ -1125,11 +1134,11 @@ namespace DurableTask.AzureStorage
             return null;
         }
 
-        async Task AbandonAndReleaseSessionAsync(OrchestrationSession session)
+        async Task AbandonAndReleaseSessionAsync(OrchestrationSession session, string details)
         {
             try
             {
-                await this.AbandonSessionAsync(session);
+                await this.AbandonSessionAsync(session, details);
             }
             finally
             {
@@ -1488,20 +1497,25 @@ namespace DurableTask.AzureStorage
                 return Utils.CompletedTask;
             }
 
-            return this.AbandonSessionAsync(session);
+            return this.AbandonSessionAsync(
+                session,
+                "The orchestration work item was abandoned by the dispatcher.");
         }
 
-        Task AbandonSessionAsync(OrchestrationSession session)
+        Task AbandonSessionAsync(OrchestrationSession session, string details)
         {
             session.StartNewLogicalTraceScope();
-            return this.AbandonMessagesAsync(session, session.CurrentMessageBatch.ToList());
+            return this.AbandonMessagesAsync(session, session.CurrentMessageBatch.ToList(), details);
         }
 
-        async Task AbandonMessagesAsync(OrchestrationSession session, IList<MessageData> messages)
+        async Task AbandonMessagesAsync(
+            OrchestrationSession session,
+            IList<MessageData> messages,
+            string details)
         {
             await messages.ParallelForEachAsync(
                 this.settings.MaxStorageOperationConcurrency,
-                message => session.ControlQueue.AbandonMessageAsync(message, session));
+                message => session.ControlQueue.AbandonMessageAsync(message, details, session));
 
             // Remove the messages from the current batch. The remaining messages
             // may still be able to be processed
@@ -1680,7 +1694,10 @@ namespace DurableTask.AzureStorage
 
             session.StartNewLogicalTraceScope();
 
-            await this.workItemQueue.AbandonMessageAsync(session.MessageData, session);
+            await this.workItemQueue.AbandonMessageAsync(
+                session.MessageData,
+                "The activity work item was abandoned by the dispatcher.",
+                session);
 
             if (this.activeActivitySessions.TryRemove(workItem.Id, out _))
             {

--- a/src/DurableTask.AzureStorage/Logging/LogEvents.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogEvents.cs
@@ -336,7 +336,8 @@ namespace DurableTask.AzureStorage.Logging
                 string partitionId,
                 long sequenceNumber,
                 string popReceipt,
-                int visibilityTimeoutSeconds)
+                int visibilityTimeoutSeconds,
+                string details)
             {
                 this.Account = account;
                 this.TaskHub = taskHub;
@@ -349,6 +350,7 @@ namespace DurableTask.AzureStorage.Logging
                 this.SequenceNumber = sequenceNumber;
                 this.PopReceipt = popReceipt;
                 this.VisibilityTimeoutSeconds = visibilityTimeoutSeconds;
+                this.Details = details;
             }
 
             [StructuredLogField]
@@ -384,6 +386,9 @@ namespace DurableTask.AzureStorage.Logging
             [StructuredLogField]
             public int VisibilityTimeoutSeconds { get; }
 
+            [StructuredLogField]
+            public string Details { get; }
+
             public override EventId EventId => new EventId(
                 EventIds.AbandoningMessage,
                 nameof(EventIds.AbandoningMessage));
@@ -391,11 +396,12 @@ namespace DurableTask.AzureStorage.Logging
             public override LogLevel Level => LogLevel.Warning;
 
             protected override string CreateLogMessage() => string.Format(
-                "{0}: Abandoning {1} message back to {2} and setting a visibility delay of {3}ms",
+                "{0}: Abandoning {1} message back to {2} and setting a visibility delay of {3}ms: {4}",
                 this.InstanceId,
                 GetEventDescription(this.EventType, this.TaskEventId),
                 this.PartitionId,
-                this.VisibilityTimeoutSeconds);
+                this.VisibilityTimeoutSeconds,
+                this.Details);
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.AbandoningMessage(
                 this.Account,
@@ -410,7 +416,8 @@ namespace DurableTask.AzureStorage.Logging
                 this.PopReceipt,
                 this.VisibilityTimeoutSeconds,
                 Utils.AppName,
-                Utils.ExtensionVersion);
+                Utils.ExtensionVersion,
+                this.Details);
         }
 
         internal class AssertFailure : StructuredLogEvent, IEventSourceEvent

--- a/src/DurableTask.AzureStorage/Logging/LogEvents.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogEvents.cs
@@ -396,12 +396,11 @@ namespace DurableTask.AzureStorage.Logging
             public override LogLevel Level => LogLevel.Warning;
 
             protected override string CreateLogMessage() => string.Format(
-                "{0}: Abandoning {1} message back to {2} and setting a visibility delay of {3}ms: {4}",
+                "{0}: Abandoning {1} message back to {2} and setting a visibility delay of {3}ms",
                 this.InstanceId,
                 GetEventDescription(this.EventType, this.TaskEventId),
                 this.PartitionId,
-                this.VisibilityTimeoutSeconds,
-                this.Details);
+                this.VisibilityTimeoutSeconds);
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.AbandoningMessage(
                 this.Account,

--- a/src/DurableTask.AzureStorage/Logging/LogEvents.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogEvents.cs
@@ -396,11 +396,12 @@ namespace DurableTask.AzureStorage.Logging
             public override LogLevel Level => LogLevel.Warning;
 
             protected override string CreateLogMessage() => string.Format(
-                "{0}: Abandoning {1} message back to {2} and setting a visibility delay of {3}ms",
+                "{0}: Abandoning {1} message back to {2} and setting a visibility delay of {3}ms: {4}",
                 this.InstanceId,
                 GetEventDescription(this.EventType, this.TaskEventId),
                 this.PartitionId,
-                this.VisibilityTimeoutSeconds);
+                this.VisibilityTimeoutSeconds,
+                this.Details);
 
             void IEventSourceEvent.WriteEventSource() => AnalyticsEventSource.Log.AbandoningMessage(
                 this.Account,

--- a/src/DurableTask.AzureStorage/Logging/LogHelper.cs
+++ b/src/DurableTask.AzureStorage/Logging/LogHelper.cs
@@ -134,7 +134,8 @@ namespace DurableTask.AzureStorage.Logging
             string partitionId,
             long sequenceNumber,
             string popReceipt,
-            int visibilityTimeoutSeconds)
+            int visibilityTimeoutSeconds,
+            string details)
         {
             var logEvent = new LogEvents.AbandoningMessage(
                 account,
@@ -147,7 +148,8 @@ namespace DurableTask.AzureStorage.Logging
                 partitionId,
                 sequenceNumber,
                 popReceipt,
-                visibilityTimeoutSeconds);
+                visibilityTimeoutSeconds,
+                details);
             this.WriteStructuredLog(logEvent);
         }
 

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -203,7 +203,7 @@ namespace DurableTask.AzureStorage.Messaging
                 instance: null,
                 traceActivityId: null,
                 sequenceNumber: -1,
-                abandonmentDetails: details);
+                details: details);
         }
 
         public override Task AbandonMessageAsync(

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -203,7 +203,7 @@ namespace DurableTask.AzureStorage.Messaging
                 instance: null,
                 traceActivityId: null,
                 sequenceNumber: -1,
-                details: details);
+                abandonmentDetails: details);
         }
 
         public override Task AbandonMessageAsync(

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -203,16 +203,16 @@ namespace DurableTask.AzureStorage.Messaging
                 instance: null,
                 traceActivityId: null,
                 sequenceNumber: -1,
-                details);
+                details: details);
         }
 
         public override Task AbandonMessageAsync(
             MessageData message,
-            string details,
+            string abandonmentDetails,
             SessionBase? session = null)
         {
             this.stats.PendingOrchestratorMessages.TryRemove(message.OriginalQueueMessage.MessageId, out _);
-            return base.AbandonMessageAsync(message, details, session);
+            return base.AbandonMessageAsync(message, abandonmentDetails, session);
         }
 
         public override Task DeleteMessageAsync(MessageData message, SessionBase? session = null)

--- a/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/ControlQueue.cs
@@ -127,7 +127,9 @@ namespace DurableTask.AzureStorage.Messaging
 
                                 // Abandon the message so we can try it again later.
                                 // Note: We will fetch the message again from the queue before retrying, so no need to read the receipt
-                                _ = await this.AbandonMessageAsync(queueMessage);
+                                _ = await this.AbandonMessageAsync(
+                                    queueMessage,
+                                    "Message deserialization failed.");
                                 return;
                             }
 
@@ -192,7 +194,7 @@ namespace DurableTask.AzureStorage.Messaging
         }
 
         // This overload is intended for cases where we aren't able to deserialize an instance of MessageData.
-        public Task<UpdateReceipt?> AbandonMessageAsync(QueueMessage queueMessage)
+        public Task<UpdateReceipt?> AbandonMessageAsync(QueueMessage queueMessage, string details)
         {
             this.stats.PendingOrchestratorMessages.TryRemove(queueMessage.MessageId, out _);
             return base.AbandonMessageAsync(
@@ -200,13 +202,17 @@ namespace DurableTask.AzureStorage.Messaging
                 taskMessage: null,
                 instance: null,
                 traceActivityId: null,
-                sequenceNumber: -1);
+                sequenceNumber: -1,
+                details);
         }
 
-        public override Task AbandonMessageAsync(MessageData message, SessionBase? session = null)
+        public override Task AbandonMessageAsync(
+            MessageData message,
+            string details,
+            SessionBase? session = null)
         {
             this.stats.PendingOrchestratorMessages.TryRemove(message.OriginalQueueMessage.MessageId, out _);
-            return base.AbandonMessageAsync(message, session);
+            return base.AbandonMessageAsync(message, details, session);
         }
 
         public override Task DeleteMessageAsync(MessageData message, SessionBase? session = null)

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -244,7 +244,7 @@ namespace DurableTask.AzureStorage.Messaging
             OrchestrationInstance? instance,
             Guid? traceActivityId,
             long sequenceNumber,
-            string abandonmentDetails)
+            string details)
         {
             string instanceId = instance?.InstanceId ?? string.Empty;
             string executionId = instance?.ExecutionId ?? string.Empty;
@@ -283,7 +283,7 @@ namespace DurableTask.AzureStorage.Messaging
                 sequenceNumber,
                 queueMessage.PopReceipt,
                 numSecondsToWait,
-                abandonmentDetails);
+                details);
 
             try
             {

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -214,7 +214,7 @@ namespace DurableTask.AzureStorage.Messaging
 
         public virtual async Task AbandonMessageAsync(
             MessageData message,
-            string details,
+            string abandonmentDetails,
             SessionBase? session = null)
         {
             QueueMessage queueMessage = message.OriginalQueueMessage;
@@ -228,7 +228,7 @@ namespace DurableTask.AzureStorage.Messaging
                 instance,
                 session?.TraceActivityId,
                 sequenceNumber,
-                details);
+                abandonmentDetails);
 
             // If we've successfully abandoned the message, update the pop receipt
             // (even though we'll likely no longer interact with this message)

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -244,7 +244,7 @@ namespace DurableTask.AzureStorage.Messaging
             OrchestrationInstance? instance,
             Guid? traceActivityId,
             long sequenceNumber,
-            string details)
+            string abandonmentDetails)
         {
             string instanceId = instance?.InstanceId ?? string.Empty;
             string executionId = instance?.ExecutionId ?? string.Empty;
@@ -283,7 +283,7 @@ namespace DurableTask.AzureStorage.Messaging
                 sequenceNumber,
                 queueMessage.PopReceipt,
                 numSecondsToWait,
-                details);
+                abandonmentDetails);
 
             try
             {

--- a/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
+++ b/src/DurableTask.AzureStorage/Messaging/TaskHubQueue.cs
@@ -212,7 +212,10 @@ namespace DurableTask.AzureStorage.Messaging
             return initialVisibilityDelay;
         }
 
-        public virtual async Task AbandonMessageAsync(MessageData message, SessionBase? session = null)
+        public virtual async Task AbandonMessageAsync(
+            MessageData message,
+            string details,
+            SessionBase? session = null)
         {
             QueueMessage queueMessage = message.OriginalQueueMessage;
             TaskMessage taskMessage = message.TaskMessage;
@@ -224,7 +227,8 @@ namespace DurableTask.AzureStorage.Messaging
                 taskMessage,
                 instance,
                 session?.TraceActivityId,
-                sequenceNumber);
+                sequenceNumber,
+                details);
 
             // If we've successfully abandoned the message, update the pop receipt
             // (even though we'll likely no longer interact with this message)
@@ -239,7 +243,8 @@ namespace DurableTask.AzureStorage.Messaging
             TaskMessage? taskMessage,
             OrchestrationInstance? instance,
             Guid? traceActivityId,
-            long sequenceNumber)
+            long sequenceNumber,
+            string details)
         {
             string instanceId = instance?.InstanceId ?? string.Empty;
             string executionId = instance?.ExecutionId ?? string.Empty;
@@ -277,7 +282,8 @@ namespace DurableTask.AzureStorage.Messaging
                 this.storageQueue.Name,
                 sequenceNumber,
                 queueMessage.PopReceipt,
-                numSecondsToWait);
+                numSecondsToWait,
+                details);
 
             try
             {

--- a/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
+++ b/src/DurableTask.AzureStorage/OrchestrationSessionManager.cs
@@ -326,7 +326,11 @@ namespace DurableTask.AzureStorage
                 filteredMessages = filteredMessages.Except(messagesToDefer);
 
                 // Defer messages on a background thread to avoid blocking the dequeue loop
-                _ = Task.Run(() => messagesToDefer.ParallelForEachAsync(msg => controlQueue.AbandonMessageAsync(msg, session: null)));
+                _ = Task.Run(() => messagesToDefer.ParallelForEachAsync(
+                    msg => controlQueue.AbandonMessageAsync(
+                        msg,
+                        "Execution-start message was deferred pending instance status reconciliation.",
+                        session: null)));
             }
 
             if (messagesToDiscard?.Count > 0)

--- a/test/DurableTask.AzureStorage.Tests/LoggingTests.cs
+++ b/test/DurableTask.AzureStorage.Tests/LoggingTests.cs
@@ -59,6 +59,7 @@ namespace DurableTask.AzureStorage.Tests
             Assert.AreEqual(LogLevel.Warning, logEvent.Level);
             Assert.AreEqual(EventIds.AbandoningMessage, logEvent.EventId.Id);
             Assert.AreEqual(nameof(EventIds.AbandoningMessage), logEvent.EventId.Name);
+            // Preserve the legacy unit label for customers that parse formatted log messages.
             Assert.AreEqual(
                 "instance-id: Abandoning [TaskScheduled#42] message back to control-queue and setting a visibility delay of 30ms",
                 ((ILogEvent)logEvent).FormattedMessage);
@@ -93,10 +94,12 @@ namespace DurableTask.AzureStorage.Tests
                 parameterNames);
         }
 
-        [TestMethod]
-        public void AbandoningMessage_WriteEventSourceWritesDetailsToFinalPayloadSlot()
+        [DataTestMethod]
+        [DataRow("The dispatcher abandoned the work item.", "The dispatcher abandoned the work item.")]
+        [DataRow("", "")]
+        [DataRow(null, "")]
+        public void AbandoningMessage_WriteEventSourceWritesDetailsToFinalPayloadSlot(string details, string expectedDetails)
         {
-            const string details = "The dispatcher abandoned the work item.";
             const string messageId = "event-source-test-message-id";
             var logEvent = new LogEvents.AbandoningMessage(
                 "test-account",
@@ -120,7 +123,7 @@ namespace DurableTask.AzureStorage.Tests
                 Assert.AreEqual(EventIds.AbandoningMessage, listener.EventId);
                 Assert.AreEqual("Details", listener.PayloadNames.Last());
                 Assert.AreEqual(Utils.ExtensionVersion, listener.Payload[listener.Payload.Count - 2]);
-                Assert.AreEqual(details, listener.Payload.Last());
+                Assert.AreEqual(expectedDetails, listener.Payload.Last());
             }
         }
 


### PR DESCRIPTION
## Summary

- Add structured `Details` to Azure Storage `AbandoningMessage` telemetry and thread code-authored explanations through all queue/session abandonment paths.
- Preserve the existing human-readable `AbandoningMessage` text exactly so customers that parse rendered log messages remain compatible.
- Append `Details` to AnalyticsEventSource event 104 and increment its version from 7 to 8. Normalize null `Details` to an empty string at the EventSource boundary.
- Add focused coverage under the case-correct `test/DurableTask.AzureStorage.Tests/` project directory for structured fields, unchanged formatted text, propagation, EventSource schema validation, and positional payload ordering with nonempty, empty, and null details.

## Compatibility

This is a telemetry-only change. `Details` is available through structured `ILogger` state and EventSource, while `FormattedMessage`/`ToString()` remains unchanged. The change preserves abandon/delete decisions, queue operations, visibility timeout/backoff, retry timing, event ID 104, the existing Warning level, and all existing EventSource payload positions. No public provider contract or discard-event schema is changed. Detail values are code-authored strings and do not include queue payloads, user input, secrets, exception messages, or stack traces.

The legacy formatted message labels the visibility delay with `ms`, even though the value represents seconds. That pre-existing label is intentionally preserved for text compatibility; the structured `VisibilityTimeoutSeconds` field remains the authoritative seconds-valued field.

### Telemetry rollout note

Metadata-driven EventSource consumers will discover the appended field automatically. A downstream ETW, Geneva, or Kusto mapping explicitly pinned to event 104 version 7 and its 13-field payload must add a version 8 mapping for the appended `Details` field. This is an ingestion-schema consideration only; it does not affect Durable Task application behavior.

## Validation

- `dotnet test test\DurableTask.AzureStorage.Tests\DurableTask.AzureStorage.Tests.csproj --no-restore --filter "FullyQualifiedName~LoggingTests|Name=ValidateEventSource" --logger "console;verbosity=normal"` - 7 passed on `net8.0` and 7 passed on `net48`, including null/empty EventSource payload cases. Run from the isolated Windows worktree after restoring missing project assets.
- `git diff --check` and `git diff --cached --check` - passed before committing.
- Case-sensitive Git index assertions confirm that `LoggingTests.cs` and its `.csproj` share the exact lowercase `test/DurableTask.AzureStorage.Tests/` directory. No Linux runtime test was performed.

Related: Azure/azure-functions-durable-extension#1608